### PR TITLE
feat: ZC1343 — use Zsh glob age qualifiers instead of `find -mtime`

### DIFF
--- a/pkg/katas/katatests/zc1343_test.go
+++ b/pkg/katas/katatests/zc1343_test.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1343(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — find without age predicate",
+			input:    `find . -type f`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — find -mtime +7",
+			input: `find . -mtime +7`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1343",
+					Message: "Use Zsh glob qualifiers (`*(m±N)`, `*(M±N)`, `*(a±N)`, `*(c±N)`) instead of `find -mtime`/`-mmin`/`-atime`/`-amin`/`-ctime`/`-cmin` for age predicates.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — find -mmin -60",
+			input: `find . -mmin -60`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1343",
+					Message: "Use Zsh glob qualifiers (`*(m±N)`, `*(M±N)`, `*(a±N)`, `*(c±N)`) instead of `find -mtime`/`-mmin`/`-atime`/`-amin`/`-ctime`/`-cmin` for age predicates.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — find -ctime 0",
+			input: `find . -ctime 0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1343",
+					Message: "Use Zsh glob qualifiers (`*(m±N)`, `*(M±N)`, `*(a±N)`, `*(c±N)`) instead of `find -mtime`/`-mmin`/`-atime`/`-amin`/`-ctime`/`-cmin` for age predicates.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1343")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1343.go
+++ b/pkg/katas/zc1343.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1343",
+		Title:    "Use Zsh `*(m±N)` glob qualifier instead of `find -mtime N`",
+		Severity: SeverityStyle,
+		Description: "Zsh's `*(mN)`, `*(m+N)`, `*(m-N)` glob qualifiers match files by age in days " +
+			"(exact / older / newer). For hours use `*(h±N)`, for minutes `*(M±N)`. " +
+			"Same expressive power as `find -mtime`, no external process.",
+		Check: checkZC1343,
+	})
+}
+
+func checkZC1343(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "find" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val == "-mtime" || val == "-mmin" || val == "-atime" || val == "-amin" ||
+			val == "-ctime" || val == "-cmin" {
+			return []Violation{{
+				KataID: "ZC1343",
+				Message: "Use Zsh glob qualifiers (`*(m±N)`, `*(M±N)`, `*(a±N)`, `*(c±N)`) instead of " +
+					"`find -mtime`/`-mmin`/`-atime`/`-amin`/`-ctime`/`-cmin` for age predicates.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 339 Katas = 0.3.39
-const Version = "0.3.39"
+// 340 Katas = 0.3.40
+const Version = "0.3.40"


### PR DESCRIPTION
ZC1343 — Use Zsh `*(m±N)` glob qualifier instead of `find -mtime N`

What: flags `find` with age predicates (`-mtime`, `-mmin`, `-atime`, `-amin`, `-ctime`, `-cmin`).
Why: Zsh glob qualifiers encode the same predicates (`*(mN)`, `*(m+N)`, `*(m-N)` for modification in days; `*(M±N)` for minutes; `*(a±N)` access; `*(c±N)` status-change) without shelling out.
Fix suggestion: `files=(**/*(m-7))` (modified in last 7 days), `old=(**/*(m+30))` (older than 30), etc.
Severity: Style