### PR TITLE
feat: ZC1393 — warn on $SRANDOM (Bash 5.1+ only)

### DIFF
--- a/pkg/katas/katatests/zc1393_test.go
+++ b/pkg/katas/katatests/zc1393_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1393(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $RANDOM",
+			input:    `echo $RANDOM`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $SRANDOM",
+			input: `echo $SRANDOM`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1393",
+					Message: "`$SRANDOM` is Bash 5.1+. In Zsh read `/dev/urandom` directly or use an external (`openssl rand`) for secure random integers.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1393")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1393.go
+++ b/pkg/katas/zc1393.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1393",
+		Title:    "Avoid `$SRANDOM` — Bash 5.1+ only, read `/dev/urandom` in Zsh",
+		Severity: SeverityWarning,
+		Description: "Bash 5.1 added `$SRANDOM` as a cryptographically secure 32-bit random value. " +
+			"Zsh does not have an equivalent variable. For secure random integers, read bytes " +
+			"from `/dev/urandom` (e.g. `(( n = 0x$(od -N4 -An -tx1 /dev/urandom | tr -d ' ') ))`) " +
+			"or use an external such as `openssl rand`.",
+		Check: checkZC1393,
+	})
+}
+
+func checkZC1393(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "SRANDOM") {
+			return []Violation{{
+				KataID: "ZC1393",
+				Message: "`$SRANDOM` is Bash 5.1+. In Zsh read `/dev/urandom` directly or use an " +
+					"external (`openssl rand`) for secure random integers.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 389 Katas = 0.3.89
-const Version = "0.3.89"
+// 390 Katas = 0.3.90
+const Version = "0.3.90"


### PR DESCRIPTION
ZC1393 — Avoid \`\$SRANDOM\` — Bash 5.1+ only, Zsh has no direct equivalent

What: flags references to \`\$SRANDOM\`.
Why: Bash 5.1 added \`\$SRANDOM\` for cryptographically secure 32-bit random values. Zsh has no equivalent; use \`/dev/urandom\` or \`openssl rand\`.
Fix suggestion: \`n=\$(od -N4 -An -tu4 /dev/urandom | tr -d ' ')\`.
Severity: Warning