### PR TITLE
feat: Add ZC1154 — use find -exec {} + for batch execution

### DIFF
--- a/pkg/katas/katatests/zc1154_test.go
+++ b/pkg/katas/katatests/zc1154_test.go
@@ -1,0 +1,34 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1154(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid find without exec",
+			input:    `find . -name "*.go"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid find -print0",
+			input:    `find . -print0`,
+			expected: []katas.Violation{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1154")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1154.go
+++ b/pkg/katas/zc1154.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1154",
+		Title:    "Use `find -exec {} +` instead of `find -exec {} \\;`",
+		Severity: SeverityStyle,
+		Description: "`find -exec cmd {} \\;` runs cmd once per file. " +
+			"`find -exec cmd {} +` batches files into fewer invocations, improving performance.",
+		Check: checkZC1154,
+	})
+}
+
+func checkZC1154(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "find" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-exec" {
+			// Check if the exec block ends with \; (not +)
+			for j := i + 1; j < len(cmd.Arguments); j++ {
+				endVal := cmd.Arguments[j].String()
+				if endVal == ";" {
+					return []Violation{{
+						KataID: "ZC1154",
+						Message: "Use `find -exec cmd {} +` instead of `find -exec cmd {} \\;`. " +
+							"The `+` form batches files for fewer process invocations.",
+						Line:   cmd.Token.Line,
+						Column: cmd.Token.Column,
+						Level:  SeverityStyle,
+					}}
+				}
+				if endVal == "+" {
+					break
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 150 Katas = 0.1.50
-const Version = "0.1.50"
+// 151 Katas = 0.1.51
+const Version = "0.1.51"


### PR DESCRIPTION
## Summary
- Add ZC1154: Flag `find -exec {} \;`, suggest `+` for batch mode
- Version: 0.1.51 (151 katas)

## Test plan
- [x] Tests pass, lint clean