### PR TITLE
feat: Add ZC1118 — use print -rn instead of echo -n

### DIFF
--- a/pkg/katas/katatests/zc1118_test.go
+++ b/pkg/katas/katatests/zc1118_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1118(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid echo without -n",
+			input:    `echo hello`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid print -rn",
+			input:    `print -rn hello`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid echo -n",
+			input: `echo -n hello`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1118",
+					Message: "Use `print -rn` instead of `echo -n`. `echo -n` behavior varies across shells; `print -rn` is the reliable Zsh idiom.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1118")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1118.go
+++ b/pkg/katas/zc1118.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1118",
+		Title: "Use `print -rn` instead of `echo -n`",
+		Description: "The behavior of `echo -n` varies across shells and platforms. " +
+			"In Zsh, `print -rn` is the reliable way to output text without a trailing newline.",
+		Check: checkZC1118,
+	})
+}
+
+func checkZC1118(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "echo" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	firstArg := cmd.Arguments[0].String()
+	if firstArg == "-n" {
+		return []Violation{{
+			KataID: "ZC1118",
+			Message: "Use `print -rn` instead of `echo -n`. " +
+				"`echo -n` behavior varies across shells; `print -rn` is the reliable Zsh idiom.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 117 Katas = 0.1.17
-const Version = "0.1.17"
+// 118 Katas = 0.1.18
+const Version = "0.1.18"


### PR DESCRIPTION
## Summary

- Add ZC1118: Flag `echo -n` usage, suggest `print -rn` for reliable Zsh output
- Version bump to 0.1.18 (118 katas)

## Test plan

- [x] 3 test cases: echo without -n, print -rn, echo -n
- [x] All tests pass, golangci-lint clean