### PR TITLE
feat: ZC1423 — warn on iptables -F / nft flush (lockout risk)

### DIFF
--- a/pkg/katas/katatests/zc1423_test.go
+++ b/pkg/katas/katatests/zc1423_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1423(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — iptables -A",
+			input:    `iptables -A INPUT -p tcp --dport 22 -j ACCEPT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — iptables -F",
+			input: `iptables -F`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1423",
+					Message: "Flushing firewall rules with `-F` removes every rule — risk of locking yourself out of remote hosts. Save + use rollback mechanism.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — nft flush ruleset",
+			input: `nft flush ruleset`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1423",
+					Message: "`nft flush ruleset` clears every firewall table — risk of locking yourself out of remote hosts. Save + use rollback mechanism.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1423")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1423.go
+++ b/pkg/katas/zc1423.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1423",
+		Title:    "Dangerous: `iptables -F` / `nft flush ruleset` — drops all firewall rules",
+		Severity: SeverityWarning,
+		Description: "Flushing the firewall ruleset removes every existing rule, typically " +
+			"reverting to the default policy. On a remote machine with policy=DROP, this locks " +
+			"you out. Save existing rules first (`iptables-save > backup`) and consider " +
+			"`iptables-apply` with a rollback timer.",
+		Check: checkZC1423,
+	})
+}
+
+func checkZC1423(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "iptables", "ip6tables":
+		for _, arg := range cmd.Arguments {
+			if arg.String() == "-F" || arg.String() == "--flush" {
+				return []Violation{{
+					KataID: "ZC1423",
+					Message: "Flushing firewall rules with `-F` removes every rule — risk of " +
+						"locking yourself out of remote hosts. Save + use rollback mechanism.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	case "nft":
+		for _, arg := range cmd.Arguments {
+			if arg.String() == "flush" {
+				return []Violation{{
+					KataID: "ZC1423",
+					Message: "`nft flush ruleset` clears every firewall table — risk of locking " +
+						"yourself out of remote hosts. Save + use rollback mechanism.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 419 Katas = 0.4.19
-const Version = "0.4.19"
+// 420 Katas = 0.4.20
+const Version = "0.4.20"


### PR DESCRIPTION
ZC1423 — Flushing firewall rules on a remote host can lock you out if default policy is DROP. Save + rollback timer recommended. Severity: Warning