### PR TITLE
feat: Add ZC1303 — avoid enable -f in Zsh, use zmodload for modules

### DIFF
--- a/pkg/katas/katatests/zc1303_test.go
+++ b/pkg/katas/katatests/zc1303_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1303(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid zmodload usage",
+			input:    `zmodload zsh/stat`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid enable without -f",
+			input:    `enable mybuiltin`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid enable -f usage",
+			input: `enable -f /path/to/builtin mybuiltin`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1303",
+					Message: "Avoid `enable -f` in Zsh — use `zmodload` to load modules. `enable -f` is Bash-specific.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1303")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1303.go
+++ b/pkg/katas/zc1303.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1303",
+		Title:    "Avoid `enable` command — use `zmodload` for Zsh modules",
+		Severity: SeverityWarning,
+		Description: "The `enable` command is a Bash builtin for enabling/disabling builtins. " +
+			"Zsh uses `zmodload` to load and manage modules, and `disable`/`enable` " +
+			"have different semantics. Use `zmodload` for module management.",
+		Check: checkZC1303,
+	})
+}
+
+func checkZC1303(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "enable" {
+		return nil
+	}
+
+	// enable with -f flag loads a builtin from a shared object (Bash-specific)
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-f" {
+			return []Violation{{
+				KataID:  "ZC1303",
+				Message: "Avoid `enable -f` in Zsh — use `zmodload` to load modules. `enable -f` is Bash-specific.",
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 299 Katas = 0.2.99
-const Version = "0.2.99"
+// 300 Katas = 0.3.0
+const Version = "0.3.0"


### PR DESCRIPTION
## Summary
- Adds ZC1303: detects `enable -f` (Bash builtin loading via shared objects)
- Recommends `zmodload` as the native Zsh module loading mechanism
- Severity: warning
- **Milestone: 300 katas — v0.3.0**

## Test plan
- [x] Unit tests pass
- [x] Full test suite passes
- [x] Lint clean