### PR TITLE
fix: Support absolute paths as commands

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -176,8 +176,6 @@ func (l *Lexer) NextToken() token.Token {
 		}
 	case '*':
 		tok = newToken(token.ASTERISK, l.ch, l.line, l.column)
-	case '/':
-		tok = newToken(token.SLASH, l.ch, l.line, l.column)
 	case '<':
 		switch l.peekChar() {
 		case '<':

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -47,7 +47,7 @@ func (p *Parser) parseStatement() ast.Statement {
 		}
 		return cmd
 	case token.COLON, token.DOT, token.LBRACKET,
-		token.GT, token.LT, token.GTGT, token.LTLT, token.GTAMP, token.LTAMP, token.AMPERSAND:
+		token.GT, token.LT, token.GTGT, token.LTLT, token.GTAMP, token.LTAMP, token.AMPERSAND, token.SLASH:
 		return p.parseSimpleCommandStatement()
 	case token.CASE:
 		return p.parseCaseStatement()

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -146,6 +146,7 @@ var keywords = map[string]Type{
 	"-le":      LE_NUM,
 	"-gt":      GT_NUM,
 	"-ge":      GE_NUM,
+	"/":        SLASH,
 }
 
 func LookupIdent(ident string) Type {


### PR DESCRIPTION
Fixes an issue where absolute paths starting with `/` were not correctly parsed as commands.

Changes:
- **Lexer:** Removed dedicated `/` token case to allow `readIdentifier` to consume paths starting with `/` as single `IDENT` tokens (unless separated by space).
- **Token:** Mapped the literal `/` to `token.SLASH` for correct arithmetic handling when isolated.
- **Parser:** Added `token.SLASH` to the list of tokens that can start a `SimpleCommandStatement`, ensuring `/` (root directory) can be parsed as a command if needed.