### PR TITLE
feat: Add ZC1095 — use Zsh builtins instead of seq

### DIFF
--- a/pkg/katas/katatests/zc1095_test.go
+++ b/pkg/katas/katatests/zc1095_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1095(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid seq with range",
+			input:    `seq 1 10`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid seq with step",
+			input:    `seq 1 2 10`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid seq with single number",
+			input: `seq 5`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1095",
+					Message: "Use `repeat N do ... done` or `for i in {1..N}` instead of `seq N`. Zsh has built-in constructs for repetition that avoid spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid seq with large number",
+			input: `seq 100`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1095",
+					Message: "Use `repeat N do ... done` or `for i in {1..N}` instead of `seq N`. Zsh has built-in constructs for repetition that avoid spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:     "valid non-numeric argument",
+			input:    `seq abc`,
+			expected: []katas.Violation{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1095")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1095.go
+++ b/pkg/katas/zc1095.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1095",
+		Title: "Use `repeat N` for simple repetition",
+		Description: "Zsh provides `repeat N do ... done` for running a block a fixed number of times. " +
+			"It is cleaner than `for i in {1..N}` or C-style for loops when the iterator variable is unused.",
+		Check: checkZC1095,
+	})
+}
+
+func checkZC1095(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "seq" {
+		return nil
+	}
+
+	// Flag bare `seq N` calls (often used in `for i in $(seq N)`)
+	// Only flag if seq has exactly one numeric argument
+	if len(cmd.Arguments) != 1 {
+		return nil
+	}
+
+	arg := cmd.Arguments[0].String()
+	for _, ch := range arg {
+		if ch < '0' || ch > '9' {
+			return nil
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1095",
+		Message: "Use `repeat N do ... done` or `for i in {1..N}` instead of `seq N`. " +
+			"Zsh has built-in constructs for repetition that avoid spawning an external process.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 104 Katas = 0.1.4
-const Version = "0.1.4"
+// 105 Katas = 0.1.5
+const Version = "0.1.5"


### PR DESCRIPTION
## Summary

- Add ZC1095: Flag `seq N` calls replaceable with Zsh builtins (`repeat N`, `{1..N}`)
- Skip seq with range/step arguments
- Version bump to 0.1.5 (105 katas)

## Test plan

- [x] 5 test cases: valid range, valid step, invalid single number, invalid large number, non-numeric
- [x] All tests pass, golangci-lint clean