### PR TITLE
feat: ZC1349 — use `${#var}` instead of `expr length` for string length

### DIFF
--- a/pkg/katas/katatests/zc1349_test.go
+++ b/pkg/katas/katatests/zc1349_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1349(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — expr arithmetic (not length)",
+			input:    `expr 1 + 2`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — expr length with var",
+			input: `expr length "$s"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1349",
+					Message: "Use `${#var}` instead of `expr length \"$var\"` for string length. Parameter expansion avoids spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — expr length with literal",
+			input: `expr length hello`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1349",
+					Message: "Use `${#var}` instead of `expr length \"$var\"` for string length. Parameter expansion avoids spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1349")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1349.go
+++ b/pkg/katas/zc1349.go
@@ -1,0 +1,43 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1349",
+		Title:    "Use `${#var}` instead of `expr length \"$var\"` for string length",
+		Severity: SeverityStyle,
+		Description: "Zsh (and POSIX) `${#var}` returns string length without spawning `expr`. " +
+			"Use it wherever you would reach for `expr length` or `expr STRING : '.*'`.",
+		Check: checkZC1349,
+	})
+}
+
+func checkZC1349(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "expr" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "length" {
+			return []Violation{{
+				KataID: "ZC1349",
+				Message: "Use `${#var}` instead of `expr length \"$var\"` for string length. " +
+					"Parameter expansion avoids spawning an external process.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 345 Katas = 0.3.45
-const Version = "0.3.45"
+// 346 Katas = 0.3.46
+const Version = "0.3.46"


### PR DESCRIPTION
ZC1349 — Use `${#var}` instead of `expr length "$var"` for string length

What: flags `expr length ...` invocations.
Why: `${#var}` returns string length natively without spawning `expr`. Works in Zsh and POSIX alike.
Fix suggestion: `len=${#var}`.
Severity: Style