### PR TITLE
feat: ZC1368 — avoid `sh -c`/`bash -c` inside Zsh scripts

### DIFF
--- a/pkg/katas/katatests/zc1368_test.go
+++ b/pkg/katas/katatests/zc1368_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1368(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sh without -c",
+			input:    `sh script.sh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — sh -c",
+			input: `sh -c 'echo hi'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1368",
+					Message: "Avoid `sh -c`/`bash -c` inside a Zsh script — inline the code as a function to keep access to arrays, associative arrays, and Zsh features. Use `zsh -c` only when a fresh shell is truly required.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — bash -c",
+			input: `bash -c 'echo hi'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1368",
+					Message: "Avoid `sh -c`/`bash -c` inside a Zsh script — inline the code as a function to keep access to arrays, associative arrays, and Zsh features. Use `zsh -c` only when a fresh shell is truly required.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1368")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1368.go
+++ b/pkg/katas/zc1368.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1368",
+		Title:    "Avoid `sh -c` / `bash -c` inside a Zsh script — inline or use a function",
+		Severity: SeverityStyle,
+		Description: "Invoking `sh -c` or `bash -c` inside a Zsh script spawns a second shell, " +
+			"loses access to the parent script's functions, arrays, and associative arrays, and " +
+			"re-interprets POSIX-only syntax. Inline the code as a function or use `zsh -c` when " +
+			"a subshell is truly required.",
+		Check: checkZC1368,
+	})
+}
+
+func checkZC1368(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "sh" && ident.Value != "bash" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-c" {
+			return []Violation{{
+				KataID: "ZC1368",
+				Message: "Avoid `sh -c`/`bash -c` inside a Zsh script — inline the code as a " +
+					"function to keep access to arrays, associative arrays, and Zsh features. " +
+					"Use `zsh -c` only when a fresh shell is truly required.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 364 Katas = 0.3.64
-const Version = "0.3.64"
+// 365 Katas = 0.3.65
+const Version = "0.3.65"


### PR DESCRIPTION
ZC1368 — Avoid `sh -c` / `bash -c` inside a Zsh script

What: flags `sh -c` and `bash -c` invocations.
Why: Spawning `sh`/`bash` inside a Zsh script loses access to Zsh arrays, associative arrays, and Zsh-specific syntax. A Zsh function call or inline command is usually better.
Fix suggestion: inline as a function, or use `zsh -c` when a fresh shell is required.
Severity: Style