### PR TITLE
feat: ZC1374 — clarify $FUNCNEST semantics differ between Bash and Zsh

### DIFF
--- a/pkg/katas/katatests/zc1374_test.go
+++ b/pkg/katas/katatests/zc1374_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1374(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo other var",
+			input:    `echo $var`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $FUNCNEST expecting depth",
+			input: `echo $FUNCNEST`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1374",
+					Message: "In Zsh, `$FUNCNEST` is the configured limit, not the current depth. Use `${#funcstack}` for current function nesting depth.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1374")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1374.go
+++ b/pkg/katas/zc1374.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1374",
+		Title:    "Avoid `$FUNCNEST` — Zsh uses `$FUNCNEST` as a limit, not a depth indicator",
+		Severity: SeverityWarning,
+		Description: "Bash's `$FUNCNEST` is both a writable limit and (implicitly) the current " +
+			"depth-query vehicle. Zsh's `$FUNCNEST` is only the limit — to read the current depth " +
+			"use `${#funcstack}`. Reading `$FUNCNEST` expecting depth returns the limit, not " +
+			"the current depth.",
+		Check: checkZC1374,
+	})
+}
+
+func checkZC1374(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "$FUNCNEST" || v == "${FUNCNEST}" {
+			return []Violation{{
+				KataID: "ZC1374",
+				Message: "In Zsh, `$FUNCNEST` is the configured limit, not the current depth. " +
+					"Use `${#funcstack}` for current function nesting depth.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 370 Katas = 0.3.70
-const Version = "0.3.70"
+// 371 Katas = 0.3.71
+const Version = "0.3.71"


### PR DESCRIPTION
ZC1374 — Avoid reading `\$FUNCNEST` as depth — Zsh uses it only as a limit

What: flags `echo`/`print`/`printf` with `\$FUNCNEST` / `\${FUNCNEST}` as an argument.
Why: In Bash, `\$FUNCNEST` is both the configured limit and the current depth. In Zsh, `\$FUNCNEST` is **only** the limit; current nesting depth is `\${#funcstack}`. Code that reads `\$FUNCNEST` expecting depth produces wrong results under Zsh.
Fix suggestion: `print \${#funcstack}` for current depth, keep `\$FUNCNEST` only when setting the limit.
Severity: Warning