### PR TITLE
chore: Update Go version to 1.25.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/afadesigns/zshellcheck
 
-go 1.23.0
+go 1.25.4
 
 require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
This PR updates the Go version in go.mod to 1.25.4 and runs .