### PR TITLE
feat: Add ZC1159 — use explicit compression flags with tar

### DIFF
--- a/pkg/katas/katatests/zc1159_test.go
+++ b/pkg/katas/katatests/zc1159_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1159(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid tar czf",
+			input:    `tar czf archive.tar.gz dir`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid tar extract",
+			input:    `tar xf archive.tar.gz`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid tar cf without compression",
+			input: `tar cf archive.tar dir`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1159",
+					Message: "Specify an explicit compression flag (`-z`, `-j`, `-J`) when creating tar archives. Relying on auto-detection reduces clarity and portability.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1159")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1159.go
+++ b/pkg/katas/zc1159.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1159",
+		Title:    "Avoid `tar` without explicit compression flag",
+		Severity: SeverityInfo,
+		Description: "Use explicit compression flags (`-z` for gzip, `-j` for bzip2, `-J` for xz) " +
+			"instead of relying on `tar` auto-detection for clarity and portability.",
+		Check: checkZC1159,
+	})
+}
+
+func checkZC1159(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "tar" {
+		return nil
+	}
+
+	hasCreate := false
+	hasCompression := false
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-c" || val == "-cf" || val == "cf" {
+			hasCreate = true
+		}
+		if val == "-z" || val == "-j" || val == "-J" || val == "--gzip" || val == "--bzip2" || val == "--xz" {
+			hasCompression = true
+		}
+		// Combined flags like czf
+		if len(val) > 1 && val[0] != '-' {
+			for _, ch := range val {
+				if ch == 'c' {
+					hasCreate = true
+				}
+				if ch == 'z' || ch == 'j' || ch == 'J' {
+					hasCompression = true
+				}
+			}
+		}
+	}
+
+	if hasCreate && !hasCompression {
+		return []Violation{{
+			KataID: "ZC1159",
+			Message: "Specify an explicit compression flag (`-z`, `-j`, `-J`) when creating tar archives. " +
+				"Relying on auto-detection reduces clarity and portability.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityInfo,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 155 Katas = 0.1.55
-const Version = "0.1.55"
+// 156 Katas = 0.1.56
+const Version = "0.1.56"


### PR DESCRIPTION
## Summary
- Add ZC1159: Flag `tar -c` without compression flag
- Severity: Info
- Version: 0.1.56 (156 katas)

## Test plan
- [x] Tests pass, lint clean