### PR TITLE
feat: Add Kata ZC1064 (command -v vs type)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ zshellcheck [flags] <file1.zsh> [file2.zsh]...
 | **ZC1061** | Prefer `{start..end}` over `seq` |
 | **ZC1062** | Prefer `grep -E` over `egrep` |
 | **ZC1063** | Prefer `grep -F` over `fgrep` |
+| **ZC1064** | Prefer `command -v` over `type` |
 
 </details>
 

--- a/pkg/katas/zc1064.go
+++ b/pkg/katas/zc1064.go
@@ -1,0 +1,32 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:          "ZC1064",
+		Title:       "Prefer `command -v` over `type`",
+		Description: "`type` output format varies and is not POSIX standard for checking existence. `command -v` is quieter and standard.",
+		Check:       checkZC1064,
+	})
+}
+
+func checkZC1064(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	if name, ok := cmd.Name.(*ast.Identifier); ok && name.Value == "type" {
+		return []Violation{{
+			KataID:  "ZC1064",
+			Message: "Prefer `command -v` over `type`. `type` output is not stable/standard for checking command existence.",
+			Line:    name.Token.Line,
+			Column:  name.Token.Column,
+		}}
+	}
+
+	return nil
+}

--- a/tests/integration_test.zsh
+++ b/tests/integration_test.zsh
@@ -223,6 +223,10 @@ run_test 'grep -E "pattern" file' "" "ZC1062: grep -E (Valid)"
 run_test 'fgrep "pattern" file' "ZC1063" "ZC1063: fgrep"
 run_test 'grep -F "pattern" file' "" "ZC1063: grep -F (Valid)"
 
+# --- ZC1064: type vs command -v ---
+run_test 'type ls' "ZC1064" "ZC1064: type"
+run_test 'command -v ls' "" "ZC1064: command -v (Valid)"
+
 # --- Summary ---
 echo "------------------------------------------------"
 if [[ $FAILURES -eq 0 ]]; then


### PR DESCRIPTION
## Description

Adds **ZC1064**: Prefer `command -v` over `type`.
Warns against using `type` (often used for checking if a command exists) as its output format varies. Recommends `command -v`, which is POSIX standard and quieter.

### Verification
- Added integration tests.
