### PR TITLE
feat: ZC1391 — prefer Zsh `(( ${+VAR} ))` over Bash `[[ -v VAR ]]`

### DIFF
--- a/pkg/katas/katatests/zc1391_test.go
+++ b/pkg/katas/katatests/zc1391_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1391(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — test -n VAR",
+			input:    `test -n "$VAR"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — test -v VAR",
+			input: `test -v VAR`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1391",
+					Message: "Use `(( ${+VAR} ))` for Zsh set-check — `-v` is a Bash 4.2+ extension, not reliably portable to Zsh.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1391")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1391.go
+++ b/pkg/katas/zc1391.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1391",
+		Title:    "Avoid `[[ -v VAR ]]` for Bash set-check — use Zsh `(( ${+VAR} ))`",
+		Severity: SeverityWarning,
+		Description: "Bash 4.2+ supports `[[ -v VAR ]]` to test whether a variable is set. Zsh " +
+			"`[[ -v VAR ]]` is parsed but not as the set-check — Zsh's canonical form is " +
+			"`(( ${+VAR} ))` which evaluates to 1 when set and 0 when unset, working reliably " +
+			"across Zsh versions.",
+		Check: checkZC1391,
+	})
+}
+
+func checkZC1391(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	// `[[` is its own node type in most AST designs, but bracket-test tokens
+	// may come through as commands. We look for "-v" as a bare arg with a
+	// following identifier in a context that looks like a bracket test.
+	if ident.Value != "test" && ident.Value != "[" && ident.Value != "[[" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		if arg.String() == "-v" && i+1 < len(cmd.Arguments) {
+			next := cmd.Arguments[i+1].String()
+			// Only flag if the "-v" is followed by an identifier (not a value to compare)
+			if len(next) > 0 && !strings.Contains(next, "=") &&
+				!strings.ContainsAny(next, "<>!/") {
+				return []Violation{{
+					KataID: "ZC1391",
+					Message: "Use `(( ${+VAR} ))` for Zsh set-check — `-v` is a Bash 4.2+ " +
+						"extension, not reliably portable to Zsh.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 387 Katas = 0.3.87
-const Version = "0.3.87"
+// 388 Katas = 0.3.88
+const Version = "0.3.88"


### PR DESCRIPTION
ZC1391 — Avoid \`[[ -v VAR ]]\` for Bash set-check — use Zsh \`(( \${+VAR} ))\`

What: flags \`test -v VAR\` / \`[ -v VAR ]\` / \`[[ -v VAR ]]\`.
Why: Bash 4.2+ added \`-v\` to test if a variable is set. Zsh's canonical form is \`(( \${+VAR} ))\` which returns 1 when set and 0 when unset — reliable across Zsh versions.
Fix suggestion: \`(( \${+VAR} )) && use_it\`.
Severity: Warning