### PR TITLE
feat: Add ZC1168 — use Zsh ${(f)...} instead of readarray/mapfile

### DIFF
--- a/pkg/katas/katatests/zc1168_test.go
+++ b/pkg/katas/katatests/zc1168_test.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1168(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:  "invalid readarray",
+			input: `readarray -t arr`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1168",
+					Message: "Use Zsh `${(f)$(cmd)}` instead of `readarray`. `readarray`/`mapfile` are Bash builtins not available in Zsh.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid mapfile",
+			input: `mapfile -t lines`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1168",
+					Message: "Use Zsh `${(f)$(cmd)}` instead of `mapfile`. `readarray`/`mapfile` are Bash builtins not available in Zsh.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1168")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1168.go
+++ b/pkg/katas/zc1168.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1168",
+		Title:    "Use `${(f)...}` instead of `readarray`/`mapfile`",
+		Severity: SeverityStyle,
+		Description: "`readarray` and `mapfile` are Bash builtins not available in Zsh. " +
+			"Use Zsh `${(f)...}` parameter expansion flag to split output into an array by newlines.",
+		Check: checkZC1168,
+	})
+}
+
+func checkZC1168(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "readarray" && ident.Value != "mapfile" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1168",
+		Message: "Use Zsh `${(f)$(cmd)}` instead of `" + ident.Value + "`. " +
+			"`readarray`/`mapfile` are Bash builtins not available in Zsh.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 164 Katas = 0.1.64
-const Version = "0.1.64"
+// 165 Katas = 0.1.65
+const Version = "0.1.65"


### PR DESCRIPTION
## Summary
- Add ZC1168: Flag `readarray`/`mapfile` (Bash builtins), suggest `${(f)$(cmd)}`
- Version: 0.1.65 (165 katas)

## Test plan
- [x] Tests pass, lint clean