### PR TITLE
feat: ZC1406 — prefer Zsh `zargs -P` over `xargs -P`

### DIFF
--- a/pkg/katas/katatests/zc1406_test.go
+++ b/pkg/katas/katatests/zc1406_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1406(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — xargs without -P",
+			input:    `xargs -n 1 echo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — xargs -P 4",
+			input: `xargs -P 4 cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1406",
+					Message: "Consider `zargs -P N` (autoload -Uz zargs) instead of `xargs -P N`. Parallel execution with Zsh functions in scope — no subshell-per-item.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — xargs -P4 attached",
+			input: `xargs -P4 cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1406",
+					Message: "Consider `zargs -P N` (autoload -Uz zargs) instead of `xargs -P N`. Parallel execution with Zsh functions in scope — no subshell-per-item.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1406")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1406.go
+++ b/pkg/katas/zc1406.go
@@ -1,0 +1,47 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1406",
+		Title:    "Prefer Zsh `zargs -P N` autoload over `xargs -P N` for parallel execution",
+		Severity: SeverityStyle,
+		Description: "Zsh provides `zargs` (loaded via `autoload -Uz zargs`) — a native equivalent " +
+			"of `xargs` with parallel execution via `-P`. It keeps variables and functions in " +
+			"scope (unlike xargs) and avoids the utility-quoting surprises of `xargs`.",
+		Check: checkZC1406,
+	})
+}
+
+func checkZC1406(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "xargs" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-P" || v == "--max-procs" ||
+			(len(v) > 2 && v[:2] == "-P") {
+			_ = i
+			return []Violation{{
+				KataID: "ZC1406",
+				Message: "Consider `zargs -P N` (autoload -Uz zargs) instead of `xargs -P N`. " +
+					"Parallel execution with Zsh functions in scope — no subshell-per-item.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 402 Katas = 0.4.2
-const Version = "0.4.2"
+// 403 Katas = 0.4.3
+const Version = "0.4.3"


### PR DESCRIPTION
ZC1406 — Prefer Zsh \`zargs -P N\` over \`xargs -P N\` for parallel execution

What: flags \`xargs -P\` / \`xargs --max-procs\`.
Why: \`zargs\` (autoload -Uz zargs) is the Zsh-native xargs replacement — supports \`-P N\` for parallelism and keeps Zsh functions and variables in scope.
Fix suggestion: \`autoload -Uz zargs; zargs -P 4 -- item1 item2 -- my_zsh_fn\`.
Severity: Style