### PR TITLE
feat: Add ZC1109 — prefer parameter expansion over cut

### DIFF
--- a/pkg/katas/katatests/zc1109_test.go
+++ b/pkg/katas/katatests/zc1109_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1109(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid cut with file",
+			input:    `cut -d: -f1 /etc/passwd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid cut with only field",
+			input:    `cut -f1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid cut in pipeline",
+			input: `cut -d: -f1`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1109",
+					Message: "Use Zsh parameter expansion for field extraction instead of `cut`. `${var%%delim*}` or `${(s.delim.)var}` avoid spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid cut with delimiter and field",
+			input: `cut -d',' -f2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1109",
+					Message: "Use Zsh parameter expansion for field extraction instead of `cut`. `${var%%delim*}` or `${(s.delim.)var}` avoid spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1109")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1109.go
+++ b/pkg/katas/zc1109.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1109",
+		Title: "Use parameter expansion instead of `cut` for field extraction",
+		Description: "For simple field extraction from variables, use Zsh parameter expansion " +
+			"like `${var%%:*}` or `${(s.:.)var}` instead of piping through `cut`.",
+		Check: checkZC1109,
+	})
+}
+
+func checkZC1109(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cut" {
+		return nil
+	}
+
+	// Only flag simple cut with -d and -f flags and no file argument
+	hasDelimiter := false
+	hasField := false
+	hasFileArg := false
+
+	for _, arg := range cmd.Arguments {
+		val := strings.Trim(arg.String(), "'\"")
+		switch {
+		case strings.HasPrefix(val, "-d"), strings.HasPrefix(val, "--delimiter"):
+			hasDelimiter = true
+		case strings.HasPrefix(val, "-f"), strings.HasPrefix(val, "--fields"):
+			hasField = true
+		case len(val) > 0 && val[0] != '-':
+			hasFileArg = true
+		}
+	}
+
+	if hasFileArg || !hasDelimiter || !hasField {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1109",
+		Message: "Use Zsh parameter expansion for field extraction instead of `cut`. " +
+			"`${var%%delim*}` or `${(s.delim.)var}` avoid spawning an external process.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+	}}
+}


### PR DESCRIPTION
## Summary

- Add ZC1109: Flag `cut -d -f` pipeline usage replaceable with `${var%%:*}` or `${(s.:.)var}`
- Skip cut with file arguments
- Aligns kata count (109) with version 0.1.9

## Test plan

- [x] 4 test cases: file arg, field-only, pipeline delimiter+field, pipeline quoted delimiter
- [x] All tests pass, golangci-lint clean