### PR TITLE
feat: Add ZC1290 — use Zsh ${(n)array} for numeric sorting instead of sort -n

### DIFF
--- a/pkg/katas/katatests/zc1290_test.go
+++ b/pkg/katas/katatests/zc1290_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1290(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid sort -n with -r flag",
+			input:    `sort -n -r file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid sort without -n",
+			input:    `sort file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid sort -n alone",
+			input: `sort -n file.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1290",
+					Message: "Use Zsh `${(n)array}` for numeric sorting instead of `sort -n`. The `(n)` flag sorts numerically in-shell.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1290")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1290.go
+++ b/pkg/katas/zc1290.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1290",
+		Title:    "Use Zsh `${(n)array}` for numeric sorting instead of `sort -n`",
+		Severity: SeverityStyle,
+		Description: "Zsh provides the `(n)` parameter expansion flag to sort array elements " +
+			"numerically. This avoids spawning an external `sort -n` process for " +
+			"simple numeric sorting of array data.",
+		Check: checkZC1290,
+	})
+}
+
+func checkZC1290(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sort" {
+		return nil
+	}
+
+	hasNumeric := false
+	hasOtherFlags := false
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-n" {
+			hasNumeric = true
+		} else if len(val) > 1 && val[0] == '-' {
+			hasOtherFlags = true
+		}
+	}
+
+	if hasNumeric && !hasOtherFlags {
+		return []Violation{{
+			KataID:  "ZC1290",
+			Message: "Use Zsh `${(n)array}` for numeric sorting instead of `sort -n`. The `(n)` flag sorts numerically in-shell.",
+			Line:    cmd.Token.Line,
+			Column:  cmd.Token.Column,
+			Level:   SeverityStyle,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 286 Katas = 0.2.86
-const Version = "0.2.86"
+// 287 Katas = 0.2.87
+const Version = "0.2.87"


### PR DESCRIPTION
## Summary
- Adds ZC1290: detects `sort -n` without other complex flags
- Recommends Zsh native `${(n)array}` parameter flag for numeric sorting
- Severity: style

## Test plan
- [x] Unit tests for valid and invalid cases
- [x] Full test suite passes
- [x] Lint clean