### PR TITLE
feat: ZC1401 — use Zsh $VENDOR instead of parsing $MACHTYPE

### DIFF
--- a/pkg/katas/katatests/zc1401_test.go
+++ b/pkg/katas/katatests/zc1401_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1401(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — awk for other field",
+			input:    `awk '{print $1}' file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — cut on MACHTYPE",
+			input: `cut -d- -f2 $MACHTYPE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1401",
+					Message: "Use Zsh `$VENDOR` for vendor field instead of splitting `$MACHTYPE` with `cut`/`awk`/`sed`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1401")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1401.go
+++ b/pkg/katas/zc1401.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1401",
+		Title:    "Prefer Zsh `$VENDOR` over parsing `$MACHTYPE` for vendor detection",
+		Severity: SeverityInfo,
+		Description: "Both Bash and Zsh expose `$MACHTYPE` (e.g. `x86_64-pc-linux-gnu`). Zsh " +
+			"additionally pre-parses the vendor component into `$VENDOR` (e.g. `pc`, `apple`). " +
+			"Avoid `cut -d- -f2 <<< $MACHTYPE` when `$VENDOR` is available directly.",
+		Check: checkZC1401,
+	})
+}
+
+func checkZC1401(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "cut", "awk", "sed":
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "MACHTYPE") {
+			return []Violation{{
+				KataID: "ZC1401",
+				Message: "Use Zsh `$VENDOR` for vendor field instead of splitting `$MACHTYPE` " +
+					"with `cut`/`awk`/`sed`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityInfo,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 397 Katas = 0.3.97
-const Version = "0.3.97"
+// 398 Katas = 0.3.98
+const Version = "0.3.98"


### PR DESCRIPTION
ZC1401 — Prefer Zsh \`\$VENDOR\` over parsing \`\$MACHTYPE\` for vendor detection

What: flags \`cut\`/\`awk\`/\`sed\` invocations referencing \`\$MACHTYPE\`.
Why: Zsh pre-parses the \`MACHTYPE\` triple into \`\$CPUTYPE\`/\`\$VENDOR\`/\`\$OSTYPE\`. Direct access is cleaner than string splitting.
Fix suggestion: \`vendor=\$VENDOR\`.
Severity: Info