### PR TITLE
feat: ZC1360 — use Zsh `*(OL)` glob qualifier instead of `ls -S`

### DIFF
--- a/pkg/katas/katatests/zc1360_test.go
+++ b/pkg/katas/katatests/zc1360_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1360(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ls -l (not sort-by-size)",
+			input:    `ls -l`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ls -S",
+			input: `ls -S`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1360",
+					Message: "Use Zsh `*(OL)` (largest-first) or `*(oL)` (smallest-first) glob qualifier instead of `ls -S`. No external process needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ls -lS",
+			input: `ls -lS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1360",
+					Message: "Use Zsh `*(OL)` (largest-first) or `*(oL)` (smallest-first) glob qualifier instead of `ls -S`. No external process needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1360")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1360.go
+++ b/pkg/katas/zc1360.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1360",
+		Title:    "Use Zsh `*(OL)` glob qualifier instead of `ls -S` for size-ordered listing",
+		Severity: SeverityStyle,
+		Description: "Zsh glob qualifier `*(OL)` orders results by size (descending). `*(oL)` is " +
+			"ascending. Combined with `[N]` subscript you get the N-th largest/smallest file " +
+			"without `ls -S` and piping.",
+		Check: checkZC1360,
+	})
+}
+
+func checkZC1360(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "ls" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-S" || v == "-Sr" || v == "-lS" || v == "-lSr" {
+			return []Violation{{
+				KataID: "ZC1360",
+				Message: "Use Zsh `*(OL)` (largest-first) or `*(oL)` (smallest-first) glob qualifier " +
+					"instead of `ls -S`. No external process needed.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 356 Katas = 0.3.56
-const Version = "0.3.56"
+// 357 Katas = 0.3.57
+const Version = "0.3.57"


### PR DESCRIPTION
ZC1360 — Use Zsh `*(OL)` glob qualifier instead of `ls -S` for size-ordered listing

What: flags `ls -S`, `-Sr`, `-lS`, `-lSr`.
Why: Zsh glob qualifier `*(OL)` orders by size descending, `*(oL)` ascending. Combined with `[N]` subscript to pick N-th item. No external `ls` spawn.
Fix suggestion: `biggest=(*(OL[1]))`, `smallest=(*(oL[1]))`.
Severity: Style