### PR TITLE
feat: ZC1427 — warn on `nc -e` (reverse-shell pattern)

### DIFF
--- a/pkg/katas/katatests/zc1427_test.go
+++ b/pkg/katas/katatests/zc1427_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1427(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — nc -l listener without -e",
+			input:    `nc -l 1234`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — nc -e",
+			input: `nc -e sh 127.0.0.1 1234`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1427",
+					Message: "`nc -e` spawns an arbitrary command for each connection — reverse-shell territory. Remove from scripts unless audited and restricted.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1427")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1427.go
+++ b/pkg/katas/zc1427.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1427",
+		Title:    "Dangerous: `nc -e` / `ncat -e` — spawns arbitrary command on network connect",
+		Severity: SeverityError,
+		Description: "`nc -e cmd` and `ncat --exec cmd` pipe the network socket to an arbitrary " +
+			"command. Incoming connections get a shell or any command you specify — the " +
+			"classic reverse-shell pattern. Many distros ship `nc` compiled without `-e` for " +
+			"this reason. Remove `-e` from scripts except in audited, restricted contexts.",
+		Check: checkZC1427,
+	})
+}
+
+func checkZC1427(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "nc" && ident.Value != "ncat" && ident.Value != "netcat" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-e" || v == "-c" {
+			return []Violation{{
+				KataID: "ZC1427",
+				Message: "`" + ident.Value + " " + v + "` spawns an arbitrary command for " +
+					"each connection — reverse-shell territory. Remove from scripts unless " +
+					"audited and restricted.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 423 Katas = 0.4.23
-const Version = "0.4.23"
+// 424 Katas = 0.4.24
+const Version = "0.4.24"


### PR DESCRIPTION
ZC1427 — `nc -e cmd` is a reverse-shell pattern. Remove from scripts unless audited. Severity: Error