### PR TITLE
feat: Add ZC1120 — use $PWD instead of pwd command

### DIFF
--- a/pkg/katas/katatests/zc1120_test.go
+++ b/pkg/katas/katatests/zc1120_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1120(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid pwd -P",
+			input:    `pwd -P`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid bare pwd",
+			input: `pwd -L`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1120",
+					Message: "Use `$PWD` instead of `pwd`. Zsh maintains `$PWD` as a built-in variable, avoiding an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1120")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1120.go
+++ b/pkg/katas/zc1120.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1120",
+		Title: "Use `$PWD` instead of `pwd`",
+		Description: "Zsh maintains `$PWD` as a built-in variable tracking the current directory. " +
+			"Avoid spawning `pwd` as an external process.",
+		Check: checkZC1120,
+	})
+}
+
+func checkZC1120(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "pwd" {
+		return nil
+	}
+
+	// pwd -P (physical) resolves symlinks — $PWD may not
+	// Only flag bare pwd or pwd -L (logical, same as $PWD)
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-P" {
+			return nil
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1120",
+		Message: "Use `$PWD` instead of `pwd`. " +
+			"Zsh maintains `$PWD` as a built-in variable, avoiding an external process.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 119 Katas = 0.1.19
-const Version = "0.1.19"
+// 120 Katas = 0.1.20
+const Version = "0.1.20"


### PR DESCRIPTION
## Summary

- Add ZC1120: Flag `pwd` calls, suggest `$PWD` built-in variable
- Skip `pwd -P` (physical path resolution differs from `$PWD`)
- Version bump to 0.1.20 (120 katas)

## Test plan

- [x] 2 test cases: pwd -P (valid), pwd -L (invalid)
- [x] All tests pass, golangci-lint clean