### PR TITLE
feat: ZC1375 — use `set --` instead of `shift $#` to clear positional args

### DIFF
--- a/pkg/katas/katatests/zc1375_test.go
+++ b/pkg/katas/katatests/zc1375_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1375(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — shift 1",
+			input:    `shift 1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — shift $#",
+			input: `shift $#`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1375",
+					Message: "Use `set --` instead of `shift $#` to clear positional arguments. Clearer intent, no dependency on `$#` accuracy at evaluation time.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1375")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1375.go
+++ b/pkg/katas/zc1375.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1375",
+		Title:    "Use `set --` (empty) instead of `shift $#` to clear positional arguments",
+		Severity: SeverityStyle,
+		Description: "`shift $#` discards all positional arguments but is indirect and depends on " +
+			"`$#` being accurate at evaluation. `set --` (with nothing after `--`) clears the " +
+			"positional parameters atomically and reads more clearly.",
+		Check: checkZC1375,
+	})
+}
+
+func checkZC1375(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "shift" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "$#" || v == "${#}" {
+			return []Violation{{
+				KataID: "ZC1375",
+				Message: "Use `set --` instead of `shift $#` to clear positional arguments. " +
+					"Clearer intent, no dependency on `$#` accuracy at evaluation time.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 371 Katas = 0.3.71
-const Version = "0.3.71"
+// 372 Katas = 0.3.72
+const Version = "0.3.72"


### PR DESCRIPTION
ZC1375 — Use `set --` (empty) instead of `shift \$#` to clear positional arguments

What: flags `shift \$#` and `shift \${#}` invocations.
Why: `shift \$#` discards all positional args indirectly. `set --` clears them atomically and reads clearer.
Fix suggestion: `set --` replaces `shift \$#` in any context.
Severity: Style