### PR TITLE
feat: ZC1356 — use `read -A` (Zsh) instead of `read -a` (Bash)

### DIFF
--- a/pkg/katas/katatests/zc1356_test.go
+++ b/pkg/katas/katatests/zc1356_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1356(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — read -A",
+			input:    `read -A arr`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — read -r line",
+			input:    `read -r line`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — read -a (Bash syntax)",
+			input: `read -a arr`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1356",
+					Message: "Use `read -A` (uppercase) in Zsh to read into an array. `read -a` has different semantics in Zsh than in Bash.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1356")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1356.go
+++ b/pkg/katas/zc1356.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1356",
+		Title:    "Use `read -A` instead of `read -a` for array read in Zsh",
+		Severity: SeverityError,
+		Description: "Zsh's `read` uses `-A` (uppercase A) to read into an array. Bash uses `-a` " +
+			"(lowercase) for the same thing. In Zsh, `read -a` assigns a flag to a scalar " +
+			"variable — not what Bash users expect. Use `-A` for portable-Zsh behavior.",
+		Check: checkZC1356,
+	})
+}
+
+func checkZC1356(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "read" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-a" {
+			return []Violation{{
+				KataID: "ZC1356",
+				Message: "Use `read -A` (uppercase) in Zsh to read into an array. " +
+					"`read -a` has different semantics in Zsh than in Bash.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 352 Katas = 0.3.52
-const Version = "0.3.52"
+// 353 Katas = 0.3.53
+const Version = "0.3.53"


### PR DESCRIPTION
ZC1356 — Use `read -A` instead of `read -a` for array read

What: flags `read -a` invocations.
Why: Zsh's `read -A` (uppercase) reads into an array; `read -a` has different semantics in Zsh than in Bash, producing wrong results when Bash scripts are run under Zsh without adjustment.
Fix suggestion: `read -A arr <<< "$input"`.
Severity: Error (produces wrong behavior, not a style nit)