### PR TITLE
feat: ZC1369 — use Zsh `${(V)var}` instead of `od -c`

### DIFF
--- a/pkg/katas/katatests/zc1369_test.go
+++ b/pkg/katas/katatests/zc1369_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1369(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — od -x (hex, different use)",
+			input:    `od -x file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — od -c",
+			input: `od -c file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1369",
+					Message: "Use Zsh `${(V)var}` to see non-printable characters in a variable — renders control chars as `\\n`, `\\t`, etc., without spawning `od`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1369")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1369.go
+++ b/pkg/katas/zc1369.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1369",
+		Title:    "Prefer Zsh `${(V)var}` over `od -c` for printable-visible character output",
+		Severity: SeverityStyle,
+		Description: "Zsh's `${(V)var}` parameter flag renders non-printable characters in " +
+			"visible form (e.g. `\\n` for newline). For simple inspection of a variable's " +
+			"contents, this avoids the `od -c` process entirely.",
+		Check: checkZC1369,
+	})
+}
+
+func checkZC1369(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "od" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-c" || v == "-C" {
+			return []Violation{{
+				KataID: "ZC1369",
+				Message: "Use Zsh `${(V)var}` to see non-printable characters in a variable — " +
+					"renders control chars as `\\n`, `\\t`, etc., without spawning `od`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 365 Katas = 0.3.65
-const Version = "0.3.65"
+// 366 Katas = 0.3.66
+const Version = "0.3.66"


### PR DESCRIPTION
ZC1369 — Prefer Zsh `${(V)var}` over `od -c` for visible-char rendering

What: flags `od -c` and `od -C` invocations.
Why: Zsh's `${(V)var}` renders non-printable characters in visible form (e.g. `\n` for newline) directly from a variable, without spawning `od`.
Fix suggestion: `print -r -- ${(V)line}`.
Severity: Style