### PR TITLE
feat: ZC1429 — warn on `umount -f`/`-l`

### DIFF
--- a/pkg/katas/katatests/zc1429_test.go
+++ b/pkg/katas/katatests/zc1429_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1429(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — umount /mnt",
+			input:    `umount /mnt/disk`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — umount -f",
+			input: `umount -f /mnt/disk`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1429",
+					Message: "`umount -f`/`-l` force/lazy unmount masks the underlying 'busy' error. Find open files with `lsof` / `fuser -m` and close them properly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — umount -l",
+			input: `umount -l /mnt/disk`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1429",
+					Message: "`umount -f`/`-l` force/lazy unmount masks the underlying 'busy' error. Find open files with `lsof` / `fuser -m` and close them properly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1429")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1429.go
+++ b/pkg/katas/zc1429.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1429",
+		Title:    "Avoid `umount -f` / `-l` — force/lazy unmount masks real issues",
+		Severity: SeverityWarning,
+		Description: "`umount -f` forces the unmount even if the FS is busy; `-l` (lazy) " +
+			"detaches immediately but keeps the FS in-use. Both can leave stale file handles " +
+			"and data loss. Fix the underlying 'target busy' (use `lsof` / `fuser -m` to find " +
+			"users) instead of forcing.",
+		Check: checkZC1429,
+	})
+}
+
+func checkZC1429(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "umount" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-f" || v == "-l" || v == "-fl" || v == "-lf" {
+			return []Violation{{
+				KataID: "ZC1429",
+				Message: "`umount -f`/`-l` force/lazy unmount masks the underlying 'busy' error. " +
+					"Find open files with `lsof` / `fuser -m` and close them properly.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 425 Katas = 0.4.25
-const Version = "0.4.25"
+// 426 Katas = 0.4.26
+const Version = "0.4.26"


### PR DESCRIPTION
ZC1429 — Force/lazy unmount masks real busy errors. Use `lsof`/`fuser -m` to fix root cause. Severity: Warning