### PR TITLE
feat: Improve reporter output with colors and file location

### DIFF
--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -185,8 +185,7 @@ func processFile(filename string, out, errOut io.Writer, config Config, registry
 		case "sarif":
 			r = reporter.NewSarifReporter(out, filename)
 		default:
-			fmt.Fprintf(out, "Violations in %s:\n", filename)
-			r = reporter.NewTextReporter(out)
+			r = reporter.NewTextReporter(out, filename)
 		}
 		if err := r.Report(violations); err != nil {
 			fmt.Fprintf(errOut, "Error reporting violations: %s\n", err)

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -14,13 +14,22 @@ type Reporter interface {
 
 // TextReporter is a simple reporter that writes plain text to an io.Writer.
 type TextReporter struct {
-	writer io.Writer
+	writer   io.Writer
+	filename string
 }
 
 // NewTextReporter creates a new TextReporter.
-func NewTextReporter(writer io.Writer) *TextReporter {
-	return &TextReporter{writer: writer}
+func NewTextReporter(writer io.Writer, filename string) *TextReporter {
+	return &TextReporter{writer: writer, filename: filename}
 }
+
+const (
+	colorReset  = "\033[0m"
+	colorRed    = "\033[31m"
+	colorYellow = "\033[33m"
+	colorCyan   = "\033[36m"
+	colorBold   = "\033[1m"
+)
 
 // Report prints the violations to the writer.
 func (r *TextReporter) Report(violations []katas.Violation) error {
@@ -29,10 +38,16 @@ func (r *TextReporter) Report(violations []katas.Violation) error {
 		if !ok {
 			return fmt.Errorf("kata with ID %s not found", v.KataID)
 		}
-		_, err := fmt.Fprintf(r.writer, "%s: %s (%s)\n", v.KataID, v.Message, kata.Title)
-		if err != nil {
-			return err
-		}
+		
+		// Format: file:line:col: [ID] Message (Title)
+		// Example: demo.zsh:10:5: [ZC1001] Invalid array access (Use ${var}...)
+		
+		fmt.Fprintf(r.writer, "%s%s:%d:%d:%s %s[%s]%s %s %s(%s)%s\n",
+			colorBold, r.filename, v.Line, v.Column, colorReset,
+			colorRed, v.KataID, colorReset,
+			v.Message,
+			colorCyan, kata.Title, colorReset,
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
Enhances the CLI output to be more user-friendly and standard.

Changes:
- **TextReporter:** Now accepts a filename and prints violations in the standard `file:line:col:` format.
- **Colors:** Added ANSI color support to highlight Kata IDs (Red), Messages, and Titles (Cyan).
- **Main:** Updated to pass filenames to the reporter and removed the redundant "Violations in ..." header for text output.