### PR TITLE
feat: ZC1376 — warn on $BASH_XTRACEFD (Bash-only)

### DIFF
--- a/pkg/katas/katatests/zc1376_test.go
+++ b/pkg/katas/katatests/zc1376_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1376(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — unrelated echo",
+			input:    `echo $VAR`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $BASH_XTRACEFD",
+			input: `echo $BASH_XTRACEFD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1376",
+					Message: "`BASH_XTRACEFD` is Bash-only. Zsh ignores it. Redirect trace output with `exec {fd}>file; exec 2>&$fd; setopt XTRACE` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1376")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1376.go
+++ b/pkg/katas/zc1376.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1376",
+		Title:    "Avoid `BASH_XTRACEFD` — use Zsh `exec {fd}>file` + `setopt XTRACE`",
+		Severity: SeverityWarning,
+		Description: "Bash's `BASH_XTRACEFD` redirects `set -x` output to a file descriptor. Zsh " +
+			"does not honor this variable; setting it is a silent no-op. To redirect trace output " +
+			"in Zsh, open a dedicated fd with `exec {fd}>file` and redirect fd 2 through it: " +
+			"`exec 2>&$fd; setopt XTRACE`.",
+		Check: checkZC1376,
+	})
+}
+
+func checkZC1376(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" && ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "$BASH_XTRACEFD" || v == "${BASH_XTRACEFD}" ||
+			v == "BASH_XTRACEFD" {
+			return []Violation{{
+				KataID: "ZC1376",
+				Message: "`BASH_XTRACEFD` is Bash-only. Zsh ignores it. Redirect trace output " +
+					"with `exec {fd}>file; exec 2>&$fd; setopt XTRACE` instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 372 Katas = 0.3.72
-const Version = "0.3.72"
+// 373 Katas = 0.3.73
+const Version = "0.3.73"


### PR DESCRIPTION
ZC1376 — Avoid \`\$BASH_XTRACEFD\` — Bash-only, use \`exec {fd}>file\` + \`setopt XTRACE\`

What: flags references to \`\$BASH_XTRACEFD\` / \`\${BASH_XTRACEFD}\`.
Why: Bash redirects \`set -x\` output to the fd named by this variable. Zsh silently ignores the variable — the trace still goes to stderr.
Fix suggestion: \`exec {fd}>trace.log; exec 2>&\$fd; setopt XTRACE\` for equivalent behavior in Zsh.
Severity: Warning