### PR TITLE
feat: Add ZC1162 — use cp -a instead of cp -r

### DIFF
--- a/pkg/katas/katatests/zc1162_test.go
+++ b/pkg/katas/katatests/zc1162_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1162(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid cp -a",
+			input:    `cp -a src/ dst/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid cp single file",
+			input:    `cp file.txt backup.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid cp -r",
+			input: `cp -r src/ dst/`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1162",
+					Message: "Use `cp -a` instead of `cp -r` to preserve permissions, timestamps, and symlinks. Archive mode ensures a faithful copy.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1162")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1162.go
+++ b/pkg/katas/zc1162.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1162",
+		Title:    "Use `cp -a` instead of `cp -r` to preserve attributes",
+		Severity: SeverityInfo,
+		Description: "`cp -r` copies recursively but may not preserve permissions, timestamps, " +
+			"or symlinks. Use `cp -a` (archive mode) to preserve all attributes.",
+		Check: checkZC1162,
+	})
+}
+
+func checkZC1162(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cp" {
+		return nil
+	}
+
+	hasRecursive := false
+	hasArchive := false
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-r" || val == "-R" {
+			hasRecursive = true
+		}
+		if val == "-a" || val == "-rp" || val == "-Rp" {
+			hasArchive = true
+		}
+	}
+
+	if hasRecursive && !hasArchive {
+		return []Violation{{
+			KataID: "ZC1162",
+			Message: "Use `cp -a` instead of `cp -r` to preserve permissions, timestamps, and symlinks. " +
+				"Archive mode ensures a faithful copy.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityInfo,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 158 Katas = 0.1.58
-const Version = "0.1.58"
+// 159 Katas = 0.1.59
+const Version = "0.1.59"


### PR DESCRIPTION
## Summary
- Add ZC1162: Flag `cp -r` without archive mode, suggest `cp -a`
- Version: 0.1.59 (159 katas)

## Test plan
- [x] Tests pass, lint clean