### PR TITLE
docs: Comprehensive wiki update: restore and refine all content

### DIFF
--- a/wiki_temp_final/Code_of_Conduct.md
+++ b/wiki_temp_final/Code_of_Conduct.md
@@ -1,0 +1,131 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+*   Demonstrating empathy and kindness toward other people
+*   Being respectful of differing opinions, viewpoints, and experiences
+*   Giving and gracefully accepting constructive feedback
+*   Accepting responsibility and apologizing to those affected by our mistakes,
+    and learning from the experience
+*   Focusing on what is best not just for us as individuals, but for the
+    overall community
+
+Examples of unacceptable behavior include:
+
+*   The use of sexualized language or imagery, and sexual attention or
+    advances of any kind
+*   Trolling, insulting or derogatory comments, and personal or political
+    attacks
+*   Public or private harassment
+*   Publishing others' private information, such as a physical or email
+    address, without their explicit permission
+*   Other conduct which could reasonably be considered inappropriate in a
+    professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Reporting Guidelines
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by contacting **@afadesigns** on GitHub.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interaction in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Community Guidelines for Discussions
+
+We use [GitHub Discussions](https://github.com/afadesigns/zshellcheck/discussions) as our primary forum for the community. We encourage you to:
+
+*   **Ask Questions (Q&A)**: If you are unsure about how to use ZShellCheck or how to solve a specific Zsh scripting problem.
+*   **Share Ideas**: If you have a suggestion for a new feature or a new Kata.
+*   **Show and Tell**: Share your success stories and scripts improved by ZShellCheck.
+*   **Be Respectful**: Treat everyone with respect and kindness. We are here to learn from each other.
+
+Please search existing discussions before starting a new one to avoid duplicates.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/wiki_temp_final/Contributing.md
+++ b/wiki_temp_final/Contributing.md
@@ -1,0 +1,81 @@
+# Contributing to zshellcheck
+
+We welcome contributions! Whether it's adding new Katas, improving the parser, or fixing bugs, your help is appreciated.
+
+## Pull Request Workflow
+
+We follow a strict Pull Request (PR) workflow to ensure code quality and maintain a clear history. This workflow is designed to facilitate smooth collaboration and maintain an organized project.
+
+1.  **Sync `main`**: Before starting new work, ensure your local `main` branch is up-to-date with the remote `main`.
+    ```bash
+    git checkout main
+    git pull origin main
+    ```
+2.  **Create a Branch**: Always create a new, descriptive branch for your changes. Use a prefix that indicates the type of change (e.g., `feat/`, `fix/`, `docs/`, `chore/`).
+    ```bash
+    git checkout -b feat/your-feature-name
+    ```
+3.  **Implement & Test**: Make your changes, adhering to coding style and conventions. Run local tests to verify functionality.
+    ```bash
+    go test ./...
+    ./tests/integration_test.zsh
+    ```
+4.  **Commit**: Commit your changes using [Conventional Commits](https://www.conventionalcommits.org/) for clear history. Examples:
+    *   `feat: Implement new Kata ZCXXXX (Short description)`
+    *   `fix: Resolve parser bug in arithmetic expressions`
+    *   `docs: Update wiki links`
+    *   `chore: Upgrade npm dependencies`
+5.  **Push**: Push your local branch to the remote repository.
+    ```bash
+    git push origin your-branch-name
+    ```
+6.  **Create Pull Request**: Use the GitHub CLI to create a Pull Request from your branch to `main`.
+    ```bash
+    gh pr create --title "feat: Your feature title" --body "A detailed description of your changes." --base main
+    ```
+    *   Provide a clear title and body explaining the *why* and *what* of your changes.
+    *   Link any relevant issues (e.g., `Closes #123`, `Fixes #45`).
+    *   **Labels**: Apply [appropriate labels](/Labels) to your PR.
+7.  **Review & Merge**: Address any review comments. Once approved and all CI checks pass, an administrator will merge the PR. We use squash merges to maintain a clean Git history.
+
+## Documentation
+
+For comprehensive documentation, including detailed usage, configuration, and a full list of implemented Katas, please refer to the [[Katas | All Katas]] page.
+
+## Coding Style
+
+*   We use `gofmt` for Go code formatting.
+*   We follow the standard Go coding conventions.
+*   Please ensure that your code is well-documented and easy to understand.
+
+### Running Linters and Formatters
+
+Before submitting a Pull Request, please ensure your code passes all linting and formatting checks:
+
+```bash
+go fmt ./...       # Format Go code
+go vet ./...       # Run Go vet (static analysis)
+golangci-lint run  # Run golangci-lint (if installed)
+```
+
+## Adding a New Kata
+
+Katas are the core rules of `zshellcheck`. To add one:
+
+1.  **Define the Kata:** Create a new file `pkg/katas/zcXXXX.go`.
+2.  **Register:** In the `init()` function, register the Kata with the `RegisterKata` function, specifying the AST node type it targets.
+3.  **Implement Logic:** Write the check function that inspects the node and returns a list of `Violation`s.
+4.  **Add Tests:** Create `pkg/katas/katatests/zcXXXX_test.go` with test cases covering valid and invalid Zsh code.
+
+### Example Kata
+
+```go
+func init() {
+    RegisterKata(ast.SimpleCommandNode, Kata{
+        ID: "ZC1099",
+        Title: "Avoid foo command",
+        Description: "The foo command is deprecated.",
+        Check: checkZC1099,
+    })
+}
+```

--- a/wiki_temp_final/Getting_Started.md
+++ b/wiki_temp_final/Getting_Started.md
@@ -1,0 +1,114 @@
+# Getting Started with ZShellCheck
+
+This guide will walk you through the essential steps to get ZShellCheck up and running, allowing you to start analyzing your Zsh code for quality and best practices.
+
+## 1. Installation
+
+ZShellCheck is written in Go and can be easily installed from source if you have a Go development environment configured.
+
+### From Go Modules
+
+To install `zshellcheck`, ensure you have Go (version 1.18 or higher) installed, then run:
+
+```bash
+go install github.com/afadesigns/zshellcheck/cmd/zshellcheck@latest
+```
+
+This will install the `zshellcheck` executable into your `$GOPATH/bin` directory. Make sure `$GOPATH/bin` is in your system's `PATH`.
+
+### Building from Source
+
+For developers who want to build `zshellcheck` from its source code:
+
+1.  Clone the repository:
+    ```bash
+    git clone https://github.com/afadesigns/zshellcheck.git
+    cd zshellcheck
+    ```
+2.  Build the executable:
+    ```bash
+    go build -o zshellcheck cmd/zshellcheck/main.go
+    ```
+    This will create an executable named `zshellcheck` in your current directory.
+
+### Pre-commit Hook (Recommended)
+
+To integrate ZShellCheck seamlessly into your development workflow and ensure code quality before commits, you can use it as a `pre-commit` hook.
+
+1.  **Install `pre-commit`**: If you haven't already, install the `pre-commit` framework:
+    ```bash
+    pip install pre-commit
+    # Or brew install pre-commit on macOS
+    ```
+
+2.  **Configure `.pre-commit-config.yaml`**: Add the following configuration to a file named `.pre-commit-config.yaml` in the root of your Zsh project:
+
+    ```yaml
+    # .pre-commit-config.yaml
+    -   repo: https://github.com/afadesigns/zshellcheck
+        rev: v0.0.93 # Always use a specific release tag for stability, e.g., v0.0.93
+        hooks:
+        -   id: zshellcheck
+    ```
+    *   **`repo`**: Points to the ZShellCheck GitHub repository.
+    *   **`rev`**: Specifies the exact [release tag](https://github.com/afadesigns/zshellcheck/releases) of ZShellCheck to use. **It is highly recommended to use a specific release tag (e.g., `v0.0.93`) for stability and reproducible builds.** Avoid `main` or `master` for production use.
+    *   **`id`**: Refers to the `zshellcheck` hook defined within the repository.
+
+3.  **Install the Hook**: From your project root, install the `pre-commit` hooks:
+    ```bash
+    pre-commit install
+    ```
+    Now, ZShellCheck will automatically run on your Zsh scripts every time you make a `git commit`.
+
+## 2. Basic Usage
+
+After installation, you can run ZShellCheck against your Zsh code files from your terminal. You can specify one or more files, or a directory to check recursively.
+
+### Analyzing Files
+
+```bash
+# Analyze a single file
+zshellcheck my_script.zsh
+
+# Analyze multiple files
+zshellcheck script1.zsh another_script.zsh
+
+# Analyze a directory recursively
+zshellcheck ./path/to/my/scripts
+```
+
+ZShellCheck will output any identified violations directly to your terminal.
+
+### Output Formats
+
+You can control the output format using the `-format` flag:
+
+*   **Text (default)**: Human-readable output.
+    ```bash
+    zshellcheck -format text my_script.zsh
+    ```
+
+*   **JSON**: Machine-readable JSON output, useful for integration with other tools or CI systems.
+    ```bash
+    zshellcheck -format json my_script.zsh
+    ```
+
+### Configuration (Disabling Checks)
+
+If you need to disable specific Katas (checks) for your project, create a `.zshellcheckrc` file in your project's root directory. This file uses YAML syntax.
+
+**Example `.zshellcheckrc`**:
+
+```yaml
+disabled_katas:
+  - ZC1005 # Example: Disable "Use whence instead of which"
+  - ZC1011 # Example: Disable "Use git porcelain commands instead of plumbing commands"
+```
+
+Any Katas listed under `disabled_katas` will be skipped by ZShellCheck when analyzing your project.
+
+## What's Next?
+
+*   Explore the [[Katas | All Katas]] page to understand the types of issues ZShellCheck identifies.
+*   Learn how to [Contribute](/Contributing) by adding new Katas or improving the parser.
+*   Dive deeper into the project's vision on the [Roadmap](/Roadmap).

--- a/wiki_temp_final/Home.md
+++ b/wiki_temp_final/Home.md
@@ -1,0 +1,42 @@
+# ZShellCheck
+
+```
+ mmmmmm  mmmm  #             ""#    ""#      mmm  #                    #
+     #" #"   " # mm    mmm     #      #    m"   " # mm    mmm    mmm   #   m
+   m#   "#mmm  #"  #  #"  #    #      #    #      #"  #  #"  #  #"  "  # m"
+  m"        "# #   #  #""""    #      #    #      #   #  #""""  #      #"#
+ ##mmmm "mmm#" #   #  "#mm"    "mm    "mm   "mmm" #   #  "#mm"  "#mm"  #  "m
+```
+
+ZShellCheck is the definitive static analysis and comprehensive development suite for the entire Zsh ecosystem, meticulously engineered as the full Zsh equivalent of ShellCheck for Bash, uniquely offering intelligent automatic fixes, advanced formatting capabilities, and deep code analysis to deliver unparalleled quality, performance, and reliability for Zsh scripts, functions, and configurations.
+
+## Inspiration
+
+ZShellCheck draws significant inspiration from the esteemed `ShellCheck` project, a powerful static analysis tool for `sh`/`bash` scripts. While `ZShellCheck` is an independent development with a native focus on Zsh's unique syntax and semantics, `ShellCheck`'s commitment to improving shell script quality served as a guiding principle in our mission to provide an equally robust and tailored solution for the Zsh community.
+
+## Features
+
+*   **Zsh-Native Parsing:** Full understanding and handling of Zsh's unique constructs, including `[[ ... ]]`, `(( ... ))`, advanced arrays, associative arrays, and parameter expansion modifiers, applicable across scripts, functions, and configuration files.
+*   **Extensible Katas:** A modular system where rules are implemented as independent "Katas," allowing for easy expansion, customization, and precise control over checks.
+*   **Highly Configurable:** Tailor ZShellCheck's behavior to your project's needs by enabling or disabling specific checks via a flexible `.zshellcheckrc` configuration file.
+*   **Seamless Integration:** Designed for effortless integration into modern development workflows, supporting `pre-commit` hooks and continuous integration (CI) pipelines to enforce quality at every stage.
+*   **Automated Fixes (Planned):** Future versions will include capabilities for automatically resolving common issues, streamlining code maintenance.
+*   **Code Formatting (Planned):** Upcoming features will provide built-in Zsh script and configuration formatting to ensure consistent style across your codebase.
+
+## Installation & Usage
+
+For detailed instructions on how to install and use `zshellcheck`, please refer to the [[Getting Started]] page.
+
+## Implemented Checks (Katas)
+
+For a complete and navigable list of all implemented checks, including detailed descriptions, bad/good examples, and configuration options, please refer to the [[Katas | All Katas]] page.
+
+## Configuration
+
+Tailor ZShellCheck to your project by creating a `.zshellcheckrc` file in your project root:
+
+```yaml
+disabled_katas:
+  - ZC1005
+  - ZC1011
+```

--- a/wiki_temp_final/Katas.md
+++ b/wiki_temp_final/Katas.md
@@ -1,0 +1,9 @@
+# All ZShellCheck Katas
+
+This page serves as a comprehensive index for all ZShellCheck Katas (static analysis checks), organized by their ID ranges. Each Kata focuses on specific Zsh best practices, common pitfalls, and efficiency improvements.
+
+Click on a range below to view detailed documentation for each Kata, including explanations, bad and good code examples, and configuration options.
+
+## Kata Ranges
+
+*   [[Katas/ZC1000-ZC1099/Index | ZC1000-ZC1099]]: Foundational Zsh Checks (e.g., syntax, arithmetic, command substitution)

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/Index.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/Index.md
@@ -1,0 +1,75 @@
+# ZC1000-ZC1099: Foundational Zsh Checks
+
+This section provides detailed documentation for Katas ranging from ZC1001 to ZC1099, focusing on foundational Zsh best practices, common pitfalls, and efficiency improvements.
+
+Click on any Kata ID below for a comprehensive explanation, including bad and good code examples, and configuration options.
+
+*   [[Katas/ZC1000-ZC1099/ZC1001 | ZC1001]]: `Use ${} for array element access`
+*   [[Katas/ZC1000-ZC1099/ZC1002 | ZC1002]]: `Use $(...) instead of backticks`
+*   [[Katas/ZC1000-ZC1099/ZC1003 | ZC1003]]: `Use ((...))` for arithmetic comparisons instead of `[` or `test`
+*   [[Katas/ZC1000-ZC1099/ZC1005 | ZC1005]]: `Use whence instead of which`
+*   [[Katas/ZC1000-ZC1099/ZC1006 | ZC1006]]: `Prefer [[ over test for tests`
+*   [[Katas/ZC1000-ZC1099/ZC1007 | ZC1007]]: `Avoid using chmod 777`
+*   [[Katas/ZC1000-ZC1099/ZC1008 | ZC1008]]: `Use $(())` for arithmetic operations`
+*   [[Katas/ZC1000-ZC1099/ZC1009 | ZC1009]]: `Use ((...)) for C-style arithmetic`
+*   [[Katas/ZC1000-ZC1099/ZC1010 | ZC1010]]: `Use [[ ... ]] instead of [ ... ]`
+*   [[Katas/ZC1000-ZC1099/ZC1011 | ZC1011]]: `Use git porcelain commands instead of plumbing commands`
+*   [[Katas/ZC1000-ZC1099/ZC1012 | ZC1012]]: `Use read -r to prevent backslash escaping`
+*   [[Katas/ZC1000-ZC1099/ZC1013 | ZC1013]]: `Use ((...))` for arithmetic operations instead of let`
+*   [[Katas/ZC1000-ZC1099/ZC1014 | ZC1014]]: `Use git switch or git restore instead of git checkout`
+*   [[Katas/ZC1000-ZC1099/ZC1017 | ZC1017]]: `Use print -r to print strings literally`
+*   [[Katas/ZC1000-ZC1099/ZC1018 | ZC1018]]: `Use ((...)) for C-style arithmetic instead of expr`
+*   [[Katas/ZC1000-ZC1099/ZC1020 | ZC1020]]: `Use [[ ... ]] for tests instead of test`
+*   [[Katas/ZC1000-ZC1099/ZC1021 | ZC1021]]: `Use symbolic permissions with chmod instead of octal`
+*   [[Katas/ZC1000-ZC1099/ZC1022 | ZC1022]]: `Use $((...))` for arithmetic expansion`
+*   [[Katas/ZC1000-ZC1099/ZC1023 | ZC1023]]: `Use $((...))` for arithmetic expansion`
+*   [[Katas/ZC1000-ZC1099/ZC1024 | ZC1024]]: `Use $((...))` for arithmetic expansion`
+*   [[Katas/ZC1000-ZC1099/ZC1025 | ZC1025]]: `Use $((...))` for arithmetic expansion`
+*   [[Katas/ZC1000-ZC1099/ZC1026 | ZC1026]]: `Use $((...))` for arithmetic expansion`
+*   [[Katas/ZC1000-ZC1099/ZC1027 | ZC1027]]: `Use $((...))` for arithmetic expansion`
+*   [[Katas/ZC1000-ZC1099/ZC1028 | ZC1028]]: `Use $((...))` for arithmetic expansion`
+*   [[Katas/ZC1000-ZC1099/ZC1029 | ZC1029]]: `Use $((...))` for arithmetic expansion`
+*   [[Katas/ZC1000-ZC1099/ZC1030 | ZC1030]]: `Use printf instead of echo`
+*   [[Katas/ZC1000-ZC1099/ZC1031 | ZC1031]]: `Use #!/usr/bin/env zsh for portability`
+*   [[Katas/ZC1000-ZC1099/ZC1032 | ZC1032]]: `Use ((...)) for C-style incrementing`
+*   [[Katas/ZC1000-ZC1099/ZC1033 | ZC1033]]: `Use $((...))` for arithmetic expansion`
+*   [[Katas/ZC1000-ZC1099/ZC1034 | ZC1034]]: `Use command -v instead of which`
+*   [[Katas/ZC1000-ZC1099/ZC1035 | ZC1035]]: `Use $((...))` for arithmetic expansion`
+*   [[Katas/ZC1000-ZC1099/ZC1036 | ZC1036]]: `Prefer [[ ... ]] over test command`
+*   [[Katas/ZC1000-ZC1099/ZC1037 | ZC1037]]: `Use 'print -r --' for variable expansion`
+*   [[Katas/ZC1000-ZC1099/ZC1038 | ZC1038]]: `Avoid useless use of cat`
+*   [[Katas/ZC1000-ZC1099/ZC1039 | ZC1039]]: `Avoid rm with root path`
+*   [[Katas/ZC1000-ZC1099/ZC1040 | ZC1040]]: `Use (N) nullglob qualifier for globs in loops`
+*   [[Katas/ZC1000-ZC1099/ZC1041 | ZC1041]]: `Do not use variables in printf format string`
+*   [[Katas/ZC1000-ZC1099/ZC1042 | ZC1042]]: `Use "$@" to iterate over arguments`
+*   [[Katas/ZC1000-ZC1099/ZC1043 | ZC1043]]: `Use local for variables in functions`
+*   [[Katas/ZC1000-ZC1099/ZC1044 | ZC1044]]: `Check for unchecked cd commands`
+*   [[Katas/ZC1000-ZC1099/ZC1045 | ZC1045]]: `Declare and assign separately to avoid masking return values`
+*   [[Katas/ZC1000-ZC1099/ZC1046 | ZC1046]]: `Avoid eval`
+*   [[Katas/ZC1000-ZC1099/ZC1047 | ZC1047]]: `Avoid sudo in scripts`
+*   [[Katas/ZC1000-ZC1099/ZC1048 | ZC1048]]: `Avoid source with relative paths`
+*   [[Katas/ZC1000-ZC1099/ZC1049 | ZC1049]]: `Prefer functions over aliases`
+*   [[Katas/ZC1000-ZC1099/ZC1050 | ZC1050]]: `Avoid iterating over ls output`
+*   [[Katas/ZC1000-ZC1099/ZC1051 | ZC1051]]: `Quote variables in rm to avoid globbing`
+*   [[Katas/ZC1000-ZC1099/ZC1052 | ZC1052]]: `Avoid sed -i for portability`
+*   [[Katas/ZC1000-ZC1099/ZC1053 | ZC1053]]: `Silence grep output in conditions`
+*   [[Katas/ZC1000-ZC1099/ZC1054 | ZC1054]]: `Use POSIX classes in regex/glob`
+*   [[Katas/ZC1000-ZC1099/ZC1055 | ZC1055]]: `Use [[ -n/-z ]] for empty string checks`
+*   [[Katas/ZC1000-ZC1099/ZC1056 | ZC1056]]: `Avoid $((...))` as a statement`
+*   [[Katas/ZC1000-ZC1099/ZC1057 | ZC1057]]: `Avoid ls in assignments`
+*   [[Katas/ZC1000-ZC1099/ZC1058 | ZC1058]]: `Avoid sudo with redirection`
+*   [[Katas/ZC1000-ZC1099/ZC1059 | ZC1059]]: `Use ${var:?}` for `rm` arguments`
+*   [[Katas/ZC1000-ZC1099/ZC1060 | ZC1060]]: `Avoid ps | grep without exclusion`
+*   [[Katas/ZC1000-ZC1099/ZC1061 | ZC1061]]: `Prefer {start..end} over seq`
+*   [[Katas/ZC1000-ZC1099/ZC1062 | ZC1062]]: `Prefer grep -E over egrep`
+*   [[Katas/ZC1000-ZC1099/ZC1063 | ZC1063]]: `Prefer grep -F over fgrep`
+*   [[Katas/ZC1000-ZC1099/ZC1064 | ZC1064]]: `Prefer command -v over type`
+*   [[Katas/ZC1000-ZC1099/ZC1065 | ZC1065]]: `Ensure spaces around [ and [[`
+*   [[Katas/ZC1000-ZC1099/ZC1066 | ZC1066]]: `Avoid iterating over cat output`
+*   [[Katas/ZC1000-ZC1099/ZC1067 | ZC1067]]: `Separate export and assignment to avoid masking return codes`
+*   [[Katas/ZC1000-ZC1099/ZC1068 | ZC1068]]: `Use add-zsh-hook instead of defining hook functions directly`
+*   [[Katas/ZC1000-ZC1099/ZC1069 | ZC1069]]: `Avoid local outside of functions`
+*   [[Katas/ZC1000-ZC1099/ZC1070 | ZC1070]]: `Use builtin or command to avoid infinite recursion in wrapper functions`
+*   [[Katas/ZC1000-ZC1099/ZC1071 | ZC1071]]: `Use += for appending to arrays`
+*   [[Katas/ZC1000-ZC1099/ZC1072 | ZC1072]]: `Use awk instead of grep | awk`
+*   [[Katas/ZC1000-ZC1099/ZC1073 | ZC1073]]: `Unnecessary use of $ in arithmetic expressions`

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1001.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1001.md
@@ -1,0 +1,27 @@
+# ZC1001: Use ${} for array element access
+
+## Description
+
+In Zsh, accessing array elements using `$array[index]` can sometimes behave unexpectedly or be misinterpreted in complex expansions. The more explicit and safer syntax is `${array[index]}`, which clearly delimits the array access from surrounding text or other expansions. This ensures the correct element is accessed, especially when dealing with nested expansions or when the array name might be followed by characters that could be part of a variable name.
+
+## Bad Example
+
+```zsh
+my_array=(alpha beta gamma)
+echo $my_array[2]suffix # Might output "beta" then "suffix", or error
+```
+
+## Good Example
+
+```zsh
+my_array=(alpha beta gamma)
+echo "The second element is ${my_array[2]}."
+# Expected output: The second element is beta.
+
+# Or, to safely concatenate:
+echo "${my_array[2]}suffix" # Clearly outputs "betasuffix"
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1001` to the `disabled_katas` list in your `.zshellcheckrc` file.

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1002.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1002.md
@@ -1,0 +1,40 @@
+# ZC1002: Use $(...) instead of backticks
+
+## Description
+
+Backticks (`` `command` ``) for command substitution are an older, deprecated syntax with several significant disadvantages compared to `$(command)`. The `$(...)` form is the modern, preferred, and **POSIX-standard** way to perform command substitution in Zsh and other compatible shells. Preferring `$(...)` offers substantial benefits:
+
+*   **Readability and Clarity:** `$(...)` clearly delimits the command being substituted, improving visual parsing and understanding of the script's logic.
+*   **Arbitrary Nesting:** `$(...)` allows for arbitrary nesting of command substitutions without complex and error-prone backslash escaping. Backticks require cumbersome escaping (e.g., `` `echo \`date\`` ``) for nesting, which quickly becomes unmanageable.
+*   **Reduced Ambiguity:** Backticks can sometimes be ambiguous with string literals or glob patterns, leading to unexpected behavior. `$(...)` avoids this ambiguity.
+*   **Robustness:** Scripts using `$(...)` are generally more robust and less prone to subtle parsing errors across different shell environments or with complex inputs.
+
+Adopting `$(...)` consistently leads to more readable, robust, and portable Zsh scripts.
+
+## Bad Example
+
+```zsh
+# Old-style backticks
+file_count=`ls | wc -l`
+timestamp=`date +"%Y-%m-%d"`
+
+# Difficult and error-prone nesting with backticks
+nested_output=`echo \`date\``
+```
+
+## Good Example
+
+```zsh
+# Modern and clear command substitution
+file_count=$(ls | wc -l)
+timestamp=$(date +"%Y-%m-%d")
+
+# Easy and readable nesting with $(...)
+nested_output=$(echo $(date))
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1002` to the `disabled_katas` list in your `.zshellcheckrc` file.
+
+```

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1003.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1003.md
@@ -1,0 +1,25 @@
+# ZC1003: Use `((...))` for arithmetic comparisons instead of `[` or `test`
+
+## Description
+
+For pure **integer arithmetic comparisons** in Zsh, `((...))` provides a more natural, C-style syntax and often better performance and robustness than `[` or `test`. The `[[...]]` construct also supports arithmetic evaluation with `((...))`, but for direct integer comparisons, `((...))` is more idiomatic and efficient. Using `[` or `test` for arithmetic comparisons relies on external commands or string evaluation, which can be slower, less type-safe (as it treats numbers as strings), and prone to subtle quoting or parsing issues.
+
+## Bad Example
+
+```zsh
+a=10; b=5
+if [ "$a" -gt "$b" ]; then echo "a > b"; fi  # Relies on external `test` or `[` command
+if test "$a" -le "$b"; then echo "a <= b"; fi # String comparison, potential issues with non-integers or edge cases
+```
+
+## Good Example
+
+```zsh
+a=10; b=5
+if (( a > b )); then echo "a > b"; fi      # Direct integer arithmetic comparison
+if (( a <= b )); then echo "a <= b"; fi   # Clearer, more performant, no quoting needed
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1003` to the `disabled_katas` list in your `.zshellcheckrc` file.

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1005.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1005.md
@@ -1,0 +1,30 @@
+# ZC1005: Use `whence` instead of `which`
+
+## Description
+
+In Zsh, `whence` is a built-in command that is significantly more powerful and accurate than the external `which` utility. `whence` reports exactly how Zsh will interpret a command, including whether it's an alias, a function, a built-in, or an executable found in your `PATH`. This provides a complete and reliable picture of command resolution within your current Zsh environment.
+
+`which`, on the other hand, is an external utility that only searches your `PATH` for executable files. It will **not** show aliases, functions, or built-ins. This fundamental difference makes `which` unreliable for determining the actual command Zsh will execute within its rich environment, leading to potential confusion or incorrect assumptions.
+
+Preferring `whence` ensures that your scripts accurately reflect Zsh's command lookup behavior and helps in debugging command resolution issues.
+
+## Bad Example
+
+```zsh
+which ls            # Might show /bin/ls, but 'ls' could be an alias like 'ls --color=auto'
+which my_zsh_function # Will never find Zsh functions or aliases
+which git           # Might show /usr/bin/git, but 'git' could be a shell function or alias
+```
+
+## Good Example
+
+```zsh
+whence ls           # Shows if 'ls' is an alias, function, or executable
+whence -c ls        # Provides more verbose, shell-like output (e.g., 'ls is alias ls --color=auto')
+whence my_zsh_function # Correctly identifies Zsh functions
+whence git          # Accurately shows the resolved command for 'git'
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1005` to the `disabled_katas` list in your `.zshellcheckrc` file.

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1006.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1006.md
@@ -1,0 +1,44 @@
+# ZC1006: Prefer `[[` over `test` for tests
+
+## Description
+
+In Zsh, `[[...]]` is a more powerful, safer, and idiomatic conditional construct than the traditional `test` command or single brackets `[...]`. The primary advantages of `[[...]]` include:
+
+*   **Intelligent Word Splitting and Globbing:** Unlike `[` or `test`, `[[...]]` does not perform word splitting or pathname expansion (globbing) on unquoted variables, avoiding many common pitfalls and unexpected behaviors. This means you generally don't need to quote variables within `[[...]]` unless you specifically want literal string matching for patterns that might otherwise be interpreted as globs.
+*   **Zsh-Specific Features:** It supports Zsh-specific features like regular expression matching (`=~`), globbing with extended patterns (`==`), and compound conditions (`&&`, `||`).
+*   **Built-in Efficiency:** `[[...]]` is a keyword, not an external command, making it often faster and more efficient.
+
+Using `test` or `[` requires meticulous quoting of variables to prevent unintended word splitting and pathname expansion, which can lead to bugs, security vulnerabilities, or simply incorrect logic. For arithmetic comparisons, `((...))` is generally preferred (see [[Katas/ZC1000-ZC1099/ZC1003 | ZC1003]]).
+
+## Bad Example
+
+```zsh
+my_var="foo bar"
+if [ -n $my_var ]; then echo "This might split into two arguments"; fi
+# Expected to fail if $my_var contains spaces, or behave unexpectedly if it expands to a file glob.
+
+file="my file.txt"
+if [ -f $file ]; then echo "File exists"; fi # Will fail if 'my file.txt' is split
+
+if test "$str1" = "$str2"; then echo "Strings are equal"; fi # Correctly quoted, but `[[...]]` is still preferred
+```
+
+## Good Example
+
+```zsh
+my_var="foo bar"
+if [[ -n $my_var ]]; then echo "Correctly handles spaces and globs"; fi
+# No quotes needed for $my_var, `[[...]]` handles it correctly.
+
+file="my file.txt"
+if [[ -f $file ]]; then echo "File exists"; fi # Safely handles spaces in file names
+
+if [[ "$str1" = "$str2" ]]; then echo "Strings are equal"; fi
+
+# Zsh-specific regex matching
+if [[ "hello world" =~ "hello (.*)" ]]; then echo "Regex match!"; fi
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1006` to the `disabled_katas` list in your `.zshellcheckrc` file.

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1007.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1007.md
@@ -1,0 +1,40 @@
+# ZC1007: Avoid using `chmod 777`
+
+## Description
+
+Setting file or directory permissions to `777` (read, write, execute for owner, group, and others) is a significant security risk. It grants unrestricted access to everyone on the system, which can lead to:
+
+*   **Sensitive Data Exposure:** Confidential files can be read by anyone.
+*   **Unauthorized Modification:** Files can be altered or deleted by any user.
+*   **Malicious Code Execution:** Executable files or scripts can be run by unauthorized individuals, potentially compromising the system.
+
+Best practice dictates adhering to the **principle of least privilege**, meaning you should assign only the minimum necessary permissions. Here are recommended secure alternatives:
+
+*   **For Directories:**
+    *   `775` (rwx for owner/group, rx for others): Common for shared directories where group members need to create/delete files, but others only need to read/traverse.
+    *   `770` (rwx for owner/group, no access for others): Stricter for sensitive shared directories.
+    *   `755` (rwx for owner, rx for group/others): Standard for public web directories or user home directories.
+*   **For Files:**
+    *   `664` (rw for owner/group, r for others): Common for shared data files.
+    *   `660` (rw for owner/group, no access for others): Stricter for sensitive shared files.
+    *   `644` (rw for owner, r for group/others): Standard for configuration files or publicly readable data.
+    *   `755` (rwx for owner, rx for group/others): Only for executable scripts.
+
+## Bad Example
+
+```zsh
+chmod 777 sensitive_script.sh # Grants execute to everyone
+chmod -R 777 public_html/     # Makes all files and subdirectories writable by everyone
+```
+
+## Good Example
+
+```zsh
+chmod 755 executable_script.zsh # Executable for owner, readable/executable for group and others
+chmod 644 config.yaml          # Readable for everyone, writable only by owner
+chmod -R 775 shared_project_data/ # Shared directory: group members can modify, others can read/traverse
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1007` to the `disabled_katas` list in your `.zshellcheckrc` file.

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1008.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1008.md
@@ -1,0 +1,45 @@
+# ZC1008: Use `$(())` for arithmetic operations
+
+## Description
+
+In Zsh, `$(())` is the preferred and most idiomatic syntax for **arithmetic expansion**. It allows for direct C-style arithmetic evaluation, returning the result of the expression without requiring external commands or explicit variable assignments for the result. Compared to alternatives like `expr` or `let`:
+
+*   **Conciseness & Integration:** `$(())` is more compact and integrates seamlessly into other command substitutions or variable assignments.
+*   **Efficiency:** It's a built-in shell feature, making it generally more efficient than invoking an external command like `expr`.
+*   **Clarity:** It clearly signals an arithmetic context, improving script readability.
+
+Using `expr` involves executing an external command, which adds overhead and can be less efficient for frequent operations. `let` is a built-in that performs arithmetic and assigns the result to a shell variable, but it doesn't directly return a value for use in pipelines or other command contexts, making `$(())` more versatile for expansion.
+
+## Bad Example
+
+```zsh
+# Using expr (external command, less efficient)
+val_expr=$(expr 10 + 5)
+echo "Result from expr: $val_expr"
+
+# Using let (assigns, doesn't return for expansion)
+x=5; y=3
+let "sum = x + y"
+echo "Result from let: $sum"
+```
+
+## Good Example
+
+```zsh
+# Using $((...)) for direct arithmetic expansion
+val_arith=$(( 10 + 5 ))
+echo "Result from arithmetic expansion: $val_arith"
+
+x=5; y=3
+sum_arith=$(( x + y ))
+echo "Result from arithmetic expansion: $sum_arith"
+
+# Example in a conditional context
+if (( a > b )); then
+  echo "a is greater than b"
+fi
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1008` to the `disabled_katas` list in your `.zshellcheckrc` file.

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1009.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1009.md
@@ -1,0 +1,49 @@
+# ZC1009: Use `((...))` for C-style arithmetic
+
+## Description
+
+In Zsh, the `((...))` construct is specifically designed for performing **C-style integer arithmetic evaluation and comparisons**. This is a powerful and efficient built-in mechanism to handle arithmetic directly within the shell, offering features like variable assignment, increment/decrement operators, and various logical/bitwise operations.
+
+Key aspects of `((...))`:
+
+*   **Conditional Context:** When used in a conditional context (e.g., `if (( ... ))`), `((...))` returns an exit status of `0` (true) if the arithmetic result is non-zero, and `1` (false) if the result is zero. This makes it ideal for conditional logic based on arithmetic.
+*   **Efficiency:** As a built-in feature, it is generally more efficient than invoking external utilities like `expr`.
+*   **Conciseness:** It provides a clean, C-like syntax for arithmetic operations.
+
+This Kata promotes using `((...))` for arithmetic contexts where its **exit status** is relevant (e.g., in `if` or `while` statements) or for direct C-style assignments/increments. For cases where you need the **result of an arithmetic expression** as a value (e.g., to assign to another variable or use in a command substitution), the arithmetic expansion `$(())` is more appropriate (see [[Katas/ZC1000-ZC1099/ZC1008 | ZC1008]]).
+
+## Bad Example
+
+```zsh
+# Using expr for a conditional check (external command, inefficient)
+if expr $a + $b > /dev/null; then echo "Sum is non-zero"; fi
+
+# Using let for incrementing (less idiomatic for C-style operation)
+let i=i+1
+
+# Performing comparison with [ (string comparison, error-prone)
+if [ "$count" -lt 10 ]; then echo "Count is less than 10"; fi
+```
+
+## Good Example
+
+```zsh
+# Using ((...)) for a conditional check based on arithmetic result
+if (( a + b )); then echo "Sum is non-zero"; fi
+
+# Using ((...)) for C-style increment/decrement
+(( i++ ))
+(( --j ))
+
+# Using ((...)) for arithmetic comparison in a conditional context
+count=5
+if (( count < 10 )); then echo "Count is less than 10"; fi
+if (( num_files >= 100 )); then echo "Many files!"; fi
+
+# Direct assignment within ((...))
+(( result = a * b ))
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1009` to the `disabled_katas` list in your `.zshellcheckrc` file.

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1010.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1010.md
@@ -1,0 +1,49 @@
+# ZC1010: Use `[[ ... ]]` instead of `[ ... ]`
+
+## Description
+
+In Zsh, `[[ ... ]]` is the preferred, more robust, and more feature-rich conditional construct compared to `[ ... ]` (which is typically an alias for the external `test` command or a shell built-in with similar behavior). The primary advantages of `[[...]]` include:
+
+*   **Built-in Keyword:** `[[...]]` is a shell keyword, not an external command. This means it behaves more predictably and efficiently, without the overhead of invoking a separate process.
+*   **Intelligent Word Splitting and Globbing:** `[[...]]` handles word splitting and pathname expansion (globbing) intelligently. You generally **do not need to quote variables** within `[[...]]` unless you specifically intend for literal string matching against patterns that might otherwise be interpreted as globs. This significantly reduces common scripting errors and improves robustness.
+*   **Enhanced Features:** It offers Zsh-specific features and improved syntax:
+    *   **Regular Expression Matching (`=~`):** Allows direct regex matching within the conditional.
+    *   **Glob Pattern Matching:** Supports extended glob patterns without explicit glob qualifiers.
+    *   **Logical Operators:** Uses C-style logical operators (`&&` for AND, `||` for OR) directly, avoiding the need for separate `-a` or `-o` flags which can have surprising precedence issues.
+
+Using `[ ... ]` requires meticulous quoting of variables and expressions to prevent unintended word splitting and pathname expansion, which can lead to bugs, security vulnerabilities, or simply incorrect logic. For arithmetic comparisons, `((...))` is often more appropriate (see [[Katas/ZC1000-ZC1099/ZC1003 | ZC1003]]).
+
+## Bad Example
+
+```zsh
+my_string="hello world"
+if [ -n $my_string ]; then echo "This might incorrectly split arguments"; fi
+# Fails if $my_string contains spaces (e.g., test -n hello world) or expands to a glob pattern
+
+file_path="/path/to/my file.txt"
+if [ -f $file_path ]; then echo "File exists"; fi # Will fail if file_path has spaces and is unquoted
+
+# Complex logic with -a (prone to precedence issues)
+if [ $a -gt 10 -a $b -lt 20 ]; then echo "Range"; fi
+```
+
+## Good Example
+
+```zsh
+my_string="hello world"
+if [[ -n $my_string ]]; then echo "Correctly handles spaces and globs"; fi
+# No quotes needed for $my_string here, `[[...]]` handles it robustly.
+
+file_path="/path/to/my file.txt"
+if [[ -f $file_path ]]; then echo "File exists"; fi # Safely handles spaces in file names
+
+# Clearer logical operators
+if [[ $a -gt 10 && $b -lt 20 ]]; then echo "Range"; fi
+
+# Regular expression matching
+if [[ "$version" =~ "^v[0-9]+\.[0-9]+$" ]]; then echo "Valid version format"; fi
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1010` to the `disabled_katas` list in your `.zshellcheckrc` file.

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1011.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1011.md
@@ -1,0 +1,44 @@
+# ZC1011: Use `git` porcelain commands instead of plumbing commands
+
+## Description
+
+Git commands are broadly categorized into two main types:
+
+*   **Porcelain commands:** These are high-level, user-friendly commands designed for common day-to-day operations (e.g., `git status`, `git commit`, `git pull`). Their output and behavior are generally stable across Git versions, making them reliable for scripting and user interaction.
+*   **Plumbing commands:** These are low-level commands that interact directly with Git's internal data structures (e.g., `git hash-object`, `git cat-file`, `git update-index`). Their output and exact behavior can be more prone to change between Git versions, and they require a deeper understanding of Git's internals.
+
+In typical shell scripts, it is **highly recommended to use porcelain commands** unless you have a very specific and well-understood need to interact with Git's internals. Relying on plumbing commands for common tasks can lead to fragile scripts that break with Git updates or are harder to understand and maintain.
+
+## Bad Example
+
+```zsh
+# Using a plumbing command to get the current commit hash (less robust)
+commit_hash=$(git rev-parse HEAD^{commit})
+
+# Using an older or less direct method for current branch name
+current_branch=$(git branch --show-current) # deprecated in some contexts / for older Git versions
+
+# Using plumbing to check if a file is tracked (less readable)
+is_tracked=$(git ls-files --error-unmatch -- "$file" &>/dev/null; echo $?)
+```
+
+## Good Example
+
+```zsh
+# Standard and robust way to get the current commit hash
+commit_hash=$(git rev-parse HEAD)
+
+# Recommended way to get the current branch name (porcelain)
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+# Using porcelain to check if a file is tracked (more common and readable)
+if git ls-files --error-unmatch -- "$file" &>/dev/null; then
+  echo "$file is tracked"
+else
+  echo "$file is not tracked"
+fi
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1011` to the `disabled_katas` list in your `.zshellcheckrc` file.

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1012.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1012.md
@@ -1,0 +1,26 @@
+# ZC1012: Use `read -r` to prevent backslash escaping
+
+## Description
+
+When using the `read` built-in command in Zsh (and other shells), it's crucial to use the `-r` option (`raw` mode). By default, `read` interprets backslashes (`\`) as escape characters, which can lead to unexpected behavior if the input contains backslashes (e.g., file paths, special characters, or multi-line input). The `-r` option prevents `read` from interpreting backslashes, ensuring that the input is stored literally as it was entered. This significantly improves script robustness and predictability, especially when reading user input or arbitrary data from files.
+
+## Bad Example
+
+```zsh
+read -p "Enter a string (e.g., C:\Program Files or line1\\nline2): " user_input
+echo "You entered: $user_input"
+# If user enters "C:\Program Files", it might be interpreted as "C:Program Files"
+# If user enters "line1\\nline2", it might be interpreted as "line1\nline2"
+```
+
+## Good Example
+
+```zsh
+read -r -p "Enter a string (e.g., C:\Program Files or line1\\nline2): " user_input
+echo "You entered: $user_input"
+# "C:\Program Files" is stored exactly as entered, "line1\\nline2" is stored as "line1\nline2"
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1012` to the `disabled_katas` list in your `.zshellcheckrc` file.

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1013.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1013.md
@@ -1,0 +1,48 @@
+# ZC1013: Use `((...))` for arithmetic operations instead of `let`
+
+## Description
+
+While `let` is a built-in command for performing arithmetic operations and assignments, Zsh's `((...))` construct offers a more modern, idiomatic, and versatile C-style syntax for arithmetic. Preferring `((...))` over `let` brings several benefits:
+
+*   **C-style Syntax:** `((...))` provides a familiar C-like syntax for arithmetic expressions, which is often more intuitive for developers coming from other programming languages.
+*   **Versatility:** It can be used directly for both arithmetic evaluation (where its exit status is based on the result) and assignments, including compound assignments (`+=`, `-=`) and increment/decrement operators (`++`, `--`).
+*   **Readability:** `((...))` makes arithmetic expressions clearer and more concise, especially for complex calculations or when integrating with conditional logic.
+*   **Efficiency:** As a built-in shell feature, `((...))` is generally efficient.
+
+`let` can sometimes be less readable, especially when expressions involve multiple variables or operators, and might require more careful quoting. This Kata encourages consistency and readability by promoting `((...))` for all C-style arithmetic needs.
+
+## Bad Example
+
+```zsh
+count=0
+let count=count+1      # Less idiomatic, requires re-typing variable name
+
+total=10
+price=2
+quantity=5
+let "total = price * quantity" # More verbose quoting for expressions
+
+# Using let for comparison (often less clear)
+if let "x < 10"; then echo "x is less"; fi
+```
+
+## Good Example
+
+```zsh
+count=0
+(( count++ ))          # Concise C-style increment
+(( count += 5 ))       # Compound assignment
+
+total=10
+price=2
+quantity=5
+(( total = price * quantity )) # Clean assignment
+
+# Using ((...)) for comparison (clearer exit status)
+x=5
+if (( x < 10 )); then echo "x is less"; fi
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1013` to the `disabled_katas` list in your `.zshellcheckrc` file.

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1014.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1014.md
@@ -1,0 +1,46 @@
+# ZC1014: Use `git switch` or `git restore` instead of `git checkout`
+
+## Description
+
+Git has introduced the specialized commands `git switch` and `git restore` to explicitly handle the distinct operations previously managed by the single, overloaded `git checkout` command. Adopting these newer commands offers significant benefits:
+
+*   **Improved Clarity:** Each command now has a single, clear responsibility:
+    *   `git switch`: Dedicated to changing branches.
+    *   `git restore`: Dedicated to reverting modified files in the working tree or restoring files from the staging area.
+*   **Reduced Ambiguity:** The original `git checkout` command had three main functions (switching branches, restoring working tree files, restoring staging index files), which could lead to confusion and accidental data loss. `git switch` and `git restore` eliminate this ambiguity.
+*   **Modern Git Practices:** Using `git switch` and `git restore` aligns with current Git best practices, making scripts and workflows easier to understand and more resilient to future Git changes.
+
+While scripts still using `git checkout` for these purposes remain functional, migrating to `git switch` and `git restore` improves readability, maintainability, and safety.
+
+## Bad Example
+
+```zsh
+# Overloaded `git checkout` for switching branches
+git checkout feature-branch
+
+# Overloaded `git checkout` for discarding local changes (risky if not careful)
+git checkout -- my_modified_file.txt
+
+# Overloaded `git checkout` to restore a file from staging (less intuitive)
+git checkout HEAD -- staged_file.txt
+```
+
+## Good Example
+
+```zsh
+# Clearer `git switch` for changing branches
+git switch feature-branch
+
+# Clearer `git restore` for discarding local changes in the working tree
+git restore my_modified_file.txt
+
+# Clearer `git restore` to unstage a file (restore from index to working tree, often implicit)
+git restore --staged another_file.txt
+
+# Restore a specific file from a commit (equivalent to checkout <commit> -- <file>)
+git restore --source=HEAD~1 file_from_prev_commit.txt
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1014` to the `disabled_katas` list in your `.zshellcheckrc` file.

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1017.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1017.md
@@ -1,0 +1,32 @@
+# ZC1017: Use `print -r` to print strings literally
+
+## Description
+
+When printing arbitrary strings or variable contents, especially those that might contain backslashes (`\`) or other characters that `echo` or `print` (without `-r`) could interpret as escape sequences, it is best practice to use `print -r`. The `print` built-in with the `-r` (raw) option ensures that backslashes are treated literally and are not interpreted as escape characters.
+
+This guarantees that the output precisely matches the input, preventing unintended interpretations or formatting issues. The behavior of `echo` can vary significantly between different shells and even different versions of the same shell, making `print -r` a more reliable, predictable, and portable choice for literal output in Zsh scripts.
+
+## Bad Example
+
+```zsh
+echo "Path: C:\Program Files"  # `echo` might interpret `\P` as an escape sequence, or simply print literally
+echo "Hello\nWorld"           # `echo` may or may not interpret `\n` as a newline, depending on shell/version
+```
+
+## Good Example
+
+```zsh
+# Using `print -r` for literal output, guaranteeing backslashes are printed as-is
+print -r "Path: C:\Program Files" # Output: Path: C:\Program Files
+print -r "Hello\\nWorld"          # Output: Hello\nWorld
+
+# Using `print` (without -r) when escape sequence interpretation is desired
+print "Hello\nWorld"           # Output:
+                                 # Hello
+                                 # World
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1017` to the `disabled_katas` list in your `.zshellcheckrc` file.
+```

--- a/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1018.md
+++ b/wiki_temp_final/Katas/ZC1000-ZC1099/ZC1018.md
@@ -1,0 +1,46 @@
+# ZC1018: Use `((...))` for C-style arithmetic instead of `expr`
+
+## Description
+
+This Kata strongly recommends using Zsh's native `((...))` arithmetic construct over the external `expr` command for all arithmetic operations and comparisons. The `((...))` syntax is a powerful, built-in feature that offers several key advantages:
+
+*   **Efficiency:** As an internal shell built-in, `((...))` avoids the overhead of invoking an external `expr` process, leading to more efficient script execution, especially for frequent arithmetic.
+*   **Readability & Conciseness:** `((...))` provides a clean, C-style syntax for arithmetic expressions, integer comparisons (e.g., `==`, `>`, `<=`), and variable assignments (including `++`, `--`, `+=`). This makes scripts easier to read and understand.
+*   **Robustness (No Quoting Issues):** `expr` often requires careful and sometimes complex escaping of operators (e.g., `\*` for multiplication), and can be prone to word splitting issues if variables are not properly quoted. `((...))` handles variables and operators correctly within its context, eliminating these common pitfalls.
+
+Consistent use of `((...))` significantly improves script performance, readability, and overall robustness by leveraging Zsh's native capabilities effectively.
+
+## Bad Example
+
+```zsh
+x=10; y=5
+
+# Using expr for arithmetic evaluation (external command, requires escaping)
+value=$(expr $x \* $y + 5)
+echo "Result from expr: $value"
+
+# Using expr for comparison (external command, verbose redirection)
+expr $x = $y > /dev/null
+if [ $? -eq 0 ]; then echo "x equals y"; fi
+```
+
+## Good Example
+
+```zsh
+x=10; y=5
+
+# Using ((...)) for direct arithmetic evaluation (more efficient, no escaping)
+value=$(( x * y + 5 ))
+echo "Result from arithmetic expansion: $value"
+
+# Using ((...)) for C-style comparison (clearer, built-in)
+if (( x == y )); then echo "x equals y"; fi
+
+# Other operations
+(( i++ )) # Increment
+(( result = x / y )) # Assignment
+```
+
+## Configuration
+
+To disable this Kata, add `ZC1018` to the `disabled_katas` list in your `.zshellcheckrc` file.

--- a/wiki_temp_final/Labels.md
+++ b/wiki_temp_final/Labels.md
@@ -1,0 +1,20 @@
+# Labels
+
+We use a specific set of labels to categorize issues and pull requests, helping us organize and prioritize work effectively. Please use them appropriately.
+
+| Label | Description |
+| :--- | :--- |
+| **`feat`** | New features or significant enhancements. |
+| **`fix`** | Bug fixes. |
+| **`docs`** | Documentation changes or improvements. |
+| **`ci`** | Updates to CI/CD configurations or workflows. |
+| **`deps`** | Dependency updates. |
+| **`refactor`** | Code restructuring without behavior changes. |
+| **`test`** | Additions or corrections to tests. |
+| **`chore`** | Routine maintenance tasks (e.g., updating build scripts, `.gitignore`). |
+| **`starter`** | Good entry-level tasks for new contributors. |
+| **`help`** | Requires extra attention or assistance. |
+| **`question`** | Seeking further information or clarification. |
+| **`nofix`** | The issue or request will not be addressed. |
+| **`duplicate`** | This issue or PR is a duplicate. |
+| **`invalid`** | The issue or PR is invalid or not applicable. |

--- a/wiki_temp_final/Roadmap.md
+++ b/wiki_temp_final/Roadmap.md
@@ -1,0 +1,27 @@
+# ZShellCheck Roadmap
+
+ZShellCheck is an evolving static analysis tool for Zsh. Our primary goal is to reach 1000 Katas (checks) to ensure comprehensive coverage of Zsh scripting pitfalls.
+
+## 🚀 Milestones
+
+### ✅ Version 0.0.x - The Foundation
+- [x] Establish core architecture (Lexer, Parser, AST, Walker).
+- [x] Implement basic linting framework.
+- [x] Set up CI/CD pipeline (GitHub Actions).
+- [x] Create initial set of Katas (ZC1000+).
+
+### 🌟 Version 1.0.0 - The 1000 Kata Milestone
+- [ ] **Goal:** Implement 1000 Katas (ZC1000 - ZC2000) covering:
+    - Syntax errors
+    - Portability issues
+    - Performance bottlenecks
+    - Security vulnerabilities
+    - Best practices
+- [ ] Stable API for integrations.
+- [ ] Comprehensive documentation and wiki.
+
+## 📈 Progress Tracking
+
+**Current Progress:** Version 0.0.72 (72/1000 Katas).
+
+For the list of currently implemented Katas, please refer to the [[Katas | All Katas]] page.

--- a/wiki_temp_final/_Sidebar.md
+++ b/wiki_temp_final/_Sidebar.md
@@ -1,0 +1,12 @@
+# ZShellCheck Wiki
+
+* [[Home]]
+* [[Getting Started]]
+* [[Contributing]]
+* [[Code_of_Conduct]]
+* [[Roadmap]]
+* [[Labels]]
+
+## Katas (Checks)
+
+* [[Katas | All Katas]]


### PR DESCRIPTION
This PR provides a comprehensive update to the ZShellCheck wiki. It restores lost content, consolidates redundant Kata pages (ZC1005 and ZC1019), removes outdated entries (ZC1015), and refines descriptions, examples, and formatting across all primary wiki pages and Kata documentation. This ensures the wiki is accurate, clear, and consistent.