### PR TITLE
feat: ZC1367 — use Zsh `strftime` instead of Bash `printf '%(fmt)T'`

### DIFF
--- a/pkg/katas/katatests/zc1367_test.go
+++ b/pkg/katas/katatests/zc1367_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1367(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — printf normal format",
+			input:    `printf '%s\n' hello`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — printf %(fmt)T",
+			input: `printf '%(%Y-%m-%d)T\n' 1700000000`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1367",
+					Message: "Use Zsh `strftime fmt seconds` (from `zsh/datetime`) instead of Bash `printf '%(fmt)T' seconds`. Same formatting, more readable, no Bash-version gating.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1367")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1367.go
+++ b/pkg/katas/zc1367.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1367",
+		Title:    "Use Zsh `strftime` instead of Bash `printf '%(fmt)T'`",
+		Severity: SeverityStyle,
+		Description: "Bash 4.2+ supports `printf '%(fmt)T\\n' seconds` to format a timestamp. Zsh's " +
+			"`zsh/datetime` module provides `strftime` which is more readable and works " +
+			"consistently across versions: `strftime '%Y-%m-%d' $EPOCHSECONDS`.",
+		Check: checkZC1367,
+	})
+}
+
+func checkZC1367(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		// Look for %(...)T format specifier
+		if strings.Contains(val, ")T") && strings.Contains(val, "%(") {
+			return []Violation{{
+				KataID: "ZC1367",
+				Message: "Use Zsh `strftime fmt seconds` (from `zsh/datetime`) instead of Bash " +
+					"`printf '%(fmt)T' seconds`. Same formatting, more readable, no Bash-version gating.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 363 Katas = 0.3.63
-const Version = "0.3.63"
+// 364 Katas = 0.3.64
+const Version = "0.3.64"


### PR DESCRIPTION
ZC1367 — Use Zsh `strftime` instead of Bash `printf '%(fmt)T'`

What: flags `printf` with a `%(fmt)T` format specifier.
Why: `printf '%(fmt)T'` is a Bash 4.2+ extension. Zsh's `zsh/datetime` module provides `strftime fmt seconds` natively — more readable and portable across Zsh versions.
Fix suggestion: `zmodload zsh/datetime; strftime '%Y-%m-%d' $EPOCHSECONDS`.
Severity: Style