### PR TITLE
feat: ZC1421 — warn on `chpasswd` without -e

### DIFF
--- a/pkg/katas/katatests/zc1421_test.go
+++ b/pkg/katas/katatests/zc1421_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1421(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — chpasswd -e (encrypted)",
+			input:    `chpasswd -e`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — chpasswd -c (plaintext)",
+			input: `chpasswd -c SHA512`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1421",
+					Message: "`chpasswd` without `-e`/`--encrypted` accepts plaintext passwords — avoid piping cleartext credentials into the process tree. Use a password hash (`-e`) or a credentials store.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1421")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1421.go
+++ b/pkg/katas/zc1421.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1421",
+		Title:    "Avoid `chpasswd` / `passwd --stdin` — plaintext passwords in process tree",
+		Severity: SeverityError,
+		Description: "Passing passwords on stdin to `chpasswd` or `passwd --stdin` exposes the " +
+			"plaintext in the process command line or pipeline — visible to `ps`, logs, and " +
+			"environment. Use encrypted-hash input (`chpasswd -e`), `usermod -p` with a hash, " +
+			"or an IaC tool that handles credentials outside the process tree.",
+		Check: checkZC1421,
+	})
+}
+
+func checkZC1421(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "chpasswd" {
+		return nil
+	}
+
+	// Any chpasswd invocation without -e (encrypted) is risky.
+	hasEncrypted := false
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-e" || arg.String() == "--encrypted" {
+			hasEncrypted = true
+		}
+	}
+	if !hasEncrypted {
+		return []Violation{{
+			KataID: "ZC1421",
+			Message: "`chpasswd` without `-e`/`--encrypted` accepts plaintext passwords — avoid " +
+				"piping cleartext credentials into the process tree. Use a password hash (`-e`) " +
+				"or a credentials store.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityError,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 417 Katas = 0.4.17
-const Version = "0.4.17"
+// 418 Katas = 0.4.18
+const Version = "0.4.18"


### PR DESCRIPTION
ZC1421 — `chpasswd` without `-e` accepts plaintext passwords, visible via `ps`/logs/env. Use hashed input or a credentials store. Severity: Error