### PR TITLE
feat: Add ZC1283 — use setopt instead of set -o for Zsh options

### DIFF
--- a/pkg/katas/katatests/zc1283_test.go
+++ b/pkg/katas/katatests/zc1283_test.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1283(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid setopt usage",
+			input:    `setopt noglob`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid unsetopt usage",
+			input:    `unsetopt noglob`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid set without -o",
+			input:    `set -e`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid set -o",
+			input: `set -o noglob`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1283",
+					Message: "Use `setopt` instead of `set -o` in Zsh scripts. `setopt` is the native Zsh idiom.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1283")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1283.go
+++ b/pkg/katas/zc1283.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1283",
+		Title:    "Use `setopt` instead of `set -o` for Zsh options",
+		Severity: SeverityStyle,
+		Description: "Zsh provides `setopt` and `unsetopt` as native builtins for managing shell " +
+			"options. Using `set -o` / `set +o` is a POSIX compatibility form that is less " +
+			"idiomatic in Zsh scripts.",
+		Check: checkZC1283,
+	})
+}
+
+func checkZC1283(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "set" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-o" {
+			return []Violation{{
+				KataID:  "ZC1283",
+				Message: "Use `setopt` instead of `set -o` in Zsh scripts. `setopt` is the native Zsh idiom.",
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 279 Katas = 0.2.79
-const Version = "0.2.79"
+// 280 Katas = 0.2.80
+const Version = "0.2.80"


### PR DESCRIPTION
## Summary
- Adds ZC1283: detects `set -o <option>` and recommends native `setopt` instead
- Zsh-specific idiom — `setopt`/`unsetopt` are the native Zsh builtins
- Severity: style

## Test plan
- [x] Unit tests for valid and invalid cases
- [x] Full test suite passes
- [x] Lint clean