### PR TITLE
feat: Add ZC1285 — use Zsh ${(o)array} for sorting instead of sort

### DIFF
--- a/pkg/katas/katatests/zc1285_test.go
+++ b/pkg/katas/katatests/zc1285_test.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1285(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid sort with flags",
+			input:    `sort -n file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid sort with key",
+			input:    `sort -k 2`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid sort with reverse flag",
+			input:    `sort -r file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "sort with single file argument",
+			input: `sort data.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1285",
+					Message: "Use Zsh `${(o)array}` for sorting instead of piping to `sort`. The `(o)` flag sorts in-shell.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1285")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1285.go
+++ b/pkg/katas/zc1285.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1285",
+		Title:    "Use Zsh `${(o)array}` for sorting instead of piping to `sort`",
+		Severity: SeverityStyle,
+		Description: "Zsh provides the `(o)` parameter expansion flag to sort array elements " +
+			"in ascending order and `(O)` for descending order. This avoids spawning " +
+			"an external `sort` process for simple array sorting.",
+		Check: checkZC1285,
+	})
+}
+
+func checkZC1285(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sort" {
+		return nil
+	}
+
+	// sort with complex flags has legitimate uses beyond simple array sorting
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-t" || val == "-k" || val == "-n" || val == "-r" ||
+			val == "-u" || val == "-h" || val == "-V" || val == "-g" ||
+			val == "-c" || val == "-m" || val == "-s" {
+			return nil
+		}
+	}
+
+	// sort with only a filename — suggest Zsh native sorting
+	if len(cmd.Arguments) == 1 {
+		return []Violation{{
+			KataID:  "ZC1285",
+			Message: "Use Zsh `${(o)array}` for sorting instead of piping to `sort`. The `(o)` flag sorts in-shell.",
+			Line:    cmd.Token.Line,
+			Column:  cmd.Token.Column,
+			Level:   SeverityStyle,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 281 Katas = 0.2.81
-const Version = "0.2.81"
+// 282 Katas = 0.2.82
+const Version = "0.2.82"


### PR DESCRIPTION
## Summary
- Adds ZC1285: detects bare `sort <file>` without complex flags
- Recommends Zsh native `${(o)array}` parameter flag for in-shell sorting
- Severity: style

## Test plan
- [x] Unit tests for valid and invalid cases
- [x] Full test suite passes
- [x] Lint clean