### PR TITLE
feat: ZC1339 — use `${#${(f)var}}` instead of `wc -l` for line count

### DIFF
--- a/pkg/katas/katatests/zc1339_test.go
+++ b/pkg/katas/katatests/zc1339_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1339(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid wc -l with file",
+			input:    `wc -l file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid wc -c",
+			input:    `wc -c`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid wc -l in pipeline",
+			input: `wc -l`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1339",
+					Message: "Use Zsh `${#${(f)var}}` for line counting instead of piping through `wc -l`. Parameter expansion avoids spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1339")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1339.go
+++ b/pkg/katas/zc1339.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1339",
+		Title:    "Use Zsh `${#${(f)var}}` instead of `wc -l` for line count",
+		Severity: SeverityStyle,
+		Description: "Zsh `${(f)var}` splits a string into lines and `${#...}` counts them. " +
+			"Avoid piping through `wc -l` for simple line counting from variables.",
+		Check: checkZC1339,
+	})
+}
+
+func checkZC1339(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "wc" {
+		return nil
+	}
+
+	hasLineFlag := false
+	hasFile := false
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-l" {
+			hasLineFlag = true
+		} else if len(val) > 0 && val[0] != '-' {
+			hasFile = true
+		}
+	}
+
+	if hasLineFlag && !hasFile {
+		return []Violation{{
+			KataID: "ZC1339",
+			Message: "Use Zsh `${#${(f)var}}` for line counting instead of piping through `wc -l`. " +
+				"Parameter expansion avoids spawning an external process.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityStyle,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 335 Katas = 0.3.35
-const Version = "0.3.35"
+// 336 Katas = 0.3.36
+const Version = "0.3.36"

--- a/tests/integration_test.zsh
+++ b/tests/integration_test.zsh
@@ -160,7 +160,7 @@ run_test 'sed "-i" "s/foo/bar/" file'	"ZC1052" 'ZC1052: sed "-i"'
 run_test 'if grep foo file; then :; fi'	"ZC1053" 'ZC1053: if grep'
 run_test 'while grep foo file; do :; done'	"ZC1053" 'ZC1053: while grep'
 run_test 'if grep -q foo file; then :; fi'	"" 'ZC1053: grep -q (Valid)'
-run_test 'if grep foo file | wc -l; then :; fi'	"" 'ZC1053: grep piped (Valid)'
+run_test 'if grep foo file | true; then :; fi'	"" 'ZC1053: grep piped (Valid)'
 
 # --- ZC1054: POSIX classes ---
 run_test 'tr "[A-Z]" "[a-z]"'	"ZC1054" 'ZC1054: tr ranges'


### PR DESCRIPTION
ZC1339 — Use Zsh `${#${(f)var}}` instead of `wc -l` for line count

What: flags `wc -l` invocations with no file argument (so it reads from stdin in a pipeline).
Why: Zsh's `(f)` parameter flag splits on newlines; `${#array}` counts elements. The combination counts lines natively without spawning an external process.
Fix suggestion: `${#${(f)var}}`
Severity: Style

Completes the `wc` family alongside ZC1081 (`-c` → `${#var}`) and ZC1185 (`-w` → `${#${(z)var}}`).