### PR TITLE
feat: ZC1415 — prefer Zsh TRAPZERR over `trap 'cmd' ERR`

### DIFF
--- a/pkg/katas/katatests/zc1415_test.go
+++ b/pkg/katas/katatests/zc1415_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1415(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — trap 'cmd' EXIT",
+			input:    `trap 'cleanup' EXIT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — trap 'cmd' ERR",
+			input: `trap 'echo oops' ERR`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1415",
+					Message: "Prefer Zsh `TRAPZERR() { ... }` function over `trap 'cmd' ERR`. The named-function form is more idiomatic and composable in Zsh.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1415")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1415.go
+++ b/pkg/katas/zc1415.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1415",
+		Title:    "Prefer Zsh `TRAPZERR` function over `trap 'cmd' ERR`",
+		Severity: SeverityInfo,
+		Description: "Both Bash and Zsh accept `trap 'cmd' ERR`, but Zsh's idiomatic form is the " +
+			"named function `TRAPZERR`: `TRAPZERR() { echo \"err at $LINENO\"; }`. The named " +
+			"function receives `$1` = signal and is easier to compose than an inline string.",
+		Check: checkZC1415,
+	})
+}
+
+func checkZC1415(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "trap" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "ERR" || v == "ZERR" {
+			return []Violation{{
+				KataID: "ZC1415",
+				Message: "Prefer Zsh `TRAPZERR() { ... }` function over `trap 'cmd' ERR`. " +
+					"The named-function form is more idiomatic and composable in Zsh.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityInfo,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 411 Katas = 0.4.11
-const Version = "0.4.11"
+// 412 Katas = 0.4.12
+const Version = "0.4.12"


### PR DESCRIPTION
ZC1415 — Zsh's `TRAPZERR() { ... }` named function is more idiomatic than `trap` string for ERR handling. Severity: Info