### PR TITLE
feat: Add ZC1302 — avoid help builtin in Zsh, use run-help or man

### DIFF
--- a/pkg/katas/katatests/zc1302_test.go
+++ b/pkg/katas/katatests/zc1302_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1302(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid man usage",
+			input:    `man zshbuiltins`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid help usage",
+			input: `help cd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1302",
+					Message: "Avoid `help` in Zsh — it is a Bash builtin. Use `run-help` or `man zshbuiltins` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1302")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1302.go
+++ b/pkg/katas/zc1302.go
@@ -1,0 +1,37 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1302",
+		Title:    "Avoid `help` builtin — use `run-help` or `man` in Zsh",
+		Severity: SeverityInfo,
+		Description: "The `help` command is a Bash builtin that displays builtin help. " +
+			"Zsh does not have a `help` builtin. Use `run-help <command>` or " +
+			"`man zshbuiltins` for Zsh builtin documentation.",
+		Check: checkZC1302,
+	})
+}
+
+func checkZC1302(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "help" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1302",
+		Message: "Avoid `help` in Zsh — it is a Bash builtin. Use `run-help` or `man zshbuiltins` instead.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityInfo,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 298 Katas = 0.2.98
-const Version = "0.2.98"
+// 299 Katas = 0.2.99
+const Version = "0.2.99"


### PR DESCRIPTION
## Summary
- Adds ZC1302: detects `help` command usage (Bash-only builtin)
- Recommends `run-help` or `man zshbuiltins` for Zsh documentation
- Severity: info

## Test plan
- [x] Unit tests pass
- [x] Full test suite passes
- [x] Lint clean