### PR TITLE
feat: ZC1390 — $GROUPS is scalar in Zsh, not array

### DIFF
--- a/pkg/katas/katatests/zc1390_test.go
+++ b/pkg/katas/katatests/zc1390_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1390(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $GROUPS (scalar)",
+			input:    `echo $GROUPS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo ${GROUPS[@]}",
+			input: `echo ${GROUPS[@]}`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1390",
+					Message: "Zsh `$GROUPS` is a scalar (primary GID), not an array. For all group IDs use `${(k)groups}` (after `zmodload zsh/parameter`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1390")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1390.go
+++ b/pkg/katas/zc1390.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1390",
+		Title:    "Avoid `$GROUPS[@]` — Zsh `$GROUPS` is a scalar, not an array",
+		Severity: SeverityError,
+		Description: "Bash's `$GROUPS` is an array of all group IDs the user belongs to, so " +
+			"`${GROUPS[@]}` iterates them. In Zsh, `$GROUPS` is a scalar (primary GID). The " +
+			"array of all group IDs is `$(groups)` output or `${(k)groups}` (if the " +
+			"`zsh/parameter` module is loaded, `$groups` is an assoc array name→gid).",
+		Check: checkZC1390,
+	})
+}
+
+func checkZC1390(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "GROUPS[") || strings.Contains(v, "${GROUPS[") {
+			return []Violation{{
+				KataID: "ZC1390",
+				Message: "Zsh `$GROUPS` is a scalar (primary GID), not an array. For all group " +
+					"IDs use `${(k)groups}` (after `zmodload zsh/parameter`).",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 386 Katas = 0.3.86
-const Version = "0.3.86"
+// 387 Katas = 0.3.87
+const Version = "0.3.87"


### PR DESCRIPTION
ZC1390 — Avoid \`\$GROUPS[@]\` — Zsh \`\$GROUPS\` is a scalar, not an array

What: flags \`\${GROUPS[...]}\` / \`\$GROUPS[...]\` subscript forms.
Why: Bash \`\$GROUPS\` is an array of all group IDs. Zsh \`\$GROUPS\` is a scalar holding only the primary GID. Subscripting it as an array produces wrong results.
Fix suggestion: \`zmodload zsh/parameter; print -l \${(k)groups}\` for all groups by name.
Severity: Error