### PR TITLE
feat: Add ZC1161 — use Zsh hash modules instead of sha256sum/md5sum

### DIFF
--- a/pkg/katas/katatests/zc1161_test.go
+++ b/pkg/katas/katatests/zc1161_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1161(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid sha256sum with file",
+			input:    `sha256sum file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid sha256sum in pipeline",
+			input: `sha256sum -`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1161",
+					Message: "Consider `zmodload zsh/sha256` or `zmodload zsh/md5` for hash operations. Zsh modules avoid spawning external hashing processes.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1161")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1161.go
+++ b/pkg/katas/zc1161.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1161",
+		Title:    "Avoid `openssl` for simple hashing — use Zsh modules",
+		Severity: SeverityStyle,
+		Description: "For simple SHA/MD5 hashing, Zsh provides `zmodload zsh/sha256` and " +
+			"`zmodload zsh/md5`. Avoid spawning `openssl` or `sha256sum` for basic hash operations.",
+		Check: checkZC1161,
+	})
+}
+
+func checkZC1161(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	name := ident.Value
+	if name != "sha256sum" && name != "sha1sum" && name != "md5sum" && name != "md5" {
+		return nil
+	}
+
+	// Only flag when used without file arguments (pipeline usage)
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if len(val) > 0 && val[0] != '-' {
+			return nil
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1161",
+		Message: "Consider `zmodload zsh/sha256` or `zmodload zsh/md5` for hash operations. " +
+			"Zsh modules avoid spawning external hashing processes.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 157 Katas = 0.1.57
-const Version = "0.1.57"
+// 158 Katas = 0.1.58
+const Version = "0.1.58"


### PR DESCRIPTION
## Summary
- Add ZC1161: Flag hash command pipeline usage, suggest `zmodload zsh/sha256`
- Version: 0.1.58 (158 katas)

## Test plan
- [x] Tests pass, lint clean