### PR TITLE
feat: ZC1428 — warn on `curl -u user:pass`

### DIFF
--- a/pkg/katas/katatests/zc1428_test.go
+++ b/pkg/katas/katatests/zc1428_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1428(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — curl with no auth",
+			input:    `curl https://example.com`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — curl -u user:pass",
+			input: `curl -u alice:secret123 https://example.com`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1428",
+					Message: "`curl -u user:pass` leaks credentials into the process list. Use `-u user:` (prompt), `--netrc`, or a credentials manager.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1428")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1428.go
+++ b/pkg/katas/zc1428.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1428",
+		Title:    "Avoid `curl -u user:pass` — credentials visible in process list",
+		Severity: SeverityError,
+		Description: "`curl -u user:password` places the credentials in the command line, where " +
+			"they show up in `ps`, `/proc/*/cmdline`, shell history, and most audit logs. Use " +
+			"`-u user:` with an interactive password prompt, `--netrc`/`--netrc-file` for " +
+			"persistent credentials, or a credentials manager.",
+		Check: checkZC1428,
+	})
+}
+
+func checkZC1428(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "curl" && ident.Value != "wget" {
+		return nil
+	}
+
+	var sawU bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-u" {
+			sawU = true
+			continue
+		}
+		// Next arg after -u containing ':' signals user:pass literal
+		if sawU {
+			sawU = false
+			for i := 0; i < len(v); i++ {
+				if v[i] == ':' && i+1 < len(v) && v[i+1] != '\x00' {
+					return []Violation{{
+						KataID: "ZC1428",
+						Message: "`curl -u user:pass` leaks credentials into the process list. " +
+							"Use `-u user:` (prompt), `--netrc`, or a credentials manager.",
+						Line:   cmd.Token.Line,
+						Column: cmd.Token.Column,
+						Level:  SeverityError,
+					}}
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 424 Katas = 0.4.24
-const Version = "0.4.24"
+// 425 Katas = 0.4.25
+const Version = "0.4.25"


### PR DESCRIPTION
ZC1428 — Credentials in argv visible via ps/proc/logs. Use netrc or prompt. Severity: Error