### PR TITLE
feat: Add ZC1334-ZC1338 — detect external commands replaceable by Zsh builtins

### DIFF
--- a/pkg/katas/katatests/zc1334_test.go
+++ b/pkg/katas/katatests/zc1334_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1334(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid whence -p usage",
+			input:    `whence -p git`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid type without -p",
+			input:    `type git`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid type -p usage",
+			input: `type -p git`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1334",
+					Message: "Avoid `type -p` in Zsh — use `whence -p` to get the command path instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1334")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1335_test.go
+++ b/pkg/katas/katatests/zc1335_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1335(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid other command",
+			input:    `cat file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "tac usage",
+			input: `tac file.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1335",
+					Message: "Consider Zsh `${(Oa)array}` for reversing array data instead of piping to `tac`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1335")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1336_test.go
+++ b/pkg/katas/katatests/zc1336_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1336(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid typeset -x usage",
+			input:    `typeset -x PATH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid printenv usage",
+			input: `printenv HOME`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1336",
+					Message: "Avoid `printenv` in Zsh — use `typeset -x` or `export` to list environment variables.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1336")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1337_test.go
+++ b/pkg/katas/katatests/zc1337_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1337(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid print usage",
+			input:    `print -l hello`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "fold usage",
+			input: `fold -w 80 file.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1337",
+					Message: "Consider Zsh `$COLUMNS` and `print` for text wrapping instead of `fold`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1337")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1338_test.go
+++ b/pkg/katas/katatests/zc1338_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1338(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid seq without -s",
+			input:    `seq 10`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid seq -s usage",
+			input: `seq -s , 10`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1338",
+					Message: "Avoid `seq -s` in Zsh — use `${(j:sep:)array}` with brace expansion for joined sequences.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1338")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1334.go
+++ b/pkg/katas/zc1334.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1334",
+		Title:    "Avoid `type -p` — use `whence -p` in Zsh",
+		Severity: SeverityWarning,
+		Description: "`type -p` is a Bash flag that prints the path of a command. " +
+			"Zsh `type` does not support `-p`. Use `whence -p` to get " +
+			"the path of an external command in Zsh.",
+		Check: checkZC1334,
+	})
+}
+
+func checkZC1334(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "type" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-p" || val == "-P" {
+			return []Violation{{
+				KataID:  "ZC1334",
+				Message: "Avoid `type -p` in Zsh — use `whence -p` to get the command path instead.",
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/katas/zc1335.go
+++ b/pkg/katas/zc1335.go
@@ -1,0 +1,37 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1335",
+		Title:    "Use Zsh array reversal instead of `tac` for in-memory data",
+		Severity: SeverityStyle,
+		Description: "`tac` reverses lines from a file or stdin. For in-memory array data, " +
+			"Zsh provides `${(Oa)array}` to reverse array element order without " +
+			"spawning an external process.",
+		Check: checkZC1335,
+	})
+}
+
+func checkZC1335(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "tac" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1335",
+		Message: "Consider Zsh `${(Oa)array}` for reversing array data instead of piping to `tac`.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityStyle,
+	}}
+}

--- a/pkg/katas/zc1336.go
+++ b/pkg/katas/zc1336.go
@@ -1,0 +1,37 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1336",
+		Title:    "Avoid `printenv` — use `typeset -x` or `export` in Zsh",
+		Severity: SeverityStyle,
+		Description: "`printenv` is an external command for listing environment variables. " +
+			"Zsh provides `typeset -x` to list exported variables and `export` " +
+			"to display them without spawning a subprocess.",
+		Check: checkZC1336,
+	})
+}
+
+func checkZC1336(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "printenv" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1336",
+		Message: "Avoid `printenv` in Zsh — use `typeset -x` or `export` to list environment variables.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityStyle,
+	}}
+}

--- a/pkg/katas/zc1337.go
+++ b/pkg/katas/zc1337.go
@@ -1,0 +1,37 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1337",
+		Title:    "Avoid `fold` command — use Zsh `print -l` with `$COLUMNS`",
+		Severity: SeverityStyle,
+		Description: "`fold` wraps text to a specified width. Zsh provides `$COLUMNS` for " +
+			"terminal width and `print -l` for line-by-line output, reducing " +
+			"dependency on external commands.",
+		Check: checkZC1337,
+	})
+}
+
+func checkZC1337(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "fold" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID:  "ZC1337",
+		Message: "Consider Zsh `$COLUMNS` and `print` for text wrapping instead of `fold`.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityStyle,
+	}}
+}

--- a/pkg/katas/zc1338.go
+++ b/pkg/katas/zc1338.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1338",
+		Title:    "Avoid `seq -s` — use Zsh `${(j:sep:)${(s::)...}}` for joining",
+		Severity: SeverityStyle,
+		Description: "`seq -s` generates a sequence with a custom separator. Zsh provides " +
+			"native brace expansion with `{start..end}` and `${(j:sep:)array}` " +
+			"for joining, avoiding an external process.",
+		Check: checkZC1338,
+	})
+}
+
+func checkZC1338(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "seq" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-s" {
+			return []Violation{{
+				KataID:  "ZC1338",
+				Message: "Avoid `seq -s` in Zsh — use `${(j:sep:)array}` with brace expansion for joined sequences.",
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 330 Katas = 0.3.30
-const Version = "0.3.30"
+// 335 Katas = 0.3.35
+const Version = "0.3.35"


### PR DESCRIPTION
## Summary
Batch of 5 katas detecting external commands that have Zsh native alternatives:
- ZC1334: `type -p` → `whence -p`
- ZC1335: `tac` → `${(Oa)array}`
- ZC1336: `printenv` → `typeset -x`
- ZC1337: `fold` → `print` with `$COLUMNS`
- ZC1338: `seq -s` → `${(j:sep:)array}` with brace expansion

## Test plan
- [x] All 5 kata tests pass
- [x] Full test suite passes
- [x] Lint clean