### PR TITLE
feat: Add ZC1100 — prefer parameter expansion over dirname/basename

### DIFF
--- a/pkg/katas/katatests/zc1100_test.go
+++ b/pkg/katas/katatests/zc1100_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1100(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid basename with suffix flag",
+			input:    `basename -s .txt file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid basename with multiple args",
+			input:    `basename /path/to/file .txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid simple dirname",
+			input: `dirname /path/to/file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1100",
+					Message: "Use `${var%/*}` instead of `dirname` to extract the directory path. Parameter expansion avoids spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid simple basename",
+			input: `basename /path/to/file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1100",
+					Message: "Use `${var##*/}` instead of `basename` to extract the filename. Parameter expansion avoids spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1100")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1100.go
+++ b/pkg/katas/zc1100.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1100",
+		Title: "Use parameter expansion instead of `dirname`/`basename`",
+		Description: "Zsh parameter expansion `${var%/*}` (dirname) and `${var##*/}` (basename) " +
+			"avoid spawning external processes for simple path manipulation.",
+		Check: checkZC1100,
+	})
+}
+
+func checkZC1100(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	name := ident.Value
+	if name != "dirname" && name != "basename" {
+		return nil
+	}
+
+	// Only flag simple single-argument calls
+	// basename with -s or -a flags is more complex
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if len(val) > 0 && val[0] == '-' {
+			return nil
+		}
+	}
+
+	if len(cmd.Arguments) != 1 {
+		return nil
+	}
+
+	var msg string
+	if name == "dirname" {
+		msg = "Use `${var%/*}` instead of `dirname` to extract the directory path. " +
+			"Parameter expansion avoids spawning an external process."
+	} else {
+		msg = "Use `${var##*/}` instead of `basename` to extract the filename. " +
+			"Parameter expansion avoids spawning an external process."
+	}
+
+	return []Violation{{
+		KataID:  "ZC1100",
+		Message: msg,
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 105 Katas = 0.1.5
-const Version = "0.1.5"
+// 106 Katas = 0.1.6
+const Version = "0.1.6"


### PR DESCRIPTION
## Summary

- Add ZC1100: Flag simple `dirname`/`basename` calls replaceable with `${var%/*}` and `${var##*/}`
- Skip calls with flags or multiple arguments
- Version bump to 0.1.6 (106 katas)

## Test plan

- [x] 4 test cases: suffix flag, multiple args, simple dirname, simple basename
- [x] All tests pass, golangci-lint clean