### PR TITLE
feat: ZC1405 — use (unset VAR; cmd) instead of `env -u VAR`

### DIFF
--- a/pkg/katas/katatests/zc1405_test.go
+++ b/pkg/katas/katatests/zc1405_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1405(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — env -i clean env",
+			input:    `env -i cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — env -u VAR",
+			input: `env -u DEBUG cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1405",
+					Message: "Use `(unset VAR; cmd)` subshell instead of `env -u VAR cmd`. In-shell scoping, no external process.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1405")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1405.go
+++ b/pkg/katas/zc1405.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1405",
+		Title:    "Avoid `env -u VAR cmd` — use Zsh `(unset VAR; cmd)` subshell",
+		Severity: SeverityStyle,
+		Description: "`env -u VAR cmd` unsets a variable for a single command. In Zsh the " +
+			"idiomatic form is a subshell: `(unset VAR; cmd)` — no external `env` spawn, and " +
+			"the unset is naturally scoped to the subshell.",
+		Check: checkZC1405,
+	})
+}
+
+func checkZC1405(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "env" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-u" {
+			return []Violation{{
+				KataID: "ZC1405",
+				Message: "Use `(unset VAR; cmd)` subshell instead of `env -u VAR cmd`. " +
+					"In-shell scoping, no external process.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 401 Katas = 0.4.1
-const Version = "0.4.1"
+// 402 Katas = 0.4.2
+const Version = "0.4.2"


### PR DESCRIPTION
ZC1405 — Avoid \`env -u VAR cmd\` — use Zsh \`(unset VAR; cmd)\` subshell

What: flags \`env -u\` invocations.
Why: \`(unset VAR; cmd)\` is in-shell, auto-scoped, and avoids an external \`env\` process.
Severity: Style