### PR TITLE
feat: ZC1363 — use Zsh `*(e:...:)` eval qualifier instead of `find -newer`

### DIFF
--- a/pkg/katas/katatests/zc1363_test.go
+++ b/pkg/katas/katatests/zc1363_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1363(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — find without -newer",
+			input:    `find . -type f`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — find -newer",
+			input: `find . -newer ref.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1363",
+					Message: "Use Zsh `*(e:'[[ $REPLY -nt REF ]]':)` eval glob qualifier instead of `find -newer`/`-anewer`/`-cnewer`/`-newerXY`. `$REPLY` holds the current match.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1363")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1363.go
+++ b/pkg/katas/zc1363.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1363",
+		Title:    "Use Zsh `*(e:...:)` eval qualifier instead of `find -newer`/`-older`",
+		Severity: SeverityStyle,
+		Description: "Zsh's `*(e:expr:)` glob qualifier evaluates an arbitrary expression per match — " +
+			"perfect for `-newer REF`-style predicates. Example: `*(e:'[[ $REPLY -nt reference ]]':)` " +
+			"selects files newer than `reference`.",
+		Check: checkZC1363,
+	})
+}
+
+func checkZC1363(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "find" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-newer" || v == "-anewer" || v == "-cnewer" ||
+			v == "-neweraa" || v == "-newercm" || v == "-newermt" {
+			return []Violation{{
+				KataID: "ZC1363",
+				Message: "Use Zsh `*(e:'[[ $REPLY -nt REF ]]':)` eval glob qualifier instead of " +
+					"`find -newer`/`-anewer`/`-cnewer`/`-newerXY`. `$REPLY` holds the current match.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 359 Katas = 0.3.59
-const Version = "0.3.59"
+// 360 Katas = 0.3.60
+const Version = "0.3.60"


### PR DESCRIPTION
ZC1363 — Use Zsh `*(e:...:)` eval qualifier instead of `find -newer`/`-older`

What: flags `find` with `-newer`, `-anewer`, `-cnewer`, `-newerXY`.
Why: Zsh's `*(e:'expr':)` evaluates an arbitrary expression per match — covers the `-newer` family (`[[ $REPLY -nt ref ]]`), `-older` (`-ot`), and more complex custom predicates without spawning find.
Fix suggestion: `files=(**/*(e:'[[ $REPLY -nt reference ]]':))`.
Severity: Style