### PR TITLE
feat: ZC1353 — avoid `printf -v` — Bash-only, use `print -v` or command substitution

### DIFF
--- a/pkg/katas/katatests/zc1353_test.go
+++ b/pkg/katas/katatests/zc1353_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1353(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — printf without -v",
+			input:    `printf 'hello %s\n' world`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — printf -v var",
+			input: `printf -v line '%d' 42`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1353",
+					Message: "Avoid `printf -v` in Zsh — use `print -v var -rf fmt ...` or `var=$(printf fmt ...)`. `-v` is Bash-specific and ignored elsewhere.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1353")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1353.go
+++ b/pkg/katas/zc1353.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1353",
+		Title:    "Avoid `printf -v` — use `print -v` or command substitution in Zsh",
+		Severity: SeverityStyle,
+		Description: "`printf -v var fmt ...` is a Bash-ism. In Zsh use `print -v var -rf fmt ...` " +
+			"or plain command substitution `var=$(printf fmt ...)`. `-v` is silently ignored by " +
+			"POSIX printf, producing surprising bugs on portable scripts.",
+		Check: checkZC1353,
+	})
+}
+
+func checkZC1353(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-v" {
+			return []Violation{{
+				KataID: "ZC1353",
+				Message: "Avoid `printf -v` in Zsh — use `print -v var -rf fmt ...` or " +
+					"`var=$(printf fmt ...)`. `-v` is Bash-specific and ignored elsewhere.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 349 Katas = 0.3.49
-const Version = "0.3.49"
+// 350 Katas = 0.3.50
+const Version = "0.3.50"


### PR DESCRIPTION
ZC1353 — Avoid `printf -v` — use `print -v` or command substitution

What: flags `printf -v ...` invocations.
Why: `printf -v var fmt args` is a Bash-ism; POSIX printf silently ignores `-v`, producing surprising behavior. Zsh's `print -v var -rf fmt args` or plain `var=$(printf fmt args)` both work.
Fix suggestion: `print -v line -rf '%d' 42` or `line=$(printf '%d' 42)`.
Severity: Style