### PR TITLE
feat: Add ZC1093 — detect useless cat in pipelines

### DIFF
--- a/pkg/katas/katatests/zc1093_test.go
+++ b/pkg/katas/katatests/zc1093_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1093(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid redirect",
+			input:    `grep pattern < file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid cat with flags",
+			input:    `cat -n file.txt | head`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid cat multiple files",
+			input:    `cat file1 file2 | sort`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid useless cat",
+			input: `cat file.txt | grep pattern`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1093",
+					Message: "`cat file | command` is inefficient. Use `command < file` or pass the filename as an argument.",
+					Line:    1,
+					Column:  14,
+				},
+			},
+		},
+		{
+			name:  "invalid useless cat with sort",
+			input: `cat data.csv | sort`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1093",
+					Message: "`cat file | command` is inefficient. Use `command < file` or pass the filename as an argument.",
+					Line:    1,
+					Column:  14,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1093")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1093.go
+++ b/pkg/katas/zc1093.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.InfixExpressionNode, Kata{
+		ID:    "ZC1093",
+		Title: "Avoid useless `cat`",
+		Description: "`cat file | command` spawns an unnecessary process. " +
+			"Use `command < file` or pass the file as an argument directly.",
+		Check: checkZC1093,
+	})
+}
+
+func checkZC1093(node ast.Node) []Violation {
+	pipe, ok := node.(*ast.InfixExpression)
+	if !ok || pipe.Operator != "|" {
+		return nil
+	}
+
+	catCmd, ok := pipe.Left.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := catCmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cat" {
+		return nil
+	}
+
+	// cat with flags like -n, -v, -e is not useless
+	for _, arg := range catCmd.Arguments {
+		val := arg.String()
+		if len(val) > 0 && val[0] == '-' {
+			return nil
+		}
+	}
+
+	// Must have exactly one file argument
+	if len(catCmd.Arguments) != 1 {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1093",
+		Message: "`cat file | command` is inefficient. " +
+			"Use `command < file` or pass the filename as an argument.",
+		Line:   pipe.TokenLiteralNode().Line,
+		Column: pipe.TokenLiteralNode().Column,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 102 Katas = 0.1.2
-const Version = "0.1.2"
+// 103 Katas = 0.1.3
+const Version = "0.1.3"


### PR DESCRIPTION
## Summary

- Add ZC1093: Detect `cat file | command` patterns where cat is unnecessary
- Suggest using input redirection (`command < file`) or passing the file directly
- Skip cat with flags (`-n`, `-v`, etc.) or multiple file arguments as valid uses
- Version bump to 0.1.3 (103 katas)

## Test plan

- [x] 5 test cases: valid redirect, cat with flags, multiple files, useless cat, useless cat with sort
- [x] All tests pass locally
- [x] golangci-lint clean