### PR TITLE
feat: Add Kata ZC1063 (Deprecated fgrep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ zshellcheck [flags] <file1.zsh> [file2.zsh]...
 | **ZC1060** | Avoid `ps | grep` without exclusion |
 | **ZC1061** | Prefer `{start..end}` over `seq` |
 | **ZC1062** | Prefer `grep -E` over `egrep` |
+| **ZC1063** | Prefer `grep -F` over `fgrep` |
 
 </details>
 

--- a/pkg/katas/zc1063.go
+++ b/pkg/katas/zc1063.go
@@ -1,0 +1,32 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:          "ZC1063",
+		Title:       "Prefer `grep -F` over `fgrep`",
+		Description: "`fgrep` is deprecated. Use `grep -F` instead.",
+		Check:       checkZC1063,
+	})
+}
+
+func checkZC1063(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	if name, ok := cmd.Name.(*ast.Identifier); ok && name.Value == "fgrep" {
+		return []Violation{{
+			KataID:  "ZC1063",
+			Message: "`fgrep` is deprecated. Use `grep -F` instead.",
+			Line:    name.Token.Line,
+			Column:  name.Token.Column,
+		}}
+	}
+
+	return nil
+}

--- a/tests/integration_test.zsh
+++ b/tests/integration_test.zsh
@@ -219,6 +219,10 @@ run_test 'seq 5' "ZC1061" "ZC1061: seq command"
 run_test 'egrep "pattern" file' "ZC1062" "ZC1062: egrep"
 run_test 'grep -E "pattern" file' "" "ZC1062: grep -E (Valid)"
 
+# --- ZC1063: fgrep ---
+run_test 'fgrep "pattern" file' "ZC1063" "ZC1063: fgrep"
+run_test 'grep -F "pattern" file' "" "ZC1063: grep -F (Valid)"
+
 # --- Summary ---
 echo "------------------------------------------------"
 if [[ $FAILURES -eq 0 ]]; then


### PR DESCRIPTION
## Description

Adds **ZC1063**: Prefer `grep -F` over `fgrep`.
`fgrep` is deprecated. Recommends using `grep -F` for fixed-string matching.

### Verification
- Added integration tests.
