### PR TITLE
feat: Add ZC1111 — use Zsh array iteration instead of xargs

### DIFF
--- a/pkg/katas/katatests/zc1111_test.go
+++ b/pkg/katas/katatests/zc1111_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1111(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid xargs with null separator",
+			input:    `xargs -0 rm`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid xargs with parallel",
+			input:    `xargs -P 4 cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid xargs with replace",
+			input:    `xargs -I {} mv {} /dest`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid simple xargs",
+			input: `xargs rm`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1111",
+					Message: "Consider using Zsh array iteration instead of `xargs`. `for item in ${(f)$(cmd)}` splits output by newlines without spawning xargs.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid xargs with command only",
+			input: `xargs grep pattern`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1111",
+					Message: "Consider using Zsh array iteration instead of `xargs`. `for item in ${(f)$(cmd)}` splits output by newlines without spawning xargs.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1111")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1111.go
+++ b/pkg/katas/zc1111.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1111",
+		Title: "Avoid `xargs` for simple command invocation",
+		Description: "Zsh can iterate arrays directly with `for` loops or use `${(f)...}` to split " +
+			"command output by newlines. Avoid `xargs` when processing lines one at a time.",
+		Check: checkZC1111,
+	})
+}
+
+func checkZC1111(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "xargs" {
+		return nil
+	}
+
+	// Only flag simple xargs without complex flags
+	// -0, -P (parallel), -I (replace string), -L are complex uses — skip them
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if len(val) > 1 && val[0] == '-' {
+			switch {
+			case val == "-0", val == "--null":
+				return nil
+			case val == "-P", val == "--max-procs":
+				return nil
+			case val == "-I", val == "--replace":
+				return nil
+			case val == "-L", val == "--max-lines":
+				return nil
+			case val == "-p", val == "--interactive":
+				return nil
+			}
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1111",
+		Message: "Consider using Zsh array iteration instead of `xargs`. " +
+			"`for item in ${(f)$(cmd)}` splits output by newlines without spawning xargs.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 110 Katas = 0.1.10
-const Version = "0.1.10"
+// 111 Katas = 0.1.11
+const Version = "0.1.11"


### PR DESCRIPTION
## Summary

- Add ZC1111: Flag simple `xargs` usage, suggest `for item in ${(f)$(cmd)}` Zsh pattern
- Skip xargs with complex flags (-0, -P, -I, -L, -p)
- Version bump to 0.1.11 (111 katas)

## Test plan

- [x] 5 test cases: null sep, parallel, replace, simple xargs, xargs with cmd
- [x] All tests pass, golangci-lint clean