### PR TITLE
fix: Wiki Sync Push to Master

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -72,4 +72,4 @@ jobs:
           cd wiki_repo
           git add .
           git diff-index --quiet HEAD || git commit -m "Docs: Update Wiki from Starlight build" # Only commit if changes exist
-          git push origin main
+          git push origin master


### PR DESCRIPTION
Ensures the Wiki sync workflow pushes to the  branch of the wiki repository, which is the GitHub Wiki default.