### PR TITLE
feat: Add ZC1300 — avoid Bash version variables in Zsh

### DIFF
--- a/pkg/katas/katatests/zc1300_test.go
+++ b/pkg/katas/katatests/zc1300_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1300(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid ZSH_VERSION usage",
+			input:    `echo $ZSH_VERSION`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_VERSINFO usage",
+			input: `echo $BASH_VERSINFO`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1300",
+					Message: "Avoid Bash version variables in Zsh — use `$ZSH_VERSION` instead. Bash version variables are undefined in Zsh.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+		{
+			name:  "invalid BASH_VERSION usage",
+			input: `echo $BASH_VERSION`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1300",
+					Message: "Avoid Bash version variables in Zsh — use `$ZSH_VERSION` instead. Bash version variables are undefined in Zsh.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1300")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1300.go
+++ b/pkg/katas/zc1300.go
@@ -1,0 +1,37 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1300",
+		Title:    "Avoid `$BASH_VERSINFO` — use `$ZSH_VERSION` in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$BASH_VERSINFO` is a Bash-specific array containing version components. " +
+			"In Zsh, use `$ZSH_VERSION` (string) or `${(s:.:)ZSH_VERSION}` to split " +
+			"it into components for version comparison.",
+		Check: checkZC1300,
+	})
+}
+
+func checkZC1300(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_VERSINFO" && ident.Value != "BASH_VERSINFO" &&
+		ident.Value != "$BASH_VERSION" && ident.Value != "BASH_VERSION" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1300",
+		Message: "Avoid Bash version variables in Zsh — use `$ZSH_VERSION` instead. Bash version variables are undefined in Zsh.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 296 Katas = 0.2.96
-const Version = "0.2.96"
+// 297 Katas = 0.2.97
+const Version = "0.2.97"


### PR DESCRIPTION
## Summary
- Adds ZC1300: detects `$BASH_VERSINFO` and `$BASH_VERSION` in Zsh scripts
- Recommends `$ZSH_VERSION` as the native Zsh equivalent
- Severity: warning (Bash version variables are undefined in Zsh)

## Test plan
- [x] Unit tests pass
- [x] Full test suite passes
- [x] Lint clean