### PR TITLE
feat: Add ZC1304-ZC1308 — detect Bash-specific variables in Zsh

### DIFF
--- a/pkg/katas/katatests/zc1304_test.go
+++ b/pkg/katas/katatests/zc1304_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1304(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid ZSH_SUBSHELL usage",
+			input:    `echo $ZSH_SUBSHELL`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_SUBSHELL usage",
+			input: `echo $BASH_SUBSHELL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1304",
+					Message: "Avoid `$BASH_SUBSHELL` in Zsh — use `$ZSH_SUBSHELL` instead. `BASH_SUBSHELL` is Bash-specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1304")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1305_test.go
+++ b/pkg/katas/katatests/zc1305_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1305(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid words usage",
+			input:    `echo $words`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid COMP_WORDS usage",
+			input: `echo $COMP_WORDS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1305",
+					Message: "Avoid `$COMP_WORDS` in Zsh — use `$words` array instead. `COMP_WORDS` is Bash completion-specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1305")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1306_test.go
+++ b/pkg/katas/katatests/zc1306_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1306(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid CURRENT usage",
+			input:    `echo $CURRENT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid COMP_CWORD usage",
+			input: `echo $COMP_CWORD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1306",
+					Message: "Avoid `$COMP_CWORD` in Zsh — use `$CURRENT` instead. `COMP_CWORD` is Bash completion-specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1306")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1307_test.go
+++ b/pkg/katas/katatests/zc1307_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1307(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid dirstack usage",
+			input:    `echo $dirstack`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid DIRSTACK usage",
+			input: `echo $DIRSTACK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1307",
+					Message: "Avoid `$DIRSTACK` in Zsh — use `$dirstack` (lowercase) instead. The uppercase form is Bash-specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1307")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1308_test.go
+++ b/pkg/katas/katatests/zc1308_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1308(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid BUFFER usage",
+			input:    `echo $BUFFER`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid COMP_LINE usage",
+			input: `echo $COMP_LINE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1308",
+					Message: "Avoid `$COMP_LINE` in Zsh — use `$BUFFER` instead. `COMP_LINE` is Bash completion-specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1308")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1304.go
+++ b/pkg/katas/zc1304.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1304",
+		Title:    "Avoid `$BASH_SUBSHELL` — use `$ZSH_SUBSHELL` in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$BASH_SUBSHELL` tracks subshell nesting depth in Bash. " +
+			"Zsh provides `$ZSH_SUBSHELL` as the native equivalent.",
+		Check: checkZC1304,
+	})
+}
+
+func checkZC1304(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_SUBSHELL" && ident.Value != "BASH_SUBSHELL" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1304",
+		Message: "Avoid `$BASH_SUBSHELL` in Zsh — use `$ZSH_SUBSHELL` instead. `BASH_SUBSHELL` is Bash-specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1305.go
+++ b/pkg/katas/zc1305.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1305",
+		Title:    "Avoid `$COMP_WORDS` — use `$words` in Zsh completion",
+		Severity: SeverityWarning,
+		Description: "`$COMP_WORDS` is a Bash completion variable containing the words on " +
+			"the command line. Zsh completion uses `$words` array for the same purpose.",
+		Check: checkZC1305,
+	})
+}
+
+func checkZC1305(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$COMP_WORDS" && ident.Value != "COMP_WORDS" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1305",
+		Message: "Avoid `$COMP_WORDS` in Zsh — use `$words` array instead. `COMP_WORDS` is Bash completion-specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1306.go
+++ b/pkg/katas/zc1306.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1306",
+		Title:    "Avoid `$COMP_CWORD` — use `$CURRENT` in Zsh completion",
+		Severity: SeverityWarning,
+		Description: "`$COMP_CWORD` is a Bash completion variable for the current cursor " +
+			"word index. Zsh completion uses `$CURRENT` for the same purpose.",
+		Check: checkZC1306,
+	})
+}
+
+func checkZC1306(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$COMP_CWORD" && ident.Value != "COMP_CWORD" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1306",
+		Message: "Avoid `$COMP_CWORD` in Zsh — use `$CURRENT` instead. `COMP_CWORD` is Bash completion-specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1307.go
+++ b/pkg/katas/zc1307.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1307",
+		Title:    "Avoid `$DIRSTACK` — use `$dirstack` (lowercase) in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$DIRSTACK` is the Bash form of the directory stack array. " +
+			"Zsh uses `$dirstack` (lowercase) for the same purpose.",
+		Check: checkZC1307,
+	})
+}
+
+func checkZC1307(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$DIRSTACK" && ident.Value != "DIRSTACK" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1307",
+		Message: "Avoid `$DIRSTACK` in Zsh — use `$dirstack` (lowercase) instead. The uppercase form is Bash-specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1308.go
+++ b/pkg/katas/zc1308.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1308",
+		Title:    "Avoid `$COMP_LINE` — use `$BUFFER` in Zsh completion",
+		Severity: SeverityWarning,
+		Description: "`$COMP_LINE` is a Bash completion variable containing the full command " +
+			"line. Zsh completion uses `$BUFFER` for the current command line content.",
+		Check: checkZC1308,
+	})
+}
+
+func checkZC1308(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$COMP_LINE" && ident.Value != "COMP_LINE" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1308",
+		Message: "Avoid `$COMP_LINE` in Zsh — use `$BUFFER` instead. `COMP_LINE` is Bash completion-specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 300 Katas = 0.3.0
-const Version = "0.3.0"
+// 305 Katas = 0.3.5
+const Version = "0.3.5"


### PR DESCRIPTION
## Summary
Batch of 5 katas detecting Bash-specific variables used in Zsh scripts:
- ZC1304: `$BASH_SUBSHELL` → `$ZSH_SUBSHELL`
- ZC1305: `$COMP_WORDS` → `$words`
- ZC1306: `$COMP_CWORD` → `$CURRENT`
- ZC1307: `$DIRSTACK` → `$dirstack`
- ZC1308: `$COMP_LINE` → `$BUFFER`
- All severity: warning

## Test plan
- [x] All 5 kata tests pass individually
- [x] Full test suite passes
- [x] Lint clean