### PR TITLE
feat: ZC1381 — avoid Bash $COMP_* in Zsh completion

### DIFF
--- a/pkg/katas/katatests/zc1381_test.go
+++ b/pkg/katas/katatests/zc1381_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1381(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $words (Zsh compsys)",
+			input:    `echo $words`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $COMP_WORDS",
+			input: `echo $COMP_WORDS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1381",
+					Message: "Bash `$COMP_*` completion variables do not exist in Zsh. Use `$words` (array of tokens), `$CURRENT` (cursor index), `$BUFFER`, or the `_arguments`/`_values` helpers from `compsys`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — echo $COMP_CWORD",
+			input: `echo $COMP_CWORD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1381",
+					Message: "Bash `$COMP_*` completion variables do not exist in Zsh. Use `$words` (array of tokens), `$CURRENT` (cursor index), `$BUFFER`, or the `_arguments`/`_values` helpers from `compsys`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1381")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1381.go
+++ b/pkg/katas/zc1381.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1381",
+		Title:    "Avoid `$COMP_WORDS`/`$COMP_CWORD` — Zsh uses `words`/`$CURRENT`",
+		Severity: SeverityError,
+		Description: "Bash programmable completion reads the partial command via `$COMP_WORDS` " +
+			"(array of tokens) and `$COMP_CWORD` (index of cursor). Zsh's completion system " +
+			"exposes the same via `words` (array) and `$CURRENT` (1-based cursor index). Using " +
+			"the Bash names in Zsh completion functions produces empty expansions.",
+		Check: checkZC1381,
+	})
+}
+
+func checkZC1381(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "COMP_WORDS") || strings.Contains(v, "COMP_CWORD") ||
+			strings.Contains(v, "COMP_LINE") || strings.Contains(v, "COMP_POINT") {
+			return []Violation{{
+				KataID: "ZC1381",
+				Message: "Bash `$COMP_*` completion variables do not exist in Zsh. Use " +
+					"`$words` (array of tokens), `$CURRENT` (cursor index), `$BUFFER`, or the " +
+					"`_arguments`/`_values` helpers from `compsys`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 377 Katas = 0.3.77
-const Version = "0.3.77"
+// 378 Katas = 0.3.78
+const Version = "0.3.78"


### PR DESCRIPTION
ZC1381 — Avoid \`\$COMP_WORDS\`/\`\$COMP_CWORD\` — Zsh completion uses \`words\`/\`\$CURRENT\`

What: flags references to Bash completion vars \`\$COMP_WORDS\`, \`\$COMP_CWORD\`, \`\$COMP_LINE\`, \`\$COMP_POINT\`.
Why: These are Bash programmable-completion globals. Zsh's compsys uses \`words\` (array), \`\$CURRENT\` (1-based cursor), \`\$BUFFER\`, and helper functions like \`_arguments\`/\`_values\`.
Fix suggestion: rewrite completion function for Zsh compsys — see \`man zshcompsys\`.
Severity: Error