### PR TITLE
feat: Add ZC1156 — prefer symbolic links over hard links

### DIFF
--- a/pkg/katas/katatests/zc1156_test.go
+++ b/pkg/katas/katatests/zc1156_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1156(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid ln -s",
+			input:    `ln -s target link`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid ln -sf",
+			input:    `ln -sf target link`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid hard link",
+			input: `ln target link`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1156",
+					Message: "Use `ln -s` for symbolic links instead of hard links. Hard links share inodes and don't work across filesystems.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1156")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1156.go
+++ b/pkg/katas/zc1156.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1156",
+		Title:    "Avoid `ln` without `-s` for symlinks",
+		Severity: SeverityInfo,
+		Description: "Hard links (`ln` without `-s`) share inodes and can cause confusion. " +
+			"Prefer symbolic links (`ln -s`) unless you specifically need hard links.",
+		Check: checkZC1156,
+	})
+}
+
+func checkZC1156(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "ln" {
+		return nil
+	}
+
+	hasSymlink := false
+	hasForce := false
+	fileCount := 0
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-s" || val == "-sf" || val == "-snf" {
+			hasSymlink = true
+		}
+		if val == "-f" {
+			hasForce = true
+		}
+		if len(val) > 0 && val[0] != '-' {
+			fileCount++
+		}
+	}
+
+	_ = hasForce
+
+	if hasSymlink || fileCount < 2 {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1156",
+		Message: "Use `ln -s` for symbolic links instead of hard links. " +
+			"Hard links share inodes and don't work across filesystems.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityInfo,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 152 Katas = 0.1.52
-const Version = "0.1.52"
+// 153 Katas = 0.1.53
+const Version = "0.1.53"


### PR DESCRIPTION
## Summary
- Add ZC1156: Flag `ln` without `-s`, suggest symbolic links
- Version: 0.1.53 (153 katas)

## Test plan
- [x] Tests pass, lint clean