### PR TITLE
fix: Starlight social config labels and href

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -12,6 +12,8 @@ export default defineConfig({
         {
           icon: 'github',
           link: 'https://github.com/afadesigns/zshellcheck',
+          label: 'GitHub',
+          href: 'https://github.com/afadesigns/zshellcheck',
         },
       ],
       sidebar: [


### PR DESCRIPTION
Corrects the Starlight social configuration by adding required  and changing  to  as per Starlight v0.33.0+.