### PR TITLE
fix: Starlight social config

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -8,9 +8,12 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'ZShellCheck',
-      social: {
-        github: 'https://github.com/afadesigns/zshellcheck',
-      },
+      social: [
+        {
+          icon: 'github',
+          link: 'https://github.com/afadesigns/zshellcheck',
+        },
+      ],
       sidebar: [
         {
           label: 'Start Here',


### PR DESCRIPTION
Updates the `social` configuration in `astro.config.mjs` to the new array format required by Starlight v0.33.0+.