### PR TITLE
feat: Add Kata ZC1061 (seq vs range)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ zshellcheck [flags] <file1.zsh> [file2.zsh]...
 | **ZC1058** | Avoid `sudo` with redirection |
 | **ZC1059** | Use `${var:?}` for `rm` arguments |
 | **ZC1060** | Avoid `ps | grep` without exclusion |
+| **ZC1061** | Prefer `{start..end}` over `seq` |
 
 </details>
 

--- a/pkg/katas/zc1061.go
+++ b/pkg/katas/zc1061.go
@@ -1,0 +1,33 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:          "ZC1061",
+		Title:       "Prefer `{start..end}` over `seq`",
+		Description: "Using `seq` creates an external process. Zsh supports integer range expansion natively: `{1..10}`.",
+		Check:       checkZC1061,
+	})
+}
+
+func checkZC1061(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	// Check if command is seq
+	if name, ok := cmd.Name.(*ast.Identifier); ok && name.Value == "seq" {
+		return []Violation{{
+			KataID:  "ZC1061",
+			Message: "Prefer `{start..end}` range expansion over `seq`. It is built-in and faster.",
+			Line:    name.Token.Line,
+			Column:  name.Token.Column,
+		}}
+	}
+
+	return nil
+}

--- a/tests/integration_test.zsh
+++ b/tests/integration_test.zsh
@@ -208,10 +208,12 @@ run_test 'rm "${VAR}"' "ZC1059" "ZC1059: rm \"\${VAR}\" (Unsafe)"
 # --- ZC1060: ps | grep ---
 run_test 'ps ax | grep foo' "ZC1060" "ZC1060: ps | grep"
 run_test 'ps ax | grep "[f]oo"' "" "ZC1060: ps | grep [] (Valid)"
-# run_test 'ps | grep -v grep' "ZC1060" "ZC1060: ps | grep -v (Warn: incomplete chain logic, still risky pattern)" 
-# My implementation flags `ps | grep` regardless of downstream pipes because it inspects the pair.
-# `ps | grep | grep -v` parses as `(ps | grep) | grep -v`.
-# The inner `ps | grep` IS flagged. This is acceptable behavior (suggesting `[]` is better).
+# run_test 'ps | grep -v grep' "ZC1060" "ZC1060: ps | grep -v (Warn: incomplete chain logic, still risky pattern)"
+
+# --- ZC1061: seq vs range ---
+run_test 'for i in $(seq 1 10); do :; done' "ZC1061" "ZC1061: for seq"
+run_test 'for i in {1..10}; do :; done' "" "ZC1061: for range (Valid)"
+run_test 'seq 5' "ZC1061" "ZC1061: seq command"
 
 # --- Summary ---
 echo "------------------------------------------------"


### PR DESCRIPTION
## Description

Adds **ZC1061**: Prefer `{start..end}` over `seq`.
Warns against using the external command `seq`, which is not always portable and slower than Zsh's built-in integer range expansion.

### Verification
- Added integration tests.
