### PR TITLE
feat: ZC1411 — use Zsh `disable` instead of Bash `enable -n`

### DIFF
--- a/pkg/katas/katatests/zc1411_test.go
+++ b/pkg/katas/katatests/zc1411_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1411(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — enable builtin",
+			input:    `enable name`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — enable -n builtin",
+			input: `enable -n echo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1411",
+					Message: "Use Zsh `disable name` instead of `enable -n name`. Zsh has a dedicated `disable` builtin that reads clearer.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1411")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1411.go
+++ b/pkg/katas/zc1411.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1411",
+		Title:    "Use Zsh `disable` instead of Bash `enable -n` to hide builtins",
+		Severity: SeverityStyle,
+		Description: "Bash's `enable -n name` disables a builtin so that the external of the same " +
+			"name is used. Zsh provides a dedicated `disable` builtin: `disable name` achieves " +
+			"the same in one verb. Re-enable later with `enable name`.",
+		Check: checkZC1411,
+	})
+}
+
+func checkZC1411(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "enable" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-n" {
+			return []Violation{{
+				KataID: "ZC1411",
+				Message: "Use Zsh `disable name` instead of `enable -n name`. Zsh has a " +
+					"dedicated `disable` builtin that reads clearer.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 407 Katas = 0.4.7
-const Version = "0.4.7"
+// 408 Katas = 0.4.8
+const Version = "0.4.8"


### PR DESCRIPTION
ZC1411 — Use Zsh `disable name` instead of Bash `enable -n name`. Zsh has a dedicated `disable` builtin. Re-enable with `enable`. Severity: Style