### PR TITLE
feat: Add ZC1297 — avoid $BASH_SOURCE in Zsh, use $0 instead

### DIFF
--- a/pkg/katas/katatests/zc1297_test.go
+++ b/pkg/katas/katatests/zc1297_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1297(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid $0 usage",
+			input:    `echo $0`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_SOURCE usage",
+			input: `echo $BASH_SOURCE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1297",
+					Message: "Avoid `$BASH_SOURCE` in Zsh — use `$0` or `${(%):-%x}` instead. `BASH_SOURCE` is Bash-specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1297")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1297.go
+++ b/pkg/katas/zc1297.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1297",
+		Title:    "Avoid `$BASH_SOURCE` — use `$0` or `${(%):-%x}` in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$BASH_SOURCE` is a Bash-specific variable that does not exist in Zsh. " +
+			"In Zsh, use `$0` inside a sourced file to get the script path, or " +
+			"`${(%):-%x}` for the current file regardless of sourcing context.",
+		Check: checkZC1297,
+	})
+}
+
+func checkZC1297(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_SOURCE" && ident.Value != "BASH_SOURCE" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1297",
+		Message: "Avoid `$BASH_SOURCE` in Zsh — use `$0` or `${(%):-%x}` instead. `BASH_SOURCE` is Bash-specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 293 Katas = 0.2.93
-const Version = "0.2.93"
+// 294 Katas = 0.2.94
+const Version = "0.2.94"


### PR DESCRIPTION
## Summary
- Adds ZC1297: detects `$BASH_SOURCE` usage in Zsh scripts
- Recommends `$0` or `${(%):-%x}` as native Zsh alternatives
- Severity: warning (BASH_SOURCE is undefined in Zsh)

## Test plan
- [x] Unit tests pass
- [x] Full test suite passes
- [x] Lint clean