### PR TITLE
feat: Add Kata ZC1043 (Enforce local variables)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ zshellcheck [flags] <file1.zsh> [file2.zsh]...
 | **ZC1040** | Use (N) nullglob qualifier for globs in loops |
 | **ZC1041** | Do not use variables in printf format string |
 | **ZC1042** | Use "$@" to iterate over arguments |
+| **ZC1043** | Use `local` for variables in functions |
 
 </details>
 

--- a/pkg/katas/zc1043.go
+++ b/pkg/katas/zc1043.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.FunctionDefinitionNode, Kata{
+		ID:          "ZC1043",
+		Title:       "Use `local` for variables in functions",
+		Description: "Variables defined in functions are global by default in Zsh. Use `local` to scope them to the function.",
+		Check:       checkZC1043,
+	})
+}
+
+func checkZC1043(node ast.Node) []Violation {
+	funcDef, ok := node.(*ast.FunctionDefinition)
+	if !ok {
+		return nil
+	}
+
+	violations := []Violation{}
+
+	ast.Walk(funcDef.Body, func(n ast.Node) bool {
+		// We only care about "naked" assignments, which are ExpressionStatements containing an assignment.
+		// Assignments inside `local x=1` are part of SimpleCommand and handled differently (not as naked ExpressionStatement).
+		
+		if exprStmt, ok := n.(*ast.ExpressionStatement); ok {
+			if assign, ok := exprStmt.Expression.(*ast.InfixExpression); ok && assign.Operator == "=" {
+				if ident, ok := assign.Left.(*ast.Identifier); ok {
+					violations = append(violations, Violation{
+						KataID:  "ZC1043",
+						Message: "Variable '" + ident.Value + "' is assigned without 'local'. It will be global. Use `local " + ident.Value + "=" + assign.Right.String() + "`.",
+						Line:    ident.Token.Line,
+						Column:  ident.Token.Column,
+					})
+				}
+			}
+		}
+		
+		// Stop walking into nested function definitions
+		if _, ok := n.(*ast.FunctionDefinition); ok && n != funcDef {
+			return false
+		}
+		
+		return true
+	})
+		if _, ok := n.(*ast.FunctionDefinition); ok && n != funcDef {
+			return false
+		}
+		
+		return true
+	})
+
+	return violations
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -177,7 +177,11 @@ func (p *Parser) parseStatement() ast.Statement {
 	case token.WHILE:
 		return p.parseWhileLoopStatement()
 	case token.LBRACE:
-		return p.parseBlockStatement(token.RBRACE)
+		tok := p.curToken
+		p.nextToken()
+		block := p.parseBlockStatement(token.RBRACE)
+		block.Token = tok
+		return block
 	case token.LPAREN:
 		return p.parseSubshellStatement()
 	case token.COLON, token.DOT, token.LBRACKET:

--- a/tests/integration_test.zsh
+++ b/tests/integration_test.zsh
@@ -97,6 +97,11 @@ run_test 'for arg in "$*"; do printf "%s\n" "$arg"; done' "ZC1042" "ZC1042: Quot
 # run_test 'for arg in $*; do printf "%s\n" "$arg"; done' "ZC1042" "ZC1042: Unquoted dollar star"
 run_test 'for arg in "$@"; do printf "%s\n" "$arg"; done' "" "ZC1042: Quoted dollar at (Valid)"
 
+# --- ZC1043: Local variables in functions ---
+run_test 'fn() { var=1; }' "ZC1043" "ZC1043: Global var"
+run_test 'fn() { local var=1; }' "" "ZC1043: Local var"
+run_test 'var=1' "" "ZC1043: Global scope (Valid)"
+
 # --- Summary ---
 echo "------------------------------------------------"
 if [[ $FAILURES -eq 0 ]]; then


### PR DESCRIPTION
## Description

Adds **ZC1043**: Use `local` for variables in functions.
Variables in Zsh functions are global by default. This check warns if an assignment is made without `local`, `declare`, or `typeset`.

### Key Changes
- **New Kata ZC1043**: Checks for naked assignments in function bodies.
- **Parser Fix**: Resolved a stack overflow in `parseBlockStatement` where recursion occurred if the block started with `{`.

### Verification
- Added integration tests.
