### PR TITLE
feat: ZC1358 — use `${PWD:P}` instead of `pwd -P` for canonical path

### DIFF
--- a/pkg/katas/katatests/zc1358_test.go
+++ b/pkg/katas/katatests/zc1358_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1358(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — pwd without -P",
+			input:    `pwd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — pwd -P",
+			input: `pwd -P`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1358",
+					Message: "Use `${PWD:P}` instead of `pwd -P` — the `P` modifier resolves symlinks and returns the canonical path without spawning an external.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1358")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1358.go
+++ b/pkg/katas/zc1358.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1358",
+		Title:    "Use `${PWD:P}` instead of `pwd -P` for physical current directory",
+		Severity: SeverityStyle,
+		Description: "`pwd -P` resolves symlinks to the physical path. Zsh's `${PWD:P}` modifier " +
+			"does the same without spawning the external — the `P` modifier returns the " +
+			"canonical (absolute, symlink-resolved) form.",
+		Check: checkZC1358,
+	})
+}
+
+func checkZC1358(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "pwd" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-P" {
+			return []Violation{{
+				KataID: "ZC1358",
+				Message: "Use `${PWD:P}` instead of `pwd -P` — the `P` modifier resolves symlinks " +
+					"and returns the canonical path without spawning an external.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 354 Katas = 0.3.54
-const Version = "0.3.54"
+// 355 Katas = 0.3.55
+const Version = "0.3.55"


### PR DESCRIPTION
ZC1358 — Use `${PWD:P}` instead of `pwd -P` for physical current directory

What: flags `pwd -P` invocations.
Why: Zsh's `P` filename modifier resolves symlinks and returns the canonical path. `${PWD:P}` does the same as `pwd -P` without spawning the external.
Fix suggestion: `canonical=${PWD:P}`.
Severity: Style