### PR TITLE
feat: ZC1398 — warn on $PROMPT_DIRTRIM (use Zsh %N~)

### DIFF
--- a/pkg/katas/katatests/zc1398_test.go
+++ b/pkg/katas/katatests/zc1398_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1398(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $PS1",
+			input:    `echo $PS1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $PROMPT_DIRTRIM",
+			input: `echo $PROMPT_DIRTRIM`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1398",
+					Message: "`$PROMPT_DIRTRIM` is Bash-only. Use the Zsh prompt escape `%N~` (N = number of path components to keep) for directory truncation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1398")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1398.go
+++ b/pkg/katas/zc1398.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1398",
+		Title:    "Avoid `$PROMPT_DIRTRIM` — use Zsh `%N~` prompt modifier",
+		Severity: SeverityWarning,
+		Description: "Bash's `$PROMPT_DIRTRIM` limits the number of directory components shown " +
+			"in `\\w`. Zsh has no such variable; use the `%N~` prompt escape (N is component " +
+			"count) or `%/` / `%~` with precmd adjustments for Zsh-native directory truncation.",
+		Check: checkZC1398,
+	})
+}
+
+func checkZC1398(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" && ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "PROMPT_DIRTRIM") {
+			return []Violation{{
+				KataID: "ZC1398",
+				Message: "`$PROMPT_DIRTRIM` is Bash-only. Use the Zsh prompt escape `%N~` " +
+					"(N = number of path components to keep) for directory truncation.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 394 Katas = 0.3.94
-const Version = "0.3.94"
+// 395 Katas = 0.3.95
+const Version = "0.3.95"


### PR DESCRIPTION
ZC1398 — Avoid \`\$PROMPT_DIRTRIM\` — Zsh uses \`%N~\` prompt escape

What: flags references to \`\$PROMPT_DIRTRIM\`.
Why: Bash limits \`\\w\` directory components via this variable. Zsh uses the \`%N~\` prompt escape (N = component count) or full \`%/\`/\`%~\` with custom precmd trimming.
Severity: Warning