### PR TITLE
feat: ZC1402 — use Zsh strftime instead of `date -d @N`

### DIFF
--- a/pkg/katas/katatests/zc1402_test.go
+++ b/pkg/katas/katatests/zc1402_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1402(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — date +fmt",
+			input:    `date +%Y-%m-%d`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — date -d",
+			input: `date -d @1700000000 +%Y-%m-%d`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1402",
+					Message: "Use Zsh `strftime` (from `zsh/datetime`) instead of `date -d @N -- +fmt`. The `-d`/`@` form is GNU-specific; `strftime` is portable Zsh.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1402")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1402.go
+++ b/pkg/katas/zc1402.go
@@ -1,0 +1,47 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1402",
+		Title:    "Avoid `date -d @seconds` — use Zsh `strftime` for epoch formatting",
+		Severity: SeverityStyle,
+		Description: "`date -d @N -- '+fmt'` / `date --date=@N` converts epoch seconds to a " +
+			"formatted date. Zsh's `zsh/datetime` module provides `strftime fmt N` directly " +
+			"— a single builtin, no `date` spawn, and the `-d`/`@` form is GNU-specific " +
+			"(not portable to BSD `date`).",
+		Check: checkZC1402,
+	})
+}
+
+func checkZC1402(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "date" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-d" || v == "--date" ||
+			(len(v) > 6 && v[:6] == "--date=") {
+			return []Violation{{
+				KataID: "ZC1402",
+				Message: "Use Zsh `strftime` (from `zsh/datetime`) instead of `date -d @N -- +fmt`. " +
+					"The `-d`/`@` form is GNU-specific; `strftime` is portable Zsh.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 398 Katas = 0.3.98
-const Version = "0.3.98"
+// 399 Katas = 0.3.99
+const Version = "0.3.99"


### PR DESCRIPTION
ZC1402 — Avoid \`date -d @seconds\` — use Zsh \`strftime\` for epoch formatting

What: flags \`date\` with \`-d\` / \`--date\` / \`--date=...\`.
Why: \`-d\` / \`@\` form is GNU-specific (BSD \`date\` uses \`-r\`). Zsh's \`strftime\` is portable and avoids the external.
Fix suggestion: \`zmodload zsh/datetime; strftime '%Y-%m-%d' 1700000000\`.
Severity: Style