### PR TITLE
feat: ZC1408 — warn on $BASH_FUNC_* exported-function envvar

### DIFF
--- a/pkg/katas/katatests/zc1408_test.go
+++ b/pkg/katas/katatests/zc1408_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1408(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $FPATH",
+			input:    `echo $FPATH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $BASH_FUNC_myfn",
+			input: `echo $BASH_FUNC_myfn`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1408",
+					Message: "`BASH_FUNC_*` exported-function envvars are Bash-only. Zsh does not consume them; export function definitions via `autoload` + `$FPATH` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1408")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1408.go
+++ b/pkg/katas/zc1408.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1408",
+		Title:    "Avoid `$BASH_FUNC_...%%` — Bash-specific exported-function envvar",
+		Severity: SeverityError,
+		Description: "Bash exports functions into environment variables named `BASH_FUNC_NAME%%`. " +
+			"These are consumed only by other Bash shells. Zsh does not recognize the format " +
+			"and will neither inherit the function nor clean these envvars.",
+		Check: checkZC1408,
+	})
+}
+
+func checkZC1408(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" && ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "BASH_FUNC_") {
+			return []Violation{{
+				KataID: "ZC1408",
+				Message: "`BASH_FUNC_*` exported-function envvars are Bash-only. Zsh does not " +
+					"consume them; export function definitions via `autoload` + `$FPATH` instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 404 Katas = 0.4.4
-const Version = "0.4.4"
+// 405 Katas = 0.4.5
+const Version = "0.4.5"


### PR DESCRIPTION
ZC1408 — Avoid \`\$BASH_FUNC_*\` — Bash-specific exported-function envvar

What: flags references to \`\$BASH_FUNC_...\` envvars.
Why: Bash exports functions into environment variables with this prefix. Zsh does not consume the format — function export must go through \`\$FPATH\` and \`autoload\`.
Severity: Error