### PR TITLE
feat: Add ZC1164 — use Zsh array subscript instead of sed -n Np

### DIFF
--- a/pkg/katas/katatests/zc1164_test.go
+++ b/pkg/katas/katatests/zc1164_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1164(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid sed substitution",
+			input:    `sed -n 's/foo/bar/p'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid sed with file",
+			input:    `sed -n '3p' file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid sed -n Np in pipeline",
+			input: `sed -n '5p'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1164",
+					Message: "Use Zsh array subscript `${lines[N]}` instead of `sed -n 'Np'`. Split input with `${(f)...}` then index directly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1164")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1164.go
+++ b/pkg/katas/zc1164.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1164",
+		Title:    "Avoid `sed -n 'Np'` — use Zsh array subscript",
+		Severity: SeverityStyle,
+		Description: "Extracting a specific line with `sed -n 'Np'` spawns a process. " +
+			"Use Zsh array subscript `${lines[N]}` after splitting with `${(f)...}`.",
+		Check: checkZC1164,
+	})
+}
+
+func checkZC1164(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sed" {
+		return nil
+	}
+
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+
+	first := cmd.Arguments[0].String()
+	if first != "-n" {
+		return nil
+	}
+
+	// Check if second arg matches pattern like '3p', '10p', etc.
+	second := strings.Trim(cmd.Arguments[1].String(), "'\"")
+	if len(second) >= 2 && second[len(second)-1] == 'p' {
+		allDigits := true
+		for _, ch := range second[:len(second)-1] {
+			if ch < '0' || ch > '9' {
+				allDigits = false
+				break
+			}
+		}
+		if allDigits && len(cmd.Arguments) == 2 {
+			return []Violation{{
+				KataID: "ZC1164",
+				Message: "Use Zsh array subscript `${lines[N]}` instead of `sed -n 'Np'`. " +
+					"Split input with `${(f)...}` then index directly.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 160 Katas = 0.1.60
-const Version = "0.1.60"
+// 161 Katas = 0.1.61
+const Version = "0.1.61"


### PR DESCRIPTION
## Summary
- Add ZC1164: Flag `sed -n 'Np'` pipeline, suggest `${lines[N]}` subscript
- Version: 0.1.61 (161 katas)

## Test plan
- [x] Tests pass, lint clean