### PR TITLE
feat: ZC1379 — avoid $PROMPT_COMMAND — use Zsh `precmd`

### DIFF
--- a/pkg/katas/katatests/zc1379_test.go
+++ b/pkg/katas/katatests/zc1379_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1379(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — unrelated echo",
+			input:    `echo hello`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $PROMPT_COMMAND",
+			input: `echo $PROMPT_COMMAND`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1379",
+					Message: "`PROMPT_COMMAND` is Bash-only. In Zsh define a `precmd` function or use `autoload -Uz add-zsh-hook; add-zsh-hook precmd my_hook`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1379")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1379.go
+++ b/pkg/katas/zc1379.go
@@ -39,9 +39,9 @@ func checkZC1379(node ast.Node) []Violation {
 				KataID: "ZC1379",
 				Message: "`PROMPT_COMMAND` is Bash-only. In Zsh define a `precmd` function or use " +
 					"`autoload -Uz add-zsh-hook; add-zsh-hook precmd my_hook`.",
-				Line:    cmd.Token.Line,
-				Column:  cmd.Token.Column,
-				Level:   SeverityWarning,
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
 			}}
 		}
 	}

--- a/pkg/katas/zc1379.go
+++ b/pkg/katas/zc1379.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1379",
+		Title:    "Avoid `$PROMPT_COMMAND` — use Zsh `precmd` function",
+		Severity: SeverityWarning,
+		Description: "Bash runs the command in `$PROMPT_COMMAND` before each prompt. Zsh does not " +
+			"honor this variable; the equivalent is a function named `precmd` (or registered via " +
+			"`add-zsh-hook precmd name`). Reading `$PROMPT_COMMAND` in Zsh is a no-op.",
+		Check: checkZC1379,
+	})
+}
+
+func checkZC1379(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" && ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "PROMPT_COMMAND") {
+			return []Violation{{
+				KataID: "ZC1379",
+				Message: "`PROMPT_COMMAND` is Bash-only. In Zsh define a `precmd` function or use " +
+					"`autoload -Uz add-zsh-hook; add-zsh-hook precmd my_hook`.",
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 375 Katas = 0.3.75
-const Version = "0.3.75"
+// 376 Katas = 0.3.76
+const Version = "0.3.76"


### PR DESCRIPTION
ZC1379 — Avoid \`\$PROMPT_COMMAND\` — use Zsh \`precmd\` function

What: flags references to \`\$PROMPT_COMMAND\` / \`\${PROMPT_COMMAND}\`.
Why: Bash runs the content of this variable before each prompt. Zsh ignores it; the Zsh-native hook is the \`precmd\` function (or \`add-zsh-hook precmd\`).
Fix suggestion: \`autoload -Uz add-zsh-hook; add-zsh-hook precmd my_prompt_hook\`.
Severity: Warning