### PR TITLE
feat: ZC1419 — flag `chmod 777` as world-writable

### DIFF
--- a/pkg/katas/katatests/zc1419_test.go
+++ b/pkg/katas/katatests/zc1419_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1419(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — chmod 755",
+			input:    `chmod 755 script.sh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — chmod 777",
+			input: `chmod 777 file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1419",
+					Message: "Avoid `chmod 777`/`a+rwx` — grants world-writable access. Prefer restrictive modes (755, 644, 700, 600) matched to the actual file purpose.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — chmod a+rwx",
+			input: `chmod a+rwx dir`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1419",
+					Message: "Avoid `chmod 777`/`a+rwx` — grants world-writable access. Prefer restrictive modes (755, 644, 700, 600) matched to the actual file purpose.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1419")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1419.go
+++ b/pkg/katas/zc1419.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1419",
+		Title:    "Avoid `chmod 777` — grants world-writable access",
+		Severity: SeverityWarning,
+		Description: "Mode 777 (or 0777) grants read/write/execute to owner, group, and world. " +
+			"Files become world-writable, which on a multi-user system or inside a container " +
+			"with mapped UIDs is almost always wrong. Use 755 for executables, 644 for regular " +
+			"files, 700 for private directories, or `umask`-aware helpers.",
+		Check: checkZC1419,
+	})
+}
+
+func checkZC1419(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "chmod" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "777" || v == "0777" || v == "a+rwx" || v == "ugo+rwx" {
+			return []Violation{{
+				KataID: "ZC1419",
+				Message: "Avoid `chmod 777`/`a+rwx` — grants world-writable access. Prefer " +
+					"restrictive modes (755, 644, 700, 600) matched to the actual file purpose.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 415 Katas = 0.4.15
-const Version = "0.4.15"
+// 416 Katas = 0.4.16
+const Version = "0.4.16"


### PR DESCRIPTION
ZC1419 — `chmod 777`/`a+rwx` grants unrestricted access. Prefer 755/644/700/600. Severity: Warning