### PR TITLE
feat: ZC1357 — use Zsh `${(q)var}` instead of `printf '%q'`

### DIFF
--- a/pkg/katas/katatests/zc1357_test.go
+++ b/pkg/katas/katatests/zc1357_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1357(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — printf %s",
+			input:    `printf '%s\n' "$line"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — printf %q",
+			input: `printf '%q' "$v"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1357",
+					Message: "Use Zsh `${(q)var}` for shell-quoting instead of `printf '%q'`. Variants: `${(qq)}`, `${(qqq)}`, `${(qqqq)}` for different quote styles.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1357")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1357.go
+++ b/pkg/katas/zc1357.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1357",
+		Title:    "Use Zsh `${(q)var}` instead of `printf '%q'` for shell-quoting",
+		Severity: SeverityStyle,
+		Description: "Bash's `printf '%q'` emits shell-quoted output. Zsh's `${(q)var}` parameter " +
+			"flag does the same in-shell, with variants `${(qq)var}`, `${(qqq)var}`, `${(qqqq)var}` " +
+			"for single-quote, double-quote, $'...', and POSIX ANSI-C styles respectively.",
+		Check: checkZC1357,
+	})
+}
+
+func checkZC1357(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		// Any format string containing %q (unescaped) triggers the kata.
+		if strings.Contains(val, "%q") {
+			return []Violation{{
+				KataID: "ZC1357",
+				Message: "Use Zsh `${(q)var}` for shell-quoting instead of `printf '%q'`. " +
+					"Variants: `${(qq)}`, `${(qqq)}`, `${(qqqq)}` for different quote styles.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 353 Katas = 0.3.53
-const Version = "0.3.53"
+// 354 Katas = 0.3.54
+const Version = "0.3.54"


### PR DESCRIPTION
ZC1357 — Use Zsh `${(q)var}` instead of `printf '%q'` for shell-quoting

What: flags `printf` with a format string containing `%q`.
Why: Bash's `%q` format specifier is a Bash extension; POSIX printf ignores it. Zsh's `${(q)var}` parameter flag produces shell-quoted output natively, with `${(qq)}`, `${(qqq)}`, `${(qqqq)}` for single-, double-, and `$'...'` styles.
Fix suggestion: `quoted=${(q)line}`.
Severity: Style