### PR TITLE
feat: Add ZC1329-ZC1333 — detect Bash history, readline, and env variables

### DIFF
--- a/pkg/katas/katatests/zc1329_test.go
+++ b/pkg/katas/katatests/zc1329_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1329(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid HISTSIZE usage",
+			input:    `echo $HISTSIZE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid HISTIGNORE usage",
+			input: `echo $HISTIGNORE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1329",
+					Message: "Avoid `$HISTIGNORE` in Zsh — use `zshaddhistory` hook for history filtering instead.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1329")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1330_test.go
+++ b/pkg/katas/katatests/zc1330_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1330(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid ZDOTDIR usage",
+			input:    `echo $ZDOTDIR`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid INPUTRC usage",
+			input: `echo $INPUTRC`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1330",
+					Message: "Avoid `$INPUTRC` in Zsh — Zsh uses `bindkey` and ZLE, not readline. `INPUTRC` is Bash-specific.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1330")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1331_test.go
+++ b/pkg/katas/katatests/zc1331_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1331(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid match usage",
+			input:    `echo $match`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid BASH_REMATCH usage",
+			input: `echo $BASH_REMATCH`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1331",
+					Message: "Avoid `$BASH_REMATCH` in Zsh — use `$match` array and `$MATCH` for regex captures instead.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1331")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1332_test.go
+++ b/pkg/katas/katatests/zc1332_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1332(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid variable",
+			input:    `echo $MYGLOB`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid GLOBIGNORE usage",
+			input: `echo $GLOBIGNORE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1332",
+					Message: "Avoid `$GLOBIGNORE` in Zsh — use `setopt EXTENDED_GLOB` with `~` operator for glob exclusion.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1332")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1333_test.go
+++ b/pkg/katas/katatests/zc1333_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1333(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid TIMEFMT usage",
+			input:    `echo $TIMEFMT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid TIMEFORMAT usage",
+			input: `echo $TIMEFORMAT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1333",
+					Message: "Avoid `$TIMEFORMAT` in Zsh — use `$TIMEFMT` instead. Format specifiers differ between Bash and Zsh.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1333")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1329.go
+++ b/pkg/katas/zc1329.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1329",
+		Title:    "Avoid `$HISTIGNORE` — use `zshaddhistory` hook in Zsh",
+		Severity: SeverityInfo,
+		Description: "`$HISTIGNORE` is a Bash variable for pattern-based history filtering. " +
+			"Zsh uses the `zshaddhistory` hook function and `setopt HIST_IGNORE_SPACE` " +
+			"for controlling which commands enter history.",
+		Check: checkZC1329,
+	})
+}
+
+func checkZC1329(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$HISTIGNORE" && ident.Value != "HISTIGNORE" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1329",
+		Message: "Avoid `$HISTIGNORE` in Zsh — use `zshaddhistory` hook for history filtering instead.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityInfo,
+	}}
+}

--- a/pkg/katas/zc1330.go
+++ b/pkg/katas/zc1330.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1330",
+		Title:    "Avoid `$INPUTRC` — use `bindkey` in Zsh",
+		Severity: SeverityInfo,
+		Description: "`$INPUTRC` points to the readline configuration file in Bash. " +
+			"Zsh uses `bindkey` and ZLE widgets for key binding configuration, " +
+			"not readline.",
+		Check: checkZC1330,
+	})
+}
+
+func checkZC1330(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$INPUTRC" && ident.Value != "INPUTRC" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1330",
+		Message: "Avoid `$INPUTRC` in Zsh — Zsh uses `bindkey` and ZLE, not readline. `INPUTRC` is Bash-specific.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityInfo,
+	}}
+}

--- a/pkg/katas/zc1331.go
+++ b/pkg/katas/zc1331.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1331",
+		Title:    "Avoid `$BASH_REMATCH` — use `$match` array in Zsh",
+		Severity: SeverityWarning,
+		Description: "`$BASH_REMATCH` holds regex capture groups in Bash. Zsh stores " +
+			"regex matches in the `$match` array (and `$MATCH` for the full match) " +
+			"when using `=~` with `setopt BASH_REMATCH` disabled.",
+		Check: checkZC1331,
+	})
+}
+
+func checkZC1331(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$BASH_REMATCH" && ident.Value != "BASH_REMATCH" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1331",
+		Message: "Avoid `$BASH_REMATCH` in Zsh — use `$match` array and `$MATCH` for regex captures instead.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1332.go
+++ b/pkg/katas/zc1332.go
@@ -1,0 +1,36 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1332",
+		Title:    "Avoid `$GLOBIGNORE` — use `setopt EXTENDED_GLOB` in Zsh",
+		Severity: SeverityInfo,
+		Description: "`$GLOBIGNORE` is a Bash variable for excluding patterns from glob expansion. " +
+			"Zsh uses `setopt EXTENDED_GLOB` with the `~` (exclusion) operator or " +
+			"`setopt NULL_GLOB` for different glob behavior.",
+		Check: checkZC1332,
+	})
+}
+
+func checkZC1332(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$GLOBIGNORE" && ident.Value != "GLOBIGNORE" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1332",
+		Message: "Avoid `$GLOBIGNORE` in Zsh — use `setopt EXTENDED_GLOB` with `~` operator for glob exclusion.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityInfo,
+	}}
+}

--- a/pkg/katas/zc1333.go
+++ b/pkg/katas/zc1333.go
@@ -1,0 +1,35 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.IdentifierNode, Kata{
+		ID:       "ZC1333",
+		Title:    "Avoid `$TIMEFORMAT` — use `$TIMEFMT` in Zsh",
+		Severity: SeverityInfo,
+		Description: "`$TIMEFORMAT` is the Bash variable for customizing `time` output. " +
+			"Zsh uses `$TIMEFMT` for the same purpose, with different format specifiers.",
+		Check: checkZC1333,
+	})
+}
+
+func checkZC1333(node ast.Node) []Violation {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value != "$TIMEFORMAT" && ident.Value != "TIMEFORMAT" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1333",
+		Message: "Avoid `$TIMEFORMAT` in Zsh — use `$TIMEFMT` instead. Format specifiers differ between Bash and Zsh.",
+		Line:    ident.Token.Line,
+		Column:  ident.Token.Column,
+		Level:   SeverityInfo,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 325 Katas = 0.3.25
-const Version = "0.3.25"
+// 330 Katas = 0.3.30
+const Version = "0.3.30"


### PR DESCRIPTION
## Summary
Batch of 5 katas detecting Bash-specific history and environment variables:
- ZC1329: `$HISTIGNORE` → `zshaddhistory` hook
- ZC1330: `$INPUTRC` → `bindkey`/ZLE
- ZC1331: `$BASH_REMATCH` → `$match` array
- ZC1332: `$GLOBIGNORE` → `setopt EXTENDED_GLOB`
- ZC1333: `$TIMEFORMAT` → `$TIMEFMT`

## Test plan
- [x] All 5 kata tests pass
- [x] Full test suite passes
- [x] Lint clean