### PR TITLE
feat: ZC1410 — bash --rcfile/--init-file (use ZDOTDIR)

### DIFF
--- a/pkg/katas/katatests/zc1410_test.go
+++ b/pkg/katas/katatests/zc1410_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1410(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — zsh plain",
+			input:    `zsh script.zsh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — bash --rcfile",
+			input: `bash --rcfile myrc script.sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1410",
+					Message: "`bash --rcfile`/`--init-file` have no Zsh equivalent flag. Use `ZDOTDIR=/path zsh` to relocate all Zsh rc files.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1410")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1410.go
+++ b/pkg/katas/zc1410.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1410",
+		Title:    "Avoid `bash --rcfile` / `--init-file` — use Zsh `$ZDOTDIR`",
+		Severity: SeverityWarning,
+		Description: "Bash's `--rcfile FILE` and `--init-file FILE` override the default init " +
+			"script. Zsh uses `$ZDOTDIR` to relocate all Zsh rc files (`$ZDOTDIR/.zshrc` etc.). " +
+			"Setting ZDOTDIR is cleaner than --rcfile and works for all Zsh init phases.",
+		Check: checkZC1410,
+	})
+}
+
+func checkZC1410(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "bash" && ident.Value != "zsh" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--rcfile" || v == "--init-file" {
+			return []Violation{{
+				KataID: "ZC1410",
+				Message: "`bash --rcfile`/`--init-file` have no Zsh equivalent flag. Use " +
+					"`ZDOTDIR=/path zsh` to relocate all Zsh rc files.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 406 Katas = 0.4.6
-const Version = "0.4.6"
+// 407 Katas = 0.4.7
+const Version = "0.4.7"


### PR DESCRIPTION
ZC1410 — `bash --rcfile FILE` / `--init-file FILE` relocates init script. Zsh has no equivalent flag; use `ZDOTDIR=/path zsh` which relocates all Zsh rc files consistently. Severity: Warning