### PR TITLE
feat: Add ZC1278 — use arithmetic expansion instead of expr

### DIFF
--- a/pkg/katas/katatests/zc1278_test.go
+++ b/pkg/katas/katatests/zc1278_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1278(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid arithmetic expansion",
+			input:    `echo $(( 1 + 2 ))`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid other command",
+			input:    `echo hello`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid expr usage",
+			input: `expr 1 + 2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1278",
+					Message: "Use Zsh arithmetic expansion `$(( ))` instead of `expr`. It is built-in and avoids forking.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1278")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1278.go
+++ b/pkg/katas/zc1278.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1278",
+		Title:    "Use `$(( ))` instead of `expr` for arithmetic",
+		Severity: SeverityStyle,
+		Description: "`expr` is an external command for arithmetic. Zsh has native arithmetic " +
+			"expansion `$(( ))` which is faster and more readable.",
+		Check: checkZC1278,
+	})
+}
+
+func checkZC1278(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "expr" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1278",
+		Message: "Use Zsh arithmetic expansion `$(( ))` instead of `expr`. It is built-in and avoids forking.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 274 Katas = 0.2.74
-const Version = "0.2.74"
+// 275 Katas = 0.2.75
+const Version = "0.2.75"


### PR DESCRIPTION
## Summary
- Adds ZC1278: detects `expr` usage and suggests Zsh's native `$(( ))` arithmetic expansion
- Severity: Style
- Version: 0.2.75 (275 katas)

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` zero violations
- [x] Version updated via `scripts/update-version.sh`