### PR TITLE
feat: ZC1410 — compopt is Bash-only (use zstyle)

### DIFF
--- a/pkg/katas/katatests/zc1410_test.go
+++ b/pkg/katas/katatests/zc1410_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1410(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — zstyle usage",
+			input:    `zstyle ':completion:*' menu select`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — compopt invocation",
+			input: `compopt -o nospace`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1410",
+					Message: "`compopt` is a Bash-only completion builtin. Zsh compsys uses `zstyle` (e.g. `zstyle ':completion:*' menu select`) for equivalent tuning.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1410")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1410.go
+++ b/pkg/katas/zc1410.go
@@ -1,0 +1,38 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1410",
+		Title:    "Avoid `compopt` — Bash programmable-completion modifier, not in Zsh",
+		Severity: SeverityError,
+		Description: "`compopt` tweaks Bash programmable-completion options for the current " +
+			"completion. Zsh's compsys does not implement `compopt`; completion options are set " +
+			"via `zstyle` / completion-function context instead.",
+		Check: checkZC1410,
+	})
+}
+
+func checkZC1410(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "compopt" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1410",
+		Message: "`compopt` is a Bash-only completion builtin. Zsh compsys uses `zstyle` " +
+			"(e.g. `zstyle ':completion:*' menu select`) for equivalent tuning.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 406 Katas = 0.4.6
-const Version = "0.4.6"
+// 407 Katas = 0.4.7
+const Version = "0.4.7"


### PR DESCRIPTION
ZC1410 — `compopt` tweaks Bash completion options. Zsh compsys uses `zstyle` for tuning. Severity: Error