### PR TITLE
feat: ZC1350 — use `${str:pos:len}` instead of `expr substr`

### DIFF
--- a/pkg/katas/katatests/zc1350_test.go
+++ b/pkg/katas/katatests/zc1350_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1350(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — expr arithmetic (not substr)",
+			input:    `expr 2 + 3`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — expr substr",
+			input: `expr substr "$s" 1 5`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1350",
+					Message: "Use `${str:pos:len}` instead of `expr substr` for substring extraction. Parameter expansion avoids spawning an external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1350")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1350.go
+++ b/pkg/katas/zc1350.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1350",
+		Title:    "Use `${str:pos:len}` instead of `expr substr` for substring extraction",
+		Severity: SeverityStyle,
+		Description: "Zsh parameter expansion `${str:pos:len}` extracts a substring starting at " +
+			"`pos` of length `len`. No external `expr` call, and the semantics are consistent " +
+			"with `${str:pos}` (to end) and negative positions.",
+		Check: checkZC1350,
+	})
+}
+
+func checkZC1350(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "expr" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "substr" {
+			return []Violation{{
+				KataID: "ZC1350",
+				Message: "Use `${str:pos:len}` instead of `expr substr` for substring extraction. " +
+					"Parameter expansion avoids spawning an external process.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 346 Katas = 0.3.46
-const Version = "0.3.46"
+// 347 Katas = 0.3.47
+const Version = "0.3.47"


### PR DESCRIPTION
ZC1350 — Use `${str:pos:len}` instead of `expr substr` for substring extraction

What: flags `expr substr ...` invocations.
Why: Parameter expansion `${str:pos:len}` does the same work natively. Supports negative `pos` for from-end offsets; omit `:len` for "to end of string".
Fix suggestion: `chunk=${s:1:5}`.
Severity: Style