### PR TITLE
feat: Add ZC1298 — avoid $FUNCNAME in Zsh, use $funcstack

### DIFF
--- a/pkg/katas/katatests/zc1298_test.go
+++ b/pkg/katas/katatests/zc1298_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1298(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid funcstack usage",
+			input:    `echo $funcstack`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid FUNCNAME usage",
+			input: `echo $FUNCNAME`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1298",
+					Message: "Avoid `$FUNCNAME` in Zsh — use `$funcstack` instead. `FUNCNAME` is Bash-specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1298")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1298.go
+++ b/pkg/katas/zc1298.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1298",
+		Title:    "Avoid `$FUNCNAME` — use `$funcstack` in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$FUNCNAME` is a Bash-specific array that does not exist in Zsh. " +
+			"Zsh provides `$funcstack` as the equivalent, containing the call stack " +
+			"of function names with the current function at index 1.",
+		Check: checkZC1298,
+	})
+}
+
+func checkZC1298(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$FUNCNAME" && ident.Value != "FUNCNAME" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1298",
+		Message: "Avoid `$FUNCNAME` in Zsh — use `$funcstack` instead. `FUNCNAME` is Bash-specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 294 Katas = 0.2.94
-const Version = "0.2.94"
+// 295 Katas = 0.2.95
+const Version = "0.2.95"


### PR DESCRIPTION
## Summary
- Adds ZC1298: detects `$FUNCNAME` usage in Zsh scripts
- Recommends `$funcstack` as the native Zsh call stack array
- Severity: warning (FUNCNAME is undefined in Zsh)

## Test plan
- [x] Unit tests pass
- [x] Full test suite passes
- [x] Lint clean