### PR TITLE
feat: Add Kata ZC1062 (Deprecated egrep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ zshellcheck [flags] <file1.zsh> [file2.zsh]...
 | **ZC1059** | Use `${var:?}` for `rm` arguments |
 | **ZC1060** | Avoid `ps | grep` without exclusion |
 | **ZC1061** | Prefer `{start..end}` over `seq` |
+| **ZC1062** | Prefer `grep -E` over `egrep` |
 
 </details>
 

--- a/pkg/katas/zc1062.go
+++ b/pkg/katas/zc1062.go
@@ -1,0 +1,32 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:          "ZC1062",
+		Title:       "Prefer `grep -E` over `egrep`",
+		Description: "`egrep` is deprecated. Use `grep -E` instead.",
+		Check:       checkZC1062,
+	})
+}
+
+func checkZC1062(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	if name, ok := cmd.Name.(*ast.Identifier); ok && name.Value == "egrep" {
+		return []Violation{{
+			KataID:  "ZC1062",
+			Message: "`egrep` is deprecated. Use `grep -E` instead.",
+			Line:    name.Token.Line,
+			Column:  name.Token.Column,
+		}}
+	}
+
+	return nil
+}

--- a/tests/integration_test.zsh
+++ b/tests/integration_test.zsh
@@ -215,6 +215,10 @@ run_test 'for i in $(seq 1 10); do :; done' "ZC1061" "ZC1061: for seq"
 run_test 'for i in {1..10}; do :; done' "" "ZC1061: for range (Valid)"
 run_test 'seq 5' "ZC1061" "ZC1061: seq command"
 
+# --- ZC1062: egrep ---
+run_test 'egrep "pattern" file' "ZC1062" "ZC1062: egrep"
+run_test 'grep -E "pattern" file' "" "ZC1062: grep -E (Valid)"
+
 # --- Summary ---
 echo "------------------------------------------------"
 if [[ $FAILURES -eq 0 ]]; then


### PR DESCRIPTION
## Description

Adds **ZC1062**: Prefer `grep -E` over `egrep`.
`egrep` is deprecated. Recommends using `grep -E` for extended regex support.

### Verification
- Added integration tests.
