### PR TITLE
feat: ZC1352 — avoid `xargs -I{}` — use Zsh `for` loop

### DIFF
--- a/pkg/katas/katatests/zc1352_test.go
+++ b/pkg/katas/katatests/zc1352_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1352(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — xargs without -I",
+			input:    `xargs -n 1 echo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — xargs -I{}",
+			input: `xargs -I{} echo hi`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1352",
+					Message: "Avoid `xargs -I{}` — iterate with `for x in ${(f)\"$(cmd)\"}; do ...; done` in Zsh. A for loop avoids one-subprocess-per-item and keeps variables in scope.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — xargs --replace",
+			input: `xargs --replace cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1352",
+					Message: "Avoid `xargs -I{}` — iterate with `for x in ${(f)\"$(cmd)\"}; do ...; done` in Zsh. A for loop avoids one-subprocess-per-item and keeps variables in scope.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1352")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1352_test.go
+++ b/pkg/katas/katatests/zc1352_test.go
@@ -31,8 +31,8 @@ func TestZC1352(t *testing.T) {
 			},
 		},
 		{
-			name:  "invalid — xargs --replace",
-			input: `xargs --replace cmd`,
+			name:  "invalid — xargs -Ixx custom replace-string",
+			input: `xargs -Ifile cp file /tmp`,
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1352",

--- a/pkg/katas/zc1352.go
+++ b/pkg/katas/zc1352.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1352",
+		Title:    "Avoid `xargs -I{}` — use a Zsh `for` loop for per-item substitution",
+		Severity: SeverityStyle,
+		Description: "`xargs -I{}` runs one command per item with `{}` substituted. A Zsh `for` " +
+			"loop over the same input (`for x in ${(f)\"$(cmd)\"}`) is clearer and keeps state " +
+			"in the current shell.",
+		Check: checkZC1352,
+	})
+}
+
+func checkZC1352(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "xargs" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-I" || v == "--replace" {
+			return []Violation{{
+				KataID: "ZC1352",
+				Message: "Avoid `xargs -I{}` — iterate with `for x in ${(f)\"$(cmd)\"}; do ...; done` " +
+					"in Zsh. A for loop avoids one-subprocess-per-item and keeps variables in scope.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/katas/zc1352.go
+++ b/pkg/katas/zc1352.go
@@ -29,7 +29,10 @@ func checkZC1352(node ast.Node) []Violation {
 
 	for _, arg := range cmd.Arguments {
 		v := arg.String()
-		if v == "-I" || v == "--replace" {
+		// -I, -I{}, -Irepl, --replace, --replace=STR
+		if v == "-I" || v == "--replace" ||
+			(len(v) > 2 && v[:2] == "-I") ||
+			(len(v) > 9 && v[:10] == "--replace=") {
 			return []Violation{{
 				KataID: "ZC1352",
 				Message: "Avoid `xargs -I{}` — iterate with `for x in ${(f)\"$(cmd)\"}; do ...; done` " +

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 348 Katas = 0.3.48
-const Version = "0.3.48"
+// 349 Katas = 0.3.49
+const Version = "0.3.49"


### PR DESCRIPTION
ZC1352 — Avoid `xargs -I{}` — use a Zsh `for` loop for per-item substitution

What: flags `xargs -I` / `xargs --replace` invocations.
Why: Per-item substitution with `-I{}` runs a fresh process per item, and variable mutations inside the command never reach the outer shell. A Zsh for loop over `${(f)"$(cmd)"}` keeps everything in-process.
Fix suggestion: `for x in ${(f)"$(cmd)"}; do ...; done`.
Severity: Style