### PR TITLE
feat: ZC1431 — warn on `crontab -r`

### DIFF
--- a/pkg/katas/katatests/zc1431_test.go
+++ b/pkg/katas/katatests/zc1431_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1431(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — crontab -l (list)",
+			input:    `crontab -l`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — crontab -r",
+			input: `crontab -r`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1431",
+					Message: "`crontab -r` removes all cron jobs with no backup. Save first (`crontab -l > cron.bak`) and use `crontab -ir` for interactive confirmation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1431")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1431.go
+++ b/pkg/katas/zc1431.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1431",
+		Title:    "Dangerous: `crontab -r` — removes all the user's cron jobs without confirmation",
+		Severity: SeverityWarning,
+		Description: "`crontab -r` deletes the entire crontab for the current user (or the target " +
+			"user with `-u`). There is no `.bak` left behind, no `-i` prompt by default on most " +
+			"platforms. Back up first with `crontab -l > /tmp/cron.bak`, then use `crontab -ir` " +
+			"(interactive) to require confirmation.",
+		Check: checkZC1431,
+	})
+}
+
+func checkZC1431(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "crontab" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-r" || v == "-ur" || v == "-ru" {
+			return []Violation{{
+				KataID: "ZC1431",
+				Message: "`crontab -r` removes all cron jobs with no backup. Save first " +
+					"(`crontab -l > cron.bak`) and use `crontab -ir` for interactive confirmation.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 427 Katas = 0.4.27
-const Version = "0.4.27"
+// 428 Katas = 0.4.28
+const Version = "0.4.28"


### PR DESCRIPTION
ZC1431 — `crontab -r` removes all cron jobs, no backup. Save + use `-ir`. Severity: Warning