### PR TITLE
feat: ZC1378 — use Zsh lowercase $dirstack instead of Bash $DIRSTACK

### DIFF
--- a/pkg/katas/katatests/zc1378_test.go
+++ b/pkg/katas/katatests/zc1378_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1378(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $dirstack (lowercase)",
+			input:    `echo $dirstack`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $DIRSTACK",
+			input: `echo $DIRSTACK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1378",
+					Message: "Use lowercase `$dirstack` in Zsh — uppercase `$DIRSTACK` is Bash-only.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1378")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1378.go
+++ b/pkg/katas/zc1378.go
@@ -36,11 +36,11 @@ func checkZC1378(node ast.Node) []Violation {
 		v := arg.String()
 		if strings.Contains(v, "DIRSTACK") {
 			return []Violation{{
-				KataID: "ZC1378",
+				KataID:  "ZC1378",
 				Message: "Use lowercase `$dirstack` in Zsh — uppercase `$DIRSTACK` is Bash-only.",
-				Line:   cmd.Token.Line,
-				Column: cmd.Token.Column,
-				Level:  SeverityError,
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityError,
 			}}
 		}
 	}

--- a/pkg/katas/zc1378.go
+++ b/pkg/katas/zc1378.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1378",
+		Title:    "Avoid uppercase `$DIRSTACK` — Zsh uses lowercase `$dirstack`",
+		Severity: SeverityError,
+		Description: "Bash's `$DIRSTACK` is the `pushd`/`popd` directory stack. Zsh exposes the " +
+			"same stack as lowercase `$dirstack` (per zsh/parameter module). Using uppercase " +
+			"`$DIRSTACK` in Zsh accesses an unrelated (and usually empty) variable.",
+		Check: checkZC1378,
+	})
+}
+
+func checkZC1378(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "DIRSTACK") {
+			return []Violation{{
+				KataID: "ZC1378",
+				Message: "Use lowercase `$dirstack` in Zsh — uppercase `$DIRSTACK` is Bash-only.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 374 Katas = 0.3.74
-const Version = "0.3.74"
+// 375 Katas = 0.3.75
+const Version = "0.3.75"


### PR DESCRIPTION
ZC1378 — Avoid uppercase \`\$DIRSTACK\` — Zsh uses lowercase \`\$dirstack\`

What: flags references to \`\$DIRSTACK\` / \`\${DIRSTACK}\`.
Why: Bash \`\$DIRSTACK\` is the pushd/popd directory stack. In Zsh the equivalent array is lowercase \`\$dirstack\` (zsh/parameter module). Using the uppercase name reads an unrelated (usually empty) variable.
Fix suggestion: \`print -l \$dirstack\`.
Severity: Error (reading wrong variable silently)