### PR TITLE
feat: ZC1426 — warn on `git clone http://`

### DIFF
--- a/pkg/katas/katatests/zc1426_test.go
+++ b/pkg/katas/katatests/zc1426_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1426(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — git clone https URL",
+			input:    `git clone https://github.com/owner/repo.git`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — git clone http URL",
+			input: `git clone http://example.com/repo.git`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1426",
+					Message: "`git clone http://` is unencrypted/unauthenticated. Use `https://` or SSH with verified host keys.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1426")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1426.go
+++ b/pkg/katas/zc1426.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1426",
+		Title:    "Avoid `git clone http://` — unencrypted transport, use `https://` or `git://`+verify",
+		Severity: SeverityWarning,
+		Description: "`git clone http://...` transfers repository content unencrypted and " +
+			"unauthenticated — susceptible to MITM insertion of malicious commits. Use " +
+			"`https://` for authenticated hosts (GitHub, GitLab) or SSH (`git@host:path`) with " +
+			"verified host keys. Plain `http://` has no integrity guarantee.",
+		Check: checkZC1426,
+	})
+}
+
+func checkZC1426(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "git" {
+		return nil
+	}
+
+	isClone := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "clone" {
+			isClone = true
+			continue
+		}
+		if isClone && strings.HasPrefix(v, "http://") {
+			return []Violation{{
+				KataID: "ZC1426",
+				Message: "`git clone http://` is unencrypted/unauthenticated. Use `https://` " +
+					"or SSH with verified host keys.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 422 Katas = 0.4.22
-const Version = "0.4.22"
+// 423 Katas = 0.4.23
+const Version = "0.4.23"


### PR DESCRIPTION
ZC1426 — HTTP transport for git clone is unauthenticated. Use HTTPS or SSH. Severity: Warning