### PR TITLE
feat: Add ZC1296 — avoid shopt in Zsh, use setopt/unsetopt instead

### DIFF
--- a/pkg/katas/katatests/zc1296_test.go
+++ b/pkg/katas/katatests/zc1296_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1296(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid setopt usage",
+			input:    `setopt extendedglob`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid shopt usage",
+			input: `shopt -s extglob`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1296",
+					Message: "Avoid `shopt` in Zsh — it is a Bash builtin. Use `setopt`/`unsetopt` for Zsh shell options.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1296")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1296.go
+++ b/pkg/katas/zc1296.go
@@ -1,0 +1,37 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1296",
+		Title:    "Avoid `shopt` in Zsh — use `setopt`/`unsetopt` instead",
+		Severity: SeverityWarning,
+		Description: "`shopt` is a Bash builtin that does not exist in Zsh. Use `setopt` " +
+			"or `unsetopt` to control Zsh shell options. Common Bash `shopt` options " +
+			"have Zsh equivalents via `setopt`.",
+		Check: checkZC1296,
+	})
+}
+
+func checkZC1296(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "shopt" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1296",
+		Message: "Avoid `shopt` in Zsh — it is a Bash builtin. Use `setopt`/`unsetopt` for Zsh shell options.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 292 Katas = 0.2.92
-const Version = "0.2.92"
+// 293 Katas = 0.2.93
+const Version = "0.2.93"


### PR DESCRIPTION
## Summary
- Adds ZC1296: detects `shopt` (Bash-only builtin) in Zsh scripts
- Recommends `setopt`/`unsetopt` as the native Zsh equivalents
- Severity: warning (shopt does not exist in Zsh)

## Test plan
- [x] Unit tests pass
- [x] Full test suite passes
- [x] Lint clean