### PR TITLE
feat: ZC1409 — warn on `test -N` (Bash-only)

### DIFF
--- a/pkg/katas/katatests/zc1409_test.go
+++ b/pkg/katas/katatests/zc1409_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1409(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — test -f file",
+			input:    `test -f file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — test -N file",
+			input: `test -N file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1409",
+					Message: "`test -N file` (modified-since-read) is a Bash extension. In Zsh use `zmodload zsh/stat; zstat -H s file; (( s[mtime] > s[atime] ))`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1409")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1409.go
+++ b/pkg/katas/zc1409.go
@@ -1,0 +1,47 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1409",
+		Title:    "Avoid `[ -N file ]` / `test -N file` — Bash-only, use Zsh `zstat` for mtime comparison",
+		Severity: SeverityInfo,
+		Description: "`[ -N file ]` and `test -N file` test whether a file has been modified since " +
+			"last read (Bash extension). Zsh does not implement `-N`. Use the `zsh/stat` module " +
+			"to compare `atime` and `mtime` explicitly: `zstat -H s file; (( s[mtime] > s[atime] ))`.",
+		Check: checkZC1409,
+	})
+}
+
+func checkZC1409(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "test" && ident.Value != "[" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-N" {
+			return []Violation{{
+				KataID: "ZC1409",
+				Message: "`test -N file` (modified-since-read) is a Bash extension. In Zsh use " +
+					"`zmodload zsh/stat; zstat -H s file; (( s[mtime] > s[atime] ))`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityInfo,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 405 Katas = 0.4.5
-const Version = "0.4.5"
+// 406 Katas = 0.4.6
+const Version = "0.4.6"


### PR DESCRIPTION
ZC1409 — Avoid \`[ -N file ]\` / \`test -N\` — Bash extension

What: flags \`test -N\` / \`[ -N ]\`.
Why: Bash-only modified-since-read test. Zsh has no \`-N\` — use \`zstat\` for explicit mtime/atime comparison.
Severity: Info