### PR TITLE
feat: Add ZC1286 — use Zsh ${array:#pattern} instead of grep -v

### DIFF
--- a/pkg/katas/katatests/zc1286_test.go
+++ b/pkg/katas/katatests/zc1286_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1286(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid grep without -v",
+			input:    `grep pattern file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid Zsh array filter",
+			input:    `echo ${array:#pattern}`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid grep -v for filtering",
+			input: `grep -v pattern file.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1286",
+					Message: "Use Zsh `${array:#pattern}` for filtering instead of `grep -v`. Parameter expansion avoids a subprocess.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1286")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1286.go
+++ b/pkg/katas/zc1286.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1286",
+		Title:    "Use Zsh `${array:#pattern}` instead of `grep -v` for filtering",
+		Severity: SeverityStyle,
+		Description: "Zsh provides `${array:#pattern}` to remove matching elements from an array " +
+			"and `${(M)array:#pattern}` to keep only matching elements. This avoids " +
+			"spawning an external `grep` process for simple filtering tasks.",
+		Check: checkZC1286,
+	})
+}
+
+func checkZC1286(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "grep" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-v" {
+			return []Violation{{
+				KataID:  "ZC1286",
+				Message: "Use Zsh `${array:#pattern}` for filtering instead of `grep -v`. Parameter expansion avoids a subprocess.",
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 282 Katas = 0.2.82
-const Version = "0.2.82"
+// 283 Katas = 0.2.83
+const Version = "0.2.83"


### PR DESCRIPTION
## Summary
- Adds ZC1286: detects `grep -v` usage for filtering
- Recommends Zsh native `${array:#pattern}` parameter expansion
- Severity: style

## Test plan
- [x] Unit tests for valid and invalid cases
- [x] Full test suite passes
- [x] Lint clean