### PR TITLE
feat: ZC1399 — use Zsh $signals array instead of `kill -l`

### DIFF
--- a/pkg/katas/katatests/zc1399_test.go
+++ b/pkg/katas/katatests/zc1399_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1399(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — kill signal pid",
+			input:    `kill -TERM 1234`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — kill -l",
+			input: `kill -l`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1399",
+					Message: "Use Zsh `print -l $signals` (after `zmodload zsh/parameter`) instead of `kill -l` for listing signal names.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1399")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1399.go
+++ b/pkg/katas/zc1399.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1399",
+		Title:    "Use Zsh `$signals` array instead of `kill -l` for signal enumeration",
+		Severity: SeverityStyle,
+		Description: "Zsh exposes the `$signals` array (from `zsh/parameter`) holding all signal " +
+			"names indexed from 0. `print -l $signals` produces the same list as `kill -l` " +
+			"without spawning an external process.",
+		Check: checkZC1399,
+	})
+}
+
+func checkZC1399(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "kill" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-l" {
+			return []Violation{{
+				KataID: "ZC1399",
+				Message: "Use Zsh `print -l $signals` (after `zmodload zsh/parameter`) instead " +
+					"of `kill -l` for listing signal names.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 395 Katas = 0.3.95
-const Version = "0.3.95"
+// 396 Katas = 0.3.96
+const Version = "0.3.96"


### PR DESCRIPTION
ZC1399 — Use Zsh \`\$signals\` array instead of \`kill -l\` for signal enumeration

What: flags \`kill -l\`.
Why: Zsh's \`zsh/parameter\` module exposes \`\$signals\` — an array of signal names. \`print -l \$signals\` produces the same list without spawning \`kill\`.
Fix suggestion: \`zmodload zsh/parameter; print -l \$signals\`.
Severity: Style