### PR TITLE
feat: Add ZC1155 — use whence -a instead of which -a

### DIFF
--- a/pkg/katas/katatests/zc1155_test.go
+++ b/pkg/katas/katatests/zc1155_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1155(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid whence -a",
+			input:    `whence -a git`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid which -a",
+			input: `which -a git`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1155",
+					Message: "Use `whence -a` instead of `which -a`. Zsh `whence` is a reliable builtin for listing all command locations.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1155")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1155.go
+++ b/pkg/katas/zc1155.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1155",
+		Title:    "Use `whence -a` instead of `which -a`",
+		Severity: SeverityInfo,
+		Description: "`which -a` may be an external command on some systems. " +
+			"Zsh builtin `whence -a` reliably lists all command locations.",
+		Check: checkZC1155,
+	})
+}
+
+func checkZC1155(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "which" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-a" {
+			return []Violation{{
+				KataID: "ZC1155",
+				Message: "Use `whence -a` instead of `which -a`. " +
+					"Zsh `whence` is a reliable builtin for listing all command locations.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityInfo,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 151 Katas = 0.1.51
-const Version = "0.1.51"
+// 152 Katas = 0.1.52
+const Version = "0.1.52"


### PR DESCRIPTION
## Summary
- Add ZC1155: Flag `which -a`, suggest Zsh builtin `whence -a`
- Version: 0.1.52 (152 katas)

## Test plan
- [x] Tests pass, lint clean