### PR TITLE
feat: ZC1372 — use Zsh `zmv` autoload instead of `rename`/`rename.ul`

### DIFF
--- a/pkg/katas/katatests/zc1372_test.go
+++ b/pkg/katas/katatests/zc1372_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1372(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — zmv usage",
+			input:    `zmv '(*).txt' '$1.md'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — rename perl-style",
+			input: `rename 's/\.txt$/.md/' *.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1372",
+					Message: "Use Zsh `zmv` (autoload -Uz zmv) instead of `rename`/`rename.ul`/`prename`. Glob-pattern renaming is handled in-shell with capture groups.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — rename.ul util-linux",
+			input: `rename.ul .txt .md *.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1372",
+					Message: "Use Zsh `zmv` (autoload -Uz zmv) instead of `rename`/`rename.ul`/`prename`. Glob-pattern renaming is handled in-shell with capture groups.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1372")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1372.go
+++ b/pkg/katas/zc1372.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1372",
+		Title:    "Use Zsh `zmv` autoload function instead of `rename`/`rename.ul`",
+		Severity: SeverityStyle,
+		Description: "Zsh's `zmv` (autoloaded via `autoload -Uz zmv`) batch-renames files using " +
+			"glob patterns with capture groups. Safer than the various `rename`/`rename.ul`/`prename` " +
+			"utilities (perl-based vs util-linux) and does not depend on which one is installed.",
+		Check: checkZC1372,
+	})
+}
+
+func checkZC1372(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "rename" && ident.Value != "rename.ul" && ident.Value != "prename" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1372",
+		Message: "Use Zsh `zmv` (autoload -Uz zmv) instead of `rename`/`rename.ul`/`prename`. " +
+			"Glob-pattern renaming is handled in-shell with capture groups.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 368 Katas = 0.3.68
-const Version = "0.3.68"
+// 369 Katas = 0.3.69
+const Version = "0.3.69"


### PR DESCRIPTION
ZC1372 — Use Zsh `zmv` autoload function instead of `rename`/`rename.ul`/`prename`

What: flags `rename`, `rename.ul`, `prename` invocations.
Why: Zsh's `zmv` (autoloaded via `autoload -Uz zmv`) batch-renames files using glob patterns with capture groups.
Fix suggestion: `autoload -Uz zmv; zmv '(*).txt' '\$1.md'`.
Severity: Style