### PR TITLE
feat: Add ZC1124 — use : builtin instead of cat /dev/null

### DIFF
--- a/pkg/katas/katatests/zc1124_test.go
+++ b/pkg/katas/katatests/zc1124_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1124(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid cat with file",
+			input:    `cat readme.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid cat /dev/null",
+			input: `cat /dev/null`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1124",
+					Message: "Use `: > file` instead of `cat /dev/null > file` to truncate. The `:` builtin avoids spawning cat.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1124")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1124.go
+++ b/pkg/katas/zc1124.go
@@ -1,0 +1,42 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1124",
+		Title: "Use `: > file` instead of `cat /dev/null > file` to truncate",
+		Description: "Truncating a file with `cat /dev/null > file` spawns an unnecessary process. " +
+			"Use `: > file` or simply `> file` in Zsh.",
+		Check: checkZC1124,
+	})
+}
+
+func checkZC1124(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cat" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "/dev/null" {
+			return []Violation{{
+				KataID: "ZC1124",
+				Message: "Use `: > file` instead of `cat /dev/null > file` to truncate. " +
+					"The `:` builtin avoids spawning cat.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 123 Katas = 0.1.23
-const Version = "0.1.23"
+// 124 Katas = 0.1.24
+const Version = "0.1.24"


### PR DESCRIPTION
## Summary

- Add ZC1124: Flag `cat /dev/null` truncation, suggest `: > file`
- Version bump to 0.1.24 (124 katas)

## Test plan

- [x] 2 test cases: cat with file (valid), cat /dev/null (invalid)
- [x] All tests pass, golangci-lint clean