### PR TITLE
feat: ZC1396 — warn on `unset -n` (Bash nameref)

### DIFF
--- a/pkg/katas/katatests/zc1396_test.go
+++ b/pkg/katas/katatests/zc1396_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1396(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — unset -v var",
+			input:    `unset -v var`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — unset -n ref",
+			input: `unset -n ref`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1396",
+					Message: "`unset -n` is a Bash nameref operation. Zsh does not honor it; use `unset -v NAME` (variable) or `unset -f NAME` (function) explicitly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1396")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1396.go
+++ b/pkg/katas/zc1396.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1396",
+		Title:    "Avoid `unset -n` — Bash nameref semantics not in Zsh",
+		Severity: SeverityError,
+		Description: "Bash's `unset -n NAME` unsets the nameref itself rather than the target " +
+			"variable it points to. Zsh does not implement namerefs; `unset -n` flags as an " +
+			"error or unsets something unintended. Use `unset -v` for variable unset and " +
+			"`unset -f` for function unset explicitly.",
+		Check: checkZC1396,
+	})
+}
+
+func checkZC1396(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "unset" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-n" {
+			return []Violation{{
+				KataID: "ZC1396",
+				Message: "`unset -n` is a Bash nameref operation. Zsh does not honor it; use " +
+					"`unset -v NAME` (variable) or `unset -f NAME` (function) explicitly.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 392 Katas = 0.3.92
-const Version = "0.3.92"
+// 393 Katas = 0.3.93
+const Version = "0.3.93"


### PR DESCRIPTION
ZC1396 — Avoid \`unset -n\` — Bash nameref operation not honored by Zsh

What: flags \`unset -n\`.
Why: Bash's \`-n\` unsets the nameref itself rather than the target. Zsh lacks nameref support; \`-n\` is error/unintended-unset territory.
Fix suggestion: \`unset -v var\` (variable) or \`unset -f fn\` (function) explicitly.
Severity: Error