### PR TITLE
feat: ZC1412 — $COMPREPLY is Bash-only (use Zsh compadd)

### DIFF
--- a/pkg/katas/katatests/zc1412_test.go
+++ b/pkg/katas/katatests/zc1412_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1412(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — echo $candidates",
+			input:    `echo $candidates`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — echo $COMPREPLY",
+			input: `echo $COMPREPLY`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1412",
+					Message: "`$COMPREPLY` is a Bash-only completion output array. In Zsh compsys use `compadd -- candidate1 candidate2`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1412")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1412.go
+++ b/pkg/katas/zc1412.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1412",
+		Title:    "Avoid `$COMPREPLY` — Bash completion output, use Zsh `compadd`",
+		Severity: SeverityError,
+		Description: "Bash completion functions populate the `$COMPREPLY` array to declare " +
+			"candidates. Zsh's compsys uses the `compadd` builtin: `compadd -- foo bar baz`. " +
+			"Setting `$COMPREPLY` in a Zsh completion does nothing.",
+		Check: checkZC1412,
+	})
+}
+
+func checkZC1412(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "COMPREPLY") {
+			return []Violation{{
+				KataID: "ZC1412",
+				Message: "`$COMPREPLY` is a Bash-only completion output array. In Zsh compsys " +
+					"use `compadd -- candidate1 candidate2`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 408 Katas = 0.4.8
-const Version = "0.4.8"
+// 409 Katas = 0.4.9
+const Version = "0.4.9"


### PR DESCRIPTION
ZC1412 — $COMPREPLY is Bash completion output array. Zsh compsys uses `compadd` builtin. Severity: Error