### PR TITLE
feat: ZC1413 — use Zsh `whence -p` instead of `hash -t`

### DIFF
--- a/pkg/katas/katatests/zc1413_test.go
+++ b/pkg/katas/katatests/zc1413_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1413(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — hash -r reset",
+			input:    `hash -r`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — hash -t",
+			input: `hash -t ls`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1413",
+					Message: "Use `whence -p cmd` (Zsh) instead of `hash -t cmd`. `whence -p` always returns the absolute path, regardless of hash state.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1413")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1413.go
+++ b/pkg/katas/zc1413.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1413",
+		Title:    "Use Zsh `whence -p cmd` instead of `hash -t cmd` for resolved path",
+		Severity: SeverityStyle,
+		Description: "Bash's `hash -t cmd` prints the hashed path for `cmd` (or fails if not " +
+			"hashed). Zsh's `whence -p cmd` prints the PATH-resolved absolute path, whether " +
+			"hashed or not — more reliable and the native Zsh idiom.",
+		Check: checkZC1413,
+	})
+}
+
+func checkZC1413(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "hash" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-t" {
+			return []Violation{{
+				KataID: "ZC1413",
+				Message: "Use `whence -p cmd` (Zsh) instead of `hash -t cmd`. " +
+					"`whence -p` always returns the absolute path, regardless of hash state.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 409 Katas = 0.4.9
-const Version = "0.4.9"
+// 410 Katas = 0.4.10
+const Version = "0.4.10"


### PR DESCRIPTION
ZC1413 — `whence -p cmd` prints absolute path regardless of hash state, more reliable than `hash -t`. Severity: Style