### PR TITLE
feat: ZC1375 — use `[[ -t fd ]]` instead of `tty -s`

### DIFF
--- a/pkg/katas/katatests/zc1375_test.go
+++ b/pkg/katas/katatests/zc1375_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1375(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — tty (print tty name)",
+			input:    `tty`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — tty -s",
+			input: `tty -s`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1375",
+					Message: "Use `[[ -t 0 ]]` (stdin), `[[ -t 1 ]]` (stdout), or `[[ -t 2 ]]` (stderr) instead of `tty -s`. In-shell file-descriptor test, no external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1375")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1375.go
+++ b/pkg/katas/zc1375.go
@@ -1,0 +1,43 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1375",
+		Title:    "Use `[[ -t fd ]]` instead of `tty -s` for tty-check",
+		Severity: SeverityStyle,
+		Description: "`tty -s` exits 0 if stdin is a terminal. Zsh's `[[ -t 0 ]]` (or `[[ -t 1 ]]` " +
+			"for stdout, `[[ -t 2 ]]` for stderr) does the same check without spawning `tty`.",
+		Check: checkZC1375,
+	})
+}
+
+func checkZC1375(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "tty" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-s" {
+			return []Violation{{
+				KataID: "ZC1375",
+				Message: "Use `[[ -t 0 ]]` (stdin), `[[ -t 1 ]]` (stdout), or `[[ -t 2 ]]` (stderr) " +
+					"instead of `tty -s`. In-shell file-descriptor test, no external process.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 371 Katas = 0.3.71
-const Version = "0.3.71"
+// 372 Katas = 0.3.72
+const Version = "0.3.72"


### PR DESCRIPTION
ZC1375 — Use `[[ -t fd ]]` instead of `tty -s` for tty-check

What: flags `tty -s` invocations.
Why: `tty -s` returns 0 iff stdin is a terminal. Zsh's `[[ -t 0 ]]` test works in-shell with any file descriptor (0 stdin, 1 stdout, 2 stderr) — no subprocess.
Fix suggestion: `[[ -t 1 ]] && colored_output || plain_output`.
Severity: Style