### PR TITLE
feat: Add ZC1153 — use cmp -s instead of diff -q for equality

### DIFF
--- a/pkg/katas/katatests/zc1153_test.go
+++ b/pkg/katas/katatests/zc1153_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1153(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid diff for viewing",
+			input:    `diff file1 file2`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid diff -q for equality",
+			input: `diff -q file1 file2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1153",
+					Message: "Use `cmp -s file1 file2` instead of `diff -q`. `cmp -s` is faster for equality checks as it stops at the first difference.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1153")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1153.go
+++ b/pkg/katas/zc1153.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1153",
+		Title:    "Use `cmp -s` instead of `diff` for equality check",
+		Severity: SeverityStyle,
+		Description: "When only checking if two files are identical (not viewing differences), " +
+			"`cmp -s` is faster than `diff` as it stops at the first difference.",
+		Check: checkZC1153,
+	})
+}
+
+func checkZC1153(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "diff" {
+		return nil
+	}
+
+	// Only flag diff -q (quiet) which is used for equality checks
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-q" {
+			return []Violation{{
+				KataID: "ZC1153",
+				Message: "Use `cmp -s file1 file2` instead of `diff -q`. " +
+					"`cmp -s` is faster for equality checks as it stops at the first difference.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 149 Katas = 0.1.49
-const Version = "0.1.49"
+// 150 Katas = 0.1.50
+const Version = "0.1.50"


### PR DESCRIPTION
## Summary
- Add ZC1153: Flag `diff -q`, suggest `cmp -s` for file equality checks
- Version: 0.1.50 (150 katas)

## Test plan
- [x] Tests pass, lint clean