### PR TITLE
feat: ZC1404 — warn on $BASH_CMDS (use Zsh $commands)

### DIFF
--- a/pkg/katas/katatests/zc1404_test.go
+++ b/pkg/katas/katatests/zc1404_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1404(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $commands (Zsh)",
+			input:    `echo $commands`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $BASH_CMDS",
+			input: `echo $BASH_CMDS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1404",
+					Message: "`$BASH_CMDS` is Bash-only. In Zsh use `$commands` (assoc array, names→paths) via `zsh/parameter`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1404")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1404.go
+++ b/pkg/katas/zc1404.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1404",
+		Title:    "Avoid `$BASH_CMDS` — Bash-specific hash-table mirror, use Zsh `$commands`",
+		Severity: SeverityWarning,
+		Description: "Bash's `$BASH_CMDS` associative array mirrors the hash-table of command " +
+			"names→paths. Zsh exposes the same via `$commands` (assoc array from " +
+			"`zsh/parameter`). `$BASH_CMDS` is unset in Zsh.",
+		Check: checkZC1404,
+	})
+}
+
+func checkZC1404(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "BASH_CMDS") {
+			return []Violation{{
+				KataID: "ZC1404",
+				Message: "`$BASH_CMDS` is Bash-only. In Zsh use `$commands` (assoc array, " +
+					"names→paths) via `zsh/parameter`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 400 Katas = 0.4.0
-const Version = "0.4.0"
+// 401 Katas = 0.4.1
+const Version = "0.4.1"


### PR DESCRIPTION
ZC1404 — Avoid \`\$BASH_CMDS\` — use Zsh \`\$commands\`

What: flags references to \`\$BASH_CMDS\`.
Why: Bash hash table as assoc array. Zsh equivalent is \`\$commands\` from \`zsh/parameter\`.
Fix suggestion: \`zmodload zsh/parameter; print -l \${(k)commands}\`.
Severity: Warning