### PR TITLE
feat: ZC1344 — use Zsh `*(L±Nk)` glob qualifier instead of `find -size`

### DIFF
--- a/pkg/katas/katatests/zc1344_test.go
+++ b/pkg/katas/katatests/zc1344_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1344(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — find without -size",
+			input:    `find . -type f`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — find -size +10M",
+			input: `find . -size +10M`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1344",
+					Message: "Use Zsh `*(L±N[kmp])` glob qualifier instead of `find -size`. Unit suffixes: `k` kilobytes, `m` megabytes, `p` 512-byte blocks.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — find -size -1k",
+			input: `find . -size -1k`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1344",
+					Message: "Use Zsh `*(L±N[kmp])` glob qualifier instead of `find -size`. Unit suffixes: `k` kilobytes, `m` megabytes, `p` 512-byte blocks.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1344")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1344.go
+++ b/pkg/katas/zc1344.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1344",
+		Title:    "Use Zsh `*(L±Nk)` glob qualifier instead of `find -size`",
+		Severity: SeverityStyle,
+		Description: "Zsh's `*(LN)`, `*(L+N)`, `*(L-N)` match files by size in 512-byte blocks " +
+			"(or bytes with a unit suffix: `k`, `m`, `p`). Same expressive power as " +
+			"`find -size` without an external process.",
+		Check: checkZC1344,
+	})
+}
+
+func checkZC1344(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "find" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-size" {
+			return []Violation{{
+				KataID: "ZC1344",
+				Message: "Use Zsh `*(L±N[kmp])` glob qualifier instead of `find -size`. " +
+					"Unit suffixes: `k` kilobytes, `m` megabytes, `p` 512-byte blocks.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 340 Katas = 0.3.40
-const Version = "0.3.40"
+// 341 Katas = 0.3.41
+const Version = "0.3.41"


### PR DESCRIPTION
ZC1344 — Use Zsh `*(L±Nk)` glob qualifier instead of `find -size`

What: flags any `find ... -size` invocation.
Why: Zsh's `*(LN)` glob qualifier matches files by size; unit suffix (`k`, `m`, `p`) gives byte granularity; `+`/`-` prefixes for larger/smaller. Same expressive power as `find -size` without an external process.
Fix suggestion: `big=(**/*(L+10m))` (larger than 10 MB), `tiny=(**/*(L-1k))` (smaller than 1 KB).
Severity: Style