### PR TITLE
feat: Add ZC1125 — use Zsh pattern matching instead of grep -q

### DIFF
--- a/pkg/katas/katatests/zc1125_test.go
+++ b/pkg/katas/katatests/zc1125_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1125(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid grep -q with file",
+			input:    `grep -q pattern file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid grep without -q",
+			input:    `grep pattern`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid grep -q in pipeline",
+			input: `grep -q pattern`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1125",
+					Message: "Use `[[ $var =~ pattern ]]` or `[[ $var == *pattern* ]]` instead of piping through `grep -q`. Zsh pattern matching avoids spawning external processes.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1125")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1125.go
+++ b/pkg/katas/zc1125.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:    "ZC1125",
+		Title: "Avoid `echo | grep` for string matching",
+		Description: "Using `echo $var | grep pattern` spawns two unnecessary processes. " +
+			"Use Zsh `[[ $var =~ pattern ]]` or `[[ $var == *pattern* ]]` for string matching.",
+		Check: checkZC1125,
+	})
+}
+
+func checkZC1125(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "grep" {
+		return nil
+	}
+
+	// Only flag grep with -q (quiet) and no file argument
+	// grep -q is typically used for string matching in conditionals
+	hasQuiet := false
+	hasFile := false
+	patternSeen := false
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if len(val) > 0 && val[0] == '-' {
+			if val == "-q" {
+				hasQuiet = true
+			}
+		} else {
+			if patternSeen {
+				hasFile = true
+				break
+			}
+			patternSeen = true
+		}
+	}
+
+	if !hasQuiet || hasFile {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1125",
+		Message: "Use `[[ $var =~ pattern ]]` or `[[ $var == *pattern* ]]` instead of piping " +
+			"through `grep -q`. Zsh pattern matching avoids spawning external processes.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 124 Katas = 0.1.24
-const Version = "0.1.24"
+// 125 Katas = 0.1.25
+const Version = "0.1.25"


### PR DESCRIPTION
## Summary

- Add ZC1125: Flag `grep -q` pipeline usage, suggest `[[ $var =~ pattern ]]`
- Skip grep -q with file arguments
- Version bump to 0.1.25 (125 katas)

## Test plan

- [x] 3 test cases: grep -q with file, grep without -q, grep -q in pipeline
- [x] All tests pass, golangci-lint clean