### PR TITLE
feat: Add Kata ZC1058 (Avoid sudo with redirection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ zshellcheck [flags] <file1.zsh> [file2.zsh]...
 | **ZC1055** | Use `[[ -n/-z ]]` for empty string checks |
 | **ZC1056** | Avoid `$((...))` as a statement |
 | **ZC1057** | Avoid `ls` in assignments |
+| **ZC1058** | Avoid `sudo` with redirection |
 
 </details>
 

--- a/pkg/katas/zc1058.go
+++ b/pkg/katas/zc1058.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.RedirectionNode, Kata{
+		ID:          "ZC1058",
+		Title:       "Avoid `sudo` with redirection",
+		Description: "Redirecting output of `sudo` (e.g. `sudo cmd > /file`) fails if the current user doesn't have permission. Use `| sudo tee /file` instead.",
+		Check:       checkZC1058,
+	})
+}
+
+func checkZC1058(node ast.Node) []Violation {
+	redir, ok := node.(*ast.Redirection)
+	if !ok {
+		return nil
+	}
+
+	// Check if Left side is a sudo command
+	// Left is Expression.
+	// Should be SimpleCommand.
+	
+	cmd, ok := redir.Left.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	if name, ok := cmd.Name.(*ast.Identifier); ok && name.Value == "sudo" {
+		// Check operator: > or >> (output)
+		if redir.Operator == ">" || redir.Operator == ">>" {
+			return []Violation{{
+				KataID:  "ZC1058",
+				Message: "Redirecting `sudo` output happens as the current user. Use `| sudo tee file` to write with privileges.",
+				Line:    redir.TokenLiteralNode().Line,
+				Column:  redir.TokenLiteralNode().Column,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -247,8 +247,8 @@ func (p *Parser) parseCommandPipeline() ast.Expression {
 
 	// Parse redirections
 	for p.peekTokenIs(token.GT) || p.peekTokenIs(token.GTGT) || 
-		p.peekTokenIs(token.LTLT) || p.peekTokenIs(token.GTAMP) || 
-		p.peekTokenIs(token.LTAMP) {
+		p.peekTokenIs(token.LT) || p.peekTokenIs(token.LTLT) || 
+		p.peekTokenIs(token.GTAMP) || p.peekTokenIs(token.LTAMP) {
 		
 		p.nextToken()
 		op := p.curToken

--- a/tests/integration_test.zsh
+++ b/tests/integration_test.zsh
@@ -192,6 +192,12 @@ run_test 'files=`ls *.txt`' "ZC1057" "ZC1057: files=\`ls\`"
 run_test 'local files=$(ls)' "ZC1057" "ZC1057: local files=\$(ls)"
 # run_test 'files=(*)' "" "ZC1057: files=(*) (Valid)"
 
+# --- ZC1058: sudo redirect ---
+run_test 'sudo echo "foo" > /etc/file' "ZC1058" "ZC1058: sudo > file"
+run_test 'sudo echo "foo" >> /etc/file' "ZC1058" "ZC1058: sudo >> file"
+run_test 'printf "foo\n" | sudo tee /etc/file' "ZC1047" "ZC1058: sudo tee (Valid - ZC1047 expected)"
+run_test 'sudo ls < /input' "ZC1047" "ZC1058: sudo < input (Valid - ZC1047 expected)"
+
 # --- Summary ---
 echo "------------------------------------------------"
 if [[ $FAILURES -eq 0 ]]; then


### PR DESCRIPTION
## Description

Adds **ZC1058**: Avoid `sudo` with redirection.
Warns against `sudo cmd > file` due to redirection happening as current user. Suggests `| sudo tee file`.

### Parser Updates
- Updated `parseCommandPipeline` to correctly parse `<` (input redirection).

### Verification
- All integration tests pass locally.
