### PR TITLE
feat: Add Kata ZC1040 (Nullglob in loops) and parser refactor

### DIFF
--- a/pkg/katas/zc1040.go
+++ b/pkg/katas/zc1040.go
@@ -1,0 +1,79 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.ForLoopStatementNode, Kata{
+		ID:          "ZC1040",
+		Title:       "Use (N) nullglob qualifier for globs in loops",
+		Description: "In Zsh, a glob that matches nothing (e.g., `*.txt`) will cause an error by default. " +
+			"Use the `(N)` glob qualifier to make it null (empty) if no matches found, preventing the error.",
+		Check: checkZC1040,
+	})
+}
+
+func checkZC1040(node ast.Node) []Violation {
+	loop, ok := node.(*ast.ForLoopStatement)
+	if !ok {
+		return nil
+	}
+
+	// Only check "for i in items..." style loops, not arithmetic loops
+	if loop.Items == nil {
+		return nil
+	}
+
+	violations := []Violation{}
+
+	for _, item := range loop.Items {
+		// We are looking for string literals that look like globs (contain *, ?, etc)
+		// but do NOT contain (N) or (N-...) qualifiers.
+		
+		val := getStringValue(item)
+		if isGlob(val) && !hasNullGlobQualifier(val) {
+			violations = append(violations, Violation{
+				KataID:  "ZC1040",
+				Message: "Glob pattern '" + val + "' may error if no files match. Append '(N)' to enable nullglob behavior: '" + val + "(N)'",
+				Line:    item.TokenLiteralNode().Line,
+				Column:  item.TokenLiteralNode().Column,
+			})
+		}
+	}
+
+	return violations
+}
+
+func getStringValue(node ast.Node) string {
+	switch n := node.(type) {
+	case *ast.StringLiteral:
+		return n.Value
+	case *ast.ConcatenatedExpression:
+		var sb strings.Builder
+		for _, p := range n.Parts {
+			sb.WriteString(getStringValue(p))
+		}
+		return sb.String()
+	case *ast.Identifier:
+		return n.Value
+	case *ast.GroupedExpression:
+		return "(" + getStringValue(n.Exp) + ")"
+	default:
+		// Fallback for operators treated as literals (like *)
+		return n.TokenLiteral()
+	}
+}
+
+func isGlob(s string) bool {
+	// Simple check for common glob characters
+	return strings.ContainsAny(s, "*?[]")
+}
+
+func hasNullGlobQualifier(s string) bool {
+	// Check for (N) at the end. Zsh qualifiers are at the end.
+	// This is a naive check.
+	return strings.Contains(s, "(N)") || strings.Contains(s, "(N") // (N) or (N...)
+}

--- a/tests/integration_test.zsh
+++ b/tests/integration_test.zsh
@@ -82,6 +82,11 @@ run_test 'if ((1 < 2)); then return true; fi' "" "Parser: If Statement"
 run_test 'rm /' "ZC1039" "ZC1039: rm /"
 run_test 'rm /tmp' "" "ZC1039: rm /tmp (Valid)"
 
+# --- ZC1040: Nullglob in loops ---
+run_test 'for i in *.txt; do printf "%s\n" "$i"; done' "ZC1040" "ZC1040: Missing (N)"
+run_test 'for i in *.txt(N); do printf "%s\n" "$i"; done' "" "ZC1040: With (N)"
+run_test 'for i in *; do printf "%s\n" "$i"; done' "ZC1040" "ZC1040: * missing (N)"
+
 # --- Summary ---
 echo "------------------------------------------------"
 if [[ $FAILURES -eq 0 ]]; then


### PR DESCRIPTION
## Description

Adds a new check **ZC1040** to warn when globs are used in `for` loops without the `(N)` nullglob qualifier. This prevents errors when no files match the glob.

### Key Changes
- **New Kata ZC1040:** checks for globs like `*.txt` in loops and suggests `*.txt(N)`.
- **Parser Refactor:** Introduced `GroupedExpression` in the AST and updated  to preserve parentheses grouping.
- **Parser Fix:** Removed `LPAREN` from command delimiters to correctly parse words with qualifiers like `*.txt(N)` as single concatenated expressions rather than splitting them.

### Verification
- Added integration tests for ZC1040.
- Verified parsing of `*.txt(N)` correctly avoids false positives.
