### PR TITLE
feat: ZC1386 — warn on $FIGNORE (Bash-only)

### DIFF
--- a/pkg/katas/katatests/zc1386_test.go
+++ b/pkg/katas/katatests/zc1386_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1386(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — unrelated echo",
+			input:    `echo hello`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $FIGNORE",
+			input: `echo $FIGNORE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1386",
+					Message: "`$FIGNORE` is Bash-only. In Zsh use `zstyle ':completion:*' ignored-patterns '*.o *.pyc'` for completion filtering.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1386")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1386.go
+++ b/pkg/katas/zc1386.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1386",
+		Title:    "Avoid `$FIGNORE` — Bash-only; Zsh uses compsys tag patterns",
+		Severity: SeverityWarning,
+		Description: "Bash's `$FIGNORE` hides filenames matching listed suffixes from completion. " +
+			"Zsh does not honor this variable; use `zstyle ':completion:*' ignored-patterns '*.o *.pyc'` " +
+			"or the file-patterns tag for equivalent filtering.",
+		Check: checkZC1386,
+	})
+}
+
+func checkZC1386(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" && ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "FIGNORE") {
+			return []Violation{{
+				KataID: "ZC1386",
+				Message: "`$FIGNORE` is Bash-only. In Zsh use " +
+					"`zstyle ':completion:*' ignored-patterns '*.o *.pyc'` for completion filtering.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 382 Katas = 0.3.82
-const Version = "0.3.82"
+// 383 Katas = 0.3.83
+const Version = "0.3.83"


### PR DESCRIPTION
ZC1386 — Avoid \`\$FIGNORE\` — Zsh uses compsys tag patterns

What: flags references to \`\$FIGNORE\`.
Why: Bash filters filename completion via \`\$FIGNORE\` (colon-separated suffix list). Zsh's compsys uses \`zstyle ':completion:*' ignored-patterns\` for the same effect.
Fix suggestion: \`zstyle ':completion:*' ignored-patterns '*.o *.pyc'\`.
Severity: Warning