### PR TITLE
feat: ZC1407 — avoid /dev/tcp (Bash-only), use zsh/net/tcp

### DIFF
--- a/pkg/katas/katatests/zc1407_test.go
+++ b/pkg/katas/katatests/zc1407_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1407(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — regular file path",
+			input:    `cat /etc/hosts`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — /dev/tcp redirect",
+			input: `echo hi > /dev/tcp/1.2.3.4/80`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1407",
+					Message: "`/dev/tcp/...` and `/dev/udp/...` are Bash-only virtual files. In Zsh load `zsh/net/tcp` and use `ztcp host port` / `ztcp -c $fd` for TCP.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1407")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1407.go
+++ b/pkg/katas/zc1407.go
@@ -1,0 +1,43 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1407",
+		Title:    "Avoid `/dev/tcp/...` — use Zsh `zsh/net/tcp` module",
+		Severity: SeverityError,
+		Description: "`/dev/tcp/host/port` is a Bash-specific virtual-file interface for TCP " +
+			"connections; Zsh does not implement it. For TCP in Zsh, load `zmodload zsh/net/tcp` " +
+			"and use `ztcp host port` which exposes the connection as a regular file descriptor.",
+		Check: checkZC1407,
+	})
+}
+
+func checkZC1407(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	// Check all args for /dev/tcp or /dev/udp paths
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "/dev/tcp/") || strings.Contains(v, "/dev/udp/") {
+			return []Violation{{
+				KataID: "ZC1407",
+				Message: "`/dev/tcp/...` and `/dev/udp/...` are Bash-only virtual files. In Zsh " +
+					"load `zsh/net/tcp` and use `ztcp host port` / `ztcp -c $fd` for TCP.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 403 Katas = 0.4.3
-const Version = "0.4.3"
+// 404 Katas = 0.4.4
+const Version = "0.4.4"


### PR DESCRIPTION
ZC1407 — Avoid \`/dev/tcp/...\` — use Zsh \`zsh/net/tcp\` module

What: flags any path containing \`/dev/tcp/\` or \`/dev/udp/\`.
Why: These virtual files are a Bash-specific extension. Zsh provides \`zsh/net/tcp\` with \`ztcp\` builtin for real TCP operations.
Fix suggestion: \`zmodload zsh/net/tcp; ztcp host port; print -u \$REPLY "GET / HTTP/1.0\\r\\n\\r\\n"\`.
Severity: Error (portability bug)