### PR TITLE
feat: Add ZC1117 — use Zsh disown instead of nohup

### DIFF
--- a/pkg/katas/katatests/zc1117_test.go
+++ b/pkg/katas/katatests/zc1117_test.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1117(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:  "invalid nohup usage",
+			input: `nohup ./server`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1117",
+					Message: "Use `cmd &!` or `cmd & disown` instead of `nohup cmd &`. Zsh `&!` is a built-in shorthand that avoids spawning nohup.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid nohup with redirect",
+			input: `nohup ./server > /dev/null`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1117",
+					Message: "Use `cmd &!` or `cmd & disown` instead of `nohup cmd &`. Zsh `&!` is a built-in shorthand that avoids spawning nohup.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1117")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1117.go
+++ b/pkg/katas/zc1117.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1117",
+		Title: "Use `&!` or `disown` instead of `nohup`",
+		Description: "Zsh provides `&!` (shorthand for `& disown`) to run a command in the background " +
+			"immune to hangups. Avoid spawning `nohup` as an external process.",
+		Check: checkZC1117,
+	})
+}
+
+func checkZC1117(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "nohup" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1117",
+		Message: "Use `cmd &!` or `cmd & disown` instead of `nohup cmd &`. " +
+			"Zsh `&!` is a built-in shorthand that avoids spawning nohup.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 116 Katas = 0.1.16
-const Version = "0.1.16"
+// 117 Katas = 0.1.17
+const Version = "0.1.17"


### PR DESCRIPTION
## Summary

- Add ZC1117: Flag `nohup` usage, suggest Zsh `&!` or `disown`
- Version bump to 0.1.17 (117 katas)

## Test plan

- [x] 2 test cases: nohup basic, nohup with redirect
- [x] All tests pass, golangci-lint clean