### PR TITLE
feat: Add ZC1115 — use Zsh string manipulation instead of rev

### DIFF
--- a/pkg/katas/katatests/zc1115_test.go
+++ b/pkg/katas/katatests/zc1115_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1115(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid rev with file",
+			input:    `rev file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid rev in pipeline",
+			input: `rev -`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1115",
+					Message: "Use Zsh string manipulation instead of `rev`. Parameter expansion can reverse strings without spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1115")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1115.go
+++ b/pkg/katas/zc1115.go
@@ -1,0 +1,43 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1115",
+		Title: "Use Zsh string manipulation instead of `rev`",
+		Description: "Zsh can reverse strings using parameter expansion. " +
+			"Avoid spawning `rev` as an external process for simple string reversal.",
+		Check: checkZC1115,
+	})
+}
+
+func checkZC1115(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "rev" {
+		return nil
+	}
+
+	// Only flag rev without file arguments (pipeline use)
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if len(val) > 0 && val[0] != '-' {
+			return nil
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1115",
+		Message: "Use Zsh string manipulation instead of `rev`. " +
+			"Parameter expansion can reverse strings without spawning an external process.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 114 Katas = 0.1.14
-const Version = "0.1.14"
+// 115 Katas = 0.1.15
+const Version = "0.1.15"


### PR DESCRIPTION
## Summary

- Add ZC1115: Flag `rev` pipeline usage, suggest Zsh parameter expansion
- Skip rev with file arguments
- Version bump to 0.1.15 (115 katas)

## Test plan

- [x] 2 test cases: rev with file (valid), rev in pipeline (invalid)
- [x] All tests pass, golangci-lint clean