### PR TITLE
feat: Add ZC1289 — use Zsh ${(u)array} for unique elements instead of sort -u

### DIFF
--- a/pkg/katas/katatests/zc1289_test.go
+++ b/pkg/katas/katatests/zc1289_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1289(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid sort with numeric and unique",
+			input:    `sort -n -u file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid sort without unique",
+			input:    `sort file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid sort -u alone",
+			input: `sort -u file.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1289",
+					Message: "Use Zsh `${(u)array}` for unique elements instead of `sort -u`. The `(u)` flag preserves order.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1289")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1289.go
+++ b/pkg/katas/zc1289.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1289",
+		Title:    "Use Zsh `${(u)array}` for unique elements instead of `sort -u`",
+		Severity: SeverityStyle,
+		Description: "Zsh provides the `(u)` parameter expansion flag to remove duplicate " +
+			"elements from an array. This preserves original order and avoids spawning " +
+			"an external `sort -u` process.",
+		Check: checkZC1289,
+	})
+}
+
+func checkZC1289(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sort" {
+		return nil
+	}
+
+	hasUnique := false
+	hasOtherFlags := false
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-u" {
+			hasUnique = true
+		} else if len(val) > 1 && val[0] == '-' {
+			hasOtherFlags = true
+		}
+	}
+
+	if hasUnique && !hasOtherFlags {
+		return []Violation{{
+			KataID:  "ZC1289",
+			Message: "Use Zsh `${(u)array}` for unique elements instead of `sort -u`. The `(u)` flag preserves order.",
+			Line:    cmd.Token.Line,
+			Column:  cmd.Token.Column,
+			Level:   SeverityStyle,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 285 Katas = 0.2.85
-const Version = "0.2.85"
+// 286 Katas = 0.2.86
+const Version = "0.2.86"


### PR DESCRIPTION
## Summary
- Adds ZC1289: detects `sort -u` without other complex flags
- Recommends Zsh native `${(u)array}` parameter flag for deduplication
- Preserves original order unlike `sort -u`
- Severity: style

## Test plan
- [x] Unit tests for valid and invalid cases
- [x] Full test suite passes
- [x] Lint clean