### PR TITLE
feat: Add ZC1319-ZC1323 — detect Bash variables and builtins in Zsh

### DIFF
--- a/pkg/katas/katatests/zc1319_test.go
+++ b/pkg/katas/katatests/zc1319_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1319(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid argument count",
+			input:    `echo $MYVAR`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_ARGC usage",
+			input: `echo $BASH_ARGC`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1319",
+					Message: "Avoid `$BASH_ARGC` in Zsh — use `$#` for argument count. `BASH_ARGC` is Bash-specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1319")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1320_test.go
+++ b/pkg/katas/katatests/zc1320_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1320(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid argv usage",
+			input:    `echo $argv`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_ARGV usage",
+			input: `echo $BASH_ARGV`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1320",
+					Message: "Avoid `$BASH_ARGV` in Zsh — use `$argv` or `$@` for positional parameters. `BASH_ARGV` is Bash-specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1320")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1321_test.go
+++ b/pkg/katas/katatests/zc1321_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1321(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid variable",
+			input:    `echo $MY_FD`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_XTRACEFD usage",
+			input: `echo $BASH_XTRACEFD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1321",
+					Message: "Avoid `$BASH_XTRACEFD` in Zsh — it is undefined. Redirect stderr directly for xtrace output.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1321")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1322_test.go
+++ b/pkg/katas/katatests/zc1322_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1322(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid non-COPROC variable",
+			input:    `echo $MY_PROC`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid COPROC usage",
+			input: `echo $COPROC`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1322",
+					Message: "Avoid `$COPROC` in Zsh — Zsh coprocesses use `read -p`/`print -p` for I/O. `COPROC` is Bash-specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1322")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1323_test.go
+++ b/pkg/katas/katatests/zc1323_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1323(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid kill usage",
+			input:    `kill -STOP 1234`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid suspend usage",
+			input: `suspend -f`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1323",
+					Message: "Avoid `suspend` in Zsh — it is a Bash builtin. Use `kill -STOP $$` if needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1323")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1319.go
+++ b/pkg/katas/zc1319.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1319",
+		Title:    "Avoid `$BASH_ARGC` — use `$#` in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$BASH_ARGC` is a Bash array tracking argument counts per stack frame. " +
+			"Zsh uses `$#` for argument count and `$argv` for the argument array.",
+		Check: checkZC1319,
+	})
+}
+
+func checkZC1319(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_ARGC" && ident.Value != "BASH_ARGC" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1319",
+		Message: "Avoid `$BASH_ARGC` in Zsh — use `$#` for argument count. `BASH_ARGC` is Bash-specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1320.go
+++ b/pkg/katas/zc1320.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1320",
+		Title:    "Avoid `$BASH_ARGV` — use `$argv` in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$BASH_ARGV` is a Bash array containing arguments in reverse order. " +
+			"Zsh provides `$argv` (or `$@`) for positional parameters.",
+		Check: checkZC1320,
+	})
+}
+
+func checkZC1320(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_ARGV" && ident.Value != "BASH_ARGV" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1320",
+		Message: "Avoid `$BASH_ARGV` in Zsh — use `$argv` or `$@` for positional parameters. `BASH_ARGV` is Bash-specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1321.go
+++ b/pkg/katas/zc1321.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1321",
+		Title:    "Avoid `$BASH_XTRACEFD` — not available in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$BASH_XTRACEFD` redirects Bash xtrace output to a file descriptor. " +
+			"Zsh does not have this variable. Use `exec 2>file` or redirect " +
+			"stderr directly for trace output redirection.",
+		Check: checkZC1321,
+	})
+}
+
+func checkZC1321(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_XTRACEFD" && ident.Value != "BASH_XTRACEFD" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1321",
+		Message: "Avoid `$BASH_XTRACEFD` in Zsh — it is undefined. Redirect stderr directly for xtrace output.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1322.go
+++ b/pkg/katas/zc1322.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1322",
+		Title:    "Avoid `$COPROC` — Zsh coproc uses different syntax",
+		Severity: SeverityWarning,
+		Description: "`$COPROC` is a Bash array for coprocess file descriptors. " +
+			"Zsh coprocesses use `coproc` keyword with different variable naming " +
+			"and `read -p`/`print -p` for I/O.",
+		Check: checkZC1322,
+	})
+}
+
+func checkZC1322(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$COPROC" && ident.Value != "COPROC" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1322",
+		Message: "Avoid `$COPROC` in Zsh — Zsh coprocesses use `read -p`/`print -p` for I/O. `COPROC` is Bash-specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1323.go
+++ b/pkg/katas/zc1323.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1323",
+		Title:    "Avoid `suspend` builtin — use `kill -STOP $$` in Zsh",
+		Severity: SeverityWarning,
+		Description: "`suspend` is a Bash builtin that suspends the shell. Zsh does not have " +
+			"a `suspend` builtin. Use `kill -STOP $$` or Ctrl-Z for the same effect.",
+		Check: checkZC1323,
+	})
+}
+
+func checkZC1323(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "suspend" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1323",
+		Message: "Avoid `suspend` in Zsh — it is a Bash builtin. Use `kill -STOP $$` if needed.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 315 Katas = 0.3.15
-const Version = "0.3.15"
+// 320 Katas = 0.3.20
+const Version = "0.3.20"


### PR DESCRIPTION
## Summary
Batch of 5 katas detecting Bash-specific variables and builtins:
- ZC1319: `$BASH_ARGC` → `$#`
- ZC1320: `$BASH_ARGV` → `$argv`
- ZC1321: `$BASH_XTRACEFD` — no Zsh equivalent
- ZC1322: `$COPROC` → Zsh coproc uses different syntax
- ZC1323: `suspend` → `kill -STOP $$`

## Test plan
- [x] All 5 kata tests pass
- [x] Full test suite passes
- [x] Lint clean