### PR TITLE
feat: ZC1392 — $CHILD_MAX is Bash-only, use limit/ulimit in Zsh

### DIFF
--- a/pkg/katas/katatests/zc1392_test.go
+++ b/pkg/katas/katatests/zc1392_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1392(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — unrelated echo",
+			input:    `echo hello`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $CHILD_MAX",
+			input: `echo $CHILD_MAX`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1392",
+					Message: "`$CHILD_MAX` is Bash-only. Zsh uses `limit -s maxproc` or `ulimit -u` for process-count limits.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1392")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1392.go
+++ b/pkg/katas/zc1392.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1392",
+		Title:    "Avoid `$CHILD_MAX` — Bash-only; Zsh uses `limit` / `ulimit -u`",
+		Severity: SeverityInfo,
+		Description: "Bash's `$CHILD_MAX` reports the maximum number of exited child processes " +
+			"Bash remembers. Zsh does not export this var. For current process limits use " +
+			"`limit -s maxproc` or `ulimit -u` — but the exact Bash semantic is not mirrored.",
+		Check: checkZC1392,
+	})
+}
+
+func checkZC1392(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "CHILD_MAX") {
+			return []Violation{{
+				KataID: "ZC1392",
+				Message: "`$CHILD_MAX` is Bash-only. Zsh uses `limit -s maxproc` or `ulimit -u` " +
+					"for process-count limits.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityInfo,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 388 Katas = 0.3.88
-const Version = "0.3.88"
+// 389 Katas = 0.3.89
+const Version = "0.3.89"


### PR DESCRIPTION
ZC1392 — Avoid \`\$CHILD_MAX\` — Bash-only

What: flags references to \`\$CHILD_MAX\`.
Why: Bash exposes \`\$CHILD_MAX\` (max remembered exited children). Zsh does not. For process-count limits use \`limit -s maxproc\` or \`ulimit -u\` — semantics differ but are closest available.
Severity: Info