### PR TITLE
feat: Add ZC1295 — use vared instead of read -e for interactive editing

### DIFF
--- a/pkg/katas/katatests/zc1295_test.go
+++ b/pkg/katas/katatests/zc1295_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1295(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid vared usage",
+			input:    `vared myvar`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid read without -e",
+			input:    `read -r myvar`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid read -e for editing",
+			input: `read -e myvar`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1295",
+					Message: "Use `vared` instead of `read -e` in Zsh. `vared` provides full ZLE editing support natively.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1295")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1295.go
+++ b/pkg/katas/zc1295.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1295",
+		Title:    "Use `vared` instead of `read -e` for interactive editing in Zsh",
+		Severity: SeverityStyle,
+		Description: "Zsh provides `vared` for interactive editing of variables with full " +
+			"ZLE support (tab completion, history, cursor movement). The `read -e` flag " +
+			"is a Bash extension; Zsh `vared` is the native equivalent.",
+		Check: checkZC1295,
+	})
+}
+
+func checkZC1295(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "read" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-e" {
+			return []Violation{{
+				KataID:  "ZC1295",
+				Message: "Use `vared` instead of `read -e` in Zsh. `vared` provides full ZLE editing support natively.",
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 291 Katas = 0.2.91
-const Version = "0.2.91"
+// 292 Katas = 0.2.92
+const Version = "0.2.92"


### PR DESCRIPTION
## Summary
- Adds ZC1295: detects `read -e` (Bash readline editing flag)
- Recommends Zsh native `vared` for interactive variable editing with ZLE
- Severity: style

## Test plan
- [x] Unit tests pass
- [x] Full test suite passes
- [x] Lint clean