### PR TITLE
feat: Add ZC1152 — use Zsh PCRE module instead of grep -P

### DIFF
--- a/pkg/katas/katatests/zc1053_test.go
+++ b/pkg/katas/katatests/zc1053_test.go
@@ -69,6 +69,23 @@ func TestZC1053(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "grep without -q in while condition",
+			input: `while grep pattern file; do echo loop; done`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1053",
+					Message: "Silence `grep` output in conditions. Use `grep -q` or redirect to `/dev/null`.",
+					Line:    1,
+					Column:  7,
+				},
+			},
+		},
+		{
+			name:     "grep -q in while condition",
+			input:    `while grep -q pattern file; do echo loop; done`,
+			expected: []katas.Violation{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/katatests/zc1060_test.go
+++ b/pkg/katas/katatests/zc1060_test.go
@@ -35,6 +35,11 @@ func TestZC1060(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "ps piped to non-grep command",
+			input:    `ps aux | sort`,
+			expected: []katas.Violation{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/katatests/zc1152_test.go
+++ b/pkg/katas/katatests/zc1152_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1152(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid grep -E",
+			input:    `grep -E "pattern" file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid grep -P",
+			input: `grep -P "\d+" file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1152",
+					Message: "Avoid `grep -P` — it's unavailable on macOS. Use `zmodload zsh/pcre` with `pcre_compile`/`pcre_match` or `grep -E` for portable regex matching.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1152")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1152.go
+++ b/pkg/katas/zc1152.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1152",
+		Title:    "Use Zsh PCRE module instead of `grep -P`",
+		Severity: SeverityStyle,
+		Description: "`grep -P` (Perl regex) is not available on all platforms (e.g., macOS). " +
+			"Use `zmodload zsh/pcre` and `pcre_compile`/`pcre_match` for portable PCRE matching.",
+		Check: checkZC1152,
+	})
+}
+
+func checkZC1152(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "grep" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-P" {
+			return []Violation{{
+				KataID: "ZC1152",
+				Message: "Avoid `grep -P` — it's unavailable on macOS. Use `zmodload zsh/pcre` " +
+					"with `pcre_compile`/`pcre_match` or `grep -E` for portable regex matching.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -3,6 +3,7 @@ package reporter
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -288,6 +289,49 @@ func TestJSONReporter_EmptyViolations(t *testing.T) {
 
 	if len(result) != 0 {
 		t.Errorf("expected empty array, got %d items", len(result))
+	}
+}
+
+type failWriter struct{}
+
+func (w *failWriter) Write(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("write failed")
+}
+
+func TestTextReporter_WriterError(t *testing.T) {
+	violations := []katas.Violation{
+		{KataID: "ZC0001", Message: "test", Level: katas.SeverityError, Line: 1, Column: 1},
+	}
+
+	cfg := config.DefaultConfig()
+	reporter := NewTextReporter(&failWriter{}, "test.zsh", "echo hello", cfg)
+	err := reporter.Report(violations)
+	if err == nil {
+		t.Error("expected error from failing writer")
+	}
+}
+
+func TestJSONReporter_WriterError(t *testing.T) {
+	violations := []katas.Violation{
+		{KataID: "ZC0001", Message: "test", Level: katas.SeverityError, Line: 1, Column: 1},
+	}
+
+	reporter := NewJSONReporter(&failWriter{})
+	err := reporter.Report(violations)
+	if err == nil {
+		t.Error("expected error from failing writer")
+	}
+}
+
+func TestSarifReporter_WriterError(t *testing.T) {
+	violations := []katas.Violation{
+		{KataID: "ZC0001", Message: "test", Level: katas.SeverityError, Line: 1, Column: 1},
+	}
+
+	reporter := NewSarifReporter(&failWriter{}, "test.zsh")
+	err := reporter.Report(violations)
+	if err == nil {
+		t.Error("expected error from failing writer")
 	}
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 148 Katas = 0.1.48
-const Version = "0.1.48"
+// 149 Katas = 0.1.49
+const Version = "0.1.49"


### PR DESCRIPTION
## Summary
- Add ZC1152: Flag `grep -P`, suggest `zmodload zsh/pcre` or `grep -E`
- Version: 0.1.49 (149 katas)

## Test plan
- [x] Tests pass, lint clean