### PR TITLE
feat: Implement ZC1016 (read -s for secrets)

### DIFF
--- a/KATAS.md
+++ b/KATAS.md
@@ -751,6 +751,40 @@ To disable this Kata, add `ZC1014` to the `disabled_katas` list in your `.zshell
 [⬆ Back to Top](#table-of-contents)
 </details>
 
+
+<div id="zc1016"></div>
+
+<details>
+<summary><strong>ZC1016</strong>: Use `read -s` when reading sensitive information <img src="https://img.shields.io/badge/Status-Active-brightgreen?style=flat-square" height="15"/></summary>
+
+### Description
+
+When asking for passwords or secrets, use `read -s` to prevent the input from being echoed to the terminal.
+
+### Bad Example
+
+```zsh
+read password
+read "token?Enter API Token: "
+```
+
+### Good Example
+
+```zsh
+read -s password
+read -s "token?Enter API Token: "
+```
+
+### Configuration
+
+To disable this Kata, add `ZC1016` to the `disabled_katas` list in your `.zshellcheckrc` file.
+
+---
+
+[⬆ Back to Top](#table-of-contents)
+</details>
+
+
 <div id="zc1017"></div>
 
 <details>

--- a/pkg/katas/katatests/zc1016_test.go
+++ b/pkg/katas/katatests/zc1016_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1016(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "safe read",
+			input:    `read name`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "safe read password with -s",
+			input:    `read -s password`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "safe read with combined flags",
+			input:    `read -rs password`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "unsafe read password",
+			input: `read password`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1016",
+					Message: "Use `read -s` to hide input when reading sensitive variable 'password'.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "unsafe read with prompt",
+			input: `read "secret_key?Enter key: "`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1016",
+					Message: "Use `read -s` to hide input when reading sensitive variable 'secret_key'.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "unsafe read multiple vars",
+			input: `read user password`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1016",
+					Message: "Use `read -s` to hide input when reading sensitive variable 'password'.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1016")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1016.go
+++ b/pkg/katas/zc1016.go
@@ -1,0 +1,81 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1016",
+		Title: "Use `read -s` when reading sensitive information",
+		Description: "When asking for passwords or secrets, use `read -s` to prevent " +
+			"the input from being echoed to the terminal.",
+		Check: checkZC1016,
+	})
+}
+
+func checkZC1016(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	if cmd.Name.String() != "read" {
+		return nil
+	}
+
+	hasS := false
+	sensitiveVars := []string{"password", "passwd", "pwd", "secret", "token", "key", "api_key"}
+
+	// Check flags
+	for _, arg := range cmd.Arguments {
+		if pe, ok := arg.(*ast.PrefixExpression); ok && pe.Operator == "-" {
+			if ident, ok := pe.Right.(*ast.Identifier); ok {
+				if strings.Contains(ident.Value, "s") {
+					hasS = true
+				}
+			}
+		}
+	}
+
+	if hasS {
+		return nil
+	}
+
+	violations := []Violation{}
+
+	for _, arg := range cmd.Arguments {
+		// Skip flags
+		if pe, ok := arg.(*ast.PrefixExpression); ok && pe.Operator == "-" {
+			continue
+		}
+
+		argStr := arg.String()
+
+		// Handle Zsh read syntax: variable?prompt
+		parts := strings.Split(argStr, "?")
+		varName := strings.TrimSpace(parts[0])
+		varName = strings.Trim(varName, "'\"")
+
+		varLower := strings.ToLower(varName)
+		isSensitive := false
+		for _, s := range sensitiveVars {
+			if strings.Contains(varLower, s) {
+				isSensitive = true
+				break
+			}
+		}
+
+		if isSensitive {
+			            violations = append(violations, Violation{				KataID:  "ZC1016",
+				Message: "Use `read -s` to hide input when reading sensitive variable '" + varName + "'.",
+				Line:    cmd.TokenLiteralNode().Line,
+				Column:  cmd.TokenLiteralNode().Column,
+			})
+		}
+	}
+
+	return violations
+}


### PR DESCRIPTION
Implemented Kata ZC1016 to warn when reading variables with names like 'password' or 'token' without the `-s` flag. Handles flags passed as separate arguments or combined.