### PR TITLE
feat: Add Kata ZC1047 (Avoid sudo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ zshellcheck [flags] <file1.zsh> [file2.zsh]...
 | **ZC1044** | Check for unchecked `cd` commands |
 | **ZC1045** | Declare and assign separately to avoid masking return values |
 | **ZC1046** | Avoid `eval` |
+| **ZC1047** | Avoid `sudo` in scripts |
 
 </details>
 

--- a/pkg/katas/zc1047.go
+++ b/pkg/katas/zc1047.go
@@ -1,0 +1,33 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:          "ZC1047",
+		Title:       "Avoid `sudo` in scripts",
+		Description: "Using `sudo` in scripts is generally discouraged. It makes the script interactive and less portable. Run the script as root or use `sudo` to invoke the script.",
+		Check:       checkZC1047,
+	})
+}
+
+func checkZC1047(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	// Check if command is sudo
+	if name, ok := cmd.Name.(*ast.Identifier); ok && name.Value == "sudo" {
+		return []Violation{{
+			KataID:  "ZC1047",
+			Message: "Avoid `sudo` in scripts. Run the entire script as root if privileges are required.",
+			Line:    name.Token.Line,
+			Column:  name.Token.Column,
+		}}
+	}
+
+	return nil
+}

--- a/tests/integration_test.zsh
+++ b/tests/integration_test.zsh
@@ -126,6 +126,10 @@ run_test 'builtin eval "ls -l"' "ZC1046" "ZC1046: builtin eval"
 run_test 'command eval "ls -l"' "ZC1046" "ZC1046: command eval"
 run_test 'printf "eval\n"' "" "ZC1046: echo word eval (Valid)"
 
+# --- ZC1047: Avoid sudo ---
+run_test 'sudo ls' "ZC1047" "ZC1047: sudo"
+run_test 'printf "sudo\n"' "" "ZC1047: echo sudo (Valid)"
+
 # --- Summary ---
 echo "------------------------------------------------"
 if [[ $FAILURES -eq 0 ]]; then


### PR DESCRIPTION
## Description

Adds **ZC1047**: Avoid `sudo` in scripts.
Warns against using `sudo` inside scripts, as it can break interactivity and portability. Suggests running the entire script as root if privileges are needed.

### Verification
- Added integration tests.
