### PR TITLE
feat: ZC1347 — use Zsh `*(g:name:)` glob qualifier instead of `find -group`

### DIFF
--- a/pkg/katas/katatests/zc1347_test.go
+++ b/pkg/katas/katatests/zc1347_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1347(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — find without -group",
+			input:    `find . -type f`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — find -group",
+			input: `find . -group wheel`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1347",
+					Message: "Use Zsh `*(g:name:)` / `*(g+gid)` / `*(G)` glob qualifiers instead of `find -group`/`-gid`/`-nogroup`. Group predicates live entirely in the shell.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — find -gid 10",
+			input: `find . -gid 10`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1347",
+					Message: "Use Zsh `*(g:name:)` / `*(g+gid)` / `*(G)` glob qualifiers instead of `find -group`/`-gid`/`-nogroup`. Group predicates live entirely in the shell.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1347")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1347.go
+++ b/pkg/katas/zc1347.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1347",
+		Title:    "Use Zsh `*(g:name:)` glob qualifier instead of `find -group`",
+		Severity: SeverityStyle,
+		Description: "Zsh's `*(g:name:)` and `*(g+gid)` glob qualifiers match files by group " +
+			"(name or numeric gid). The `*(G)` shorthand matches files in the current user's group. " +
+			"Avoid `find -group`/`-gid`/`-nogroup` for the same selection.",
+		Check: checkZC1347,
+	})
+}
+
+func checkZC1347(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "find" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-group" || v == "-gid" || v == "-nogroup" {
+			return []Violation{{
+				KataID: "ZC1347",
+				Message: "Use Zsh `*(g:name:)` / `*(g+gid)` / `*(G)` glob qualifiers instead of " +
+					"`find -group`/`-gid`/`-nogroup`. Group predicates live entirely in the shell.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 343 Katas = 0.3.43
-const Version = "0.3.43"
+// 344 Katas = 0.3.44
+const Version = "0.3.44"


### PR DESCRIPTION
ZC1347 — Use Zsh `*(g:name:)` glob qualifier instead of `find -group`

What: flags `find` with `-group`, `-gid`, or `-nogroup`.
Why: Zsh glob qualifiers encode group ownership: `*(g:name:)`, `*(g+gid)`, `*(G)` for current user's primary group.
Fix suggestion: `mygroup=(**/*(G))`, `wheel=(**/*(g:wheel:))`.
Severity: Style