### PR TITLE
feat: ZC1370 — prefer Zsh `repeat N { ... }` over `yes str | head`

### DIFF
--- a/pkg/katas/katatests/zc1370_test.go
+++ b/pkg/katas/katatests/zc1370_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1370(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — non-yes command",
+			input:    `echo hello`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — yes str",
+			input: `yes banana`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1370",
+					Message: "Prefer Zsh `repeat N { print str }` over `yes str | head -n N` for producing N copies of a line. No external `yes` process, no pipe.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1370")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1370.go
+++ b/pkg/katas/zc1370.go
@@ -1,0 +1,38 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1370",
+		Title:    "Prefer Zsh `repeat N { ... }` over `yes str | head -n N` for finite output",
+		Severity: SeverityStyle,
+		Description: "`yes` plus `head` is a common idiom for producing N copies of a line. " +
+			"Zsh's `repeat N { print str }` does the same loop in-shell without spawning yes " +
+			"or the pipe, and without the SIGPIPE handshake.",
+		Check: checkZC1370,
+	})
+}
+
+func checkZC1370(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "yes" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1370",
+		Message: "Prefer Zsh `repeat N { print str }` over `yes str | head -n N` for producing " +
+			"N copies of a line. No external `yes` process, no pipe.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 366 Katas = 0.3.66
-const Version = "0.3.66"
+// 367 Katas = 0.3.67
+const Version = "0.3.67"


### PR DESCRIPTION
ZC1370 — Prefer Zsh `repeat N { ... }` over `yes str | head -n N`

What: flags `yes ...` invocations.
Why: `yes str | head -n N` is a common idiom for N copies of a line. Zsh's `repeat N { print str }` achieves the same with no external process and no pipe.
Fix suggestion: `repeat 5 { print banana }`.
Severity: Style