### PR TITLE
feat: Add ZC1284 — use Zsh ${(s:sep:)var} instead of cut -d for splitting

### DIFF
--- a/pkg/katas/katatests/zc1284_test.go
+++ b/pkg/katas/katatests/zc1284_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1284(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid Zsh split expansion",
+			input:    `echo ${(s/:/)PATH}`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid cut with dot delimiter (covered by ZC1280)",
+			input:    `cut -d. -f2`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid cut with colon delimiter",
+			input: `cut -d: -f1`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1284",
+					Message: "Use Zsh parameter expansion `${(s:sep:)var}` for field splitting instead of `cut -d -f`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid cut with comma delimiter",
+			input: `cut -d, -f3`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1284",
+					Message: "Use Zsh parameter expansion `${(s:sep:)var}` for field splitting instead of `cut -d -f`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1284")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1284.go
+++ b/pkg/katas/zc1284.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1284",
+		Title:    "Use Zsh `${(s:sep:)var}` instead of `cut -d` for field splitting",
+		Severity: SeverityStyle,
+		Description: "Zsh provides the `(s:separator:)` parameter expansion flag to split strings " +
+			"into arrays by a delimiter. This is more idiomatic than invoking `cut -d` and " +
+			"avoids spawning an external process.",
+		Check: checkZC1284,
+	})
+}
+
+func checkZC1284(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cut" {
+		return nil
+	}
+
+	hasDelim := false
+	hasField := false
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if strings.HasPrefix(val, "-d") && val != "-d." {
+			hasDelim = true
+		}
+		if strings.HasPrefix(val, "-f") {
+			hasField = true
+		}
+	}
+
+	if hasDelim && hasField {
+		return []Violation{{
+			KataID:  "ZC1284",
+			Message: "Use Zsh parameter expansion `${(s:sep:)var}` for field splitting instead of `cut -d -f`.",
+			Line:    cmd.Token.Line,
+			Column:  cmd.Token.Column,
+			Level:   SeverityStyle,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 280 Katas = 0.2.80
-const Version = "0.2.80"
+// 281 Katas = 0.2.81
+const Version = "0.2.81"


### PR DESCRIPTION
## Summary
- Adds ZC1284: detects `cut -d<delim> -f<N>` patterns (excluding `-d.` which is ZC1280)
- Recommends Zsh native `${(s:sep:)var}` parameter expansion flag for splitting
- Severity: style

## Test plan
- [x] Unit tests for valid and invalid cases
- [x] Full test suite passes
- [x] Lint clean