### PR TITLE
feat: Add ZC1169 — prefer cp+chmod over install -m

### DIFF
--- a/pkg/katas/katatests/zc1169_test.go
+++ b/pkg/katas/katatests/zc1169_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1169(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid install without -m",
+			input:    `install -d /usr/local/bin`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid install -m",
+			input: `install -m 755 script /usr/local/bin/script`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1169",
+					Message: "Consider using `cp` + `chmod` instead of `install -m`. Separate commands are clearer in shell scripts.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1169")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1169.go
+++ b/pkg/katas/zc1169.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1169",
+		Title:    "Avoid `install` for simple copy+chmod — use `cp` then `chmod`",
+		Severity: SeverityStyle,
+		Description: "`install` command is less common and may confuse readers. " +
+			"For clarity, use separate `cp` and `chmod` commands or `install` only in Makefiles.",
+		Check: checkZC1169,
+	})
+}
+
+func checkZC1169(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "install" {
+		return nil
+	}
+
+	// Only flag install with -m (mode) flag in scripts
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-m" {
+			return []Violation{{
+				KataID: "ZC1169",
+				Message: "Consider using `cp` + `chmod` instead of `install -m`. " +
+					"Separate commands are clearer in shell scripts.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 165 Katas = 0.1.65
-const Version = "0.1.65"
+// 166 Katas = 0.1.66
+const Version = "0.1.66"


### PR DESCRIPTION
ZC1169: Flag install -m, suggest cp+chmod. Version 0.1.66 (166 katas)