### PR TITLE
feat: ZC1384 — warn on $EXECIGNORE (Bash-only)

### DIFF
--- a/pkg/katas/katatests/zc1384_test.go
+++ b/pkg/katas/katatests/zc1384_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1384(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — unrelated echo",
+			input:    `echo hello`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $EXECIGNORE",
+			input: `echo $EXECIGNORE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1384",
+					Message: "`$EXECIGNORE` is Bash-only. For completion filtering in Zsh use `zstyle ':completion:*' ignored-patterns 'pattern'`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1384")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1384.go
+++ b/pkg/katas/zc1384.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1384",
+		Title:    "Avoid `$EXECIGNORE` — Bash-only; Zsh uses completion-system ignore patterns",
+		Severity: SeverityWarning,
+		Description: "Bash's `$EXECIGNORE` excludes matching commands from PATH hashing. Zsh does " +
+			"not honor this variable; use the compsys tag-based filters " +
+			"(`zstyle ':completion:*' ignored-patterns ...`) for a similar effect on completion.",
+		Check: checkZC1384,
+	})
+}
+
+func checkZC1384(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" && ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "EXECIGNORE") {
+			return []Violation{{
+				KataID: "ZC1384",
+				Message: "`$EXECIGNORE` is Bash-only. For completion filtering in Zsh use " +
+					"`zstyle ':completion:*' ignored-patterns 'pattern'`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 380 Katas = 0.3.80
-const Version = "0.3.80"
+// 381 Katas = 0.3.81
+const Version = "0.3.81"


### PR DESCRIPTION
ZC1384 — Avoid \`\$EXECIGNORE\` — Zsh uses compsys tag-based filters

What: flags references to \`\$EXECIGNORE\`.
Why: \`\$EXECIGNORE\` is a Bash-only PATH-hashing filter. Zsh exposes completion filtering through \`zstyle ':completion:*' ignored-patterns ...\`.
Fix suggestion: \`zstyle ':completion:*' ignored-patterns '*.log'\`.
Severity: Warning