### PR TITLE
feat: ZC1382 — use Zsh $BUFFER/$CURSOR instead of $READLINE_*

### DIFF
--- a/pkg/katas/katatests/zc1382_test.go
+++ b/pkg/katas/katatests/zc1382_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1382(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $BUFFER (Zsh ZLE)",
+			input:    `echo $BUFFER`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $READLINE_LINE",
+			input: `echo $READLINE_LINE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1382",
+					Message: "Bash `$READLINE_*` vars do not exist in Zsh. Inside ZLE widgets use `$BUFFER`, `$CURSOR`, `$MARK`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — echo $READLINE_POINT",
+			input: `echo $READLINE_POINT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1382",
+					Message: "Bash `$READLINE_*` vars do not exist in Zsh. Inside ZLE widgets use `$BUFFER`, `$CURSOR`, `$MARK`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1382")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1382.go
+++ b/pkg/katas/zc1382.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1382",
+		Title:    "Avoid `$READLINE_LINE`/`$READLINE_POINT` — Zsh ZLE uses `$BUFFER`/`$CURSOR`",
+		Severity: SeverityError,
+		Description: "Bash readline exposes the current input line as `$READLINE_LINE` and cursor " +
+			"offset as `$READLINE_POINT` inside `bind -x` handlers. Zsh's Line Editor (ZLE) uses " +
+			"`$BUFFER` (line text) and `$CURSOR` (1-based column) inside widget functions. The " +
+			"Bash names are unset in Zsh.",
+		Check: checkZC1382,
+	})
+}
+
+func checkZC1382(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "READLINE_LINE") || strings.Contains(v, "READLINE_POINT") ||
+			strings.Contains(v, "READLINE_MARK") {
+			return []Violation{{
+				KataID: "ZC1382",
+				Message: "Bash `$READLINE_*` vars do not exist in Zsh. Inside ZLE widgets use " +
+					"`$BUFFER`, `$CURSOR`, `$MARK`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 378 Katas = 0.3.78
-const Version = "0.3.78"
+// 379 Katas = 0.3.79
+const Version = "0.3.79"


### PR DESCRIPTION
ZC1382 — Avoid \`\$READLINE_LINE\`/\`\$READLINE_POINT\` — Zsh ZLE uses \`\$BUFFER\`/\`\$CURSOR\`

What: flags references to \`\$READLINE_LINE\`, \`\$READLINE_POINT\`, \`\$READLINE_MARK\`.
Why: Bash's readline library exposes these in \`bind -x\` handlers. Zsh's ZLE uses \`\$BUFFER\`, \`\$CURSOR\`, \`\$MARK\` inside widget functions.
Fix suggestion: \`echo \$BUFFER\`, \`(( CURSOR+=1 ))\`, etc. inside ZLE widgets.
Severity: Error