### PR TITLE
feat: ZC1366 — use Zsh `limit` instead of POSIX `ulimit`

### DIFF
--- a/pkg/katas/katatests/zc1366_test.go
+++ b/pkg/katas/katatests/zc1366_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1366(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — limit builtin",
+			input:    `limit cputime 10`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ulimit",
+			input: `ulimit -t 10`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1366",
+					Message: "Use Zsh `limit` (human-readable) or `limit -s` (stdout-only) instead of POSIX `ulimit` for Zsh-native resource queries.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1366")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1366.go
+++ b/pkg/katas/zc1366.go
@@ -1,0 +1,39 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1366",
+		Title:    "Use Zsh `limit` instead of POSIX `ulimit` for idiomatic resource queries",
+		Severity: SeverityStyle,
+		Description: "Zsh provides both `ulimit` (POSIX compatibility) and `limit` (Zsh native). " +
+			"`limit` prints human-readable values (`cputime 10 seconds` vs `-t 10`) and accepts " +
+			"`unlimited` as a value. Prefer `limit` for Zsh-idiomatic scripts; keep `ulimit` only " +
+			"when the script must run under Bash as well.",
+		Check: checkZC1366,
+	})
+}
+
+func checkZC1366(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "ulimit" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1366",
+		Message: "Use Zsh `limit` (human-readable) or `limit -s` (stdout-only) instead of " +
+			"POSIX `ulimit` for Zsh-native resource queries.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 362 Katas = 0.3.62
-const Version = "0.3.62"
+// 363 Katas = 0.3.63
+const Version = "0.3.63"


### PR DESCRIPTION
ZC1366 — Use Zsh `limit` instead of POSIX `ulimit` for idiomatic resource queries

What: flags `ulimit` invocations.
Why: Zsh provides `limit` as the native resource-query builtin; output is human-readable (`cputime 10 seconds` vs `-t 10`) and accepts `unlimited` as a value.
Fix suggestion: `limit cputime 10` instead of `ulimit -t 10`. Keep `ulimit` only when the script runs under Bash too.
Severity: Style