### PR TITLE
feat: ZC1400 — use Zsh $CPUTYPE instead of parsing $HOSTTYPE

### DIFF
--- a/pkg/katas/katatests/zc1400_test.go
+++ b/pkg/katas/katatests/zc1400_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1400(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — awk for other field",
+			input:    `awk '{print $1}' file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — cut on HOSTTYPE",
+			input: `cut -d- -f1 $HOSTTYPE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1400",
+					Message: "Use Zsh `$CPUTYPE` for pure architecture instead of splitting `$HOSTTYPE` with `cut`/`awk`/`sed`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1400")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1400.go
+++ b/pkg/katas/zc1400.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1400",
+		Title:    "Use Zsh `$CPUTYPE` for architecture detection instead of parsing `$HOSTTYPE`",
+		Severity: SeverityInfo,
+		Description: "Bash's `$HOSTTYPE` is a combined architecture/vendor/OS string (e.g. " +
+			"`x86_64-pc-linux-gnu`). Zsh exposes the same as `$HOSTTYPE` but additionally splits " +
+			"out `$CPUTYPE` (e.g. `x86_64`) for pure architecture queries — no `awk -F-` " +
+			"needed to extract.",
+		Check: checkZC1400,
+	})
+}
+
+func checkZC1400(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	// Only fire when HOSTTYPE is being parsed/split (cut, awk, sed usage).
+	switch ident.Value {
+	case "cut", "awk", "sed":
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "HOSTTYPE") {
+			return []Violation{{
+				KataID: "ZC1400",
+				Message: "Use Zsh `$CPUTYPE` for pure architecture instead of splitting " +
+					"`$HOSTTYPE` with `cut`/`awk`/`sed`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityInfo,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 396 Katas = 0.3.96
-const Version = "0.3.96"
+// 397 Katas = 0.3.97
+const Version = "0.3.97"


### PR DESCRIPTION
ZC1400 — Use Zsh \`\$CPUTYPE\` for architecture detection instead of parsing \`\$HOSTTYPE\`

What: flags \`cut\`/\`awk\`/\`sed\` invocations that reference \`\$HOSTTYPE\`.
Why: Zsh pre-splits the compound \`\$HOSTTYPE\` into \`\$CPUTYPE\` (architecture) and \`\$OSTYPE\` (OS). No text-splitting external needed.
Fix suggestion: \`arch=\$CPUTYPE\` instead of \`arch=\$(cut -d- -f1 <<<\$HOSTTYPE)\`.
Severity: Info