### PR TITLE
feat: Add Kata ZC1055 (Empty string checks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ zshellcheck [flags] <file1.zsh> [file2.zsh]...
 | **ZC1052** | Avoid `sed -i` for portability |
 | **ZC1053** | Silence `grep` output in conditions |
 | **ZC1054** | Use POSIX classes in regex/glob |
+| **ZC1055** | Use `[[ -n/-z ]]` for empty string checks |
 
 </details>
 

--- a/pkg/katas/zc1055.go
+++ b/pkg/katas/zc1055.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.InfixExpressionNode, Kata{
+		ID:          "ZC1055",
+		Title:       "Use `[[ -n/-z ]]` for empty string checks",
+		Description: "Comparing with empty string is less idiomatic than using `[[ -z $var ]]` (is empty) or `[[ -n $var ]]` (is not empty).",
+		Check:       checkZC1055,
+	})
+}
+
+func checkZC1055(node ast.Node) []Violation {
+	expr, ok := node.(*ast.InfixExpression)
+	if !ok {
+		return nil
+	}
+
+	// Check for == "" or != ""
+	if expr.Operator != "==" && expr.Operator != "!=" {
+		return nil
+	}
+
+	// Check if either side is empty string literal
+	isEmptyString := func(n ast.Node) bool {
+		if str, ok := n.(*ast.StringLiteral); ok {
+			// Check for "" or ''
+			val := str.Value
+			return val == `""` || val == `''`
+		}
+		return false
+	}
+
+	if isEmptyString(expr.Left) || isEmptyString(expr.Right) {
+		opSuggestion := "-z"
+		if expr.Operator == "!=" {
+			opSuggestion = "-n"
+		}
+		
+		return []Violation{{
+			KataID:  "ZC1055",
+			Message: "Use `[[ " + opSuggestion + " ... ]]` instead of comparing with empty string.",
+			Line:    expr.TokenLiteralNode().Line,
+			Column:  expr.TokenLiteralNode().Column,
+		}}
+	}
+
+	return nil
+}

--- a/tests/integration_test.zsh
+++ b/tests/integration_test.zsh
@@ -173,6 +173,12 @@ run_test 'if grep foo file | wc -l; then :; fi' "" "ZC1053: grep piped (Valid)"
 run_test 'tr "[A-Z]" "[a-z]"' "ZC1054" "ZC1054: tr ranges"
 run_test 'tr "[[:upper:]]" "[[:lower:]]"' "" "ZC1054: tr POSIX (Valid)"
 
+# --- ZC1055: Null checks ---
+run_test '[[ $var == "" ]]' "ZC1055" "ZC1055: == empty"
+run_test '[[ "" != $var ]]' "ZC1055" "ZC1055: != empty"
+run_test '[[ -z $var ]]' "" "ZC1055: -z (Valid)"
+run_test '[[ -n $var ]]' "" "ZC1055: -n (Valid)"
+
 # --- Summary ---
 echo "------------------------------------------------"
 if [[ $FAILURES -eq 0 ]]; then


### PR DESCRIPTION
## Description

Adds **ZC1055**: Use `[[ -n/-z ]]` for empty string checks.
Warns against comparing with empty string (e.g. `[[ $var == "" ]]` or `!= ""`), suggesting idiomatic `-z` (is empty) or `-n` (is not empty).

### Verification
- Added integration tests.
