### PR TITLE
feat: Add ZC1151 — avoid cat -A for non-printable inspection

### DIFF
--- a/cmd/zshellcheck/main_test.go
+++ b/cmd/zshellcheck/main_test.go
@@ -209,6 +209,26 @@ func TestRun_StyleSeverity(t *testing.T) {
 	_ = code
 }
 
+func TestRun_WithViolationsTextFormat(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.zsh")
+	// Input likely to produce violations
+	if err := os.WriteFile(path, []byte("#!/bin/zsh\nfor i in $(ls); do echo $i; done\nrm -rf ${dir}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	resetFlags()
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"zshellcheck", "-no-color", "-format", "text", path}
+
+	code := run()
+	// Should return 1 if violations found
+	if code != 1 {
+		t.Logf("expected exit code 1 for violations, got %d", code)
+	}
+}
+
 func TestRun_InfoSeverity(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.zsh")

--- a/pkg/katas/katatests/zc1151_test.go
+++ b/pkg/katas/katatests/zc1151_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1151(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid cat with file",
+			input:    `cat file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid cat -A",
+			input: `cat -A file.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1151",
+					Message: "Avoid `cat -A` for inspecting non-printable characters. Use `od -c` or `hexdump -C` for reliable cross-platform output.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1151")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1151.go
+++ b/pkg/katas/zc1151.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1151",
+		Title:    "Avoid `cat -A` — use `print -v` or od for non-printable characters",
+		Severity: SeverityStyle,
+		Description: "`cat -A` shows non-printable characters but varies across platforms. " +
+			"Use Zsh `print -v` or `od -c` for reliable non-printable character inspection.",
+		Check: checkZC1151,
+	})
+}
+
+func checkZC1151(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cat" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-A" || val == "-v" || val == "-e" {
+			return []Violation{{
+				KataID: "ZC1151",
+				Message: "Avoid `cat " + val + "` for inspecting non-printable characters. " +
+					"Use `od -c` or `hexdump -C` for reliable cross-platform output.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 147 Katas = 0.1.47
-const Version = "0.1.47"
+// 148 Katas = 0.1.48
+const Version = "0.1.48"


### PR DESCRIPTION
## Summary
- Add ZC1151: Flag `cat -A/-v/-e`, suggest `od -c` or `hexdump -C`
- Version: 0.1.48 (148 katas)

## Test plan
- [x] Tests pass, lint clean