### PR TITLE
feat: Add ZC1119 — use EPOCHSECONDS instead of date +%s

### DIFF
--- a/pkg/katas/katatests/zc1119_test.go
+++ b/pkg/katas/katatests/zc1119_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1119(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid date with format",
+			input:    `date "+%Y-%m-%d"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid date no args",
+			input:    `date -u`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid date +%s",
+			input: `date '+%s'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1119",
+					Message: "Use `$EPOCHSECONDS` or `$EPOCHREALTIME` (via `zmodload zsh/datetime`) instead of `date +%s`. Avoids spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1119")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1119.go
+++ b/pkg/katas/zc1119.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1119",
+		Title: "Use `$EPOCHSECONDS` instead of `date +%s`",
+		Description: "Zsh provides `$EPOCHSECONDS` and `$EPOCHREALTIME` via `zsh/datetime` module. " +
+			"Avoid spawning `date` for simple Unix timestamp retrieval.",
+		Check: checkZC1119,
+	})
+}
+
+func checkZC1119(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "date" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := strings.Trim(arg.String(), "'\"")
+		if val == "+%s" || val == "+%s%N" {
+			return []Violation{{
+				KataID: "ZC1119",
+				Message: "Use `$EPOCHSECONDS` or `$EPOCHREALTIME` (via `zmodload zsh/datetime`) " +
+					"instead of `date +%s`. Avoids spawning an external process.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 118 Katas = 0.1.18
-const Version = "0.1.18"
+// 119 Katas = 0.1.19
+const Version = "0.1.19"


### PR DESCRIPTION
## Summary

- Add ZC1119: Flag `date +%s` calls, suggest `$EPOCHSECONDS` via zsh/datetime
- Skip date with other format strings
- Version bump to 0.1.19 (119 katas)

## Test plan

- [x] 3 test cases: date with format, date -u, date +%s
- [x] All tests pass, golangci-lint clean