### PR TITLE
feat: Add ZC1112 — use Zsh pattern matching instead of grep -c

### DIFF
--- a/pkg/katas/katatests/zc1112_test.go
+++ b/pkg/katas/katatests/zc1112_test.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1112(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid grep -c with file",
+			input:    `grep -c pattern file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid grep without -c",
+			input:    `grep pattern`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid grep -c in pipeline",
+			input: `grep -c pattern`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1112",
+					Message: "Use Zsh array filtering `${(M)array:#pattern}` or `${#${(f)...}}` for counting instead of `grep -c`. Avoids spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:     "valid grep -v (not count)",
+			input:    `grep -v pattern`,
+			expected: []katas.Violation{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1112")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1112.go
+++ b/pkg/katas/zc1112.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1112",
+		Title: "Avoid `grep -c` — use Zsh pattern matching for counting",
+		Description: "For counting matches in a variable, use Zsh `${#${(f)...}}` or array filtering " +
+			"with `${(M)array:#pattern}` instead of piping through `grep -c`.",
+		Check: checkZC1112,
+	})
+}
+
+func checkZC1112(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "grep" {
+		return nil
+	}
+
+	// Only flag grep -c without file arguments (pipeline use)
+	hasCountFlag := false
+	hasFileAfterPattern := false
+	patternSeen := false
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if len(val) > 0 && val[0] == '-' {
+			if val == "-c" || val == "--count" {
+				hasCountFlag = true
+			}
+		} else {
+			if patternSeen {
+				hasFileAfterPattern = true
+				break
+			}
+			patternSeen = true
+		}
+	}
+
+	if !hasCountFlag || hasFileAfterPattern {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1112",
+		Message: "Use Zsh array filtering `${(M)array:#pattern}` or `${#${(f)...}}` for counting " +
+			"instead of `grep -c`. Avoids spawning an external process.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 111 Katas = 0.1.11
-const Version = "0.1.11"
+// 112 Katas = 0.1.12
+const Version = "0.1.12"


### PR DESCRIPTION
## Summary

- Add ZC1112: Flag `grep -c` pipeline usage, suggest `${(M)array:#pattern}` for counting
- Skip grep -c with file arguments
- Version bump to 0.1.12 (112 katas)

## Test plan

- [x] 4 test cases: with file, without -c, pipeline -c, -v flag
- [x] All tests pass, golangci-lint clean