### PR TITLE
fix: Update release-drafter action to resolvable SHA

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Draft next release
-        uses: release-drafter/release-drafter@3f0f87098bd6b5c5b947848f6e70e2586851638d # v6.0.0
+        uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary

- Fix release-drafter workflow that has been failing on every push to main
- Replace stale `release-drafter/release-drafter` SHA with current v6 commit

## Test plan

- [ ] Release Drafter workflow succeeds on merge to main