### PR TITLE
feat: Add ZC1110 — use Zsh subscripts instead of head/tail -1

### DIFF
--- a/pkg/katas/katatests/zc1110_test.go
+++ b/pkg/katas/katatests/zc1110_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1110(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid head with file",
+			input:    `head -1 file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid head -5",
+			input:    `head -5`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid tail with file",
+			input:    `tail -1 file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid head -1 in pipeline",
+			input: `head -1`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1110",
+					Message: "Use `${lines[1]}` instead of `head -1`. Zsh array subscripts avoid spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid tail -1 in pipeline",
+			input: `tail -1`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1110",
+					Message: "Use `${lines[-1]}` instead of `tail -1`. Zsh array subscripts avoid spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid head -n 1",
+			input: `head -n 1`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1110",
+					Message: "Use `${lines[1]}` instead of `head -1`. Zsh array subscripts avoid spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1110")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1110.go
+++ b/pkg/katas/zc1110.go
@@ -1,0 +1,73 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1110",
+		Title: "Use Zsh subscripts instead of `head -1` or `tail -1`",
+		Description: "Zsh array subscripts `${lines[1]}` and `${lines[-1]}` can extract the first or last " +
+			"element without spawning `head` or `tail` as external processes.",
+		Check: checkZC1110,
+	})
+}
+
+func checkZC1110(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	name := ident.Value
+	if name != "head" && name != "tail" {
+		return nil
+	}
+
+	// Only flag `head -1` / `head -n 1` / `tail -1` / `tail -n 1` without file args
+	hasFileArg := false
+	isSingleLine := false
+	skipNext := false
+
+	for i, arg := range cmd.Arguments {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		val := arg.String()
+		switch {
+		case val == "-1" || val == "-n1":
+			isSingleLine = true
+		case val == "-n" && i+1 < len(cmd.Arguments) && cmd.Arguments[i+1].String() == "1":
+			isSingleLine = true
+			skipNext = true
+		case len(val) > 0 && val[0] != '-':
+			hasFileArg = true
+		}
+	}
+
+	if hasFileArg || !isSingleLine {
+		return nil
+	}
+
+	var suggestion string
+	if name == "head" {
+		suggestion = "`${lines[1]}`"
+	} else {
+		suggestion = "`${lines[-1]}`"
+	}
+
+	return []Violation{{
+		KataID: "ZC1110",
+		Message: "Use " + suggestion + " instead of `" + name + " -1`. " +
+			"Zsh array subscripts avoid spawning an external process.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 109 Katas = 0.1.9
-const Version = "0.1.9"
+// 110 Katas = 0.1.10
+const Version = "0.1.10"


### PR DESCRIPTION
## Summary

- Add ZC1110: Flag `head -1` and `tail -1` pipeline usage, suggest `${lines[1]}` / `${lines[-1]}`
- Supports `-1`, `-n1`, `-n 1` flag forms
- Skip calls with file arguments
- Version bump to 0.1.10 (110 katas)

## Test plan

- [x] 6 test cases covering valid and invalid head/tail usage
- [x] All tests pass, golangci-lint clean