### PR TITLE
feat: ZC1418 — use Zsh `limit -h`/`-s` instead of `ulimit -H`/`-S`

### DIFF
--- a/pkg/katas/katatests/zc1418_test.go
+++ b/pkg/katas/katatests/zc1418_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1418(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ulimit -t",
+			input:    `ulimit -t 10`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ulimit -H",
+			input: `ulimit -H -t 60`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1418",
+					Message: "Use Zsh `limit -h` (hard) / `limit -s` (soft) instead of `ulimit -H`/`-S`. Zsh's `limit` builtin is more human-readable.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1418")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1418.go
+++ b/pkg/katas/zc1418.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1418",
+		Title:    "Use Zsh `limit -h`/`-s` instead of `ulimit -H`/`-S` for hard/soft limits",
+		Severity: SeverityStyle,
+		Description: "Bash's `ulimit` uses uppercase `-H` (hard) and `-S` (soft). Zsh's native " +
+			"`limit` builtin uses lowercase `-h` and `-s` for the same. The Zsh form is easier " +
+			"to remember and produces human-readable output.",
+		Check: checkZC1418,
+	})
+}
+
+func checkZC1418(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "ulimit" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-H" || v == "-S" || v == "-HS" || v == "-SH" {
+			return []Violation{{
+				KataID: "ZC1418",
+				Message: "Use Zsh `limit -h` (hard) / `limit -s` (soft) instead of " +
+					"`ulimit -H`/`-S`. Zsh's `limit` builtin is more human-readable.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 414 Katas = 0.4.14
-const Version = "0.4.14"
+// 415 Katas = 0.4.15
+const Version = "0.4.15"


### PR DESCRIPTION
ZC1418 — Zsh's `limit` builtin uses lowercase -h/-s and produces human-readable output. Severity: Style