### PR TITLE
feat: Add ZC1108 — use Zsh case conversion instead of tr

### DIFF
--- a/pkg/katas/katatests/zc1108_test.go
+++ b/pkg/katas/katatests/zc1108_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1108(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid tr delete",
+			input:    `tr -d '\n'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid tr squeeze",
+			input:    `tr -s ' '`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid tr with different sets",
+			input:    `tr ':' '\n'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid tr lowercase to uppercase POSIX",
+			input: `tr '[:lower:]' '[:upper:]'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1108",
+					Message: "Use `${(U)var}` for case conversion instead of `tr`. Zsh parameter expansion flags avoid spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid tr uppercase to lowercase range",
+			input: `tr 'A-Z' 'a-z'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1108",
+					Message: "Use `${(L)var}` for case conversion instead of `tr`. Zsh parameter expansion flags avoid spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1108")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1108.go
+++ b/pkg/katas/zc1108.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1108",
+		Title: "Use Zsh case conversion instead of `tr`",
+		Description: "Zsh provides `${(U)var}` for uppercase and `${(L)var}` for lowercase. " +
+			"Avoid piping through `tr '[:lower:]' '[:upper:]'` for simple case conversion.",
+		Check: checkZC1108,
+	})
+}
+
+func checkZC1108(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "tr" {
+		return nil
+	}
+
+	if len(cmd.Arguments) != 2 {
+		return nil
+	}
+
+	arg1 := strings.Trim(cmd.Arguments[0].String(), "'\"")
+	arg2 := strings.Trim(cmd.Arguments[1].String(), "'\"")
+
+	isLowerToUpper := (arg1 == "[:lower:]" && arg2 == "[:upper:]") ||
+		(arg1 == "a-z" && arg2 == "A-Z")
+	isUpperToLower := (arg1 == "[:upper:]" && arg2 == "[:lower:]") ||
+		(arg1 == "A-Z" && arg2 == "a-z")
+
+	if !isLowerToUpper && !isUpperToLower {
+		return nil
+	}
+
+	var suggestion string
+	if isLowerToUpper {
+		suggestion = "`${(U)var}`"
+	} else {
+		suggestion = "`${(L)var}`"
+	}
+
+	return []Violation{{
+		KataID: "ZC1108",
+		Message: "Use " + suggestion + " for case conversion instead of `tr`. " +
+			"Zsh parameter expansion flags avoid spawning an external process.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 106 Katas = 0.1.6
-const Version = "0.1.6"
+// 108 Katas = 0.1.8
+const Version = "0.1.8"


### PR DESCRIPTION
## Summary

- Add ZC1108: Flag `tr` for case conversion, suggest `${(U)var}` / `${(L)var}`
- Supports both POSIX class and range syntax detection
- Version bump to 0.1.8 (108 katas)

## Test plan

- [x] 5 test cases: delete, squeeze, different sets, lower-to-upper, upper-to-lower
- [x] All tests pass, golangci-lint clean