### PR TITLE
fix(ci): Resolve lint and Windows test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,9 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: latest
           args: --timeout=5m
+          install-mode: goinstall
 
   test:
     name: Tests
@@ -41,7 +42,7 @@ jobs:
       - name: Build
         run: go build -v ./...
       - name: Test
-        run: go test -v -coverprofile=coverage.out ./...
+        run: go test -v "-coverprofile=coverage.out" ./...
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
Fixes CI failures observed in previous runs.

- **Lint:** Configures  to build from source () using Go 1.25, as the pre-built binaries are built with older Go versions and fail to load Go 1.25 code.
- **Windows:** Quotes the  flag in FAIL	. [setup failed] to prevent argument parsing issues in PowerShell.