### PR TITLE
feat: ZC1389 — warn on $HOSTFILE (Bash-only)

### DIFF
--- a/pkg/katas/katatests/zc1389_test.go
+++ b/pkg/katas/katatests/zc1389_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1389(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $hosts (Zsh)",
+			input:    `echo $hosts`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $HOSTFILE",
+			input: `echo $HOSTFILE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1389",
+					Message: "`$HOSTFILE` is Bash-only. Zsh reads hostnames for completion from the `$hosts` array (lowercase).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1389")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1389.go
+++ b/pkg/katas/zc1389.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1389",
+		Title:    "Avoid `$HOSTFILE` — Bash-only; Zsh uses `$hosts` array",
+		Severity: SeverityWarning,
+		Description: "Bash reads `$HOSTFILE` to feed hostname completion. Zsh populates hostname " +
+			"completion from the `$hosts` array (lowercase). Setting `$HOSTFILE` in Zsh is " +
+			"ignored; extend `$hosts` instead.",
+		Check: checkZC1389,
+	})
+}
+
+func checkZC1389(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" && ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "HOSTFILE") {
+			return []Violation{{
+				KataID: "ZC1389",
+				Message: "`$HOSTFILE` is Bash-only. Zsh reads hostnames for completion from the " +
+					"`$hosts` array (lowercase).",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 385 Katas = 0.3.85
-const Version = "0.3.85"
+// 386 Katas = 0.3.86
+const Version = "0.3.86"


### PR DESCRIPTION
ZC1389 — Avoid \`\$HOSTFILE\` — Zsh uses \`\$hosts\` array

What: flags references to \`\$HOSTFILE\`.
Why: Bash reads \`\$HOSTFILE\` for hostname completion. Zsh uses the \`\$hosts\` array (lowercase) populated from \`/etc/hosts\` and \`~/.hosts\` by default.
Fix suggestion: \`hosts+=(\$(awk '!/^#/ && \$2 { print \$2 }' /etc/hosts))\`.
Severity: Warning