### PR TITLE
feat: Add ZC1288 — use typeset instead of declare in Zsh scripts

### DIFF
--- a/pkg/katas/katatests/zc1288_test.go
+++ b/pkg/katas/katatests/zc1288_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1288(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid typeset usage",
+			input:    `typeset -A mymap`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid local usage",
+			input:    `local myvar=hello`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid declare usage",
+			input: `declare -A mymap`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1288",
+					Message: "Use `typeset` instead of `declare` in Zsh scripts. `typeset` is the native Zsh idiom.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid declare with -i flag",
+			input: `declare -i count`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1288",
+					Message: "Use `typeset` instead of `declare` in Zsh scripts. `typeset` is the native Zsh idiom.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1288")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1288.go
+++ b/pkg/katas/zc1288.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.DeclarationStatementNode, Kata{
+		ID:       "ZC1288",
+		Title:    "Use `typeset` instead of `declare` in Zsh scripts",
+		Severity: SeverityStyle,
+		Description: "`typeset` is the native Zsh builtin for variable declarations. " +
+			"`declare` is a Bash compatibility alias. Using `typeset` is more idiomatic " +
+			"and signals that the script is Zsh-native.",
+		Check: checkZC1288,
+	})
+}
+
+func checkZC1288(node ast.Node) []Violation {
+	decl, ok := node.(*ast.DeclarationStatement)
+	if !ok {
+		return nil
+	}
+
+	if decl.Command != "declare" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1288",
+		Message: "Use `typeset` instead of `declare` in Zsh scripts. `typeset` is the native Zsh idiom.",
+		Line:    decl.Token.Line,
+		Column:  decl.Token.Column,
+		Level:   SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 284 Katas = 0.2.84
-const Version = "0.2.84"
+// 285 Katas = 0.2.85
+const Version = "0.2.85"


### PR DESCRIPTION
## Summary
- Adds ZC1288: detects `declare` usage in Zsh scripts
- Recommends native `typeset` as the idiomatic Zsh builtin
- Severity: style

## Test plan
- [x] Unit tests for valid and invalid cases
- [x] Full test suite passes
- [x] Lint clean