### PR TITLE
feat: Add ZC1324-ZC1328 — detect Bash prompt and history variables

### DIFF
--- a/pkg/katas/katatests/zc1324_test.go
+++ b/pkg/katas/katatests/zc1324_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1324(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid precmd usage",
+			input:    `echo $precmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid PROMPT_COMMAND usage",
+			input: `echo $PROMPT_COMMAND`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1324",
+					Message: "Avoid `$PROMPT_COMMAND` in Zsh — use the `precmd` hook function instead. `PROMPT_COMMAND` is Bash-specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1324")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1325_test.go
+++ b/pkg/katas/katatests/zc1325_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1325(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid PS1 usage",
+			input:    `echo $PS1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid PS0 usage",
+			input: `echo $PS0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1325",
+					Message: "Avoid `$PS0` in Zsh — use the `preexec` hook function instead. `PS0` is Bash 4.4+ specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1325")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1326_test.go
+++ b/pkg/katas/katatests/zc1326_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1326(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid HISTFILE usage",
+			input:    `echo $HISTFILE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid HISTTIMEFORMAT usage",
+			input: `echo $HISTTIMEFORMAT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1326",
+					Message: "Avoid `$HISTTIMEFORMAT` in Zsh — use `setopt EXTENDED_HISTORY` and `fc -li` instead.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1326")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1327_test.go
+++ b/pkg/katas/katatests/zc1327_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1327(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid fc usage",
+			input:    `fc -l`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid history without flags",
+			input:    `history 10`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid history -c usage",
+			input: `history -c`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1327",
+					Message: "Avoid `history -c` in Zsh — Bash history flags differ. Use `fc` commands for Zsh history management.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1327")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1328_test.go
+++ b/pkg/katas/katatests/zc1328_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1328(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid HISTSIZE usage",
+			input:    `echo $HISTSIZE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid HISTCONTROL usage",
+			input: `echo $HISTCONTROL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1328",
+					Message: "Avoid `$HISTCONTROL` in Zsh — use `setopt HIST_IGNORE_DUPS` and related options instead.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1328")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1324.go
+++ b/pkg/katas/zc1324.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1324",
+		Title:    "Avoid `$PROMPT_COMMAND` — use `precmd` hook in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$PROMPT_COMMAND` is a Bash variable that executes a command before " +
+			"each prompt. Zsh uses the `precmd` hook function for the same purpose.",
+		Check: checkZC1324,
+	})
+}
+
+func checkZC1324(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$PROMPT_COMMAND" && ident.Value != "PROMPT_COMMAND" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1324",
+		Message: "Avoid `$PROMPT_COMMAND` in Zsh — use the `precmd` hook function instead. `PROMPT_COMMAND` is Bash-specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1325.go
+++ b/pkg/katas/zc1325.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1325",
+		Title:    "Avoid `$PS0` — use `preexec` hook in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$PS0` is a Bash 4.4+ prompt string displayed before command execution. " +
+			"Zsh uses the `preexec` hook function for running code before each command.",
+		Check: checkZC1325,
+	})
+}
+
+func checkZC1325(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$PS0" && ident.Value != "PS0" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1325",
+		Message: "Avoid `$PS0` in Zsh — use the `preexec` hook function instead. `PS0` is Bash 4.4+ specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1326.go
+++ b/pkg/katas/zc1326.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1326",
+		Title:    "Avoid `$HISTTIMEFORMAT` — use `fc -li` in Zsh",
+		Severity: SeverityInfo,
+		Description: "`$HISTTIMEFORMAT` is a Bash variable for formatting history timestamps. " +
+			"Zsh stores timestamps automatically when `EXTENDED_HISTORY` is set, " +
+			"and displays them with `fc -li` or `history -i`.",
+		Check: checkZC1326,
+	})
+}
+
+func checkZC1326(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$HISTTIMEFORMAT" && ident.Value != "HISTTIMEFORMAT" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1326",
+		Message: "Avoid `$HISTTIMEFORMAT` in Zsh — use `setopt EXTENDED_HISTORY` and `fc -li` instead.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityInfo,
+	}}
+}

--- a/pkg/katas/zc1327.go
+++ b/pkg/katas/zc1327.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1327",
+		Title:    "Avoid `history -c` — Zsh uses different history management",
+		Severity: SeverityWarning,
+		Description: "`history -c` clears history in Bash. Zsh provides `fc -p` for pushing " +
+			"history to a new file and `fc -P` for popping. Use `fc -W` to write and " +
+			"`fc -R` to read history files.",
+		Check: checkZC1327,
+	})
+}
+
+func checkZC1327(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "history" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-c" || val == "-w" || val == "-r" || val == "-a" {
+			return []Violation{{
+				KataID:  "ZC1327",
+				Message: "Avoid `history " + val + "` in Zsh — Bash history flags differ. Use `fc` commands for Zsh history management.",
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/katas/zc1328.go
+++ b/pkg/katas/zc1328.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1328",
+		Title:    "Avoid `$HISTCONTROL` — use Zsh `setopt` history options",
+		Severity: SeverityInfo,
+		Description: "`$HISTCONTROL` is a Bash variable controlling history deduplication. " +
+			"Zsh uses `setopt HIST_IGNORE_DUPS`, `HIST_IGNORE_ALL_DUPS`, and " +
+			"`HIST_IGNORE_SPACE` for the same functionality.",
+		Check: checkZC1328,
+	})
+}
+
+func checkZC1328(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$HISTCONTROL" && ident.Value != "HISTCONTROL" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1328",
+		Message: "Avoid `$HISTCONTROL` in Zsh — use `setopt HIST_IGNORE_DUPS` and related options instead.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityInfo,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 320 Katas = 0.3.20
-const Version = "0.3.20"
+// 325 Katas = 0.3.25
+const Version = "0.3.25"


### PR DESCRIPTION
## Summary
Batch of 5 katas detecting Bash-specific prompt and history variables:
- ZC1324: `$PROMPT_COMMAND` → `precmd` hook
- ZC1325: `$PS0` → `preexec` hook
- ZC1326: `$HISTTIMEFORMAT` → `setopt EXTENDED_HISTORY`
- ZC1327: `history -c/-w/-r/-a` → `fc` commands
- ZC1328: `$HISTCONTROL` → `setopt HIST_IGNORE_DUPS`

## Test plan
- [x] All 5 kata tests pass
- [x] Full test suite passes
- [x] Lint clean