### PR TITLE
feat: Add ZC1299 — avoid $BASH_LINENO in Zsh, use $funcfiletrace

### DIFF
--- a/pkg/katas/katatests/zc1299_test.go
+++ b/pkg/katas/katatests/zc1299_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1299(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid funcfiletrace usage",
+			input:    `echo $funcfiletrace`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_LINENO usage",
+			input: `echo $BASH_LINENO`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1299",
+					Message: "Avoid `$BASH_LINENO` in Zsh — use `$funcfiletrace` instead. `BASH_LINENO` is Bash-specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1299")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1299.go
+++ b/pkg/katas/zc1299.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1299",
+		Title:    "Avoid `$BASH_LINENO` — use `$funcfiletrace` in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$BASH_LINENO` is a Bash-specific array that does not exist in Zsh. " +
+			"Zsh provides `$funcfiletrace` as the equivalent, containing file:line " +
+			"pairs for each call in the function stack.",
+		Check: checkZC1299,
+	})
+}
+
+func checkZC1299(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_LINENO" && ident.Value != "BASH_LINENO" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1299",
+		Message: "Avoid `$BASH_LINENO` in Zsh — use `$funcfiletrace` instead. `BASH_LINENO` is Bash-specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 295 Katas = 0.2.95
-const Version = "0.2.95"
+// 296 Katas = 0.2.96
+const Version = "0.2.96"


### PR DESCRIPTION
## Summary
- Adds ZC1299: detects `$BASH_LINENO` usage in Zsh scripts
- Recommends `$funcfiletrace` as the native Zsh equivalent
- Severity: warning (BASH_LINENO is undefined in Zsh)

## Test plan
- [x] Unit tests pass
- [x] Full test suite passes
- [x] Lint clean