### PR TITLE
feat: Add ZC1279 — use realpath instead of readlink -f

### DIFF
--- a/pkg/katas/katatests/zc1279_test.go
+++ b/pkg/katas/katatests/zc1279_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1279(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid realpath usage",
+			input:    `realpath /some/path`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid readlink without -f",
+			input:    `readlink /some/symlink`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid readlink -f",
+			input: `readlink -f /some/path`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1279",
+					Message: "Use `realpath` instead of `readlink -f`. `realpath` is more portable, especially on macOS.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1279")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1279.go
+++ b/pkg/katas/zc1279.go
@@ -1,0 +1,43 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1279",
+		Title:    "Use `realpath` instead of `readlink -f` for canonical paths",
+		Severity: SeverityInfo,
+		Description: "`readlink -f` is not portable across all platforms (notably macOS). " +
+			"Use `realpath` which is POSIX-standard and available on modern systems.",
+		Check: checkZC1279,
+	})
+}
+
+func checkZC1279(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "readlink" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-f" {
+			return []Violation{{
+				KataID:  "ZC1279",
+				Message: "Use `realpath` instead of `readlink -f`. `realpath` is more portable, especially on macOS.",
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityInfo,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 275 Katas = 0.2.75
-const Version = "0.2.75"
+// 276 Katas = 0.2.76
+const Version = "0.2.76"


### PR DESCRIPTION
## Summary
- Adds ZC1279: detects `readlink -f` and suggests `realpath` for better cross-platform portability
- `readlink -f` is not available on macOS without coreutils
- Severity: Info
- Version: 0.2.76 (276 katas)

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` zero violations
- [x] Version updated via `scripts/update-version.sh`