### PR TITLE
feat: ZC1383 — use Zsh $TIMEFMT instead of Bash $TIMEFORMAT

### DIFF
--- a/pkg/katas/katatests/zc1383_test.go
+++ b/pkg/katas/katatests/zc1383_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1383(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $TIMEFMT (Zsh)",
+			input:    `echo $TIMEFMT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $TIMEFORMAT",
+			input: `echo $TIMEFORMAT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1383",
+					Message: "`$TIMEFORMAT` is Bash-only. Zsh reads `$TIMEFMT` (shorter name) for the `time` builtin's output format.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1383")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1383.go
+++ b/pkg/katas/zc1383.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1383",
+		Title:    "Avoid `$TIMEFORMAT` — Zsh uses `$TIMEFMT`",
+		Severity: SeverityWarning,
+		Description: "Bash's `$TIMEFORMAT` controls the output of the `time` builtin. Zsh uses a " +
+			"shorter name, `$TIMEFMT`, for the same purpose. Setting `TIMEFORMAT` in a Zsh script " +
+			"has no effect; the Zsh `time` builtin reads `$TIMEFMT`.",
+		Check: checkZC1383,
+	})
+}
+
+func checkZC1383(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" && ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "TIMEFORMAT") {
+			return []Violation{{
+				KataID: "ZC1383",
+				Message: "`$TIMEFORMAT` is Bash-only. Zsh reads `$TIMEFMT` (shorter name) for the " +
+					"`time` builtin's output format.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 379 Katas = 0.3.79
-const Version = "0.3.79"
+// 380 Katas = 0.3.80
+const Version = "0.3.80"


### PR DESCRIPTION
ZC1383 — Avoid \`\$TIMEFORMAT\` — Zsh uses \`\$TIMEFMT\`

What: flags references to \`\$TIMEFORMAT\`.
Why: Bash reads \`\$TIMEFORMAT\` to format the \`time\` builtin's output. Zsh uses the shorter name \`\$TIMEFMT\`. Setting \`TIMEFORMAT\` in Zsh has no effect.
Fix suggestion: \`TIMEFMT='%J  %U user  %S system  %P cpu  %*E total'\`.
Severity: Warning