### PR TITLE
feat: Add ZC1094 — prefer parameter expansion over sed

### DIFF
--- a/pkg/katas/katatests/zc1094_test.go
+++ b/pkg/katas/katatests/zc1094_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1094(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid sed with -i flag",
+			input:    `sed -i 's/foo/bar/' file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid sed with file argument",
+			input:    `sed 's/foo/bar/' file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid sed with -e flag",
+			input:    `sed -e 's/foo/bar/' -e 's/baz/qux/'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid simple sed substitution",
+			input: `sed 's/foo/bar/'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1094",
+					Message: "Use `${var//pattern/replacement}` instead of piping through `sed` for simple substitutions. Parameter expansion avoids spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid sed global substitution",
+			input: `sed 's/foo/bar/g'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1094",
+					Message: "Use `${var//pattern/replacement}` instead of piping through `sed` for simple substitutions. Parameter expansion avoids spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1094")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1094.go
+++ b/pkg/katas/zc1094.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1094",
+		Title: "Use parameter expansion instead of `sed` for simple substitutions",
+		Description: "For simple string substitutions on variables, use Zsh parameter expansion " +
+			"`${var//pattern/replacement}` instead of piping through `sed`. It avoids spawning an external process.",
+		Check: checkZC1094,
+	})
+}
+
+func checkZC1094(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sed" {
+		return nil
+	}
+
+	// Only flag simple sed invocations: sed 's/pattern/replacement/' or sed 's/pattern/replacement/g'
+	// Skip sed with flags like -i (in-place), -n, -e (multiple expressions), -f (script file)
+	hasComplexFlags := false
+	hasSubstitution := false
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if len(val) > 0 && val[0] == '-' {
+			hasComplexFlags = true
+			break
+		}
+		if len(val) >= 4 && val[0] == 's' && (val[1] == '/' || val[1] == '|' || val[1] == '#') {
+			hasSubstitution = true
+		}
+		// Also check quoted forms
+		if len(val) >= 6 && (val[0] == '\'' || val[0] == '"') {
+			inner := val[1 : len(val)-1]
+			if len(inner) >= 4 && inner[0] == 's' && (inner[1] == '/' || inner[1] == '|' || inner[1] == '#') {
+				hasSubstitution = true
+			}
+		}
+	}
+
+	if hasComplexFlags || !hasSubstitution {
+		return nil
+	}
+
+	// Only flag if sed has exactly one argument (the substitution pattern)
+	if len(cmd.Arguments) != 1 {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1094",
+		Message: "Use `${var//pattern/replacement}` instead of piping through `sed` for simple substitutions. " +
+			"Parameter expansion avoids spawning an external process.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 103 Katas = 0.1.3
-const Version = "0.1.3"
+// 104 Katas = 0.1.4
+const Version = "0.1.4"


### PR DESCRIPTION
## Summary

- Add ZC1094: Flag standalone `sed 's/pattern/replacement/'` calls replaceable with `${var//pattern/repl}`
- Skip sed with flags (-i, -e, -n) or file arguments
- Version bump to 0.1.4 (104 katas)

## Test plan

- [x] 5 test cases covering valid and invalid sed usage
- [x] All tests pass, golangci-lint clean