### PR TITLE
feat: ZC1395 — warn on `wait -n` (Bash 4.3+ only)

### DIFF
--- a/pkg/katas/katatests/zc1395_test.go
+++ b/pkg/katas/katatests/zc1395_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1395(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — wait $pid",
+			input:    `wait $pid`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — wait -n",
+			input: `wait -n`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1395",
+					Message: "`wait -n` is Bash 4.3+. Zsh's `wait` waits on specific PIDs/jobs or (bare `wait`) all jobs. For any-child semantics, loop over PIDs with individual `wait $pid` calls.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1395")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1395.go
+++ b/pkg/katas/zc1395.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1395",
+		Title:    "Avoid `wait -n` — Bash 4.3+ only; Zsh `wait` on job IDs",
+		Severity: SeverityWarning,
+		Description: "Bash 4.3+ added `wait -n` (wait for any job to finish). Zsh's `wait` does " +
+			"not accept `-n`; instead wait explicitly on job IDs or PIDs, or use `wait` with no " +
+			"args (waits for all). For any-of semantics use `wait $pid1 $pid2; ...` in a loop.",
+		Check: checkZC1395,
+	})
+}
+
+func checkZC1395(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "wait" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-n" {
+			return []Violation{{
+				KataID: "ZC1395",
+				Message: "`wait -n` is Bash 4.3+. Zsh's `wait` waits on specific PIDs/jobs or " +
+					"(bare `wait`) all jobs. For any-child semantics, loop over PIDs with " +
+					"individual `wait $pid` calls.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 391 Katas = 0.3.91
-const Version = "0.3.91"
+// 392 Katas = 0.3.92
+const Version = "0.3.92"


### PR DESCRIPTION
ZC1395 — Avoid \`wait -n\` — Bash 4.3+ only

What: flags \`wait -n\`.
Why: Bash 4.3+ added \`-n\` to wait for any one job to finish. Zsh's \`wait\` does not accept \`-n\`. Loop on individual PIDs for any-child semantics.
Severity: Warning