### PR TITLE
feat: Add ZC1309-ZC1313 — detect Bash builtins and variables in Zsh

### DIFF
--- a/pkg/katas/katatests/zc1309_test.go
+++ b/pkg/katas/katatests/zc1309_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1309(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid non-Bash variable",
+			input:    `echo $MY_COMMAND`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_COMMAND usage",
+			input: `echo $BASH_COMMAND`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1309",
+					Message: "Avoid `$BASH_COMMAND` in Zsh — it is undefined. Use `$ZSH_DEBUG_CMD` in debug traps if needed.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1309")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1310_test.go
+++ b/pkg/katas/katatests/zc1310_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1310(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid variable",
+			input:    `echo $MY_STRING`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_EXECUTION_STRING usage",
+			input: `echo $BASH_EXECUTION_STRING`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1310",
+					Message: "Avoid `$BASH_EXECUTION_STRING` in Zsh — it is undefined. Access command arguments directly instead.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1310")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1311_test.go
+++ b/pkg/katas/katatests/zc1311_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1311(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid compdef usage",
+			input:    `compdef _git git`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid complete usage",
+			input: `complete -F _git git`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1311",
+					Message: "Avoid `complete` in Zsh — it is a Bash builtin. Use `compdef` for Zsh completion registration.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1311")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1312_test.go
+++ b/pkg/katas/katatests/zc1312_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1312(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid compadd usage",
+			input:    `compadd foo bar baz`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid compgen usage",
+			input: `compgen -W "foo bar" -`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1312",
+					Message: "Avoid `compgen` in Zsh — it is a Bash builtin. Use `compadd` or Zsh completion functions instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1312")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1313_test.go
+++ b/pkg/katas/katatests/zc1313_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1313(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid aliases usage",
+			input:    `echo $aliases`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_ALIASES usage",
+			input: `echo $BASH_ALIASES`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1313",
+					Message: "Avoid `$BASH_ALIASES` in Zsh — use the `aliases` associative array instead.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1313")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1309.go
+++ b/pkg/katas/zc1309.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1309",
+		Title:    "Avoid `$BASH_COMMAND` — not available in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$BASH_COMMAND` contains the currently executing command in Bash. " +
+			"Zsh does not provide a direct equivalent. Use `$ZSH_DEBUG_CMD` in " +
+			"debug traps or restructure the logic.",
+		Check: checkZC1309,
+	})
+}
+
+func checkZC1309(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_COMMAND" && ident.Value != "BASH_COMMAND" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1309",
+		Message: "Avoid `$BASH_COMMAND` in Zsh — it is undefined. Use `$ZSH_DEBUG_CMD` in debug traps if needed.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1310.go
+++ b/pkg/katas/zc1310.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1310",
+		Title:    "Avoid `$BASH_EXECUTION_STRING` — not available in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$BASH_EXECUTION_STRING` contains the argument to `bash -c`. " +
+			"Zsh does not provide this variable. Access the script argument directly.",
+		Check: checkZC1310,
+	})
+}
+
+func checkZC1310(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_EXECUTION_STRING" && ident.Value != "BASH_EXECUTION_STRING" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1310",
+		Message: "Avoid `$BASH_EXECUTION_STRING` in Zsh — it is undefined. Access command arguments directly instead.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1311.go
+++ b/pkg/katas/zc1311.go
@@ -1,0 +1,37 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1311",
+		Title:    "Avoid `complete` command — use `compdef` in Zsh",
+		Severity: SeverityWarning,
+		Description: "`complete` is a Bash builtin for registering tab completions. " +
+			"Zsh uses `compdef` for completion registration and the `compctl` " +
+			"legacy interface. Use `compdef` for the modern Zsh completion system.",
+		Check: checkZC1311,
+	})
+}
+
+func checkZC1311(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "complete" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1311",
+		Message: "Avoid `complete` in Zsh — it is a Bash builtin. Use `compdef` for Zsh completion registration.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1312.go
+++ b/pkg/katas/zc1312.go
@@ -1,0 +1,37 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1312",
+		Title:    "Avoid `compgen` command — use `compadd` in Zsh",
+		Severity: SeverityWarning,
+		Description: "`compgen` is a Bash builtin for generating completions. " +
+			"Zsh uses `compadd` and the completion system functions for adding " +
+			"completion candidates.",
+		Check: checkZC1312,
+	})
+}
+
+func checkZC1312(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "compgen" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1312",
+		Message: "Avoid `compgen` in Zsh — it is a Bash builtin. Use `compadd` or Zsh completion functions instead.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1313.go
+++ b/pkg/katas/zc1313.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1313",
+		Title:    "Avoid `$BASH_ALIASES` — use Zsh `aliases` hash",
+		Severity: SeverityWarning,
+		Description: "`$BASH_ALIASES` is a Bash associative array of defined aliases. " +
+			"Zsh provides the `aliases` associative array for the same purpose.",
+		Check: checkZC1313,
+	})
+}
+
+func checkZC1313(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_ALIASES" && ident.Value != "BASH_ALIASES" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1313",
+		Message: "Avoid `$BASH_ALIASES` in Zsh — use the `aliases` associative array instead.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 305 Katas = 0.3.5
-const Version = "0.3.5"
+// 310 Katas = 0.3.10
+const Version = "0.3.10"


### PR DESCRIPTION
## Summary
Batch of 5 katas detecting Bash-specific builtins and variables:
- ZC1309: `$BASH_COMMAND` → `$ZSH_DEBUG_CMD`
- ZC1310: `$BASH_EXECUTION_STRING` — no Zsh equivalent
- ZC1311: `complete` → `compdef`
- ZC1312: `compgen` → `compadd`
- ZC1313: `$BASH_ALIASES` → `aliases` hash
- All severity: warning

## Test plan
- [x] All 5 kata tests pass
- [x] Full test suite passes
- [x] Lint clean