### PR TITLE
feat: Add ZC1165 — use Zsh expansion for simple awk field extraction

### DIFF
--- a/pkg/katas/katatests/zc1165_test.go
+++ b/pkg/katas/katatests/zc1165_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1165(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid awk with complex script",
+			input:    `awk '{sum+=$1} END{print sum}'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid awk with file",
+			input:    `awk '{print $1}' file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid simple awk print $1",
+			input: `awk '{print $1}'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1165",
+					Message: "Use Zsh parameter expansion (`${var%% *}` or `${var##* }`) instead of `awk '{print $1}'` for simple field extraction without spawning awk.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1165")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1165.go
+++ b/pkg/katas/zc1165.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1165",
+		Title:    "Use Zsh parameter expansion for simple `awk` field extraction",
+		Severity: SeverityStyle,
+		Description: "Simple `awk '{print $1}'` or `awk '{print $NF}'` can often be replaced with " +
+			"Zsh parameter expansion `${var%% *}` (first field) or `${var##* }` (last field).",
+		Check: checkZC1165,
+	})
+}
+
+func checkZC1165(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "awk" {
+		return nil
+	}
+
+	// Only flag awk with a single print statement and no file argument
+	if len(cmd.Arguments) != 1 {
+		return nil
+	}
+
+	arg := strings.Trim(cmd.Arguments[0].String(), "'\"")
+	if arg == "{print $1}" || arg == "{print $NF}" {
+		return []Violation{{
+			KataID: "ZC1165",
+			Message: "Use Zsh parameter expansion (`${var%% *}` or `${var##* }`) instead of " +
+				"`awk '{print $1}'` for simple field extraction without spawning awk.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityStyle,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 161 Katas = 0.1.61
-const Version = "0.1.61"
+// 162 Katas = 0.1.62
+const Version = "0.1.62"


### PR DESCRIPTION
## Summary
- Add ZC1165: Flag simple `awk '{print $1}'`, suggest `${var%% *}`
- Version: 0.1.62 (162 katas)

## Test plan
- [x] Tests pass, lint clean