### PR TITLE
feat: ZC1362 — use `[[ -o option ]]` instead of `test -o option`

### DIFF
--- a/pkg/katas/katatests/zc1362_test.go
+++ b/pkg/katas/katatests/zc1362_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1362(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — test without -o",
+			input:    `test -f file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — test -o noglob",
+			input: `test -o noglob`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1362",
+					Message: "Use `[[ -o option ]]` for option checks in Zsh — `test -o` means logical OR, not option-query, producing wrong results.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1362")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1362.go
+++ b/pkg/katas/zc1362.go
@@ -1,0 +1,47 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1362",
+		Title:    "Use `[[ -o option ]]` instead of `test -o option` for Zsh option checks",
+		Severity: SeverityInfo,
+		Description: "In Zsh, `[[ -o name ]]` tests whether a shell option is set. The `test` / `[` " +
+			"builtin interprets `-o` as a logical OR, not an option-query — so `test -o foo` is " +
+			"a syntax error or wrong behavior. Use the `[[ ... ]]` form for option tests.",
+		Check: checkZC1362,
+	})
+}
+
+func checkZC1362(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "test" && ident.Value != "[" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-o" {
+			return []Violation{{
+				KataID: "ZC1362",
+				Message: "Use `[[ -o option ]]` for option checks in Zsh — `test -o` means logical OR, " +
+					"not option-query, producing wrong results.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityInfo,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 358 Katas = 0.3.58
-const Version = "0.3.58"
+// 359 Katas = 0.3.59
+const Version = "0.3.59"


### PR DESCRIPTION
ZC1362 — Use `[[ -o option ]]` instead of `test -o option` for Zsh option checks

What: flags `test -o` / `[ -o` invocations.
Why: In Zsh, `[[ -o option ]]` queries a shell option. The external `test` builtin interprets `-o` as logical OR — producing wrong results or syntax errors for option checks.
Fix suggestion: `[[ -o noglob ]] && ...`
Severity: Info (semantic gotcha when porting from `test` expressions)