### PR TITLE
feat: ZC1364 — use Zsh `${var:pos:len}` instead of `cut -c`

### DIFF
--- a/pkg/katas/katatests/zc1364_test.go
+++ b/pkg/katas/katatests/zc1364_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1364(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — cut -f (field, different kata)",
+			input:    `cut -f 2 file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — cut -c",
+			input: `cut -c 1-5 file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1364",
+					Message: "Use Zsh `${var:pos:len}` for character ranges instead of `cut -c`. Parameter expansion is in-shell and zero-indexed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — cut -c attached",
+			input: `cut -c1-5 file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1364",
+					Message: "Use Zsh `${var:pos:len}` for character ranges instead of `cut -c`. Parameter expansion is in-shell and zero-indexed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1364")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1364.go
+++ b/pkg/katas/zc1364.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1364",
+		Title:    "Use Zsh `${var:pos:len}` instead of `cut -c` for character ranges",
+		Severity: SeverityStyle,
+		Description: "`cut -c N-M` extracts characters N through M from each line. Zsh's " +
+			"`${var:pos:len}` (0-indexed position, length) does the same from a variable " +
+			"without spawning `cut`.",
+		Check: checkZC1364,
+	})
+}
+
+func checkZC1364(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cut" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := strings.TrimFunc(arg.String(), func(r rune) bool { return r == '\'' || r == '"' })
+		if val == "-c" || val == "--characters" ||
+			(len(val) > 2 && val[:2] == "-c") ||
+			strings.HasPrefix(val, "--characters=") {
+			return []Violation{{
+				KataID: "ZC1364",
+				Message: "Use Zsh `${var:pos:len}` for character ranges instead of `cut -c`. " +
+					"Parameter expansion is in-shell and zero-indexed.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 360 Katas = 0.3.60
-const Version = "0.3.60"
+// 361 Katas = 0.3.61
+const Version = "0.3.61"


### PR DESCRIPTION
ZC1364 — Use Zsh `${var:pos:len}` instead of `cut -c` for character ranges

What: flags `cut -c ...` and `cut -c1-5` attached-form invocations.
Why: `${var:pos:len}` (zero-indexed position, length count) extracts the same substring natively. No external `cut` process for character-range selection.
Fix suggestion: `chunk=${line:0:5}` replaces `echo "$line" | cut -c 1-5`.
Severity: Style