### PR TITLE
feat: ZC1417 — prefer Zsh TRAPRETURN over `trap 'cmd' RETURN`

### DIFF
--- a/pkg/katas/katatests/zc1417_test.go
+++ b/pkg/katas/katatests/zc1417_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1417(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — trap 'cleanup' EXIT",
+			input:    `trap 'cleanup' EXIT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — trap 'cmd' RETURN",
+			input: `trap 'print done' RETURN`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1417",
+					Message: "Prefer Zsh `TRAPRETURN() { ... }` function over `trap 'cmd' RETURN`. Named-function form is more idiomatic in Zsh.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1417")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1417.go
+++ b/pkg/katas/zc1417.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1417",
+		Title:    "Prefer Zsh `TRAPRETURN` function over `trap 'cmd' RETURN`",
+		Severity: SeverityInfo,
+		Description: "Bash's `trap 'cmd' RETURN` runs `cmd` when a function returns. Zsh accepts " +
+			"the `RETURN` signal name but the idiomatic form is a function named `TRAPRETURN`: " +
+			"`TRAPRETURN() { print \"returning $?\"; }`.",
+		Check: checkZC1417,
+	})
+}
+
+func checkZC1417(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "trap" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "RETURN" {
+			return []Violation{{
+				KataID: "ZC1417",
+				Message: "Prefer Zsh `TRAPRETURN() { ... }` function over `trap 'cmd' RETURN`. " +
+					"Named-function form is more idiomatic in Zsh.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityInfo,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 413 Katas = 0.4.13
-const Version = "0.4.13"
+// 414 Katas = 0.4.14
+const Version = "0.4.14"


### PR DESCRIPTION
ZC1417 — Zsh's named `TRAPRETURN` function is idiomatic. Severity: Info