### PR TITLE
feat: ZC1341 — use Zsh `*(.x)` glob qualifier instead of `find -executable`

### DIFF
--- a/pkg/katas/katatests/zc1341_test.go
+++ b/pkg/katas/katatests/zc1341_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1341(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — find with other predicate",
+			input:    `find . -type f`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — find -executable",
+			input: `find . -executable`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1341",
+					Message: "Use Zsh `*(.x)` glob qualifier instead of `find -executable`. The `.` restricts to regular files and `x` to the executable bit.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — find -executable with -type f",
+			input: `find . -type f -executable`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1341",
+					Message: "Use Zsh `*(.x)` glob qualifier instead of `find -executable`. The `.` restricts to regular files and `x` to the executable bit.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1341")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1341.go
+++ b/pkg/katas/zc1341.go
@@ -1,0 +1,43 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1341",
+		Title:    "Use Zsh `*(.x)` glob qualifier instead of `find -executable`",
+		Severity: SeverityStyle,
+		Description: "Zsh's `*(.x)` glob qualifier matches regular files that are executable. " +
+			"Avoid shelling out to `find -executable` when the same selection is one glob away.",
+		Check: checkZC1341,
+	})
+}
+
+func checkZC1341(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "find" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-executable" {
+			return []Violation{{
+				KataID: "ZC1341",
+				Message: "Use Zsh `*(.x)` glob qualifier instead of `find -executable`. " +
+					"The `.` restricts to regular files and `x` to the executable bit.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 337 Katas = 0.3.37
-const Version = "0.3.37"
+// 338 Katas = 0.3.38
+const Version = "0.3.38"


### PR DESCRIPTION
ZC1341 — Use Zsh `*(.x)` glob qualifier instead of `find -executable`

What: flags any `find ... -executable` invocation.
Why: Zsh's glob qualifier `*(.x)` restricts expansion to regular files (`.`) that have the executable bit (`x`), covering the common use case without an external process. For recursive search use `**/*(.x)` (with extended_glob).
Fix suggestion: `for f in *(.x); do ...; done` or `scripts=(**/*(.x))`
Severity: Style