### PR TITLE
feat: Add ZC1116 — use Zsh multios instead of tee

### DIFF
--- a/pkg/katas/katatests/zc1116_test.go
+++ b/pkg/katas/katatests/zc1116_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1116(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid tee with append",
+			input:    `tee -a logfile`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid simple tee",
+			input: `tee output.log`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1116",
+					Message: "Use Zsh multios (`setopt multios`) instead of `tee`. With multios, `cmd > file1 > file2` writes to both files without spawning tee.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid tee with multiple files",
+			input: `tee file1 file2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1116",
+					Message: "Use Zsh multios (`setopt multios`) instead of `tee`. With multios, `cmd > file1 > file2` writes to both files without spawning tee.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1116")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1116.go
+++ b/pkg/katas/zc1116.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1116",
+		Title: "Use Zsh multios instead of `tee`",
+		Description: "Zsh `setopt multios` allows redirecting output to multiple files with " +
+			"`cmd > file1 > file2`. Avoid spawning `tee` for simple output duplication.",
+		Check: checkZC1116,
+	})
+}
+
+func checkZC1116(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "tee" {
+		return nil
+	}
+
+	// Only flag simple tee without -a (append) or -i (ignore interrupt)
+	// tee -a is append mode which multios handles differently
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if len(val) > 0 && val[0] == '-' {
+			return nil
+		}
+	}
+
+	// Must have at least one file argument
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1116",
+		Message: "Use Zsh multios (`setopt multios`) instead of `tee`. " +
+			"With multios, `cmd > file1 > file2` writes to both files without spawning tee.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 115 Katas = 0.1.15
-const Version = "0.1.15"
+// 116 Katas = 0.1.16
+const Version = "0.1.16"


### PR DESCRIPTION
## Summary

- Add ZC1116: Flag simple `tee` calls, suggest Zsh multios (`setopt multios`)
- Skip tee with flags (-a, -i)
- Version bump to 0.1.16 (116 katas)

## Test plan

- [x] 3 test cases: tee -a (valid), simple tee, tee with multiple files
- [x] All tests pass, golangci-lint clean