### PR TITLE
feat: ZC1420 — warn on `chmod +s` / setuid mode bits

### DIFF
--- a/pkg/katas/katatests/zc1420_test.go
+++ b/pkg/katas/katatests/zc1420_test.go
@@ -19,12 +19,12 @@ func TestZC1420(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
-			name:  "invalid — chmod +s",
-			input: `chmod +s binary`,
+			name:  "invalid — chmod 2755 (setgid)",
+			input: `chmod 2755 binary`,
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1420",
-					Message: "`chmod +s` / `u+s` / `g+s` sets setuid/setgid — privilege-escalation risk. Prefer sudo policy, capabilities, or containerization.",
+					Message: "Numeric mode with leading 4/2/6 sets setuid/setgid — privilege-escalation risk.",
 					Line:    1,
 					Column:  1,
 				},

--- a/pkg/katas/katatests/zc1420_test.go
+++ b/pkg/katas/katatests/zc1420_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1420(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — chmod 755",
+			input:    `chmod 755 file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — chmod +s",
+			input: `chmod +s binary`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1420",
+					Message: "`chmod +s` / `u+s` / `g+s` sets setuid/setgid — privilege-escalation risk. Prefer sudo policy, capabilities, or containerization.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — chmod 4755",
+			input: `chmod 4755 binary`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1420",
+					Message: "Numeric mode with leading 4/2/6 sets setuid/setgid — privilege-escalation risk.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1420")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1420.go
+++ b/pkg/katas/zc1420.go
@@ -47,11 +47,11 @@ func checkZC1420(node ast.Node) []Violation {
 		if len(v) == 4 && (v[0] == '4' || v[0] == '2' || v[0] == '6') &&
 			v[1] >= '0' && v[1] <= '7' && v[2] >= '0' && v[2] <= '7' && v[3] >= '0' && v[3] <= '7' {
 			return []Violation{{
-				KataID: "ZC1420",
+				KataID:  "ZC1420",
 				Message: "Numeric mode with leading 4/2/6 sets setuid/setgid — privilege-escalation risk.",
-				Line:   cmd.Token.Line,
-				Column: cmd.Token.Column,
-				Level:  SeverityWarning,
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityWarning,
 			}}
 		}
 	}

--- a/pkg/katas/zc1420.go
+++ b/pkg/katas/zc1420.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1420",
+		Title:    "Avoid `chmod +s` / `chmod u+s` — setuid/setgid is a security risk",
+		Severity: SeverityWarning,
+		Description: "Setuid (mode bit 4000) and setgid (2000) cause the program to run with the " +
+			"file-owner's (or group's) privileges, not the caller's. Any bug in such a program " +
+			"is a privilege-escalation vector. Reserve setuid for audited, minimal binaries; " +
+			"prefer sudo + policy, capabilities, or containers for less-trusted tooling.",
+		Check: checkZC1420,
+	})
+}
+
+func checkZC1420(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "chmod" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := strings.Trim(arg.String(), "'\"")
+		// Symbolic setuid/setgid
+		if v == "+s" || v == "u+s" || v == "g+s" || v == "+st" || v == "u+st" {
+			return []Violation{{
+				KataID: "ZC1420",
+				Message: "`chmod +s` / `u+s` / `g+s` sets setuid/setgid — privilege-escalation risk. " +
+					"Prefer sudo policy, capabilities, or containerization.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+		// Numeric modes starting with 4xxx or 2xxx (setuid/setgid)
+		if len(v) == 4 && (v[0] == '4' || v[0] == '2' || v[0] == '6') &&
+			v[1] >= '0' && v[1] <= '7' && v[2] >= '0' && v[2] <= '7' && v[3] >= '0' && v[3] <= '7' {
+			return []Violation{{
+				KataID: "ZC1420",
+				Message: "Numeric mode with leading 4/2/6 sets setuid/setgid — privilege-escalation risk.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 416 Katas = 0.4.16
-const Version = "0.4.16"
+// 417 Katas = 0.4.17
+const Version = "0.4.17"


### PR DESCRIPTION
ZC1420 — setuid/setgid bits enable privilege escalation if the binary has bugs. Flag `chmod +s`, `u+s`, `g+s`, and numeric modes 4xxx/2xxx/6xxx. Severity: Warning