### PR TITLE
feat: Add ZC1314-ZC1318 — detect more Bash-specific variables and builtins

### DIFF
--- a/pkg/katas/katatests/zc1314_test.go
+++ b/pkg/katas/katatests/zc1314_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1314(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid non-Bash variable",
+			input:    `echo $MY_PATH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_LOADABLES_PATH",
+			input: `echo $BASH_LOADABLES_PATH`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1314",
+					Message: "Avoid `$BASH_LOADABLES_PATH` in Zsh — it is undefined. Use `zmodload` with full module names.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1314")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1315_test.go
+++ b/pkg/katas/katatests/zc1315_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1315(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid emulate usage",
+			input:    `emulate -L sh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_COMPAT usage",
+			input: `echo $BASH_COMPAT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1315",
+					Message: "Avoid `$BASH_COMPAT` in Zsh — use `emulate` for shell compatibility mode instead.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1315")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1316_test.go
+++ b/pkg/katas/katatests/zc1316_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1316(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid funcfiletrace usage",
+			input:    `echo $funcfiletrace`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid caller usage",
+			input: `caller 0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1316",
+					Message: "Avoid `caller` in Zsh — it is a Bash builtin. Use `$funcfiletrace` and `$funcstack` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1316")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1317_test.go
+++ b/pkg/katas/katatests/zc1317_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1317(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid ZDOTDIR usage",
+			input:    `echo $ZDOTDIR`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_ENV usage",
+			input: `echo $BASH_ENV`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1317",
+					Message: "Avoid `$BASH_ENV` in Zsh — use `$ZDOTDIR` for Zsh startup file locations instead.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1317")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1318_test.go
+++ b/pkg/katas/katatests/zc1318_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1318(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid commands usage",
+			input:    `echo $commands`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_CMDS usage",
+			input: `echo $BASH_CMDS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1318",
+					Message: "Avoid `$BASH_CMDS` in Zsh — use the `$commands` hash for command path lookups instead.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1318")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1314.go
+++ b/pkg/katas/zc1314.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1314",
+		Title:    "Avoid `$BASH_LOADABLES_PATH` — not available in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$BASH_LOADABLES_PATH` is a Bash variable for loadable builtin search paths. " +
+			"Zsh has no equivalent; use `zmodload` with full module names instead.",
+		Check: checkZC1314,
+	})
+}
+
+func checkZC1314(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_LOADABLES_PATH" && ident.Value != "BASH_LOADABLES_PATH" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1314",
+		Message: "Avoid `$BASH_LOADABLES_PATH` in Zsh — it is undefined. Use `zmodload` with full module names.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1315.go
+++ b/pkg/katas/zc1315.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1315",
+		Title:    "Avoid `$BASH_COMPAT` — use `emulate` for compatibility in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$BASH_COMPAT` sets Bash compatibility level. Zsh uses `emulate` " +
+			"to control compatibility mode (e.g., `emulate -L sh` for POSIX mode).",
+		Check: checkZC1315,
+	})
+}
+
+func checkZC1315(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_COMPAT" && ident.Value != "BASH_COMPAT" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1315",
+		Message: "Avoid `$BASH_COMPAT` in Zsh — use `emulate` for shell compatibility mode instead.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1316.go
+++ b/pkg/katas/zc1316.go
@@ -1,0 +1,37 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1316",
+		Title:    "Avoid `caller` builtin — use `$funcfiletrace` in Zsh",
+		Severity: SeverityWarning,
+		Description: "`caller` is a Bash builtin that returns the call stack context. " +
+			"Zsh provides `$funcfiletrace`, `$funcstack`, and `$funcsourcetrace` " +
+			"for inspecting the call stack.",
+		Check: checkZC1316,
+	})
+}
+
+func checkZC1316(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "caller" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1316",
+		Message: "Avoid `caller` in Zsh — it is a Bash builtin. Use `$funcfiletrace` and `$funcstack` instead.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1317.go
+++ b/pkg/katas/zc1317.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1317",
+		Title:    "Avoid `$BASH_ENV` — use `$ZDOTDIR` and `$ENV` in Zsh",
+		Severity: SeverityInfo,
+		Description: "`$BASH_ENV` specifies a startup file for non-interactive Bash shells. " +
+			"Zsh uses `$ZDOTDIR` to locate `.zshrc` and related files, and `$ENV` " +
+			"for POSIX-compatible startup.",
+		Check: checkZC1317,
+	})
+}
+
+func checkZC1317(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_ENV" && ident.Value != "BASH_ENV" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1317",
+		Message: "Avoid `$BASH_ENV` in Zsh — use `$ZDOTDIR` for Zsh startup file locations instead.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityInfo,
+	}}
+}

--- a/pkg/katas/zc1318.go
+++ b/pkg/katas/zc1318.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1318",
+		Title:    "Avoid `$BASH_CMDS` — use `$commands` hash in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$BASH_CMDS` is a Bash associative array caching command lookups. " +
+			"Zsh provides the `$commands` hash for the same purpose, mapping " +
+			"command names to their full paths.",
+		Check: checkZC1318,
+	})
+}
+
+func checkZC1318(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_CMDS" && ident.Value != "BASH_CMDS" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1318",
+		Message: "Avoid `$BASH_CMDS` in Zsh — use the `$commands` hash for command path lookups instead.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 310 Katas = 0.3.10
-const Version = "0.3.10"
+// 315 Katas = 0.3.15
+const Version = "0.3.15"


### PR DESCRIPTION
## Summary
Batch of 5 katas detecting Bash-specific variables and builtins:
- ZC1314: `$BASH_LOADABLES_PATH` — no Zsh equivalent
- ZC1315: `$BASH_COMPAT` → `emulate`
- ZC1316: `caller` → `$funcfiletrace`/`$funcstack`
- ZC1317: `$BASH_ENV` → `$ZDOTDIR`
- ZC1318: `$BASH_CMDS` → `$commands` hash

## Test plan
- [x] All 5 kata tests pass
- [x] Full test suite passes
- [x] Lint clean