### PR TITLE
feat: ZC1394 — warn on $BASH (use Zsh $ZSH_NAME)

### DIFF
--- a/pkg/katas/katatests/zc1394_test.go
+++ b/pkg/katas/katatests/zc1394_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1394(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $ZSH_NAME",
+			input:    `echo $ZSH_NAME`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $BASH",
+			input: `echo $BASH`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1394",
+					Message: "`$BASH` is Bash-only. Zsh exposes the interpreter name via `$ZSH_NAME` and the executable path indirectly via `$0`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1394")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1394.go
+++ b/pkg/katas/zc1394.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"regexp"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+// bashVarRE matches `$BASH` used as a standalone variable (not `$BASH_`).
+var bashVarRE = regexp.MustCompile(`\$BASH(?:[^_A-Z]|$)`)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1394",
+		Title:    "Avoid `$BASH` — Zsh uses `$ZSH_NAME` for the interpreter name",
+		Severity: SeverityInfo,
+		Description: "Bash's `$BASH` holds the path to the running Bash executable. Zsh's " +
+			"equivalent is `$ZSH_NAME` (for the binary name) or `$0` (interactive shell). " +
+			"Using `$BASH` in a Zsh script yields empty output.",
+		Check: checkZC1394,
+	})
+}
+
+func checkZC1394(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if bashVarRE.MatchString(v) {
+			return []Violation{{
+				KataID: "ZC1394",
+				Message: "`$BASH` is Bash-only. Zsh exposes the interpreter name via `$ZSH_NAME` " +
+					"and the executable path indirectly via `$0`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityInfo,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 390 Katas = 0.3.90
-const Version = "0.3.90"
+// 391 Katas = 0.3.91
+const Version = "0.3.91"


### PR DESCRIPTION
ZC1394 — Avoid \`\$BASH\` — Zsh uses \`\$ZSH_NAME\`

What: flags standalone \`\$BASH\` references (not \`\$BASH_*\` names).
Why: Bash populates \`\$BASH\` with the interpreter path. Zsh exposes the interpreter name via \`\$ZSH_NAME\`; \`\$BASH\` is unset.
Fix suggestion: \`[[ \$ZSH_NAME == zsh ]] && ...\`.
Severity: Info