### PR TITLE
feat: Implement ZC1082 (Prefer expansion over sed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Kata ZC1079**: Quote RHS of `==` in `[[ ... ]]` to prevent pattern matching.
 - **Kata ZC1080**: Use `(N)` nullglob qualifier for globs in loops.
 - **Kata ZC1081**: Use `${#var}` to get string length instead of `wc -c`.
+- **Kata ZC1082**: Prefer `${var//old/new}` over `sed` for simple replacements.
 - **Documentation**: Added `TROUBLESHOOTING.md`, `GOVERNANCE.md`, `COMPARISON.md`, `GLOSSARY.md`, `CITATION.cff`.
 - **Documentation**: Expanded `KATAS.md` with new Katas.
 

--- a/KATAS.md
+++ b/KATAS.md
@@ -83,6 +83,7 @@ Comprehensive list of all 70 implemented checks, migrated from the Wiki.
 - [ZC1079: Quote RHS of `==` in `[[ ... ]]` to prevent pattern matching](#zc1079)
 - [ZC1080: Use `(N)` nullglob qualifier for globs in loops](#zc1080)
 - [ZC1081: Use `${#var}` to get string length instead of `wc -c`](#zc1081)
+- [ZC1082: Prefer `${var//old/new}` over `sed` for simple replacements](#zc1082)
 
 ---
 
@@ -2959,6 +2960,38 @@ To disable this Kata, add `ZC1081` to the `disabled_katas` list in your `.zshell
 
 [⬆ Back to Top](#table-of-contents)
 </details>
+
+
+<div id="zc1082"></div>
+
+<details>
+<summary><strong>ZC1082</strong>: Prefer `${var//old/new}` over `sed` for simple replacements <img src="https://img.shields.io/badge/Status-Active-brightgreen?style=flat-square" height="15"/></summary>
+
+### Description
+
+Using `sed` for simple string replacement is slower than Zsh's built-in parameter expansion. Use `${var/old/new}` (replace first) or `${var//old/new}` (replace all).
+
+### Bad Example
+
+```zsh
+new=$(echo $var | sed 's/foo/bar/g')
+```
+
+### Good Example
+
+```zsh
+new=${var//foo/bar}
+```
+
+### Configuration
+
+To disable this Kata, add `ZC1082` to the `disabled_katas` list in your `.zshellcheckrc` file.
+
+---
+
+[⬆ Back to Top](#table-of-contents)
+</details>
+
 
 
 

--- a/pkg/katas/katatests/zc1082_test.go
+++ b/pkg/katas/katatests/zc1082_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1082(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid expansion",
+			input:    `new=${var//foo/bar}`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "invalid sed s///",
+			input:    `new=$(echo $var | sed 's/foo/bar/')`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1082",
+					Message: "Use `${var//old/new}` for string replacement. Pipeline to `sed` is inefficient.",
+					Line:    1,
+					Column:  17,
+				},
+			},
+		},
+		{
+			name:     "invalid sed s///g",
+			input:    `new=$(echo $var | sed "s/foo/bar/g")`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1082",
+					Message: "Use `${var//old/new}` for string replacement. Pipeline to `sed` is inefficient.",
+					Line:    1,
+					Column:  17,
+				},
+			},
+		},
+		{
+			name:     "invalid sed different separator",
+			input:    `new=$(print $var | sed 's|foo|bar|')`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1082",
+					Message: "Use `${var//old/new}` for string replacement. Pipeline to `sed` is inefficient.",
+					Line:    1,
+					Column:  18,
+				},
+			},
+		},
+		{
+			name:     "valid sed other usage",
+			input:    `echo $var | sed -n '/p/p'`,
+			expected: []katas.Violation{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1082")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1082.go
+++ b/pkg/katas/zc1082.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.InfixExpressionNode, Kata{
+		ID:    "ZC1082",
+		Title: "Prefer `${var//old/new}` over `sed` for simple replacements",
+		Description: "Using `sed` for simple string replacement is slower than Zsh's built-in " +
+			"parameter expansion. Use `${var/old/new}` (replace first) or `${var//old/new}` (replace all).",
+		Check: checkZC1082,
+	})
+}
+
+func checkZC1082(node ast.Node) []Violation {
+	infix, ok := node.(*ast.InfixExpression)
+	if !ok || infix.Operator != "|" {
+		return nil
+	}
+
+	// Check Right side: sed
+	rightCmd, ok := infix.Right.(*ast.SimpleCommand)
+	if !ok || rightCmd.Name.String() != "sed" {
+		return nil
+	}
+
+	// Check Left side: echo/printf/print
+	leftCmd, ok := infix.Left.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	cmdName := leftCmd.Name.String()
+	if cmdName != "echo" && cmdName != "print" && cmdName != "printf" {
+		return nil
+	}
+
+	// Analyze sed arguments
+	for _, arg := range rightCmd.Arguments {
+		argStr := arg.String()
+		// Remove quotes
+		argStr = strings.Trim(argStr, "\"'")
+		
+		// Look for s/old/new/ or s/old/new/g
+		// Basic check: starts with s/
+		if strings.HasPrefix(argStr, "s/") || strings.HasPrefix(argStr, "s|") || strings.HasPrefix(argStr, "s@") {
+			// It's a substitution
+			return []Violation{{
+				KataID:  "ZC1082",
+				Message: "Use `${var//old/new}` for string replacement. Pipeline to `sed` is inefficient.",
+				Line:    infix.TokenLiteralNode().Line,
+				Column:  infix.TokenLiteralNode().Column,
+			}}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Implemented Kata ZC1082 to detect inefficient use of `sed` pipelines for simple string replacement (e.g., `s/old/new/g`), suggesting Zsh built-in parameter expansion `${var//old/new}` instead.