### PR TITLE
feat: ZC1422 — warn on `sudo -S` (password-via-stdin)

### DIFF
--- a/pkg/katas/katatests/zc1422_test.go
+++ b/pkg/katas/katatests/zc1422_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1422(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sudo -u user cmd",
+			input:    `sudo -u alice whoami`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — sudo -S cmd",
+			input: `sudo -S apt update`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1422",
+					Message: "`sudo -S` enables password-via-stdin. Avoid piping plaintext credentials. Use `sudo -A` (askpass), `NOPASSWD:` in sudoers, or `pkexec`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1422")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1422.go
+++ b/pkg/katas/zc1422.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1422",
+		Title:    "Avoid `sudo -S` — reads password from stdin, exposes plaintext",
+		Severity: SeverityError,
+		Description: "`sudo -S` reads the password from stdin, enabling `echo $PW | sudo -S cmd` " +
+			"patterns that place the plaintext password in the process tree and shell history. " +
+			"Prefer `sudo -A` with a graphical askpass, `NOPASSWD:` in sudoers for specific " +
+			"commands, or `pkexec` for policy-based privilege elevation.",
+		Check: checkZC1422,
+	})
+}
+
+func checkZC1422(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sudo" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-S" {
+			return []Violation{{
+				KataID: "ZC1422",
+				Message: "`sudo -S` enables password-via-stdin. Avoid piping plaintext " +
+					"credentials. Use `sudo -A` (askpass), `NOPASSWD:` in sudoers, or `pkexec`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 418 Katas = 0.4.18
-const Version = "0.4.18"
+// 419 Katas = 0.4.19
+const Version = "0.4.19"


### PR DESCRIPTION
ZC1422 — `sudo -S` enables `echo pw | sudo -S` patterns that put plaintext in process tree. Use askpass, NOPASSWD, or pkexec. Severity: Error