### PR TITLE
feat: ZC1348 — use Zsh glob type qualifiers instead of `find -type`

### DIFF
--- a/pkg/katas/katatests/zc1348_test.go
+++ b/pkg/katas/katatests/zc1348_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1348(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — find without -type",
+			input:    `find . -name "*.txt"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — find -type f",
+			input: `find . -type f`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1348",
+					Message: "Use Zsh glob type qualifiers (`*(/)`, `*(.)`, `*(@)`, `*(=)`, `*(p)`, `*(*)`, `*(%)`) instead of `find -type`. No external process required.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — find -type d",
+			input: `find / -type d`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1348",
+					Message: "Use Zsh glob type qualifiers (`*(/)`, `*(.)`, `*(@)`, `*(=)`, `*(p)`, `*(*)`, `*(%)`) instead of `find -type`. No external process required.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1348")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1348.go
+++ b/pkg/katas/zc1348.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1348",
+		Title:    "Use Zsh glob type qualifiers instead of `find -type`",
+		Severity: SeverityStyle,
+		Description: "Zsh glob qualifiers select node type directly: `*(/)` directories, `*(.)` " +
+			"regular files, `*(@)` symlinks, `*(=)` sockets, `*(p)` named pipes, `*(*)` " +
+			"executable regular files, `*(%)` char/block devices. Avoid `find -type X` for " +
+			"the same selection.",
+		Check: checkZC1348,
+	})
+}
+
+func checkZC1348(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "find" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-type" {
+			return []Violation{{
+				KataID: "ZC1348",
+				Message: "Use Zsh glob type qualifiers (`*(/)`, `*(.)`, `*(@)`, `*(=)`, `*(p)`, `*(*)`, " +
+					"`*(%)`) instead of `find -type`. No external process required.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 344 Katas = 0.3.44
-const Version = "0.3.44"
+// 345 Katas = 0.3.45
+const Version = "0.3.45"


### PR DESCRIPTION
ZC1348 — Use Zsh glob type qualifiers instead of `find -type`

What: flags `find` with `-type`.
Why: Zsh's glob qualifiers map directly to file-type predicates: `*(/)` directories, `*(.)` regular files, `*(@)` symlinks, `*(=)` sockets, `*(p)` named pipes, `*(*)` executable regular files, `*(%)` block/char devices.
Fix suggestion: `files=(**/*(.))`, `dirs=(**/*(/))`, `links=(**/*(@))`.
Severity: Style