### PR TITLE
feat: Implement ZC1073 (Unnecessary $ in arithmetic)

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -40,7 +40,21 @@ const (
 	RedirectionNode
 	FunctionDefinitionNode
 	GroupedExpressionNode
+	ArithmeticCommandNode
 )
+
+type ArithmeticCommand struct {
+	Token      token.Token // The '((' token
+	Expression Expression
+}
+
+func (ac *ArithmeticCommand) Type() NodeType                { return ArithmeticCommandNode }
+func (ac *ArithmeticCommand) statementNode()                {}
+func (ac *ArithmeticCommand) TokenLiteral() string          { return ac.Token.Literal }
+func (ac *ArithmeticCommand) TokenLiteralNode() token.Token { return ac.Token }
+func (ac *ArithmeticCommand) String() string {
+	return "((" + ac.Expression.String() + "))"
+}
 
 type GroupedExpression struct {
 	Token token.Token // The '(' token
@@ -827,6 +841,8 @@ func Walk(node Node, f WalkFn) {
 		Walk(n.Body, f)
 	case *GroupedExpression:
 		Walk(n.Exp, f)
+	case *ArithmeticCommand:
+		Walk(n.Expression, f)
 	}
 }
 

--- a/pkg/katas/katatests/zc1073_test.go
+++ b/pkg/katas/katatests/zc1073_test.go
@@ -1,0 +1,79 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1073(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid arithmetic",
+			input:    `(( i = i + 1 ))`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid special vars",
+			input:    `(( $# > 0 ))`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid positional",
+			input:    `(( $1 > 5 ))`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid expansion",
+			input:    `(( ${#arr} > 0 ))`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "invalid simple variable",
+			input:    `(( $i > 5 ))`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1073",
+					Message: "Unnecessary use of `$` in arithmetic expressions. Use `(( var ))` instead of `(( $var ))`.",
+					Line:    1,
+					Column:  4,
+				},
+			},
+		},
+		{
+			name:     "invalid multiple",
+			input:    `(( $x + $y ))`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1073",
+					Message: "Unnecessary use of `$` in arithmetic expressions. Use `(( var ))` instead of `(( $var ))`.",
+					Line:    1,
+					Column:  4,
+				},
+				{
+					KataID:  "ZC1073",
+					Message: "Unnecessary use of `$` in arithmetic expressions. Use `(( var ))` instead of `(( $var ))`.",
+					Line:    1,
+					Column:  9,
+				},
+			},
+		},
+		{
+			name:     "valid command subst",
+			input:    `(( $(date +%s) > 0 ))`,
+			expected: []katas.Violation{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1073")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1073.go
+++ b/pkg/katas/zc1073.go
@@ -1,0 +1,90 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.ArithmeticCommandNode, Kata{
+		ID:          "ZC1073",
+		Title:       "Unnecessary use of `$` in arithmetic expressions",
+		Description: "Variables in `((...))` do not need `$` prefix. Use `(( var > 0 ))` instead of `(( $var > 0 ))`.",
+		Check:       checkZC1073,
+	})
+}
+
+func checkZC1073(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.ArithmeticCommand)
+	if !ok {
+		return nil
+	}
+
+	if cmd.Expression == nil {
+		return nil
+	}
+
+	var violations []Violation
+
+	ast.Walk(cmd.Expression, func(n ast.Node) bool {
+		// Check for PrefixExpression with '$'
+		if prefix, ok := n.(*ast.PrefixExpression); ok && prefix.Operator == "$" {
+			if ident, ok := prefix.Right.(*ast.Identifier); ok {
+				if isUserVariable(ident.Value) {
+					violations = append(violations, Violation{
+						KataID:  "ZC1073",
+						Message: "Unnecessary use of `$` in arithmetic expressions. Use `(( var ))` instead of `(( $var ))`.",
+						Line:    prefix.Token.Line,
+						Column:  prefix.Token.Column,
+					})
+				}
+			}
+			return true
+		}
+
+		// Check for Identifier starting with '$' (if lexer emits VARIABLE)
+		if ident, ok := n.(*ast.Identifier); ok {
+			if len(ident.Value) > 1 && ident.Value[0] == '$' {
+				varName := ident.Value[1:]
+				if isUserVariable(varName) {
+					violations = append(violations, Violation{
+						KataID:  "ZC1073",
+						Message: "Unnecessary use of `$` in arithmetic expressions. Use `(( var ))` instead of `(( $var ))`.",
+						Line:    ident.Token.Line,
+						Column:  ident.Token.Column,
+					})
+				}
+			}
+		}
+
+		return true
+	})
+
+	return violations
+}
+
+func isUserVariable(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	
+	first := name[0]
+	if !isAlpha(first) && first != '_' {
+		return false
+	}
+
+	for i := 1; i < len(name); i++ {
+		if !isAlphaNumeric(name[i]) && name[i] != '_' {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isAlpha(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+func isAlphaNumeric(b byte) bool {
+	return isAlpha(b) || (b >= '0' && b <= '9')
+}

--- a/tests/integration_test.zsh
+++ b/tests/integration_test.zsh
@@ -269,6 +269,11 @@ run_test 'grep -i pattern file | gawk "{print}"' "ZC1072" "ZC1072: grep -i | gaw
 run_test 'grep -r pattern . | awk "{print}"' "" "ZC1072: grep -r | awk (Valid)"
 run_test 'awk "/pattern/ {print}" file' "" "ZC1072: awk only (Valid)"
 
+# --- ZC1073: Unnecessary $ in arithmetic ---
+run_test '(( $x > 5 ))' "ZC1073" "ZC1073: (( \$x ))"
+run_test '(( x > 5 ))' "" "ZC1073: (( x )) (Valid)"
+run_test '(( $# > 0 ))' "" "ZC1073: (( \$# )) (Valid)"
+
 # --- Summary ---
 echo "------------------------------------------------"
 if [[ $FAILURES -eq 0 ]]; then


### PR DESCRIPTION
Adds detection for unnecessary `$` prefix in arithmetic expressions, e.g. `(( $var ))` -> `(( var ))`. Also adds parser support for `((...))` statements and special variables like `$#`.