### PR TITLE
feat: ZC1430 — prefer Zsh `sched` over `at`/`batch`

### DIFF
--- a/pkg/katas/katatests/zc1430_test.go
+++ b/pkg/katas/katatests/zc1430_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1430(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sched in-shell",
+			input:    `sched +1:00 cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — at now",
+			input: `at now + 1 minute`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1430",
+					Message: "Prefer Zsh `sched` (from `zsh/sched`) for in-shell scheduling instead of `at`/`batch`. No daemon dependency, runs in the current shell's environment.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1430")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1430.go
+++ b/pkg/katas/zc1430.go
@@ -1,0 +1,42 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1430",
+		Title:    "Prefer Zsh `zsh/sched` module over `at now` / `batch` for in-shell scheduling",
+		Severity: SeverityStyle,
+		Description: "`at`/`batch` schedule commands via the atd daemon — requires daemon " +
+			"running, leaves a spool-file audit trail, and runs in a fresh environment. For " +
+			"in-shell scheduling the Zsh `zsh/sched` module (`sched +1:00 cmd`) runs the " +
+			"command from the current shell without the daemon dependency.",
+		Check: checkZC1430,
+	})
+}
+
+func checkZC1430(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "at" && ident.Value != "batch" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1430",
+		Message: "Prefer Zsh `sched` (from `zsh/sched`) for in-shell scheduling instead of " +
+			"`at`/`batch`. No daemon dependency, runs in the current shell's environment.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 426 Katas = 0.4.26
-const Version = "0.4.26"
+// 427 Katas = 0.4.27
+const Version = "0.4.27"


### PR DESCRIPTION
ZC1430 — Zsh's `zsh/sched` module schedules commands in-shell, no atd dependency. Severity: Style