### PR TITLE
feat: Add ZC1157 — consider Zsh expansion over strings command

### DIFF
--- a/pkg/katas/katatests/zc1157_test.go
+++ b/pkg/katas/katatests/zc1157_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1157(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid strings with flags",
+			input:    `strings -a binary`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid simple strings",
+			input: `strings binary`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1157",
+					Message: "Consider Zsh parameter expansion for string extraction from variables. `strings` is typically needed only for binary file analysis.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1157")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1157.go
+++ b/pkg/katas/zc1157.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1157",
+		Title:    "Avoid `strings` command — use Zsh `${(ps:\\0:)var}`",
+		Severity: SeverityStyle,
+		Description: "The `strings` command extracts printable strings from binaries. " +
+			"For simple filtering, Zsh parameter expansion with `(ps:\\0:)` can split on null bytes.",
+		Check: checkZC1157,
+	})
+}
+
+func checkZC1157(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "strings" {
+		return nil
+	}
+
+	// Only flag simple strings without special flags
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if len(val) > 0 && val[0] == '-' {
+			return nil
+		}
+	}
+
+	if len(cmd.Arguments) != 1 {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1157",
+		Message: "Consider Zsh parameter expansion for string extraction from variables. " +
+			"`strings` is typically needed only for binary file analysis.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 153 Katas = 0.1.53
-const Version = "0.1.53"
+// 154 Katas = 0.1.54
+const Version = "0.1.54"


### PR DESCRIPTION
## Summary
- Add ZC1157: Flag simple `strings` usage, suggest Zsh alternatives
- Version: 0.1.54 (154 katas)

## Test plan
- [x] Tests pass, lint clean