### PR TITLE
feat: Add ZC1293 — use [[ ]] instead of test command in Zsh

### DIFF
--- a/pkg/katas/katatests/zc1293_test.go
+++ b/pkg/katas/katatests/zc1293_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1293(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid [[ ]] usage",
+			input:    `[[ -f file.txt ]]`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid test command",
+			input: `test -f file.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1293",
+					Message: "Use `[[ ]]` instead of the `test` command in Zsh. `[[ ]]` is more powerful and does not require variable quoting.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid test with -z flag",
+			input: `test -z "$var"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1293",
+					Message: "Use `[[ ]]` instead of the `test` command in Zsh. `[[ ]]` is more powerful and does not require variable quoting.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1293")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1293.go
+++ b/pkg/katas/zc1293.go
@@ -1,0 +1,37 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1293",
+		Title:    "Use `[[ ]]` instead of `test` command in Zsh",
+		Severity: SeverityStyle,
+		Description: "Zsh `[[ ]]` provides a more powerful conditional expression syntax than " +
+			"the `test` command. It supports pattern matching, regex, and does not require " +
+			"quoting of variable expansions to prevent word splitting.",
+		Check: checkZC1293,
+	})
+}
+
+func checkZC1293(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "test" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1293",
+		Message: "Use `[[ ]]` instead of the `test` command in Zsh. `[[ ]]` is more powerful and does not require variable quoting.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 289 Katas = 0.2.89
-const Version = "0.2.89"
+// 290 Katas = 0.2.90
+const Version = "0.2.90"


### PR DESCRIPTION
## Summary
- Adds ZC1293: detects `test` command usage
- Recommends Zsh native `[[ ]]` conditional syntax
- `[[ ]]` supports pattern matching, regex, and doesn't need variable quoting
- Severity: style

## Test plan
- [x] Unit tests for valid and invalid cases
- [x] Full test suite passes
- [x] Lint clean