### PR TITLE
feat: Add ZC1294 — use bindkey instead of bind for Zsh key bindings

### DIFF
--- a/pkg/katas/katatests/zc1294_test.go
+++ b/pkg/katas/katatests/zc1294_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1294(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid bindkey usage",
+			input:    `bindkey -e`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid bind usage",
+			input: `bind -x '"\C-r": history-search'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1294",
+					Message: "Use `bindkey` instead of `bind` in Zsh. `bind` is a Bash builtin; Zsh uses `bindkey` for ZLE key bindings.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1294")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1294.go
+++ b/pkg/katas/zc1294.go
@@ -1,0 +1,37 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1294",
+		Title:    "Use `bindkey` instead of `bind` for key bindings in Zsh",
+		Severity: SeverityWarning,
+		Description: "`bind` is a Bash builtin for key bindings. Zsh uses `bindkey` for " +
+			"ZLE (Zsh Line Editor) key bindings. Using `bind` in a Zsh script will " +
+			"fail unless Bash compatibility is loaded.",
+		Check: checkZC1294,
+	})
+}
+
+func checkZC1294(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "bind" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1294",
+		Message: "Use `bindkey` instead of `bind` in Zsh. `bind` is a Bash builtin; Zsh uses `bindkey` for ZLE key bindings.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 290 Katas = 0.2.90
-const Version = "0.2.90"
+// 291 Katas = 0.2.91
+const Version = "0.2.91"


### PR DESCRIPTION
## Summary
- Adds ZC1294: detects Bash `bind` command usage in Zsh scripts
- Recommends Zsh native `bindkey` for ZLE key bindings
- Severity: warning (bind will fail in pure Zsh)

## Test plan
- [x] Unit tests for valid and invalid cases
- [x] Full test suite passes
- [x] Lint clean