### PR TITLE
feat: ZC1385 — warn on $PS0 (Bash-only)

### DIFF
--- a/pkg/katas/katatests/zc1385_test.go
+++ b/pkg/katas/katatests/zc1385_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1385(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — unrelated echo",
+			input:    `echo hello`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $PS0",
+			input: `echo $PS0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1385",
+					Message: "`$PS0` is Bash-only. Zsh uses the `preexec` hook function for pre-execution prompts.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1385")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1385.go
+++ b/pkg/katas/zc1385.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1385",
+		Title:    "Avoid `$PS0` — Bash-only; Zsh uses `preexec` hook",
+		Severity: SeverityWarning,
+		Description: "Bash 4.4+ prints `$PS0` after reading a command and before executing it. Zsh " +
+			"does not honor `$PS0`; the equivalent is a `preexec` function (or " +
+			"`add-zsh-hook preexec funcname`) which receives the command line as `$1`.",
+		Check: checkZC1385,
+	})
+}
+
+func checkZC1385(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" && ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "$PS0") || strings.Contains(v, "${PS0}") || v == "PS0" {
+			return []Violation{{
+				KataID: "ZC1385",
+				Message: "`$PS0` is Bash-only. Zsh uses the `preexec` hook function for " +
+					"pre-execution prompts.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 381 Katas = 0.3.81
-const Version = "0.3.81"
+// 382 Katas = 0.3.82
+const Version = "0.3.82"


### PR DESCRIPTION
ZC1385 — Avoid \`\$PS0\` — Bash-only; Zsh uses \`preexec\` hook

What: flags references to \`\$PS0\`.
Why: Bash 4.4+ expands \`\$PS0\` between reading and executing a command. Zsh has no such variable; the equivalent is a \`preexec\` function.
Fix suggestion: \`preexec() { echo "running: \$1"; }\` or \`add-zsh-hook preexec my_preexec\`.
Severity: Warning