### PR TITLE
feat: ZC1403 — 400-kata milestone: $HISTFILESIZE→$SAVEHIST

### DIFF
--- a/pkg/katas/katatests/zc1403_test.go
+++ b/pkg/katas/katatests/zc1403_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1403(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $SAVEHIST (Zsh)",
+			input:    `echo $SAVEHIST`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $HISTFILESIZE",
+			input: `echo $HISTFILESIZE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1403",
+					Message: "`$HISTFILESIZE` is Bash-only. Zsh uses `$SAVEHIST` for on-disk history size. Setting `HISTFILESIZE` in Zsh has no effect.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1403")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1403.go
+++ b/pkg/katas/zc1403.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1403",
+		Title:    "Setting `$HISTFILESIZE` alone is incomplete in Zsh — pair with `$SAVEHIST`",
+		Severity: SeverityWarning,
+		Description: "Bash uses `$HISTSIZE` (in-memory) and `$HISTFILESIZE` (on disk). Zsh uses " +
+			"`$HISTSIZE` (in-memory) and `$SAVEHIST` (on disk). Setting only `$HISTFILESIZE` in " +
+			"Zsh has no effect on disk — `$SAVEHIST` must be set. Mixing both names leaves " +
+			"disk-history behavior undefined.",
+		Check: checkZC1403,
+	})
+}
+
+func checkZC1403(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" && ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "HISTFILESIZE") {
+			return []Violation{{
+				KataID: "ZC1403",
+				Message: "`$HISTFILESIZE` is Bash-only. Zsh uses `$SAVEHIST` for on-disk history " +
+					"size. Setting `HISTFILESIZE` in Zsh has no effect.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 399 Katas = 0.3.99
-const Version = "0.3.99"
+// 400 Katas = 0.4.0
+const Version = "0.4.0"


### PR DESCRIPTION
ZC1403 — 400-kata milestone: warn on \$HISTFILESIZE (use Zsh \$SAVEHIST)

**Milestone**: kata count reaches 400, which rolls version.go to v0.4.0 under the
MAJOR=count/1000, MINOR=count%1000/100, PATCH=count%100 formula.

What: flags references to \$HISTFILESIZE.
Why: Bash uses \$HISTSIZE (in-memory) and \$HISTFILESIZE (on disk). Zsh uses \$HISTSIZE and \$SAVEHIST. Setting only \$HISTFILESIZE in Zsh has no effect on the saved-history file size.

Severity: Warning