### PR TITLE
feat: Implement ZC1079 (Quote conditional RHS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Kata ZC1076**: Use `autoload -Uz` for lazy loading.
 - **Kata ZC1077**: Prefer `${var:u/l}` over `tr` for case conversion.
 - **Kata ZC1078**: Quote `$@` and `$*` when passing arguments.
+- **Kata ZC1079**: Quote RHS of `==` in `[[ ... ]]` to prevent pattern matching.
 - **Documentation**: Added `TROUBLESHOOTING.md`, `GOVERNANCE.md`, `COMPARISON.md`, `GLOSSARY.md`, `CITATION.cff`.
 - **Documentation**: Expanded `KATAS.md` with new Katas.
 

--- a/KATAS.md
+++ b/KATAS.md
@@ -80,6 +80,7 @@ Comprehensive list of all 70 implemented checks, migrated from the Wiki.
 - [ZC1076: Use `autoload -Uz` for lazy loading](#zc1076)
 - [ZC1077: Prefer `${var:u/l}` over `tr` for case conversion](#zc1077)
 - [ZC1078: Quote `$@` and `$*` when passing arguments](#zc1078)
+- [ZC1079: Quote RHS of `==` in `[[ ... ]]` to prevent pattern matching](#zc1079)
 
 ---
 
@@ -2856,6 +2857,40 @@ To disable this Kata, add `ZC1078` to the `disabled_katas` list in your `.zshell
 
 [⬆ Back to Top](#table-of-contents)
 </details>
+
+
+<div id="zc1079"></div>
+
+<details>
+<summary><strong>ZC1079</strong>: Quote RHS of `==` in `[[ ... ]]` to prevent pattern matching <img src="https://img.shields.io/badge/Status-Active-brightgreen?style=flat-square" height="15"/></summary>
+
+### Description
+
+In `[[ ... ]]`, unquoted variable expansions on the right-hand side of `==` or `!=` are treated as patterns (globbing). If you intend to compare strings literally, quote the variable.
+
+### Bad Example
+
+```zsh
+[[ $var == $other ]]  # Matches if $other contains wildcards
+[[ $var != $other ]]
+```
+
+### Good Example
+
+```zsh
+[[ $var == "$other" ]] # Literal string comparison
+[[ $var == pattern* ]] # Unquoted literals are fine for patterns
+```
+
+### Configuration
+
+To disable this Kata, add `ZC1079` to the `disabled_katas` list in your `.zshellcheckrc` file.
+
+---
+
+[⬆ Back to Top](#table-of-contents)
+</details>
+
 
 
 

--- a/pkg/katas/katatests/zc1079_test.go
+++ b/pkg/katas/katatests/zc1079_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1079(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid quoted comparison",
+			input:    `[[ $var == "$other" ]]`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid literal comparison",
+			input:    `[[ $var == "foo" ]]`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid pattern comparison (literal)",
+			input:    `[[ $var == foo* ]]`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "invalid unquoted variable == ",
+			input:    `[[ $var == $other ]]`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1079",
+					Message: "Unquoted RHS matches as pattern. Quote to force string comparison: `\"$var\"`.",
+					Line:    1,
+					Column:  12,
+				},
+			},
+		},
+		{
+			name:     "invalid unquoted variable !=",
+			input:    `[[ $var != $other ]]`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1079",
+					Message: "Unquoted RHS matches as pattern. Quote to force string comparison: `\"$var\"`.",
+					Line:    1,
+					Column:  12,
+				},
+			},
+		},
+		{
+			name:     "invalid array access",
+			input:    `[[ $var = ${arr[1]} ]]`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1079",
+					Message: "Unquoted RHS matches as pattern. Quote to force string comparison: `\"$var\"`.",
+					Line:    1,
+					Column:  11,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1079")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1079.go
+++ b/pkg/katas/zc1079.go
@@ -1,0 +1,83 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.DoubleBracketExpressionNode, Kata{
+		ID:    "ZC1079",
+		Title: "Quote RHS of `==` in `[[ ... ]]` to prevent pattern matching",
+		Description: "In `[[ ... ]]`, unquoted variable expansions on the right-hand side of `==` or `!=` " +
+			"are treated as patterns (globbing). If you intend to compare strings literally, quote the variable.",
+		Check: checkZC1079,
+	})
+}
+
+func checkZC1079(node ast.Node) []Violation {
+	dbe, ok := node.(*ast.DoubleBracketExpression)
+	if !ok {
+		return nil
+	}
+
+	violations := []Violation{}
+
+	for _, expr := range dbe.Expressions {
+		infix, ok := expr.(*ast.InfixExpression)
+		if !ok {
+			continue
+		}
+
+		// Check for equality/inequality operators
+		if infix.Operator != "==" && infix.Operator != "=" && infix.Operator != "!=" {
+			continue
+		}
+
+		// Check Right side
+		// If it is an Identifier (variable), ArrayAccess, or Concatenated containing variable,
+		// AND it is NOT quoted (not StringLiteral).
+		
+		// Note: Parser handles quoted strings as StringLiteral.
+		// Unquoted $var is Identifier.
+		
+		isSuspicious := false
+		var tokenNode ast.Node
+
+		switch r := infix.Right.(type) {
+		case *ast.Identifier:
+			if len(r.Value) > 0 && r.Value[0] == '$' {
+				isSuspicious = true
+				tokenNode = r
+			}
+		case *ast.ArrayAccess:
+			isSuspicious = true // ${arr[i]}
+			tokenNode = r
+		case *ast.InvalidArrayAccess:
+			// ZC1001 covers syntax, but it's also unquoted.
+			isSuspicious = true
+			tokenNode = r
+		case *ast.ConcatenatedExpression:
+			// Check if any part is an unquoted variable
+			for _, part := range r.Parts {
+				if ident, ok := part.(*ast.Identifier); ok {
+					if len(ident.Value) > 0 && ident.Value[0] == '$' {
+						isSuspicious = true
+						tokenNode = ident
+						break
+					}
+				}
+			}
+		}
+
+		if isSuspicious {
+			violations = append(violations, Violation{
+				KataID:  "ZC1079",
+				Message: "Unquoted RHS matches as pattern. Quote to force string comparison: `\"$var\"`.",
+				Line:    tokenNode.TokenLiteralNode().Line,
+				Column:  tokenNode.TokenLiteralNode().Column,
+			})
+		}
+	}
+
+	return violations
+}


### PR DESCRIPTION
Implemented Kata ZC1079 to warn about unquoted variable expansions on the RHS of `==` and `!=` inside `[[ ... ]]`. This prevents unintentional pattern matching (globbing).