### PR TITLE
feat: Add Kata ZC1049 (Prefer functions over aliases)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ zshellcheck [flags] <file1.zsh> [file2.zsh]...
 | **ZC1046** | Avoid `eval` |
 | **ZC1047** | Avoid `sudo` in scripts |
 | **ZC1048** | Avoid `source` with relative paths |
+| **ZC1049** | Prefer functions over aliases |
 
 </details>
 

--- a/pkg/katas/zc1049.go
+++ b/pkg/katas/zc1049.go
@@ -1,0 +1,33 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:          "ZC1049",
+		Title:       "Prefer functions over aliases",
+		Description: "Aliases are expanded at parse time and can be confusing in scripts. Use functions for more predictable behavior.",
+		Check:       checkZC1049,
+	})
+}
+
+func checkZC1049(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	// Check if command is alias
+	if name, ok := cmd.Name.(*ast.Identifier); ok && name.Value == "alias" {
+		return []Violation{{
+			KataID:  "ZC1049",
+			Message: "Prefer functions over aliases. Aliases are expanded at parse time and can behave unexpectedly in scripts.",
+			Line:    name.Token.Line,
+			Column:  name.Token.Column,
+		}}
+	}
+
+	return nil
+}

--- a/tests/integration_test.zsh
+++ b/tests/integration_test.zsh
@@ -136,6 +136,12 @@ run_test '. ../lib.zsh' "ZC1048" "ZC1048: . ../"
 run_test 'source "${0:a:h}/lib.zsh"' "" "ZC1048: Absolute source (Valid)"
 run_test 'source /etc/profile' "" "ZC1048: Absolute path (Valid)"
 
+# --- ZC1049: Aliases ---
+run_test 'alias foo="echo bar"' "ZC1049" "ZC1049: alias definition"
+run_test 'alias -g G="| grep"' "ZC1049" "ZC1049: global alias"
+run_test 'unalias foo' "" "ZC1049: unalias (Valid)"
+run_test 'function foo() { printf "bar\n"; }' "" "ZC1049: function (Valid)"
+
 # --- Summary ---
 echo "------------------------------------------------"
 if [[ $FAILURES -eq 0 ]]; then


### PR DESCRIPTION
## Description

Adds **ZC1049**: Prefer functions over aliases.
Aliases are expanded at parse time and can be confusing or behave unexpectedly in scripts. Functions are preferred for clarity and robustness.

### Verification
- Added integration tests.
