### PR TITLE
feat: Add ZC1114 — consider Zsh process substitution over mktemp

### DIFF
--- a/pkg/katas/katatests/zc1114_test.go
+++ b/pkg/katas/katatests/zc1114_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1114(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid mktemp -d",
+			input:    `mktemp -d`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid mktemp",
+			input: `mktemp /tmp/zsh.XXXXXX`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1114",
+					Message: "Consider using Zsh `=(cmd)` for temporary files instead of `mktemp`. Zsh auto-cleans temporary files created with `=(...)` process substitution.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid bare mktemp",
+			input: `mktemp -t prefix`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1114",
+					Message: "Consider using Zsh `=(cmd)` for temporary files instead of `mktemp`. Zsh auto-cleans temporary files created with `=(...)` process substitution.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1114")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1114.go
+++ b/pkg/katas/zc1114.go
@@ -1,0 +1,43 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1114",
+		Title: "Consider Zsh `=(...)` for temporary files",
+		Description: "Zsh `=(cmd)` creates a temporary file with the command output that is automatically " +
+			"cleaned up. Consider this instead of manual `mktemp` and cleanup patterns.",
+		Check: checkZC1114,
+	})
+}
+
+func checkZC1114(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "mktemp" {
+		return nil
+	}
+
+	// Skip mktemp -d (directory creation — no Zsh equivalent)
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-d" {
+			return nil
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1114",
+		Message: "Consider using Zsh `=(cmd)` for temporary files instead of `mktemp`. " +
+			"Zsh auto-cleans temporary files created with `=(...)` process substitution.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 113 Katas = 0.1.13
-const Version = "0.1.13"
+// 114 Katas = 0.1.14
+const Version = "0.1.14"


### PR DESCRIPTION
## Summary

- Add ZC1114: Flag `mktemp` calls, suggest Zsh `=(cmd)` for auto-cleanup temp files
- Skip `mktemp -d` (directories have no Zsh equivalent)
- Version bump to 0.1.14 (114 katas)

## Test plan

- [x] 3 test cases: mktemp -d (valid), mktemp with template, mktemp with -t
- [x] All tests pass, golangci-lint clean