### PR TITLE
feat: ZC1342 — use Zsh `*(L0)` glob qualifier instead of `find -empty`

### DIFF
--- a/pkg/katas/katatests/zc1342_test.go
+++ b/pkg/katas/katatests/zc1342_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1342(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — find without -empty",
+			input:    `find . -type f`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — find -empty",
+			input: `find . -empty`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1342",
+					Message: "Use Zsh `*(L0)` glob qualifier instead of `find -empty`. Add `.` for regular files only: `*(.L0)`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — find -type f -empty",
+			input: `find . -type f -empty -delete`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1342",
+					Message: "Use Zsh `*(L0)` glob qualifier instead of `find -empty`. Add `.` for regular files only: `*(.L0)`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1342")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1342.go
+++ b/pkg/katas/zc1342.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1342",
+		Title:    "Use Zsh `*(L0)` glob qualifier instead of `find -empty`",
+		Severity: SeverityStyle,
+		Description: "Zsh's `*(L0)` glob qualifier matches files with length 0. " +
+			"Combine with `.` or `/` to restrict to regular files or directories. " +
+			"Avoid shelling out to `find -empty` for the same result.",
+		Check: checkZC1342,
+	})
+}
+
+func checkZC1342(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "find" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-empty" {
+			return []Violation{{
+				KataID: "ZC1342",
+				Message: "Use Zsh `*(L0)` glob qualifier instead of `find -empty`. " +
+					"Add `.` for regular files only: `*(.L0)`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 338 Katas = 0.3.38
-const Version = "0.3.38"
+// 339 Katas = 0.3.39
+const Version = "0.3.39"


### PR DESCRIPTION
ZC1342 — Use Zsh `*(L0)` glob qualifier instead of `find -empty`

What: flags any `find ... -empty` invocation.
Why: Zsh's `*(L0)` glob qualifier matches files whose length is zero; combined with `.` it restricts to regular files, and with `/` to directories. Same selection, no external process.
Fix suggestion: `*(L0)` (any), `*(.L0)` (regular files), `*(/L0)` (directories).
Severity: Style