### PR TITLE
feat: Add Kata ZC1048 (Relative source paths)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ zshellcheck [flags] <file1.zsh> [file2.zsh]...
 | **ZC1045** | Declare and assign separately to avoid masking return values |
 | **ZC1046** | Avoid `eval` |
 | **ZC1047** | Avoid `sudo` in scripts |
+| **ZC1048** | Avoid `source` with relative paths |
 
 </details>
 

--- a/pkg/katas/zc1048.go
+++ b/pkg/katas/zc1048.go
@@ -1,0 +1,71 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:          "ZC1048",
+		Title:       "Avoid `source` with relative paths",
+		Description: "Sourcing a file with a relative path (e.g. `source ./lib.zsh`) depends on the current working directory. Use `${0:a:h}/lib.zsh` to source relative to the script location.",
+		Check:       checkZC1048,
+	})
+}
+
+func checkZC1048(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	// Check if command is source or .
+	name := cmd.Name.String()
+	if name != "source" && name != "." {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	arg := cmd.Arguments[0]
+	
+	// Check if arg is a StringLiteral or ConcatenatedExpression starting with "./" or "../"
+	val := getStringValueZC1048(arg)
+	
+	// Remove quoting for check manually to avoid tool call escaping issues
+	if len(val) > 0 && (val[0] == '"' || val[0] == '\'') {
+		val = val[1:]
+	}
+	if len(val) > 0 && (val[len(val)-1] == '"' || val[len(val)-1] == '\'') {
+		val = val[:len(val)-1]
+	}
+
+	if strings.HasPrefix(val, "./") || strings.HasPrefix(val, "../") {
+		return []Violation{{ 
+			KataID:  "ZC1048",
+			Message: "Avoid `source` with relative paths. Use `${0:a:h}/...` to resolve relative to the script.",
+			Line:    arg.TokenLiteralNode().Line,
+			Column:  arg.TokenLiteralNode().Column,
+		}}
+	}
+
+	return nil
+}
+
+func getStringValueZC1048(node ast.Node) string {
+	switch n := node.(type) {
+	case *ast.StringLiteral:
+		return n.Value
+	case *ast.ConcatenatedExpression:
+		var sb strings.Builder
+		for _, p := range n.Parts {
+			sb.WriteString(getStringValueZC1048(p))
+		}
+		return sb.String()
+	}
+	return ""
+}

--- a/tests/integration_test.zsh
+++ b/tests/integration_test.zsh
@@ -130,6 +130,12 @@ run_test 'printf "eval\n"' "" "ZC1046: echo word eval (Valid)"
 run_test 'sudo ls' "ZC1047" "ZC1047: sudo"
 run_test 'printf "sudo\n"' "" "ZC1047: echo sudo (Valid)"
 
+# --- ZC1048: Relative source ---
+run_test 'source ./lib.zsh' "ZC1048" "ZC1048: source ./"
+run_test '. ../lib.zsh' "ZC1048" "ZC1048: . ../"
+run_test 'source "${0:a:h}/lib.zsh"' "" "ZC1048: Absolute source (Valid)"
+run_test 'source /etc/profile' "" "ZC1048: Absolute path (Valid)"
+
 # --- Summary ---
 echo "------------------------------------------------"
 if [[ $FAILURES -eq 0 ]]; then


### PR DESCRIPTION
## Description

Adds **ZC1048**: Avoid `source` with relative paths.
Sourcing with `./` or `../` depends on the current working directory (PWD), which makes scripts fragile.
Recommends using `${0:a:h}/...` to resolve paths relative to the script's location.

### Verification
- Added integration tests for `source ./`, `. ../`, and absolute/dynamic paths.
