### PR TITLE
feat: Add ZC1281 — use sort -u instead of sort | uniq

### DIFF
--- a/pkg/katas/katatests/zc1281_test.go
+++ b/pkg/katas/katatests/zc1281_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1281(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid sort -u usage",
+			input:    `sort -u file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid uniq with flags",
+			input:    `uniq -c file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid uniq with file",
+			input: `uniq file.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1281",
+					Message: "Use `sort -u` instead of `sort | uniq`. The `-u` flag deduplicates in a single pass.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1281")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1281.go
+++ b/pkg/katas/zc1281.go
@@ -1,0 +1,43 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1281",
+		Title:    "Use `sort -u` instead of `sort | uniq` for deduplication",
+		Severity: SeverityStyle,
+		Description: "`sort -u` combines sorting and deduplication in a single pass, " +
+			"which is more efficient than piping `sort` into `uniq` as a separate process.",
+		Check: checkZC1281,
+	})
+}
+
+func checkZC1281(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "uniq" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-c" || val == "-d" || val == "-D" || val == "-u" {
+			return nil
+		}
+	}
+
+	return []Violation{{
+		KataID:  "ZC1281",
+		Message: "Use `sort -u` instead of `sort | uniq`. The `-u` flag deduplicates in a single pass.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 277 Katas = 0.2.77
-const Version = "0.2.77"
+// 278 Katas = 0.2.78
+const Version = "0.2.78"


### PR DESCRIPTION
## Summary
- Adds ZC1281: detects bare `uniq` usage and suggests `sort -u` for combined sort+dedup
- Skips detection when `uniq` has flags like `-c`, `-d`, `-D` that provide functionality beyond dedup
- Severity: Style
- Version: 0.2.78 (278 katas)

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` zero violations
- [x] Version updated via `scripts/update-version.sh`