### PR TITLE
feat: ZC1432 — warn on `chattr +i`/`+a`

### DIFF
--- a/pkg/katas/katatests/zc1432_test.go
+++ b/pkg/katas/katatests/zc1432_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1432(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — chattr -i (remove)",
+			input:    `chattr -i file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — chattr +i",
+			input: `chattr +i secret.conf`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1432",
+					Message: "`chattr +i`/`+a` sets immutable/append-only — blocks later cleanup. Document the `-i`/`-a` cleanup path or reconsider if really needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — chattr +a",
+			input: `chattr +a log.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1432",
+					Message: "`chattr +i`/`+a` sets immutable/append-only — blocks later cleanup. Document the `-i`/`-a` cleanup path or reconsider if really needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1432")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1432.go
+++ b/pkg/katas/zc1432.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1432",
+		Title:    "Warn on `chattr +i` / `+a` — immutable/append-only attributes block cleanup",
+		Severity: SeverityWarning,
+		Description: "`chattr +i` marks a file immutable (even root cannot delete without " +
+			"`chattr -i` first). `+a` makes it append-only. Useful for hardening but often " +
+			"surprises later scripts. If you set these in provisioning, document the cleanup " +
+			"path; in scripts, verify they are truly needed.",
+		Check: checkZC1432,
+	})
+}
+
+func checkZC1432(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "chattr" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		// Detect +i / +a / +u (append, immutable, undelete) flags
+		if strings.HasPrefix(v, "+") && (strings.ContainsAny(v, "ia") || v == "+u") {
+			return []Violation{{
+				KataID: "ZC1432",
+				Message: "`chattr +i`/`+a` sets immutable/append-only — blocks later cleanup. " +
+					"Document the `-i`/`-a` cleanup path or reconsider if really needed.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 428 Katas = 0.4.28
-const Version = "0.4.28"
+// 429 Katas = 0.4.29
+const Version = "0.4.29"


### PR DESCRIPTION
ZC1432 — chattr immutable/append-only blocks future cleanup. Document cleanup path. Severity: Warning