### PR TITLE
chore: Exclude .genkit/traces_idx from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ go.work
 bin/
 zshellcheck
 .genkit/traces_idx
+.genkit/traces_idx


### PR DESCRIPTION
Adds .genkit/traces_idx to .gitignore to exclude tracing artifacts.