### PR TITLE
feat: ZC1432 — warn on `passwd -d`

### DIFF
--- a/pkg/katas/katatests/zc1432_test.go
+++ b/pkg/katas/katatests/zc1432_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1432(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — passwd -l (lock)",
+			input:    `passwd -l alice`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — passwd -d (delete)",
+			input: `passwd -d alice`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1432",
+					Message: "`passwd -d user` deletes the password — account becomes passwordless. Use `passwd -l user` to lock, or `usermod -L` + delete SSH keys to disable login.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1432")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1432.go
+++ b/pkg/katas/zc1432.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1432",
+		Title:    "Dangerous: `passwd -d user` — deletes the password, leaving the account passwordless",
+		Severity: SeverityError,
+		Description: "`passwd -d user` removes the password entirely, making the account usable " +
+			"without any password (depending on PAM config). This is almost never what you want — " +
+			"use `passwd -l user` to lock the account, or `usermod -L` + delete the ssh keys to " +
+			"fully disable login.",
+		Check: checkZC1432,
+	})
+}
+
+func checkZC1432(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "passwd" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-d" {
+			return []Violation{{
+				KataID: "ZC1432",
+				Message: "`passwd -d user` deletes the password — account becomes passwordless. " +
+					"Use `passwd -l user` to lock, or `usermod -L` + delete SSH keys to disable login.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 428 Katas = 0.4.28
-const Version = "0.4.28"
+// 429 Katas = 0.4.29
+const Version = "0.4.29"


### PR DESCRIPTION
ZC1432 — `passwd -d` removes password entirely, account becomes passwordless. Use -l or usermod -L. Severity: Error