### PR TITLE
feat: Implement ZC1004 (Use return instead of exit)

### DIFF
--- a/KATAS.md
+++ b/KATAS.md
@@ -7,6 +7,7 @@ Comprehensive list of all 70 implemented checks, migrated from the Wiki.
 - [ZC1001: Use ${} for array element access](#zc1001)
 - [ZC1002: Use $(...) instead of backticks](#zc1002)
 - [ZC1003: Use `((...))` for arithmetic comparisons instead of `[` or `test`](#zc1003)
+- [ZC1004: Use `return` instead of `exit` in functions](#zc1004)
 - [ZC1005: Use `whence` instead of `which`](#zc1005)
 - [ZC1006: Prefer `[[` over `test` for tests](#zc1006)
 - [ZC1007: Avoid using `chmod 777`](#zc1007)
@@ -198,6 +199,46 @@ To disable this Kata, add `ZC1003` to the `disabled_katas` list in your `.zshell
 
 [⬆ Back to Top](#table-of-contents)
 </details>
+
+
+<div id="zc1004"></div>
+
+<details>
+<summary><strong>ZC1004</strong>: Use `return` instead of `exit` in functions <img src="https://img.shields.io/badge/Status-Active-brightgreen?style=flat-square" height="15"/></summary>
+
+### Description
+
+Using `exit` in a function terminates the entire shell, which is often unintended in interactive sessions or sourced scripts. Use `return` to exit the function.
+
+### Bad Example
+
+```zsh
+my_func() {
+  if [[ -z $1 ]]: then
+    exit 1 # Kills the shell!
+  fi
+}
+```
+
+### Good Example
+
+```zsh
+my_func() {
+  if [[ -z $1 ]]: then
+    return 1
+  fi
+}
+```
+
+### Configuration
+
+To disable this Kata, add `ZC1004` to the `disabled_katas` list in your `.zshellcheckrc` file.
+
+---
+
+[⬆ Back to Top](#table-of-contents)
+</details>
+
 
 <div id="zc1005"></div>
 

--- a/pkg/katas/katatests/zc1004_test.go
+++ b/pkg/katas/katatests/zc1004_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1004(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid return",
+			input:    `my_func() { return 0; }`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid exit in subshell",
+			input:    `my_func() { ( exit 1 ) }`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid exit in command sub",
+			input:    `my_func() { local x=$(exit 1); }`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid exit",
+			input: `my_func() { exit 1; }`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1004",
+					Message: "Use `return` instead of `exit` in functions to avoid killing the shell.",
+					Line:    1,
+					Column:  13,
+				},
+			},
+		},
+		{
+			name:  "invalid exit deep",
+			input: `my_func() { if true; then exit 1; fi }`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1004",
+					Message: "Use `return` instead of `exit` in functions to avoid killing the shell.",
+					Line:    1,
+					Column:  27,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1004")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1004.go
+++ b/pkg/katas/zc1004.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+	"github.com/afadesigns/zshellcheck/pkg/token"
+)
+
+func init() {
+	kata := Kata{
+		ID:    "ZC1004",
+		Title: "Use `return` instead of `exit` in functions",
+		Description: "Using `exit` in a function terminates the entire shell, which is often unintended " +
+			"in interactive sessions or sourced scripts. Use `return` to exit the function.",
+		Check: checkZC1004,
+	}
+	RegisterKata(ast.FunctionDefinitionNode, kata)
+	RegisterKata(ast.FunctionLiteralNode, kata)
+}
+
+func checkZC1004(node ast.Node) []Violation {
+	var body ast.Statement
+
+	switch n := node.(type) {
+	case *ast.FunctionDefinition:
+		body = n.Body
+	case *ast.FunctionLiteral:
+		body = n.Body
+	default:
+		return nil
+	}
+
+	violations := []Violation{}
+
+	ast.Walk(body, func(n ast.Node) bool {
+		// Stop traversal at subshell boundaries where exit is safe/scoped
+		switch t := n.(type) {
+		case *ast.GroupedExpression: // ( ... )
+			return false
+		case *ast.CommandSubstitution: // ` ... `
+			return false
+		case *ast.DollarParenExpression: // $( ... )
+			return false
+		case *ast.BlockStatement:
+			if t.Token.Type == token.LPAREN { // ( ... ) as a statement block
+				return false
+			}
+		}
+
+		if cmd, ok := n.(*ast.SimpleCommand); ok {
+			if cmd.Name.String() == "exit" {
+				violations = append(violations, Violation{
+					KataID:  "ZC1004",
+					Message: "Use `return` instead of `exit` in functions to avoid killing the shell.",
+					Line:    cmd.TokenLiteralNode().Line,
+					Column:  cmd.TokenLiteralNode().Column,
+				})
+			}
+		}
+		return true
+	})
+
+	return violations
+}


### PR DESCRIPTION
Implemented Kata ZC1004 to warn against using `exit` inside functions, suggesting `return` instead. Includes tests handling subshells correctly.