### PR TITLE
feat: ZC1345 — use Zsh `*(f:mode:)` glob qualifier instead of `find -perm`

### DIFF
--- a/pkg/katas/katatests/zc1345_test.go
+++ b/pkg/katas/katatests/zc1345_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1345(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — find without -perm",
+			input:    `find . -type f`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — find -perm 755",
+			input: `find . -perm 755`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1345",
+					Message: "Use Zsh `*(f:mode:)` glob qualifier instead of `find -perm`. Octal (`*(f:0755:)`) or symbolic (`*(f:u+x:)`) expressions are both supported.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — find -perm -u+x",
+			input: `find . -perm -u+x`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1345",
+					Message: "Use Zsh `*(f:mode:)` glob qualifier instead of `find -perm`. Octal (`*(f:0755:)`) or symbolic (`*(f:u+x:)`) expressions are both supported.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1345")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1345.go
+++ b/pkg/katas/zc1345.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1345",
+		Title:    "Use Zsh `*(f:mode:)` glob qualifier instead of `find -perm`",
+		Severity: SeverityStyle,
+		Description: "Zsh's `*(f:mode:)` glob qualifier matches files by permission mode. " +
+			"Use octal (`*(f:0755:)`) or symbolic (`*(f:u+x:)`) inside the colon-delimited form. " +
+			"Avoids spawning `find` for permission filters.",
+		Check: checkZC1345,
+	})
+}
+
+func checkZC1345(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "find" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-perm" {
+			return []Violation{{
+				KataID: "ZC1345",
+				Message: "Use Zsh `*(f:mode:)` glob qualifier instead of `find -perm`. " +
+					"Octal (`*(f:0755:)`) or symbolic (`*(f:u+x:)`) expressions are both supported.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 341 Katas = 0.3.41
-const Version = "0.3.41"
+// 342 Katas = 0.3.42
+const Version = "0.3.42"


### PR DESCRIPTION
ZC1345 — Use Zsh `*(f:mode:)` glob qualifier instead of `find -perm`

What: flags any `find ... -perm` invocation.
Why: Zsh glob qualifier `*(f:mode:)` accepts octal (`*(f:0755:)`) or symbolic (`*(f:u+x:)`) mode expressions and is evaluated entirely in the shell.
Fix suggestion: `bins=(**/*(f:u+x:))` (has owner-executable bit), `secret=(**/*(f:0600:))`.
Severity: Style