### PR TITLE
feat: Implement ZC1075 (Quote variables)

### DIFF
--- a/KATAS.md
+++ b/KATAS.md
@@ -76,6 +76,7 @@ Comprehensive list of all 70 implemented checks, migrated from the Wiki.
 - [ZC1072: Use `awk` instead of `grep | awk`](#zc1072)
 - [ZC1073: Unnecessary use of `$` in arithmetic expressions](#zc1073)
 - [ZC1074: Prefer modifiers :h/:t over dirname/basename](#zc1074)
+- [ZC1075: Quote variable expansions to prevent globbing](#zc1075)
 
 ---
 
@@ -2719,3 +2720,37 @@ To disable this Kata, add `ZC1074` to the `disabled_katas` list in your `.zshell
 
 [⬆ Back to Top](#table-of-contents)
 </details>
+
+
+<div id="zc1075"></div>
+
+<details>
+<summary><strong>ZC1075</strong>: Quote variable expansions to prevent globbing <img src="https://img.shields.io/badge/Status-Active-brightgreen?style=flat-square" height="15"/></summary>
+
+### Description
+
+Unquoted variable expansions in Zsh are subject to globbing (filename generation). If the variable contains characters like `*` or `?`, it might match files unexpectedly. Use quotes `"$var"` to prevent this.
+
+### Bad Example
+
+```zsh
+rm $file
+ls ${files[1]}
+```
+
+### Good Example
+
+```zsh
+rm "$file"
+ls "${files[1]}"
+```
+
+### Configuration
+
+To disable this Kata, add `ZC1075` to the `disabled_katas` list in your `.zshellcheckrc` file.
+
+---
+
+[⬆ Back to Top](#table-of-contents)
+</details>
+

--- a/pkg/katas/katatests/zc1075_test.go
+++ b/pkg/katas/katatests/zc1075_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1075(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "quoted variable",
+			input:    `rm "$var"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "unquoted variable",
+			input:    `rm $var`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1075",
+					Message: "Unquoted variable expansion '$var' is subject to globbing. Quote it: \"$var\".",
+					Line:    1,
+					Column:  4,
+				},
+			},
+		},
+		{
+			name:     "unquoted array access",
+			input:    `ls ${files[1]}`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1075",
+					Message: "Unquoted array access is subject to globbing. Quote it.",
+					Line:    1,
+					Column:  4,
+				},
+			},
+		},
+		{
+			name:     "quoted array access",
+			input:    `ls "${files[1]}"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "unquoted concatenated",
+			input:    `cp $src/file dest`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1075",
+					Message: "Unquoted variable expansion '$src/file' is subject to globbing. Quote it: \"$src/file\".",
+					Line:    1,
+					Column:  4,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1075")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1075.go
+++ b/pkg/katas/zc1075.go
@@ -1,0 +1,76 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1075",
+		Title: "Quote variable expansions to prevent globbing",
+		Description: "Unquoted variable expansions in Zsh are subject to globbing (filename generation). " +
+			"If the variable contains characters like `*` or `?`, it might match files unexpectedly. " +
+			"Use quotes `\"$var\"` to prevent this.",
+		Check: checkZC1075,
+	})
+}
+
+func checkZC1075(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	violations := []Violation{}
+
+	for _, arg := range cmd.Arguments {
+		// Check if argument is a simple identifier starting with $
+		// or a braced expression ${...} that is NOT inside a string literal.
+		// The parser might wrap these in different ways.
+		
+		// If it's a bare IdentifierNode (variable expansion), it's unquoted.
+		if ident, ok := arg.(*ast.Identifier); ok {
+			// Identifiers that start with $ are variable expansions
+			if len(ident.Value) > 0 && ident.Value[0] == '$' {
+				violations = append(violations, Violation{
+					KataID:  "ZC1075",
+					Message: "Unquoted variable expansion '" + ident.Value + "' is subject to globbing. Quote it: \""+ ident.Value + "\".",
+					Line:    ident.Token.Line,
+					Column:  ident.Token.Column,
+				})
+			}
+		} else if _, ok := arg.(*ast.ArrayAccess); ok {
+			// Array access ${arr[idx]} is also subject to globbing if unquoted
+			violations = append(violations, Violation{
+				KataID:  "ZC1075",
+				Message: "Unquoted array access is subject to globbing. Quote it.",
+				Line:    arg.TokenLiteralNode().Line,
+				Column:  arg.TokenLiteralNode().Column,
+			})
+		} else if _, ok := arg.(*ast.InvalidArrayAccess); ok {
+			// $arr[idx] - ZC1001 flags this, but it's also unquoted. 
+			// Let ZC1001 handle the syntax error, but ZC1075 could also flag globbing.
+			// We'll skip to reduce noise.
+		}
+		
+		// Note: StringLiteral arguments are quoted, so we don't check them.
+		// But ConcatenatedExpression might contain unquoted parts.
+		// e.g. $var/foo
+		if concat, ok := arg.(*ast.ConcatenatedExpression); ok {
+			for _, part := range concat.Parts {
+				if ident, ok := part.(*ast.Identifier); ok {
+					if len(ident.Value) > 0 && ident.Value[0] == '$' {
+						violations = append(violations, Violation{
+							KataID:  "ZC1075",
+							Message: "Unquoted variable expansion '" + ident.Value + "' in concatenated string is subject to globbing.",
+							Line:    ident.Token.Line,
+							Column:  ident.Token.Column,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return violations
+}


### PR DESCRIPTION
Implemented Kata ZC1075 to warn about unquoted variable expansions and array accesses which are subject to globbing.

Exceptions handled:
- Quoted variables (obvious)
- Variable assignment (parser doesn't treat RHS as simple command args usually, but if it does, we might need check. Wait, assignment  is safe from globbing in Zsh? Actually yes, in Zsh assignment doesn't split/glob. But  does. This Kata targets SimpleCommand arguments.)