### PR TITLE
feat: Support XDG Base Directory Specification

### DIFF
--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -77,9 +77,6 @@ func run() int {
 		fmt.Fprint(os.Stderr, config.Banner)
 	}
 
-	// Start with default config
-	config := config.DefaultConfig()
-
 	configFileXdgConfigPath, _ := xdg.ConfigFile("zshellcheck/config.yaml")
 	configFileHomePath := filepath.Join(xdg.Home, ".zshellcheckrc")
 	config, err := loadConfig(configFileXdgConfigPath, configFileHomePath, ".zshellcheckrc")

--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -77,7 +77,7 @@ func run() int {
 		fmt.Fprint(os.Stderr, config.Banner)
 	}
 
-	configFileXdgConfigPath, _ := xdg.ConfigFile("zshellcheck/config.yaml")
+	configFileXdgConfigPath, _ := xdg.SearchConfigFile("zshellcheck/config.yaml")
 	configFileHomePath := filepath.Join(xdg.Home, ".zshellcheckrc")
 	config, err := loadConfig(configFileXdgConfigPath, configFileHomePath, ".zshellcheckrc")
 	if err != nil {

--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -77,7 +77,12 @@ func run() int {
 		fmt.Fprint(os.Stderr, config.Banner)
 	}
 
-	configFileXdgConfigPath, _ := xdg.SearchConfigFile("zshellcheck/config.yaml")
+	// Pick either config.yml or config.yaml, but not both
+	configFileXdgConfigPath, err := xdg.SearchConfigFile("zshellcheck/config.yml")
+	if err != nil {
+		configFileXdgConfigPath, _ = xdg.SearchConfigFile("zshellcheck/config.yaml")
+	}
+
 	configFileHomePath := filepath.Join(xdg.Home, ".zshellcheckrc")
 	config, err := loadConfig(configFileXdgConfigPath, configFileHomePath, ".zshellcheckrc")
 	if err != nil {

--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -9,6 +9,7 @@ import (
 	"runtime/pprof"
 	"strings"
 
+	"github.com/adrg/xdg"
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 	"github.com/afadesigns/zshellcheck/pkg/config"
 	"github.com/afadesigns/zshellcheck/pkg/katas"
@@ -76,7 +77,12 @@ func run() int {
 		fmt.Fprint(os.Stderr, config.Banner)
 	}
 
-	config, err := loadConfig(".zshellcheckrc")
+	// Start with default config
+	config := config.DefaultConfig()
+
+	configFileXdgConfigPath, _ := xdg.ConfigFile("zshellcheck/config.yaml")
+	configFileHomePath := filepath.Join(xdg.Home, ".zshellcheckrc")
+	config, err := loadConfig(configFileXdgConfigPath, configFileHomePath, ".zshellcheckrc")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading config: %s\n", err)
 		return 1
@@ -120,25 +126,29 @@ func run() int {
 	return 0
 }
 
-func loadConfig(path string) (config.Config, error) {
+func loadConfig(paths ...string) (config.Config, error) {
 	cfg := config.DefaultConfig()
 
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return cfg, nil
+	for _, path := range paths {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			continue
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return cfg, err
+		}
+
+		var fileConfig config.Config
+		err = yaml.Unmarshal(data, &fileConfig)
+		if err != nil {
+			return cfg, err
+		}
+
+		cfg = config.MergeConfig(cfg, fileConfig)
 	}
 
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return cfg, err
-	}
-
-	var fileConfig config.Config
-	err = yaml.Unmarshal(data, &fileConfig)
-	if err != nil {
-		return cfg, err
-	}
-
-	return config.MergeConfig(cfg, fileConfig), nil
+	return cfg, nil
 }
 
 func processPath(path string, out, errOut io.Writer, config config.Config, registry *katas.KatasRegistry, format string, allowedSeverities []katas.Severity) int {

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -50,6 +50,8 @@ zshellcheck --severity style my_script.zsh
 
 ZShellCheck looks for a file named `.zshellcheckrc` in the current working directory. The file uses **YAML** syntax.
 
+Global settings can be placed in `~/.config/zshellcheck/config.yml` or `${XDG_CONFIG_HOME}/zshellcheck/config.yml`.
+
 ### Disabling Katas
 
 To suppress specific checks (Katas), use the `disabled_katas` list:

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,8 @@ module github.com/afadesigns/zshellcheck
 go 1.23
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require (
+	github.com/adrg/xdg v0.5.3 // indirect
+	golang.org/x/sys v0.26.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
+github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Description

<!--
Please include a summary of the change and which issue is fixed.
If this PR adds a new Kata, please describe the check briefly.
-->

This PR adds support for the XDG Base Directory Spec.

1. `~/.config/zshellcheck/config.yml` is loaded if it exists
1. `~/.zshellcheckrc` is merged if it exists
1. `./.zshellcheckrc` is merged if it exists

The implementation is backwards compatible, the existing tests still pass.

Note, I noticed when running the `integration_test.zsh` script that any katas disabled in the `config.yml` file will show as failed. In may be good to add a `--norc` flag to be used in cases like this, although this is not an issue in CI or on machines where no custom files exist.

Fixes #309

## Type of change

- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `docs`: Documentation update
- [ ] `chore`: Maintenance (deps, build, etc.)
- [ ] `refactor`: Code restructuring
- [ ] `test`: Adding missing tests

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
- [x] I have read the [DEVELOPMENT.md](DEVELOPMENT.md) guide.
- [x] **Linting**: My code passes `go fmt` and `go vet`.
- [ ] **Tests**: I have added tests for my changes (especially for new Katas).
- [x] **Integration**: I have run `./tests/integration_test.zsh` and it passes.
- [x] **Documentation**: I have updated relevant documentation (if applicable).

## For New Katas (If Applicable)

_**N/A**_

- [ ] Added `pkg/katas/zcXXXX.go`
- [ ] Registered in `pkg/katas/katas.go`
- [ ] Added tests in `pkg/katas/katatests/zcXXXX_test.go`
- [ ] Verified that the ID (`ZCXXXX`) is unique and sequential.