### PR TITLE
feat: Implement ZC1076 (autoload -Uz)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Kata ZC1016**: Use `read -s` when reading sensitive information.
 - **Kata ZC1074**: Prefer modifiers `:h`/:`t` over `dirname`/`basename`.
 - **Kata ZC1075**: Quote variable expansions to prevent globbing.
+- **Kata ZC1076**: Use `autoload -Uz` for lazy loading.
 - **Documentation**: Added `TROUBLESHOOTING.md`, `GOVERNANCE.md`, `COMPARISON.md`, `GLOSSARY.md`, `CITATION.cff`.
 - **Documentation**: Expanded `KATAS.md` with new Katas.
 

--- a/KATAS.md
+++ b/KATAS.md
@@ -77,6 +77,7 @@ Comprehensive list of all 70 implemented checks, migrated from the Wiki.
 - [ZC1073: Unnecessary use of `$` in arithmetic expressions](#zc1073)
 - [ZC1074: Prefer modifiers :h/:t over dirname/basename](#zc1074)
 - [ZC1075: Quote variable expansions to prevent globbing](#zc1075)
+- [ZC1076: Use `autoload -Uz` for lazy loading](#zc1076)
 
 ---
 
@@ -2753,4 +2754,39 @@ To disable this Kata, add `ZC1075` to the `disabled_katas` list in your `.zshell
 
 [⬆ Back to Top](#table-of-contents)
 </details>
+
+
+<div id="zc1076"></div>
+
+<details>
+<summary><strong>ZC1076</strong>: Use `autoload -Uz` for lazy loading <img src="https://img.shields.io/badge/Status-Active-brightgreen?style=flat-square" height="15"/></summary>
+
+### Description
+
+When using `autoload` to lazy-load functions, it is best practice to use the `-Uz` flags.
+*   `-U`: Marks the function as "undefined" and prevents alias expansion during definition.
+*   `-z`: Ensures Zsh style autoloading (as opposed to ksh style).
+
+### Bad Example
+
+```zsh
+autoload my_func
+autoload -U my_func
+```
+
+### Good Example
+
+```zsh
+autoload -Uz my_func
+```
+
+### Configuration
+
+To disable this Kata, add `ZC1076` to the `disabled_katas` list in your `.zshellcheckrc` file.
+
+---
+
+[⬆ Back to Top](#table-of-contents)
+</details>
+
 

--- a/pkg/katas/katatests/zc1076_test.go
+++ b/pkg/katas/katatests/zc1076_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1076(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid autoload",
+			input:    `autoload -Uz my_func`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid autoload split flags",
+			input:    `autoload -U -z my_func`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid autoload with other flags",
+			input:    `autoload -UzX my_func`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "missing U",
+			input: `autoload -z my_func`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1076",
+					Message: "Use `autoload -Uz` to ensure consistent and safe function loading.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "missing z",
+			input: `autoload -U my_func`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1076",
+					Message: "Use `autoload -Uz` to ensure consistent and safe function loading.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "missing flags",
+			input: `autoload my_func`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1076",
+					Message: "Use `autoload -Uz` to ensure consistent and safe function loading.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1076")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1076.go
+++ b/pkg/katas/zc1076.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1076",
+		Title: "Use `autoload -Uz` for lazy loading",
+		Description: "When using `autoload`, prefer `-Uz` to ensure standard Zsh behavior (no alias expansion, zsh style). " +
+			"`-U` prevents alias expansion, and `-z` ensures Zsh style autoloading.",
+		Check: checkZC1076,
+	})
+}
+
+func checkZC1076(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	if cmd.Name.String() != "autoload" {
+		return nil
+	}
+
+	hasU := false
+	hasZ := false
+
+	for _, arg := range cmd.Arguments {
+		// The parser might treat flags as PrefixExpression or Identifier depending on context
+		// But usually simple flags are handled as part of arguments list if they are simple strings
+		
+		// Check if it's a prefix expression (e.g. -Uz)
+		if pe, ok := arg.(*ast.PrefixExpression); ok && pe.Operator == "-" {
+			if ident, ok := pe.Right.(*ast.Identifier); ok {
+				if strings.Contains(ident.Value, "U") {
+					hasU = true
+				}
+				if strings.Contains(ident.Value, "z") {
+					hasZ = true
+				}
+			}
+		}
+		// Or if parser just treats it as Identifier starting with -
+		// (This depends on lexer/parser specifics, usually flags are parsed as PrefixExpr or just Identifier if space separated?)
+		// Let's assume the test failure means it wasn't catching the string check properly in previous attempt because of AST structure.
+		// Previous attempt checked `arg.String()` which might reconstruct `-` + `U` but AST might be PrefixExpr.
+	}
+
+	if !hasU || !hasZ {
+		return []Violation{{
+			KataID:  "ZC1076",
+			Message: "Use `autoload -Uz` to ensure consistent and safe function loading.",
+			Line:    cmd.TokenLiteralNode().Line,
+			Column:  cmd.TokenLiteralNode().Column,
+		}}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Implemented Kata ZC1076 to encourage using `autoload -Uz` for lazy loading functions to prevent alias expansion and ensure Zsh style.