### PR TITLE
feat: ZC1359 — use Zsh `$groups` instead of `id -Gn`/`-G`/`-gn`/`-g`

### DIFF
--- a/pkg/katas/katatests/zc1359_test.go
+++ b/pkg/katas/katatests/zc1359_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1359(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — id without group flag",
+			input:    `id -u`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — id -Gn",
+			input: `id -Gn`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1359",
+					Message: "Avoid `id -Gn`/`-G`/`-gn`/`-g` — use Zsh `$groups` (names→gids assoc array) or `$GID` for the primary group after `zmodload zsh/parameter`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — id -g",
+			input: `id -g`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1359",
+					Message: "Avoid `id -Gn`/`-G`/`-gn`/`-g` — use Zsh `$groups` (names→gids assoc array) or `$GID` for the primary group after `zmodload zsh/parameter`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1359")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1359.go
+++ b/pkg/katas/zc1359.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1359",
+		Title:    "Avoid `id -Gn` — use Zsh `$groups` associative array",
+		Severity: SeverityStyle,
+		Description: "Zsh's `zsh/parameter` module exposes the `$groups` associative array mapping " +
+			"group names to GIDs for the current process. Load with `zmodload zsh/parameter` " +
+			"(often auto-loaded) and inspect `${(k)groups}` for names, avoiding an external " +
+			"`id -Gn`/`groups` call.",
+		Check: checkZC1359,
+	})
+}
+
+func checkZC1359(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "id" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-Gn" || v == "-G" || v == "-gn" || v == "-g" {
+			return []Violation{{
+				KataID: "ZC1359",
+				Message: "Avoid `id -Gn`/`-G`/`-gn`/`-g` — use Zsh `$groups` (names→gids assoc array) " +
+					"or `$GID` for the primary group after `zmodload zsh/parameter`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 355 Katas = 0.3.55
-const Version = "0.3.55"
+// 356 Katas = 0.3.56
+const Version = "0.3.56"


### PR DESCRIPTION
ZC1359 — Use Zsh `$groups` associative array instead of `id -Gn`

What: flags `id -Gn`, `-G`, `-gn`, `-g`.
Why: Zsh's `zsh/parameter` module exposes `$groups` (names→gids), `$GID` (primary gid), and `$USERNAME`/`$LOGNAME` for user info. No external `id` call needed.
Fix suggestion: `zmodload zsh/parameter; print -l ${(k)groups}` or `echo $GID`.
Severity: Style