### PR TITLE
feat: ZC1397 — warn on Bash $COMP_TYPE/$COMP_KEY

### DIFF
--- a/pkg/katas/katatests/zc1397_test.go
+++ b/pkg/katas/katatests/zc1397_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1397(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $compstate (Zsh)",
+			input:    `echo $compstate`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $COMP_TYPE",
+			input: `echo $COMP_TYPE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1397",
+					Message: "Bash `$COMP_TYPE`/`$COMP_KEY`/`$COMP_WORDBREAKS` are not Zsh-native. Use `$compstate` associative array for completion context in Zsh.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1397")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1397.go
+++ b/pkg/katas/zc1397.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1397",
+		Title:    "Avoid `$COMP_TYPE`/`$COMP_KEY` — Bash completion globals, not in Zsh",
+		Severity: SeverityError,
+		Description: "Bash programmable completion exposes `$COMP_TYPE` (completion type) and " +
+			"`$COMP_KEY` (completion key pressed). Zsh's compsys does not use these variables; " +
+			"query completion context via `$compstate` assoc array or context keys from " +
+			"`_arguments`/`_values` instead.",
+		Check: checkZC1397,
+	})
+}
+
+func checkZC1397(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "COMP_TYPE") || strings.Contains(v, "COMP_KEY") ||
+			strings.Contains(v, "COMP_WORDBREAKS") {
+			return []Violation{{
+				KataID: "ZC1397",
+				Message: "Bash `$COMP_TYPE`/`$COMP_KEY`/`$COMP_WORDBREAKS` are not Zsh-native. " +
+					"Use `$compstate` associative array for completion context in Zsh.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 393 Katas = 0.3.93
-const Version = "0.3.93"
+// 394 Katas = 0.3.94
+const Version = "0.3.94"


### PR DESCRIPTION
ZC1397 — Avoid Bash \`\$COMP_TYPE\`/\`\$COMP_KEY\`/\`\$COMP_WORDBREAKS\`

What: flags references to Bash completion-context variables.
Why: These exist in Bash programmable completion only. Zsh's compsys uses the \`\$compstate\` associative array.
Severity: Error