### PR TITLE
feat: Add ZC1301 — avoid $PIPESTATUS in Zsh, use $pipestatus

### DIFF
--- a/pkg/katas/katatests/zc1301_test.go
+++ b/pkg/katas/katatests/zc1301_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1301(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid pipestatus usage",
+			input:    `echo $pipestatus`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid PIPESTATUS usage",
+			input: `echo $PIPESTATUS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1301",
+					Message: "Avoid `$PIPESTATUS` in Zsh — use `$pipestatus` (lowercase) instead. The uppercase form is Bash-specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1301")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1301.go
+++ b/pkg/katas/zc1301.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1301",
+		Title:    "Avoid `$PIPESTATUS` — use `$pipestatus` (lowercase) in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$PIPESTATUS` is a Bash array containing exit statuses from the last " +
+			"pipeline. Zsh uses `$pipestatus` (lowercase) for the same purpose. " +
+			"The uppercase form is undefined in Zsh.",
+		Check: checkZC1301,
+	})
+}
+
+func checkZC1301(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$PIPESTATUS" && ident.Value != "PIPESTATUS" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1301",
+		Message: "Avoid `$PIPESTATUS` in Zsh — use `$pipestatus` (lowercase) instead. The uppercase form is Bash-specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 297 Katas = 0.2.97
-const Version = "0.2.97"
+// 298 Katas = 0.2.98
+const Version = "0.2.98"


### PR DESCRIPTION
## Summary
- Adds ZC1301: detects `$PIPESTATUS` (Bash-specific uppercase) in Zsh scripts
- Recommends `$pipestatus` (lowercase) as the native Zsh equivalent
- Severity: warning

## Test plan
- [x] Unit tests pass
- [x] Full test suite passes
- [x] Lint clean