### PR TITLE
feat: ZC1387 — use Zsh $options instead of Bash $SHELLOPTS

### DIFF
--- a/pkg/katas/katatests/zc1387_test.go
+++ b/pkg/katas/katatests/zc1387_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1387(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $options (Zsh)",
+			input:    `echo $options`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $SHELLOPTS",
+			input: `echo $SHELLOPTS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1387",
+					Message: "`$SHELLOPTS` is Bash-only. In Zsh inspect `$options` (assoc array, keys are option names) via `print -l ${(kv)options}`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1387")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1387.go
+++ b/pkg/katas/zc1387.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1387",
+		Title:    "Avoid `$SHELLOPTS` — Zsh uses `$options` associative array",
+		Severity: SeverityWarning,
+		Description: "Bash's `$SHELLOPTS` is a colon-separated list of set options. Zsh exposes " +
+			"the same information via the `$options` associative array (keys are option names, " +
+			"values are `on`/`off`). `$SHELLOPTS` is unset in Zsh.",
+		Check: checkZC1387,
+	})
+}
+
+func checkZC1387(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" && ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "SHELLOPTS") {
+			return []Violation{{
+				KataID: "ZC1387",
+				Message: "`$SHELLOPTS` is Bash-only. In Zsh inspect `$options` (assoc array, " +
+					"keys are option names) via `print -l ${(kv)options}`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 383 Katas = 0.3.83
-const Version = "0.3.83"
+// 384 Katas = 0.3.84
+const Version = "0.3.84"


### PR DESCRIPTION
ZC1387 — Avoid \`\$SHELLOPTS\` — Zsh uses \`\$options\` associative array

What: flags references to \`\$SHELLOPTS\`.
Why: Bash's colon-separated \`\$SHELLOPTS\` enumerates enabled \`set\` options. Zsh exposes the same (plus \`setopt\` toggles) via the \`\$options\` assoc array.
Fix suggestion: \`print -l \${(kv)options}\` or \`[[ \${options[xtrace]} == on ]]\`.
Severity: Warning