### PR TITLE
feat: ZC1373 — use Zsh `${(0)var}` NUL-split flag instead of `env -0`

### DIFF
--- a/pkg/katas/katatests/zc1373_test.go
+++ b/pkg/katas/katatests/zc1373_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1373(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — env without -0",
+			input:    `env VAR=val cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — env -0",
+			input: `env -0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1373",
+					Message: "Use Zsh `${(0)\"$(<file)\"}` to split NUL-terminated content in-shell. `env -0` is usually followed by `xargs -0` or a read loop — both avoided.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1373")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1373.go
+++ b/pkg/katas/zc1373.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1373",
+		Title:    "Use Zsh `${(0)var}` flag for NUL-split parsing instead of `env -0`",
+		Severity: SeverityStyle,
+		Description: "When reading NUL-terminated data (e.g. `/proc/*/environ`), Zsh's `${(0)var}` " +
+			"parameter flag splits on NUL into an array natively. Avoid `env -0 | xargs -0 ...` " +
+			"chains that require two additional processes.",
+		Check: checkZC1373,
+	})
+}
+
+func checkZC1373(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "env" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-0" || v == "--null" {
+			return []Violation{{
+				KataID: "ZC1373",
+				Message: "Use Zsh `${(0)\"$(<file)\"}` to split NUL-terminated content in-shell. " +
+					"`env -0` is usually followed by `xargs -0` or a read loop — both avoided.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 369 Katas = 0.3.69
-const Version = "0.3.69"
+// 370 Katas = 0.3.70
+const Version = "0.3.70"


### PR DESCRIPTION
ZC1373 — Use Zsh `${(0)var}` flag for NUL-split parsing instead of `env -0`

What: flags `env -0` / `env --null` invocations.
Why: Zsh's `${(0)var}` parameter flag splits a string on NUL into an array natively. Reading `/proc/*/environ` or similar NUL-delimited sources no longer needs `env -0 | xargs -0` pipelines.
Fix suggestion: `envs=(${(0)"$(<file)"}) ; print -l $envs`.
Severity: Style