### PR TITLE
feat: ZC1388 — use Zsh $mailpath instead of Bash $MAILPATH

### DIFF
--- a/pkg/katas/katatests/zc1388_test.go
+++ b/pkg/katas/katatests/zc1388_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1388(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $mailpath (Zsh)",
+			input:    `echo $mailpath`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $MAILPATH",
+			input: `echo $MAILPATH`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1388",
+					Message: "Use Zsh lowercase `$mailpath` (array) instead of Bash uppercase `$MAILPATH` (colon-separated string).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1388")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1388.go
+++ b/pkg/katas/zc1388.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1388",
+		Title:    "Use Zsh lowercase `$mailpath` array instead of colon-separated `$MAILPATH`",
+		Severity: SeverityWarning,
+		Description: "Bash uses `$MAILPATH` — a colon-separated string of mail files with " +
+			"optional `?message` suffixes. Zsh uses lowercase `$mailpath` as an array (each " +
+			"element: `file?message`), which is typed and parseable. Setting the uppercase " +
+			"name in Zsh is ignored.",
+		Check: checkZC1388,
+	})
+}
+
+func checkZC1388(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" && ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "$MAILPATH") || strings.Contains(v, "${MAILPATH}") ||
+			strings.Contains(v, "MAILPATH=") {
+			return []Violation{{
+				KataID: "ZC1388",
+				Message: "Use Zsh lowercase `$mailpath` (array) instead of Bash uppercase " +
+					"`$MAILPATH` (colon-separated string).",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 384 Katas = 0.3.84
-const Version = "0.3.84"
+// 385 Katas = 0.3.85
+const Version = "0.3.85"


### PR DESCRIPTION
ZC1388 — Use Zsh lowercase \`\$mailpath\` array instead of colon-separated \`\$MAILPATH\`

What: flags references to \`\$MAILPATH\` (uppercase) — both \`\$VAR\` and assignment form.
Why: Bash stores mailpath as a colon-separated string. Zsh uses lowercase \`\$mailpath\` as a typed array. Setting the Bash name in Zsh is ignored.
Fix suggestion: \`mailpath=(~/Mail/inbox'?New mail in inbox')\`.
Severity: Warning