### PR TITLE
feat: Implement ZC1078 (Quote arguments)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Kata ZC1075**: Quote variable expansions to prevent globbing.
 - **Kata ZC1076**: Use `autoload -Uz` for lazy loading.
 - **Kata ZC1077**: Prefer `${var:u/l}` over `tr` for case conversion.
+- **Kata ZC1078**: Quote `$@` and `$*` when passing arguments.
 - **Documentation**: Added `TROUBLESHOOTING.md`, `GOVERNANCE.md`, `COMPARISON.md`, `GLOSSARY.md`, `CITATION.cff`.
 - **Documentation**: Expanded `KATAS.md` with new Katas.
 

--- a/KATAS.md
+++ b/KATAS.md
@@ -79,6 +79,7 @@ Comprehensive list of all 70 implemented checks, migrated from the Wiki.
 - [ZC1075: Quote variable expansions to prevent globbing](#zc1075)
 - [ZC1076: Use `autoload -Uz` for lazy loading](#zc1076)
 - [ZC1077: Prefer `${var:u/l}` over `tr` for case conversion](#zc1077)
+- [ZC1078: Quote `$@` and `$*` when passing arguments](#zc1078)
 
 ---
 
@@ -2822,6 +2823,40 @@ To disable this Kata, add `ZC1077` to the `disabled_katas` list in your `.zshell
 
 [⬆ Back to Top](#table-of-contents)
 </details>
+
+
+<div id="zc1078"></div>
+
+<details>
+<summary><strong>ZC1078</strong>: Quote `$@` and `$*` when passing arguments <img src="https://img.shields.io/badge/Status-Active-brightgreen?style=flat-square" height="15"/></summary>
+
+### Description
+
+Using unquoted `$@` or `$*` splits arguments by IFS (usually space). Use `"$@"` to preserve the original argument grouping, or `"$*"` to join them into a single string.
+
+### Bad Example
+
+```zsh
+my_cmd $@
+my_cmd $*
+```
+
+### Good Example
+
+```zsh
+my_cmd "$@"
+my_cmd "$*"
+```
+
+### Configuration
+
+To disable this Kata, add `ZC1078` to the `disabled_katas` list in your `.zshellcheckrc` file.
+
+---
+
+[⬆ Back to Top](#table-of-contents)
+</details>
+
 
 
 

--- a/pkg/katas/katatests/zc1078_test.go
+++ b/pkg/katas/katatests/zc1078_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1078(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "quoted arguments",
+			input:    `cmd "$@"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "quoted star",
+			input:    `cmd "$*"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "unquoted arguments",
+			input:    `cmd $@`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1078",
+					Message: "Unquoted $@ splits arguments. Use \"$@\" to preserve structure.",
+					Line:    1,
+					Column:  5,
+				},
+			},
+		},
+		{
+			name:     "unquoted star",
+			input:    `cmd $*`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1078",
+					Message: "Unquoted $* splits arguments. Use \"$*\" to preserve structure.",
+					Line:    1,
+					Column:  5,
+				},
+			},
+		},
+		{
+			name:     "mixed",
+			input:    `cmd arg1 $@ arg2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1078",
+					Message: "Unquoted $@ splits arguments. Use \"$@\" to preserve structure.",
+					Line:    1,
+					Column:  10,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1078")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1078.go
+++ b/pkg/katas/zc1078.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1078",
+		Title: "Quote `$@` and `$*` when passing arguments",
+		Description: "Using unquoted `$@` or `$*` splits arguments by IFS (usually space). " +
+			"Use `\"$@\"` to preserve the original argument grouping, or `\"$*\"` to join them into a single string.",
+		Check: checkZC1078,
+	})
+}
+
+func checkZC1078(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	violations := []Violation{}
+
+	for _, arg := range cmd.Arguments {
+		// Check string representation to catch various parsed forms of $@ and $*
+		// unquoted $@ might be parsed as Identifier "$@" -> String() == "$@"
+		// unquoted $* might be parsed as GroupedExpression -> String() == "($*)"
+		// or other variations depending on parser state (e.g. PrefixExpression)
+		
+		s := arg.String()
+		
+		// Removing parens from GroupedExpression string representation for checking
+		// (Note: String() adds parens for GroupedExpression)
+		if len(s) >= 2 && s[0] == '(' && s[len(s)-1] == ')' {
+			s = s[1 : len(s)-1]
+		}
+
+		if s == "$@" || s == "$*" {
+			violations = append(violations, Violation{
+				KataID:  "ZC1078",
+				Message: "Unquoted " + s + " splits arguments. Use \"" + s + "\" to preserve structure.",
+				Line:    arg.TokenLiteralNode().Line,
+				Column:  arg.TokenLiteralNode().Column,
+			})
+		}
+	}
+
+	return violations
+}


### PR DESCRIPTION
Implemented Kata ZC1078 to warn about unquoted usage of `` and `` in simple commands, which splits arguments by IFS (usually space). Suggests quoting to preserve structure.