### PR TITLE
fix: install.sh substring checksum match picks up sibling files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -285,16 +285,20 @@ if [ "$BUILD_SUCCESS" = false ]; then
 
     # Download Binary
     if curl -sL -o "$FILENAME" "$URL"; then
-        # Verify
+        # Verify — match the exact filename at end-of-line so sibling
+        # entries (e.g. <archive>.sbom.json) are not selected by substring.
         if [ "$HAS_CHECKSUMS" = true ]; then
-            if command -v sha256sum &> /dev/null; then
-                if grep "$FILENAME" checksums.txt | sha256sum -c - --status; then
+            local_sum_line=$(awk -v f="$FILENAME" '$2 == f {print; exit}' checksums.txt)
+            if [ -z "$local_sum_line" ]; then
+                echo -e "${YELLOW}No checksum entry for $FILENAME in checksums.txt. Skipping verification.${NC}"
+            elif command -v sha256sum &> /dev/null; then
+                if printf '%s\n' "$local_sum_line" | sha256sum -c - --status; then
                     echo -e "${GREEN}Checksum verified.${NC}"
                 else
                     echo -e "${RED}Checksum verification failed!${NC}"; exit 1
                 fi
             elif command -v shasum &> /dev/null; then
-                 if grep "$FILENAME" checksums.txt | shasum -a 256 -c - --status; then
+                if printf '%s\n' "$local_sum_line" | shasum -a 256 -c - --status; then
                     echo -e "${GREEN}Checksum verified.${NC}"
                 else
                     echo -e "${RED}Checksum verification failed!${NC}"; exit 1


### PR DESCRIPTION
## Summary

Post-release smoke test of v0.3.35 exposed a checksum verification failure:

```
sha256sum: zshellcheck_Linux_x86_64.tar.gz.sbom.json: No such file or directory
Checksum verification failed!
```

The release archive layout now includes per-archive siblings (.sbom.json, .sig, .pem) and the installer's `grep "$FILENAME" checksums.txt` selects those lines too because the filename is a substring prefix.

## Fix

Match the exact filename at field 2 of the checksum line via `awk`. No false-positive matches, no over-selection, and more robust to future sibling additions.

## Test plan

- [x] Manual: `bash install.sh -y -v v0.3.35` now succeeds (verified locally against the tagged release archives)
- [ ] CI green