### PR TITLE
feat: ZC1371 — use Zsh array `:t` modifier instead of `basename -a`

### DIFF
--- a/pkg/katas/katatests/zc1371_test.go
+++ b/pkg/katas/katatests/zc1371_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1371(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — basename single path",
+			input:    `basename /usr/bin/zsh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — basename -a",
+			input: `basename -a /a/b /c/d`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1371",
+					Message: "Use Zsh `${paths:t}` on an array for bulk basename extraction instead of `basename -a`. The `:t` modifier applies to every array element.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1371")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1371.go
+++ b/pkg/katas/zc1371.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1371",
+		Title:    "Use Zsh array `:t` modifier instead of `basename -a` for bulk path stripping",
+		Severity: SeverityStyle,
+		Description: "`basename -a a b c` returns the file name component of each path. Zsh's " +
+			"`${array:t}` parameter modifier applies the same tail-component extraction to every " +
+			"element of an array at once — no external process.",
+		Check: checkZC1371,
+	})
+}
+
+func checkZC1371(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "basename" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-a" || v == "--multiple" {
+			return []Violation{{
+				KataID: "ZC1371",
+				Message: "Use Zsh `${paths:t}` on an array for bulk basename extraction instead of " +
+					"`basename -a`. The `:t` modifier applies to every array element.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 367 Katas = 0.3.67
-const Version = "0.3.67"
+// 368 Katas = 0.3.68
+const Version = "0.3.68"


### PR DESCRIPTION
ZC1371 — Use Zsh array `:t` modifier instead of `basename -a` for bulk path stripping

What: flags `basename -a ...` and `basename --multiple`.
Why: Zsh's `${array:t}` modifier extracts the tail component from every element in one go, inside the shell.
Fix suggestion: `names=(${paths:t})`.
Severity: Style