### PR TITLE
feat: Implement ZC1081 (String length)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Kata ZC1078**: Quote `$@` and `$*` when passing arguments.
 - **Kata ZC1079**: Quote RHS of `==` in `[[ ... ]]` to prevent pattern matching.
 - **Kata ZC1080**: Use `(N)` nullglob qualifier for globs in loops.
+- **Kata ZC1081**: Use `${#var}` to get string length instead of `wc -c`.
 - **Documentation**: Added `TROUBLESHOOTING.md`, `GOVERNANCE.md`, `COMPARISON.md`, `GLOSSARY.md`, `CITATION.cff`.
 - **Documentation**: Expanded `KATAS.md` with new Katas.
 

--- a/KATAS.md
+++ b/KATAS.md
@@ -82,6 +82,7 @@ Comprehensive list of all 70 implemented checks, migrated from the Wiki.
 - [ZC1078: Quote `$@` and `$*` when passing arguments](#zc1078)
 - [ZC1079: Quote RHS of `==` in `[[ ... ]]` to prevent pattern matching](#zc1079)
 - [ZC1080: Use `(N)` nullglob qualifier for globs in loops](#zc1080)
+- [ZC1081: Use `${#var}` to get string length instead of `wc -c`](#zc1081)
 
 ---
 
@@ -2926,6 +2927,39 @@ To disable this Kata, add `ZC1080` to the `disabled_katas` list in your `.zshell
 
 [⬆ Back to Top](#table-of-contents)
 </details>
+
+
+<div id="zc1081"></div>
+
+<details>
+<summary><strong>ZC1081</strong>: Use `${#var}` to get string length instead of `wc -c` <img src="https://img.shields.io/badge/Status-Active-brightgreen?style=flat-square" height="15"/></summary>
+
+### Description
+
+Using `echo $var | wc -c` involves a subshell and external command overhead. Zsh has a built-in operator `${#var}` to get the length of a string instantly.
+
+### Bad Example
+
+```zsh
+len=$(echo $var | wc -c)
+len=$(print -r $var | wc -m)
+```
+
+### Good Example
+
+```zsh
+len=${#var}
+```
+
+### Configuration
+
+To disable this Kata, add `ZC1081` to the `disabled_katas` list in your `.zshellcheckrc` file.
+
+---
+
+[⬆ Back to Top](#table-of-contents)
+</details>
+
 
 
 

--- a/pkg/katas/katatests/zc1081_test.go
+++ b/pkg/katas/katatests/zc1081_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1081(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid length check",
+			input:    `len=${#var}`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "invalid echo pipe wc -c",
+			input:    `len=$(echo $var | wc -c)`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1081",
+					Message: "Use `${#var}` to get string length. Pipeline to `wc` is inefficient.",
+					Line:    1,
+					Column:  17,
+				},
+			},
+		},
+		{
+			name:     "invalid print pipe wc -m",
+			input:    `len=$(print -r $var | wc -m)`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1081",
+					Message: "Use `${#var}` to get string length. Pipeline to `wc` is inefficient.",
+					Line:    1,
+					Column:  21,
+				},
+			},
+		},
+		{
+			name:     "wc on file (valid)",
+			input:    `wc -c file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "cat pipe wc (valid-ish)",
+			input:    `cat file | wc -c`,
+			expected: []katas.Violation{}, // ZC1038 might flag cat usage, but ZC1081 shouldn't
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1081")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1081.go
+++ b/pkg/katas/zc1081.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.InfixExpressionNode, Kata{
+		ID:    "ZC1081",
+		Title: "Use `${#var}` to get string length instead of `wc -c`",
+		Description: "Using `echo $var | wc -c` involves a subshell and external command overhead. " +
+			"Zsh has a built-in operator `${#var}` to get the length of a string instantly.",
+		Check: checkZC1081,
+	})
+}
+
+func checkZC1081(node ast.Node) []Violation {
+	infix, ok := node.(*ast.InfixExpression)
+	if !ok {
+		return nil
+	}
+
+	if infix.Operator != "|" {
+		return nil
+	}
+
+	// Check Right side: wc -c or wc -m
+	rightCmd, ok := infix.Right.(*ast.SimpleCommand)
+	if !ok || rightCmd.Name.String() != "wc" {
+		return nil
+	}
+
+	isCharCount := false
+	for _, arg := range rightCmd.Arguments {
+		s := arg.String()
+		if strings.Contains(s, "-c") || strings.Contains(s, "-m") {
+			isCharCount = true
+			break
+		}
+	}
+
+	if !isCharCount {
+		return nil
+	}
+
+	// Check Left side: echo ... or printf ...
+	leftCmd, ok := infix.Left.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	cmdName := leftCmd.Name.String()
+	if cmdName == "echo" || cmdName == "print" || cmdName == "printf" {
+		return []Violation{{
+			KataID:  "ZC1081",
+			Message: "Use `${#var}` to get string length. Pipeline to `wc` is inefficient.",
+			Line:    infix.TokenLiteralNode().Line,
+			Column:  infix.TokenLiteralNode().Column,
+		}}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Implemented Kata ZC1081 to warn against usage of `echo $var | wc -c` or similar pipelines to calculate string length, suggesting the built-in `${#var}` instead for performance.