### PR TITLE
fix: Simplify README.md for Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,15 @@
 # ZShellCheck
 
-```
- mmmmmm  mmmm  #             ""#    ""#      mmm  #                    #
-     #" #"   " # mm    mmm     #      #    m"   " # mm    mmm    mmm   #   m
-   m#   "#mmm  #"  #  #"  #    #      #    #      #"  #  #"  #  #"  "  # m"
-  m"        "# #   #  #""""    #      #    #      #   #  #""""  #      #"#
- ##mmmm "mmm#" #   #  "#mm"    "mm    "mm   "mmm" #   #  "#mm"  "#mm"  #  "m
-```
-
 `zshellcheck` is a static analysis tool (linter) specifically designed for Zsh scripts. Unlike `shellcheck`, which focuses on POSIX sh/bash compatibility, `zshellcheck` understands Zsh syntax, best practices, and common pitfalls.
 
 It parses Zsh scripts into an Abstract Syntax Tree (AST) and runs a series of checks ("Katas") to identify issues.
 
 ## Features
 
--   **Zsh-Specific Parsing:** Handles Zsh constructs like `[[ ... ]]`, `(( ... ))`, arrays, associative arrays, and modifiers.
--   **Extensible Katas:** Rules are implemented as independent "Katas" that can be easily added or disabled.
--   **Configurable:** Disable specific checks via `.zshellcheckrc` configuration file.
--   **Integration Ready:** Designed to work with `pre-commit` and CI pipelines.
+*   **Zsh-Specific Parsing:** Handles Zsh constructs like `[[ ... ]]`, `(( ... ))`, arrays, associative arrays, and modifiers.
+*   **Extensible Katas:** Rules are implemented as independent "Katas" that can be easily added or disabled.
+*   **Configurable:** Disable specific checks via `.zshellcheckrc` configuration file.
+*   **Integration Ready:** Designed to work with `pre-commit` and CI pipelines.
 
 ## Documentation
 


### PR DESCRIPTION
Removes ASCII art and Starlight-specific formatting from README.md to ensure proper rendering when manually copied to the GitHub Wiki.