### PR TITLE
feat: ZC1365 — use Zsh `zstat` module instead of `stat -c`

### DIFF
--- a/pkg/katas/katatests/zc1365_test.go
+++ b/pkg/katas/katatests/zc1365_test.go
@@ -31,8 +31,8 @@ func TestZC1365(t *testing.T) {
 			},
 		},
 		{
-			name:  "invalid — stat --format",
-			input: `stat --format %Y file`,
+			name:  "invalid — stat -c %Y (mtime)",
+			input: `stat -c %Y file`,
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1365",

--- a/pkg/katas/katatests/zc1365_test.go
+++ b/pkg/katas/katatests/zc1365_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1365(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — stat without format flag",
+			input:    `stat file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — stat -c %s",
+			input: `stat -c %s file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1365",
+					Message: "Use Zsh `zmodload zsh/stat; zstat -H meta file` for file metadata instead of `stat -c '%...'`. The associative array `meta` exposes every stat field.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — stat --format",
+			input: `stat --format %Y file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1365",
+					Message: "Use Zsh `zmodload zsh/stat; zstat -H meta file` for file metadata instead of `stat -c '%...'`. The associative array `meta` exposes every stat field.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1365")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1365.go
+++ b/pkg/katas/zc1365.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1365",
+		Title:    "Use Zsh `zstat` module instead of `stat -c` for file metadata",
+		Severity: SeverityStyle,
+		Description: "Zsh's `zsh/stat` module (loaded with `zmodload zsh/stat` — the command is " +
+			"named `zstat`) exposes every `stat(2)` field natively: mtime, size, owner, group, " +
+			"mode, links, etc. Avoid external `stat -c '%...'` invocations.",
+		Check: checkZC1365,
+	})
+}
+
+func checkZC1365(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "stat" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-c" || v == "--format" || v == "--printf" {
+			return []Violation{{
+				KataID: "ZC1365",
+				Message: "Use Zsh `zmodload zsh/stat; zstat -H meta file` for file metadata instead " +
+					"of `stat -c '%...'`. The associative array `meta` exposes every stat field.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 361 Katas = 0.3.61
-const Version = "0.3.61"
+// 362 Katas = 0.3.62
+const Version = "0.3.62"


### PR DESCRIPTION
ZC1365 — Use Zsh `zstat` module instead of `stat -c` for file metadata

What: flags `stat -c`, `stat --format`, `stat --printf`.
Why: Zsh's `zsh/stat` module (command `zstat`) exposes every stat(2) field natively. `zstat -H meta file` populates an associative array keyed by field name.
Fix suggestion: `zmodload zsh/stat; zstat -H meta file; echo "${meta[size]}"`.
Severity: Style