### PR TITLE
feat: ZC1346 — use Zsh `*(u:name:)` glob qualifier instead of `find -user`

### DIFF
--- a/pkg/katas/katatests/zc1346_test.go
+++ b/pkg/katas/katatests/zc1346_test.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1346(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — find without -user",
+			input:    `find . -type f`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — find -user",
+			input: `find . -user alice`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1346",
+					Message: "Use Zsh `*(u:name:)` / `*(u+uid)` / `*(U)` glob qualifiers instead of `find -user`/`-uid`/`-nouser`. Ownership predicates live entirely in the shell.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — find -uid",
+			input: `find / -uid 1000`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1346",
+					Message: "Use Zsh `*(u:name:)` / `*(u+uid)` / `*(U)` glob qualifiers instead of `find -user`/`-uid`/`-nouser`. Ownership predicates live entirely in the shell.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — find -nouser",
+			input: `find / -nouser`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1346",
+					Message: "Use Zsh `*(u:name:)` / `*(u+uid)` / `*(U)` glob qualifiers instead of `find -user`/`-uid`/`-nouser`. Ownership predicates live entirely in the shell.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1346")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1346.go
+++ b/pkg/katas/zc1346.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1346",
+		Title:    "Use Zsh `*(u:name:)` glob qualifier instead of `find -user`",
+		Severity: SeverityStyle,
+		Description: "Zsh's `*(u:name:)` and `*(u+uid)` glob qualifiers match files by owner " +
+			"(name or numeric uid). The `*(U)` shorthand matches files owned by the current user. " +
+			"Avoid `find -user` for the same selection.",
+		Check: checkZC1346,
+	})
+}
+
+func checkZC1346(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "find" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-user" || v == "-uid" || v == "-nouser" {
+			return []Violation{{
+				KataID: "ZC1346",
+				Message: "Use Zsh `*(u:name:)` / `*(u+uid)` / `*(U)` glob qualifiers instead of " +
+					"`find -user`/`-uid`/`-nouser`. Ownership predicates live entirely in the shell.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 342 Katas = 0.3.42
-const Version = "0.3.42"
+// 343 Katas = 0.3.43
+const Version = "0.3.43"


### PR DESCRIPTION
ZC1346 — Use Zsh `*(u:name:)` glob qualifier instead of `find -user`

What: flags `find` with `-user`, `-uid`, or `-nouser`.
Why: Zsh glob qualifiers encode ownership: `*(u:name:)` by name, `*(u+uid)` by numeric uid, `*(U)` for current user. No external process.
Fix suggestion: `mine=(**/*(U))`, `alice=(**/*(u:alice:))`, `numeric=(**/*(u+1000))`.
Severity: Style