### PR TITLE
feat: ZC1380 — use Zsh $HISTORY_IGNORE instead of $HISTIGNORE

### DIFF
--- a/pkg/katas/katatests/zc1380_test.go
+++ b/pkg/katas/katatests/zc1380_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1380(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $HISTORY_IGNORE (Zsh)",
+			input:    `echo $HISTORY_IGNORE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $HISTIGNORE",
+			input: `echo $HISTIGNORE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1380",
+					Message: "`$HISTIGNORE` is Bash-only. In Zsh use `$HISTORY_IGNORE` (underscored) for the same history-pattern filter.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1380")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1380.go
+++ b/pkg/katas/zc1380.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1380",
+		Title:    "Avoid `$HISTIGNORE` — use Zsh `$HISTORY_IGNORE`",
+		Severity: SeverityWarning,
+		Description: "Bash filters history entries matching `$HISTIGNORE` patterns. Zsh uses a " +
+			"parameter named `$HISTORY_IGNORE` (underscore in the middle). Setting `HISTIGNORE` " +
+			"in Zsh is a no-op.",
+		Check: checkZC1380,
+	})
+}
+
+func checkZC1380(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" && ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "HISTIGNORE") && !strings.Contains(v, "HISTORY_IGNORE") {
+			return []Violation{{
+				KataID: "ZC1380",
+				Message: "`$HISTIGNORE` is Bash-only. In Zsh use `$HISTORY_IGNORE` (underscored) " +
+					"for the same history-pattern filter.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 376 Katas = 0.3.76
-const Version = "0.3.76"
+// 377 Katas = 0.3.77
+const Version = "0.3.77"


### PR DESCRIPTION
ZC1380 — Avoid \`\$HISTIGNORE\` — use Zsh \`\$HISTORY_IGNORE\`

What: flags references to \`\$HISTIGNORE\`.
Why: Bash filter-variable name is \`HISTIGNORE\` (no underscore). Zsh's equivalent is \`HISTORY_IGNORE\` (underscored). Setting the Bash name in Zsh is a silent no-op.
Fix suggestion: \`HISTORY_IGNORE='(ls|cd|pwd)'\`.
Severity: Warning