### PR TITLE
feat: Add ZC1113 — use Zsh path modifiers instead of realpath/readlink

### DIFF
--- a/pkg/katas/katatests/zc1113_test.go
+++ b/pkg/katas/katatests/zc1113_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1113(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid readlink without resolve flag",
+			input:    `readlink /path/to/link`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid realpath",
+			input: `realpath /path/to/file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1113",
+					Message: "Use `${var:A}` instead of `realpath` to resolve absolute paths. Zsh path modifiers avoid spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid readlink -f",
+			input: `readlink -f /path/to/link`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1113",
+					Message: "Use `${var:A}` instead of `readlink -f` to resolve absolute paths. Zsh path modifiers avoid spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:     "valid realpath with complex flags",
+			input:    `realpath --relative-to /base /path`,
+			expected: []katas.Violation{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1113")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1113.go
+++ b/pkg/katas/zc1113.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1113",
+		Title: "Use `${var:A}` instead of `realpath` or `readlink -f`",
+		Description: "Zsh provides the `:A` modifier to resolve a path to its absolute form, " +
+			"following symlinks. Avoid spawning `realpath` or `readlink -f` as external processes.",
+		Check: checkZC1113,
+	})
+}
+
+func checkZC1113(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	name := ident.Value
+
+	if name == "realpath" {
+		for _, arg := range cmd.Arguments {
+			val := arg.String()
+			if len(val) > 1 && val[0] == '-' && val != "-s" {
+				return nil
+			}
+		}
+		return []Violation{{
+			KataID: "ZC1113",
+			Message: "Use `${var:A}` instead of `realpath` to resolve absolute paths. " +
+				"Zsh path modifiers avoid spawning an external process.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+		}}
+	}
+
+	if name == "readlink" {
+		hasResolveFlag := false
+		for _, arg := range cmd.Arguments {
+			val := arg.String()
+			if val == "-f" || val == "-e" || val == "-m" {
+				hasResolveFlag = true
+			}
+		}
+		if !hasResolveFlag {
+			return nil
+		}
+		return []Violation{{
+			KataID: "ZC1113",
+			Message: "Use `${var:A}` instead of `readlink -f` to resolve absolute paths. " +
+				"Zsh path modifiers avoid spawning an external process.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 112 Katas = 0.1.12
-const Version = "0.1.12"
+// 113 Katas = 0.1.13
+const Version = "0.1.13"


### PR DESCRIPTION
## Summary

- Add ZC1113: Flag `realpath` and `readlink -f` calls, suggest `${var:A}`
- Skip readlink without resolve flags and realpath with complex flags
- Version bump to 0.1.13 (113 katas)

## Test plan

- [x] 4 test cases covering valid and invalid usage
- [x] All tests pass, golangci-lint clean