### PR TITLE
docs: move release badge inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg?token=placeholder)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![SLSA](https://img.shields.io/badge/SLSA-Level%203-brightgreen)](https://slsa.dev)
-
 ![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck)
 
 ```


### PR DESCRIPTION
Moves the release badge to be inline with the other status badges.