### PR TITLE
feat: ZC1351 — use `[[ =~ ]]` instead of `expr match`/`expr index`

### DIFF
--- a/pkg/katas/katatests/zc1351_test.go
+++ b/pkg/katas/katatests/zc1351_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1351(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — expr arithmetic",
+			input:    `expr 1 + 2`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — expr match",
+			input: `expr match "$s" '^foo'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1351",
+					Message: "Use `[[ $str =~ pattern ]]` with `$match` / `$MATCH` arrays instead of `expr match`/`expr index`. Regex evaluation stays in the shell.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — expr index",
+			input: `expr index "$s" aeiou`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1351",
+					Message: "Use `[[ $str =~ pattern ]]` with `$match` / `$MATCH` arrays instead of `expr match`/`expr index`. Regex evaluation stays in the shell.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1351")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1351.go
+++ b/pkg/katas/zc1351.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1351",
+		Title:    "Use `[[ $str =~ pattern ]]` instead of `expr match` / `expr :` for regex",
+		Severity: SeverityStyle,
+		Description: "Zsh's `[[ $str =~ pattern ]]` evaluates regex natively and populates `$match` / " +
+			"`$MATCH` / `$mbegin` / `$mend` arrays. Avoid shelling out to `expr match` or the " +
+			"`expr STRING : REGEX` form.",
+		Check: checkZC1351,
+	})
+}
+
+func checkZC1351(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "expr" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "match" || v == "index" {
+			return []Violation{{
+				KataID: "ZC1351",
+				Message: "Use `[[ $str =~ pattern ]]` with `$match` / `$MATCH` arrays instead of " +
+					"`expr match`/`expr index`. Regex evaluation stays in the shell.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 347 Katas = 0.3.47
-const Version = "0.3.47"
+// 348 Katas = 0.3.48
+const Version = "0.3.48"


### PR DESCRIPTION
ZC1351 — Use `[[ $str =~ pattern ]]` for regex instead of `expr match` / `expr index`

What: flags `expr match` and `expr index` invocations.
Why: `[[ $str =~ pattern ]]` evaluates regex natively in Zsh and populates `$match`, `$MATCH`, `$mbegin`, `$mend` arrays.
Fix suggestion: `[[ $str =~ '(foo)([0-9]+)' ]] && echo "${match[1]} ${match[2]}"`.
Severity: Style