### PR TITLE
feat: ZC1416 — use Zsh preexec instead of `trap 'cmd' DEBUG`

### DIFF
--- a/pkg/katas/katatests/zc1416_test.go
+++ b/pkg/katas/katatests/zc1416_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1416(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — trap 'cmd' EXIT",
+			input:    `trap 'cleanup' EXIT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — trap 'cmd' DEBUG",
+			input: `trap 'echo $BASH_COMMAND' DEBUG`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1416",
+					Message: "Use Zsh `preexec() { ... }` (or `add-zsh-hook preexec`) instead of `trap 'cmd' DEBUG`. Zsh's DEBUG trap does not fire the same way as Bash's.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1416")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1416.go
+++ b/pkg/katas/zc1416.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1416",
+		Title:    "Prefer Zsh `preexec` hook over `trap 'cmd' DEBUG`",
+		Severity: SeverityWarning,
+		Description: "Bash's `trap 'cmd' DEBUG` runs `cmd` before each simple command. Zsh's " +
+			"equivalent is the `preexec` function (or `add-zsh-hook preexec name`) which " +
+			"receives the about-to-execute command line as `$1`, `$2`, `$3`. The DEBUG trap " +
+			"is not fired in Zsh the way it is in Bash — use preexec for portability.",
+		Check: checkZC1416,
+	})
+}
+
+func checkZC1416(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "trap" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "DEBUG" {
+			return []Violation{{
+				KataID: "ZC1416",
+				Message: "Use Zsh `preexec() { ... }` (or `add-zsh-hook preexec`) instead of " +
+					"`trap 'cmd' DEBUG`. Zsh's DEBUG trap does not fire the same way as Bash's.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 412 Katas = 0.4.12
-const Version = "0.4.12"
+// 413 Katas = 0.4.13
+const Version = "0.4.13"


### PR DESCRIPTION
ZC1416 — Zsh's DEBUG trap doesn't fire like Bash's. Use `preexec` function. Severity: Warning