### PR TITLE
feat: Add ZC1160 — prefer curl over wget for portability

### DIFF
--- a/pkg/katas/katatests/zc1160_test.go
+++ b/pkg/katas/katatests/zc1160_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1160(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid curl",
+			input:    `curl -o file.tar.gz https://example.com/file.tar.gz`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid wget",
+			input: `wget https://example.com/file.tar.gz`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1160",
+					Message: "Prefer `curl` over `wget` for portability. `curl` is pre-installed on macOS and most Linux distributions.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1160")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1160.go
+++ b/pkg/katas/zc1160.go
@@ -1,0 +1,37 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1160",
+		Title:    "Prefer `curl` over `wget` for portability",
+		Severity: SeverityStyle,
+		Description: "`wget` is not installed by default on macOS. " +
+			"`curl` is available on virtually all Unix systems and is more portable.",
+		Check: checkZC1160,
+	})
+}
+
+func checkZC1160(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "wget" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1160",
+		Message: "Prefer `curl` over `wget` for portability. " +
+			"`curl` is pre-installed on macOS and most Linux distributions.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 156 Katas = 0.1.56
-const Version = "0.1.56"
+// 157 Katas = 0.1.57
+const Version = "0.1.57"


### PR DESCRIPTION
## Summary
- Add ZC1160: Flag `wget`, suggest `curl` for cross-platform portability
- Version: 0.1.57 (157 katas)

## Test plan
- [x] Tests pass, lint clean