### PR TITLE
feat: ZC1377 — avoid $BASH_ALIASES (Bash-only)

### DIFF
--- a/pkg/katas/katatests/zc1377_test.go
+++ b/pkg/katas/katatests/zc1377_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1377(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $aliases",
+			input:    `echo $aliases`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $BASH_ALIASES",
+			input: `echo $BASH_ALIASES`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1377",
+					Message: "`$BASH_ALIASES` is Bash-only. In Zsh use `$aliases` (assoc array) — same structure, e.g. `print -l ${(kv)aliases}`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1377")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1377.go
+++ b/pkg/katas/zc1377.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1377",
+		Title:    "Avoid `$BASH_ALIASES` — use Zsh `$aliases` associative array",
+		Severity: SeverityWarning,
+		Description: "Bash's `$BASH_ALIASES` is an associative array of alias→value mappings. Zsh " +
+			"exposes the same information via `$aliases` (also an assoc array). `$BASH_ALIASES` " +
+			"is unset in Zsh; reading it yields nothing.",
+		Check: checkZC1377,
+	})
+}
+
+func checkZC1377(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "BASH_ALIASES") {
+			return []Violation{{
+				KataID: "ZC1377",
+				Message: "`$BASH_ALIASES` is Bash-only. In Zsh use `$aliases` (assoc array) — " +
+					"same structure, e.g. `print -l ${(kv)aliases}`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 373 Katas = 0.3.73
-const Version = "0.3.73"
+// 374 Katas = 0.3.74
+const Version = "0.3.74"


### PR DESCRIPTION
ZC1377 — Avoid \`\$BASH_ALIASES\` — use Zsh \`\$aliases\`

What: flags references to \`\$BASH_ALIASES\` / \`\${BASH_ALIASES}\`.
Why: \`\$BASH_ALIASES\` is Bash-only. In Zsh the equivalent associative array is \`\$aliases\` (lowercase, built into the \`zsh/parameter\` module).
Fix suggestion: \`print -l \${(kv)aliases}\`.
Severity: Warning