### PR TITLE
feat: ZC1354 — use `whence -w`/`whence -a`/`whence -p` instead of `type -t`/`-a`/`-P`

### DIFF
--- a/pkg/katas/katatests/zc1354_test.go
+++ b/pkg/katas/katatests/zc1354_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1354(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — type without flags",
+			input:    `type grep`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — type -t",
+			input: `type -t grep`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1354",
+					Message: "Use Zsh `whence -w` (category), `whence -a` (all), or `whence -p` (path) instead of Bash-specific `type -t`/`-a`/`-P`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — type -P",
+			input: `type -P grep`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1354",
+					Message: "Use Zsh `whence -w` (category), `whence -a` (all), or `whence -p` (path) instead of Bash-specific `type -t`/`-a`/`-P`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1354")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1354.go
+++ b/pkg/katas/zc1354.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1354",
+		Title:    "Use `whence -w` instead of Bash-specific `type -t` for command classification",
+		Severity: SeverityStyle,
+		Description: "`type -t` returns the category (alias, keyword, function, builtin, file) " +
+			"of a command in Bash. Zsh's `whence -w` produces `name: category` output with " +
+			"the same information and without shelling out for the sub-field extraction.",
+		Check: checkZC1354,
+	})
+}
+
+func checkZC1354(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "type" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-t" || v == "-a" || v == "-P" {
+			return []Violation{{
+				KataID: "ZC1354",
+				Message: "Use Zsh `whence -w` (category), `whence -a` (all), or `whence -p` (path) " +
+					"instead of Bash-specific `type -t`/`-a`/`-P`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 350 Katas = 0.3.50
-const Version = "0.3.50"
+// 351 Katas = 0.3.51
+const Version = "0.3.51"


### PR DESCRIPTION
ZC1354 — Use Zsh `whence -w` instead of Bash-specific `type -t`

What: flags `type -t`, `type -a`, `type -P` invocations.
Why: These `type` flags are Bash extensions. Zsh provides the same information via `whence -w` (category), `whence -a` (all matches), `whence -p` (path only) — portable Zsh, no external fallback needed.
Fix suggestion: `whence -w grep` instead of `type -t grep`.
Severity: Style