### PR TITLE
feat: Add ZC1280 — use Zsh ${var:e} instead of cut for file extension

### DIFF
--- a/pkg/katas/katatests/zc1280_test.go
+++ b/pkg/katas/katatests/zc1280_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1280(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid Zsh :e modifier",
+			input:    `echo ${file:e}`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid cut with different delimiter",
+			input:    `cut -d: -f1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid cut to extract extension",
+			input: `cut -d. -f2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1280",
+					Message: "Use Zsh parameter expansion `${var:e}` to extract the file extension instead of `cut -d. -f2`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1280")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1280.go
+++ b/pkg/katas/zc1280.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1280",
+		Title:    "Use `Zsh ${var:e}` instead of shell expansion to extract file extension",
+		Severity: SeverityStyle,
+		Description: "Zsh provides the `:e` (extension) modifier for parameter expansion which " +
+			"extracts the file extension, avoiding complex shell patterns or external tools.",
+		Check: checkZC1280,
+	})
+}
+
+func checkZC1280(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cut" {
+		return nil
+	}
+
+	hasDot := false
+	hasField := false
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-d." || val == "-d" {
+			hasDot = true
+		}
+		if val == "-f2" {
+			hasField = true
+		}
+		if val == "." {
+			hasDot = true
+		}
+	}
+
+	if hasDot && hasField {
+		return []Violation{{
+			KataID:  "ZC1280",
+			Message: "Use Zsh parameter expansion `${var:e}` to extract the file extension instead of `cut -d. -f2`.",
+			Line:    cmd.Token.Line,
+			Column:  cmd.Token.Column,
+			Level:   SeverityStyle,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 276 Katas = 0.2.76
-const Version = "0.2.76"
+// 277 Katas = 0.2.77
+const Version = "0.2.77"


### PR DESCRIPTION
## Summary
- Adds ZC1280: detects `cut -d. -f2` pattern for extracting file extensions
- Suggests Zsh's `:e` parameter expansion modifier as a built-in alternative
- Severity: Style
- Version: 0.2.77 (277 katas)

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` zero violations
- [x] Version updated via `scripts/update-version.sh`