### PR TITLE
feat: Add Kata ZC1041 (printf format string safety)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ zshellcheck [flags] <file1.zsh> [file2.zsh]...
 | **ZC1037** | Use 'print -r --' for variable expansion |
 | **ZC1038** | Avoid useless use of cat |
 | **ZC1039** | Avoid `rm` with root path |
+| **ZC1040** | Use (N) nullglob qualifier for globs in loops |
+| **ZC1041** | Do not use variables in printf format string |
 
 </details>
 

--- a/pkg/katas/zc1039.go
+++ b/pkg/katas/zc1039.go
@@ -1,6 +1,8 @@
 package katas
 
 import (
+	"strings"
+
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
@@ -29,7 +31,8 @@ func checkZC1039(node ast.Node) []Violation {
 
 	for _, arg := range cmd.Arguments {
 		if str, ok := arg.(*ast.StringLiteral); ok {
-			if str.Value == "/" {
+			val := strings.Trim(str.Value, "\"'")
+			if val == "/" {
 				violations = append(violations, Violation{
 					KataID:  "ZC1039",
 					Message: "Avoid `rm` on the root directory `/`. This is highly dangerous.",

--- a/pkg/katas/zc1040.go
+++ b/pkg/katas/zc1040.go
@@ -34,6 +34,12 @@ func checkZC1040(node ast.Node) []Violation {
 		// but do NOT contain (N) or (N-...) qualifiers.
 		
 		val := getStringValue(item)
+		
+		// If it is quoted, it is NOT a glob expansion.
+		if len(val) > 0 && (val[0] == '"' || val[0] == '\'') {
+			continue
+		}
+
 		if isGlob(val) && !hasNullGlobQualifier(val) {
 			violations = append(violations, Violation{
 				KataID:  "ZC1040",

--- a/pkg/katas/zc1041.go
+++ b/pkg/katas/zc1041.go
@@ -1,0 +1,76 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:          "ZC1041",
+		Title:       "Do not use variables in printf format string",
+		Description: "Using variables in `printf` format strings allows for format string attacks and unexpected behavior if the variable contains `%`. Use `printf '%s' \"$var\"` instead.",
+		Check:       checkZC1041,
+	})
+}
+
+func checkZC1041(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	// Check if command is printf
+	if cmdName, ok := cmd.Name.(*ast.Identifier); !ok || cmdName.Value != "printf" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	firstArg := cmd.Arguments[0]
+
+	// The first argument should be a static StringLiteral.
+	// If it is an Identifier ($var), ConcatenatedExpression ("$var"), or CommandSubstitution, warn.
+	// Note: A StringLiteral might still contain interpolation if the lexer didn't split it, 
+	// but generally in this AST, StringLiteral is safe/static or single-quoted.
+	// We warn if it's NOT a StringLiteral.
+
+	_, isStringLiteral := firstArg.(*ast.StringLiteral)
+
+	if !isStringLiteral {
+		violations := []Violation{{
+			KataID:  "ZC1041",
+			Message: "Do not use variables in printf format string. Use `printf '..%s..' \"$var\"` instead.",
+			Line:    firstArg.TokenLiteralNode().Line,
+			Column:  firstArg.TokenLiteralNode().Column,
+		}}
+		return violations
+	}
+
+	// Even if it is a StringLiteral, it might be "$var" (interpolation).
+	// We should inspect the value.
+	if str, ok := firstArg.(*ast.StringLiteral); ok {
+		val := str.Value
+		// If it contains $ and is not single-quoted, it's likely a variable.
+		// Heuristic: if it starts with " and contains $, it's risky.
+		if len(val) > 0 && val[0] == '"' {
+			// Check for $ not escaped? The lexer hands us the raw string usually.
+			// Simple check: if it has unescaped $, flag it.
+			// This is a basic heuristic.
+			for i := 0; i < len(val); i++ {
+				if val[i] == '$' && (i == 0 || val[i-1] != '\\') {
+					violations := []Violation{{
+						KataID:  "ZC1041",
+						Message: "Do not use variables in printf format string. Use `printf '..%s..' \"$var\"` instead.",
+						Line:    firstArg.TokenLiteralNode().Line,
+						Column:  firstArg.TokenLiteralNode().Column,
+					}}
+					return violations
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -252,7 +252,12 @@ func (l *Lexer) NextToken() token.Token {
 		tok.Type = token.STRING
 		tok.Line = l.line
 		tok.Column = l.column
-		tok.Literal = l.readString()
+		tok.Literal = l.readString('"')
+	case '\'':
+		tok.Type = token.STRING
+		tok.Line = l.line
+		tok.Column = l.column
+		tok.Literal = l.readString('\'')
 	case 0:
 		tok.Literal = ""
 		tok.Type = token.EOF
@@ -302,15 +307,18 @@ func (l *Lexer) readNumber() string {
 	return l.input[position:l.position]
 }
 
-func (l *Lexer) readString() string {
-	position := l.position + 1
+func (l *Lexer) readString(quote byte) string {
+	position := l.position // include opening quote
 	for {
 		l.readChar()
-		if l.ch == '"' || l.ch == 0 {
+		if l.ch == quote || l.ch == 0 {
 			break
 		}
+		if l.ch == '\\' {
+			l.readChar() // skip escaped char
+		}
 	}
-	return l.input[position:l.position]
+	return l.input[position : l.position+1] // include closing quote
 }
 
 func (l *Lexer) skipWhitespace() bool {

--- a/tests/integration_test.zsh
+++ b/tests/integration_test.zsh
@@ -87,6 +87,11 @@ run_test 'for i in *.txt; do printf "%s\n" "$i"; done' "ZC1040" "ZC1040: Missing
 run_test 'for i in *.txt(N); do printf "%s\n" "$i"; done' "" "ZC1040: With (N)"
 run_test 'for i in *; do printf "%s\n" "$i"; done' "ZC1040" "ZC1040: * missing (N)"
 
+# --- ZC1041: printf format string ---
+run_test 'printf "$var"' "ZC1041" "ZC1041: Variable format string"
+run_test 'printf "Hello %s" "$var"' "" "ZC1041: Static format string"
+run_test 'printf $fmt "arg"' "ZC1041" "ZC1041: Identifier format string"
+
 # --- Summary ---
 echo "------------------------------------------------"
 if [[ $FAILURES -eq 0 ]]; then


### PR DESCRIPTION
## Description

Adds **ZC1041**: Do not use variables in printf format string.
Warns against  which can lead to format string attacks or bugs. Suggests .

### Key Changes
- **New Kata ZC1041**: Checks  arguments.
- **Lexer Update**:  now includes the surrounding quotes in the returned literal. This allows Katas to distinguish between single-quoted (literal) and double-quoted (interpolated) strings, which is critical for ZC1041 (and ZC1040/ZC1039).
- **Kata Updates**: Updated ZC1039 and ZC1040 to handle/ignore quoted strings correctly based on the new Lexer behavior.

### Verification
- Added integration tests for ZC1041.
- Verified regressions for ZC1039 and ZC1040 fixed.
