### PR TITLE
feat: Add source code context to reporter

### DIFF
--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -185,7 +185,7 @@ func processFile(filename string, out, errOut io.Writer, config Config, registry
 		case "sarif":
 			r = reporter.NewSarifReporter(out, filename)
 		default:
-			r = reporter.NewTextReporter(out, filename)
+			r = reporter.NewTextReporter(out, filename, string(data))
 		}
 		if err := r.Report(violations); err != nil {
 			fmt.Fprintf(errOut, "Error reporting violations: %s\n", err)

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -26,14 +26,22 @@ func TestTextReporter_Report(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	reporter := NewTextReporter(&buf)
+	source := "first line\nsecond line\n"
+	reporter := NewTextReporter(&buf, "test.zsh", source)
+	// Update violations to include line/col
+	violations[0].Line = 1
+	violations[0].Column = 1
+
 	err := reporter.Report(violations)
 	if err != nil {
 		t.Fatalf("Report() returned an error: %v", err)
 	}
 
-	expected := "ZC9999: This is a test violation. (Test Kata)\n"
-	if buf.String() != expected {
-		t.Errorf("Report() produced incorrect output.\nGot: %q\nWant: %q", buf.String(), expected)
+	// Update expected output to match new format with colors and context
+	if !bytes.Contains(buf.Bytes(), []byte("This is a test violation.")) {
+		t.Errorf("Report() produced incorrect output.\nGot:\n%s", buf.String())
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("first line")) {
+		t.Errorf("Report() output missing source line.\nGot:\n%s", buf.String())
 	}
 }


### PR DESCRIPTION
Adds source code context to the reporter output.

Changes:
- **TextReporter:** Now requires source code string in constructor.
- **Output:** Prints the line of code where the violation occurred, with a yellow caret `^` pointing to the specific column.
- **Tests:** Updated tests to verify source code output.