### PR TITLE
fix: Ignore 'dbe' in typos check

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+dbe = "dbe"


### PR DESCRIPTION
Adds  to  to ignore the Double Bracket Expression abbreviation which was triggering false positives.