### PR TITLE
feat: Add ZC1292 — use Zsh ${var//old/new} instead of tr for char translation

### DIFF
--- a/pkg/katas/katatests/zc1292_test.go
+++ b/pkg/katas/katatests/zc1292_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1292(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid tr with character ranges",
+			input:    `tr 'a-z' 'A-Z'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid tr with POSIX classes",
+			input:    `tr '[:upper:]' '[:lower:]'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid tr with single char translation",
+			input: `tr '/' '_'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1292",
+					Message: "Use Zsh `${var////_}` for character substitution instead of `tr`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1292")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1292.go
+++ b/pkg/katas/zc1292.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1292",
+		Title:    "Use Zsh `${var//old/new}` instead of `tr` for character translation",
+		Severity: SeverityStyle,
+		Description: "Zsh provides `${var//old/new}` for global substitution within a variable. " +
+			"For simple single-character translation, this avoids spawning `tr` as an " +
+			"external process.",
+		Check: checkZC1292,
+	})
+}
+
+func checkZC1292(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "tr" {
+		return nil
+	}
+
+	if len(cmd.Arguments) != 2 {
+		return nil
+	}
+
+	first := strings.Trim(cmd.Arguments[0].String(), "'\"")
+	second := strings.Trim(cmd.Arguments[1].String(), "'\"")
+
+	// Only flag simple single-character translations, not ranges or classes
+	if len(first) == 1 && len(second) == 1 {
+		return []Violation{{
+			KataID:  "ZC1292",
+			Message: "Use Zsh `${var//" + first + "/" + second + "}` for character substitution instead of `tr`.",
+			Line:    cmd.Token.Line,
+			Column:  cmd.Token.Column,
+			Level:   SeverityStyle,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 288 Katas = 0.2.88
-const Version = "0.2.88"
+// 289 Katas = 0.2.89
+const Version = "0.2.89"


### PR DESCRIPTION
## Summary
- Adds ZC1292: detects `tr` with single-character arguments
- Recommends Zsh native `${var//old/new}` parameter expansion
- Does not conflict with ZC1277 which handles case conversion ranges
- Severity: style

## Test plan
- [x] Unit tests for valid and invalid cases
- [x] Full test suite passes
- [x] Lint clean