### PR TITLE
feat: ZC1361 — avoid `awk 'NR==N'` — use Zsh array subscript

### DIFF
--- a/pkg/katas/katatests/zc1361_test.go
+++ b/pkg/katas/katatests/zc1361_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1361(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — awk with generic program",
+			input:    `awk '{print $1}' file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — awk NR==5",
+			input: `awk 'NR==5' file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1361",
+					Message: "Avoid `awk 'NR==N'` — split with `${(f)\"$(<file)\"}` in Zsh and index: `lines=(${(f)\"$(<file)\"}); print $lines[N]`. No awk process needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1361")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1361.go
+++ b/pkg/katas/zc1361.go
@@ -1,0 +1,47 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1361",
+		Title:    "Avoid `awk 'NR==N'` — use Zsh array subscript on `${(f)...}`",
+		Severity: SeverityStyle,
+		Description: "Picking the N-th line with `awk 'NR==N'` spawns awk. Zsh can split file " +
+			"contents on newlines with `${(f)\"$(<file)\"}` and index directly: `lines=(${(f)\"$(<f)\"}); print $lines[N]`.",
+		Check: checkZC1361,
+	})
+}
+
+func checkZC1361(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "awk" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		// Look for NR== or NR == in the awk program
+		if strings.Contains(val, "NR==") || strings.Contains(val, "NR ==") {
+			return []Violation{{
+				KataID: "ZC1361",
+				Message: "Avoid `awk 'NR==N'` — split with `${(f)\"$(<file)\"}` in Zsh and index: " +
+					"`lines=(${(f)\"$(<file)\"}); print $lines[N]`. No awk process needed.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 357 Katas = 0.3.57
-const Version = "0.3.57"
+// 358 Katas = 0.3.58
+const Version = "0.3.58"


### PR DESCRIPTION
ZC1361 — Avoid `awk 'NR==N'` — use Zsh array subscript on `${(f)...}`

What: flags `awk` programs containing `NR==N` (pick N-th line).
Why: Zsh can split on newlines natively with `${(f)"$(<file)"}`, producing an array that is directly indexable. Skips awk process startup for a trivial operation.
Fix suggestion: `lines=(${(f)"$(<file)"}); print $lines[5]`.
Severity: Style