### PR TITLE
feat: Add ZC1282 — use Zsh ${var:r} instead of sed to remove file extension

### DIFF
--- a/pkg/katas/katatests/zc1282_test.go
+++ b/pkg/katas/katatests/zc1282_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1282(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid Zsh :r modifier",
+			input:    `echo ${file:r}`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid sed with different pattern",
+			input:    `sed s/foo/bar/g`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid sed to strip extension",
+			input: `sed 's/\.[^.]*$//'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1282",
+					Message: "Use Zsh parameter expansion `${var:r}` to remove the file extension instead of `sed`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1282")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1282.go
+++ b/pkg/katas/zc1282.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1282",
+		Title:    "Use Zsh `${var:r}` instead of `sed` to remove file extension",
+		Severity: SeverityStyle,
+		Description: "Zsh provides the `:r` modifier to remove a filename extension. " +
+			"Using `sed` or `cut` to strip the extension is unnecessary when the built-in " +
+			"parameter expansion handles it directly.",
+		Check: checkZC1282,
+	})
+}
+
+func checkZC1282(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sed" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "'s/\\.[^.]*$//'" || val == "s/\\.[^.]*$//" ||
+			val == "'s/\\.[^.]*$//g'" || val == "s/\\.[^.]*$//g" {
+			return []Violation{{
+				KataID:  "ZC1282",
+				Message: "Use Zsh parameter expansion `${var:r}` to remove the file extension instead of `sed`.",
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 278 Katas = 0.2.78
-const Version = "0.2.78"
+// 279 Katas = 0.2.79
+const Version = "0.2.79"


### PR DESCRIPTION
## Summary
- Adds ZC1282: detects `sed 's/\.[^.]*$//'` patterns for stripping file extensions
- Recommends using Zsh built-in `${var:r}` modifier instead
- Severity: style

## Test plan
- [x] Unit tests pass for valid and invalid cases
- [x] Full test suite passes
- [x] Lint clean