### PR TITLE
feat: Add ZC1158 — use --no-dereference with chown -R

### DIFF
--- a/pkg/katas/katatests/zc1158_test.go
+++ b/pkg/katas/katatests/zc1158_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1158(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid chown without -R",
+			input:    `chown user:group file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid chown -Rh",
+			input:    `chown -Rh user:group dir`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid chown -R without -h",
+			input: `chown -R user:group dir`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1158",
+					Message: "Use `chown -Rh` or `chown -R --no-dereference` to prevent following symlinks during recursive ownership changes.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1158")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1158.go
+++ b/pkg/katas/zc1158.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1158",
+		Title:    "Avoid `chown -R` without `--no-dereference`",
+		Severity: SeverityWarning,
+		Description: "`chown -R` follows symlinks by default, potentially changing ownership " +
+			"outside the intended directory. Use `--no-dereference` or `-h` to avoid this.",
+		Check: checkZC1158,
+	})
+}
+
+func checkZC1158(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "chown" {
+		return nil
+	}
+
+	hasRecursive := false
+	hasSafe := false
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-R" {
+			hasRecursive = true
+		}
+		if val == "-h" || val == "--no-dereference" {
+			hasSafe = true
+		}
+	}
+
+	if hasRecursive && !hasSafe {
+		return []Violation{{
+			KataID: "ZC1158",
+			Message: "Use `chown -Rh` or `chown -R --no-dereference` to prevent following " +
+				"symlinks during recursive ownership changes.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 154 Katas = 0.1.54
-const Version = "0.1.54"
+// 155 Katas = 0.1.55
+const Version = "0.1.55"


### PR DESCRIPTION
## Summary
- Add ZC1158: Flag `chown -R` without `-h`/`--no-dereference` (symlink safety)
- Severity: Warning
- Version: 0.1.55 (155 katas)

## Test plan
- [x] Tests pass, lint clean