### PR TITLE
feat: Add ZC1287 — use Zsh ${(V)var} instead of cat -v

### DIFF
--- a/pkg/katas/katatests/zc1287_test.go
+++ b/pkg/katas/katatests/zc1287_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1287(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid cat with file",
+			input:    `cat file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid cat with -n flag",
+			input:    `cat -n file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid cat -v for visible chars",
+			input: `cat -v file.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1287",
+					Message: "Use Zsh `${(V)var}` to make control characters visible instead of `cat -v`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid cat -A for all visible",
+			input: `cat -A file.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1287",
+					Message: "Use Zsh `${(V)var}` to make control characters visible instead of `cat -v`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1287")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1287.go
+++ b/pkg/katas/zc1287.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1287",
+		Title:    "Use `cat -v` alternative: Zsh `${(V)var}` for visible control characters",
+		Severity: SeverityStyle,
+		Description: "Zsh provides the `(V)` parameter expansion flag to make control characters " +
+			"visible in a variable. This avoids piping through `cat -v` for simple " +
+			"visibility of non-printable characters.",
+		Check: checkZC1287,
+	})
+}
+
+func checkZC1287(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cat" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-v" || val == "-A" {
+			return []Violation{{
+				KataID:  "ZC1287",
+				Message: "Use Zsh `${(V)var}` to make control characters visible instead of `cat -v`.",
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 283 Katas = 0.2.83
-const Version = "0.2.83"
+// 284 Katas = 0.2.84
+const Version = "0.2.84"


### PR DESCRIPTION
## Summary
- Adds ZC1287: detects `cat -v` and `cat -A` for displaying control characters
- Recommends Zsh native `${(V)var}` parameter expansion flag
- Severity: style

## Test plan
- [x] Unit tests for valid and invalid cases
- [x] Full test suite passes
- [x] Lint clean