### PR TITLE
feat: ZC1355 — use `print -r` instead of `echo -E` for raw output

### DIFF
--- a/pkg/katas/katatests/zc1355_test.go
+++ b/pkg/katas/katatests/zc1355_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1355(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo without -E",
+			input:    `echo hello`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo -E raw",
+			input: `echo -E "$line"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1355",
+					Message: "Use `print -r` instead of `echo -E` for raw output. `-E` is a Bash-ism and ignored by POSIX echo.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1355")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1355.go
+++ b/pkg/katas/zc1355.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1355",
+		Title:    "Use `print -r` instead of `echo -E` for raw output",
+		Severity: SeverityStyle,
+		Description: "`echo -E` disables backslash interpretation, but the flag is Bash-ism and " +
+			"ignored by POSIX `echo`. Zsh's `print -r` is the idiomatic raw-printer; combine " +
+			"with `-n` (no newline), `-l` (one per line), `-u<fd>` (file descriptor), or `--` " +
+			"(end of flags) as needed.",
+		Check: checkZC1355,
+	})
+}
+
+func checkZC1355(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "echo" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-E" {
+			return []Violation{{
+				KataID: "ZC1355",
+				Message: "Use `print -r` instead of `echo -E` for raw output. " +
+					"`-E` is a Bash-ism and ignored by POSIX echo.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 351 Katas = 0.3.51
-const Version = "0.3.51"
+// 352 Katas = 0.3.52
+const Version = "0.3.52"


### PR DESCRIPTION
ZC1355 — Use `print -r` instead of `echo -E` for raw output

What: flags `echo -E ...` invocations.
Why: `echo -E` (disable backslash interpretation) is a Bash-ism; POSIX echo silently ignores `-E`. Zsh's `print -r` is the idiomatic raw-printer and works in all cases.
Fix suggestion: `print -r -- "$line"`.
Severity: Style