### PR TITLE
feat: ZC1414 — warn on `hash -d` (opposite semantics)

### DIFF
--- a/pkg/katas/katatests/zc1414_test.go
+++ b/pkg/katas/katatests/zc1414_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1414(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — hash -r",
+			input:    `hash -r`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — hash -d",
+			input: `hash -d ls`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1414",
+					Message: "`hash -d` has opposite semantics in Bash (delete) vs Zsh (define named directory). Use `unhash cmd` for Zsh command-hash removal, or `hash -d NAME=/path` for named-directory definition.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1414")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1414.go
+++ b/pkg/katas/zc1414.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1414",
+		Title:    "Beware `hash -d` — Bash deletes from hash table, Zsh defines named directory",
+		Severity: SeverityError,
+		Description: "The `-d` flag has opposite meanings across shells: Bash `hash -d NAME` " +
+			"removes `NAME` from the command-hash table. Zsh `hash -d NAME=PATH` **defines** a " +
+			"named directory (`~NAME` expansion). A Bash script ported to Zsh breaks silently " +
+			"when `hash -d ls` is interpreted as defining `~ls`.",
+		Check: checkZC1414,
+	})
+}
+
+func checkZC1414(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "hash" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-d" {
+			return []Violation{{
+				KataID: "ZC1414",
+				Message: "`hash -d` has opposite semantics in Bash (delete) vs Zsh (define " +
+					"named directory). Use `unhash cmd` for Zsh command-hash removal, or " +
+					"`hash -d NAME=/path` for named-directory definition.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 410 Katas = 0.4.10
-const Version = "0.4.10"
+// 411 Katas = 0.4.11
+const Version = "0.4.11"


### PR DESCRIPTION
ZC1414 — `hash -d` deletes in Bash, defines named dir in Zsh. Use `unhash` for removal in Zsh. Severity: Error