### PR TITLE
feat: Add ZC1291 — use Zsh ${(O)array} for reverse sorting instead of sort -r

### DIFF
--- a/pkg/katas/katatests/zc1291_test.go
+++ b/pkg/katas/katatests/zc1291_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1291(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid sort -r with -n",
+			input:    `sort -r -n file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid sort without -r",
+			input:    `sort file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid sort -r alone",
+			input: `sort -r file.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1291",
+					Message: "Use Zsh `${(O)array}` for reverse sorting instead of `sort -r`. The `(O)` flag sorts descending in-shell.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1291")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1291.go
+++ b/pkg/katas/zc1291.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1291",
+		Title:    "Use Zsh `${(O)array}` for reverse sorting instead of `sort -r`",
+		Severity: SeverityStyle,
+		Description: "Zsh provides the `(O)` parameter expansion flag to sort array elements " +
+			"in descending (reverse) order. This avoids spawning an external `sort -r` " +
+			"process for simple reverse sorting of array data.",
+		Check: checkZC1291,
+	})
+}
+
+func checkZC1291(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sort" {
+		return nil
+	}
+
+	hasReverse := false
+	hasOtherFlags := false
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-r" {
+			hasReverse = true
+		} else if len(val) > 1 && val[0] == '-' {
+			hasOtherFlags = true
+		}
+	}
+
+	if hasReverse && !hasOtherFlags {
+		return []Violation{{
+			KataID:  "ZC1291",
+			Message: "Use Zsh `${(O)array}` for reverse sorting instead of `sort -r`. The `(O)` flag sorts descending in-shell.",
+			Line:    cmd.Token.Line,
+			Column:  cmd.Token.Column,
+			Level:   SeverityStyle,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 287 Katas = 0.2.87
-const Version = "0.2.87"
+// 288 Katas = 0.2.88
+const Version = "0.2.88"


### PR DESCRIPTION
## Summary
- Adds ZC1291: detects `sort -r` without other complex flags
- Recommends Zsh native `${(O)array}` parameter flag for descending sort
- Severity: style

## Test plan
- [x] Unit tests for valid and invalid cases
- [x] Full test suite passes
- [x] Lint clean