### PR TITLE
feat: ZC1433 — warn on `userdel -f`/`-r`

### DIFF
--- a/pkg/katas/katatests/zc1433_test.go
+++ b/pkg/katas/katatests/zc1433_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1433(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — userdel plain",
+			input:    `userdel alice`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — userdel -f",
+			input: `userdel -f alice`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1433",
+					Message: "`userdel -f`/`-r` forcibly removes user (kills processes, deletes home). Check for active sessions first with `who -u` / `loginctl list-users`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — userdel -rf",
+			input: `userdel -rf alice`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1433",
+					Message: "`userdel -f`/`-r` forcibly removes user (kills processes, deletes home). Check for active sessions first with `who -u` / `loginctl list-users`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1433")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1433.go
+++ b/pkg/katas/zc1433.go
@@ -1,0 +1,47 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1433",
+		Title:    "Caution with `userdel -f` / `-r` — removes home directory and kills processes",
+		Severity: SeverityWarning,
+		Description: "`userdel -f` proceeds even when the user is logged in or has running " +
+			"processes, potentially killing unsaved work. `-r` additionally deletes the home " +
+			"directory and mail spool. Combined (`-rf`) these are destructive and often " +
+			"misused for 'clean up a user' without warning. Verify no active sessions first.",
+		Check: checkZC1433,
+	})
+}
+
+func checkZC1433(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "userdel" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-f" || v == "-r" || v == "-rf" || v == "-fr" ||
+			v == "--force" || v == "--remove" {
+			return []Violation{{
+				KataID: "ZC1433",
+				Message: "`userdel -f`/`-r` forcibly removes user (kills processes, deletes home). " +
+					"Check for active sessions first with `who -u` / `loginctl list-users`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 429 Katas = 0.4.29
-const Version = "0.4.29"
+// 430 Katas = 0.4.30
+const Version = "0.4.30"


### PR DESCRIPTION
ZC1433 — `userdel -f/-r` kills active sessions, deletes home. Check sessions first. Severity: Warning