### PR TITLE
feat: Implement ZC1080 (nullglob in loops)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Kata ZC1077**: Prefer `${var:u/l}` over `tr` for case conversion.
 - **Kata ZC1078**: Quote `$@` and `$*` when passing arguments.
 - **Kata ZC1079**: Quote RHS of `==` in `[[ ... ]]` to prevent pattern matching.
+- **Kata ZC1080**: Use `(N)` nullglob qualifier for globs in loops.
 - **Documentation**: Added `TROUBLESHOOTING.md`, `GOVERNANCE.md`, `COMPARISON.md`, `GLOSSARY.md`, `CITATION.cff`.
 - **Documentation**: Expanded `KATAS.md` with new Katas.
 

--- a/KATAS.md
+++ b/KATAS.md
@@ -81,6 +81,7 @@ Comprehensive list of all 70 implemented checks, migrated from the Wiki.
 - [ZC1077: Prefer `${var:u/l}` over `tr` for case conversion](#zc1077)
 - [ZC1078: Quote `$@` and `$*` when passing arguments](#zc1078)
 - [ZC1079: Quote RHS of `==` in `[[ ... ]]` to prevent pattern matching](#zc1079)
+- [ZC1080: Use `(N)` nullglob qualifier for globs in loops](#zc1080)
 
 ---
 
@@ -2890,6 +2891,42 @@ To disable this Kata, add `ZC1079` to the `disabled_katas` list in your `.zshell
 
 [⬆ Back to Top](#table-of-contents)
 </details>
+
+
+<div id="zc1080"></div>
+
+<details>
+<summary><strong>ZC1080</strong>: Use `(N)` nullglob qualifier for globs in loops <img src="https://img.shields.io/badge/Status-Active-brightgreen?style=flat-square" height="15"/></summary>
+
+### Description
+
+In Zsh, if a glob matches no files, it throws an error by default (`zsh: no matches found: ...`). When iterating over a glob in a `for` loop, use the `(N)` glob qualifier to allow it to match nothing (nullglob). This prevents the script from crashing or printing an error if the directory is empty.
+
+### Bad Example
+
+```zsh
+for f in *.txt; do
+  echo "Found $f"
+done
+```
+
+### Good Example
+
+```zsh
+for f in *.txt(N); do
+  echo "Found $f"
+done
+```
+
+### Configuration
+
+To disable this Kata, add `ZC1080` to the `disabled_katas` list in your `.zshellcheckrc` file.
+
+---
+
+[⬆ Back to Top](#table-of-contents)
+</details>
+
 
 
 

--- a/pkg/katas/katatests/zc1080_test.go
+++ b/pkg/katas/katatests/zc1080_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1080(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid nullglob",
+			input:    `for f in *.txt(N); do echo $f; done`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid no glob",
+			input:    `for f in a b c; do echo $f; done`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid variable",
+			input:    `for f in $files; do echo $f; done`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "invalid glob star",
+			input:    `for f in *.txt; do echo $f; done`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1080",
+					Message: "Glob '*.txt' will error if no matches found. Append `(N)` to make it nullglob.",
+					Line:    1,
+					Column:  10,
+				},
+			},
+		},
+		{
+			name:     "invalid glob question",
+			input:    `for f in file?; do echo $f; done`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1080",
+					Message: "Glob 'file?' will error if no matches found. Append `(N)` to make it nullglob.",
+					Line:    1,
+					Column:  10,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1080")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1080.go
+++ b/pkg/katas/zc1080.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.ForLoopStatementNode, Kata{
+		ID:    "ZC1080",
+		Title: "Use `(N)` nullglob qualifier for globs in loops",
+		Description: "In Zsh, if a glob matches no files, it throws an error by default. " +
+			"When iterating over a glob in a `for` loop, use the `(N)` glob qualifier to allow it to match nothing (nullglob).",
+		Check: checkZC1080,
+	})
+}
+
+func checkZC1080(node ast.Node) []Violation {
+	loop, ok := node.(*ast.ForLoopStatement)
+	if !ok {
+		return nil
+	}
+
+	// Only check for-each loops: for i in items...
+	if loop.Items == nil {
+		return nil // C-style loop
+	}
+
+	violations := []Violation{}
+
+	for _, item := range loop.Items {
+		// Check if item looks like a glob pattern (contains *, ?, [])
+		// and DOES NOT contain (N) or (nullglob) qualifier.
+		
+		// Parser might return it as Identifier (if simple glob) or Prefix/Infix (if paths).
+		// Or just String().
+		
+		s := item.String()
+		
+		// Simple heuristic for glob characters
+		isGlob := strings.ContainsAny(s, "*?[]")
+		
+		if isGlob {
+			// Check for existing nullglob qualifier
+			// (N) is standard short form.
+			// We check if it ends with (N) or contains (N) in qualifiers.
+			// Zsh qualifiers are usually at the end in parens.
+			
+			if !strings.Contains(s, "(N)") && !strings.Contains(s, "N") { 
+				// "N" checking is tricky because (N) is the syntax. 
+				// If we have qualifiers like (*.txt)(.N), we check for N inside parens.
+				// But parsing qualifiers without a full zsh lexer is hard.
+				// Let's stick to checking for explicit "(N)" or "N" inside the last parenthesized group?
+				// Or simplistically: if it doesn't contain "(N)", warn.
+				
+				// Refined check: 
+				// Must contain glob char.
+				// Must NOT contain "(N)".
+				
+				violations = append(violations, Violation{
+					KataID:  "ZC1080",
+					Message: "Glob '" + s + "' will error if no matches found. Append `(N)` to make it nullglob.",
+					Line:    item.TokenLiteralNode().Line,
+					Column:  item.TokenLiteralNode().Column,
+				})
+			}
+		}
+	}
+
+	return violations
+}


### PR DESCRIPTION
Implemented Kata ZC1080 to warn when iterating over glob patterns without the `(N)` (nullglob) qualifier, which can cause script errors if no files match.