### PR TITLE
feat: Add ZC1167 — avoid timeout command, use Zsh TMOUT

### DIFF
--- a/pkg/katas/katatests/zc1167_test.go
+++ b/pkg/katas/katatests/zc1167_test.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1167(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:  "invalid timeout command",
+			input: `timeout 5 cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1167",
+					Message: "Avoid `timeout` — it's unavailable on macOS. Use Zsh `TMOUT` variable or `zmodload zsh/sched` for portable timeout functionality.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1167")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1167.go
+++ b/pkg/katas/zc1167.go
@@ -1,0 +1,37 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1167",
+		Title:    "Avoid `timeout` command — use Zsh `TMOUT` or `zsh/sched`",
+		Severity: SeverityStyle,
+		Description: "`timeout` is not available on all systems (macOS lacks it by default). " +
+			"Use Zsh `TMOUT` variable or `zmodload zsh/sched` for timeout functionality.",
+		Check: checkZC1167,
+	})
+}
+
+func checkZC1167(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "timeout" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1167",
+		Message: "Avoid `timeout` — it's unavailable on macOS. Use Zsh `TMOUT` variable " +
+			"or `zmodload zsh/sched` for portable timeout functionality.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 163 Katas = 0.1.63
-const Version = "0.1.63"
+// 164 Katas = 0.1.64
+const Version = "0.1.64"


### PR DESCRIPTION
## Summary
- Add ZC1167: Flag `timeout`, suggest Zsh `TMOUT` or `zsh/sched`
- Version: 0.1.64 (164 katas)

## Test plan
- [x] Tests pass, lint clean