### PR TITLE
feat: ZC1434 — warn on `swapoff -a`

### DIFF
--- a/pkg/katas/katatests/zc1434_test.go
+++ b/pkg/katas/katatests/zc1434_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1434(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — swapoff specific file",
+			input:    `swapoff swap.img`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — swapoff -a",
+			input: `swapoff -a`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1434",
+					Message: "`swapoff -a` disables ALL swap areas — risks OOM on memory-constrained hosts. Disable specific swaps (`swapoff /swapfile`) after checking `free -m`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1434")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1434.go
+++ b/pkg/katas/zc1434.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1434",
+		Title:    "Warn on `swapoff -a` — disables all swap, can OOM-kill",
+		Severity: SeverityWarning,
+		Description: "`swapoff -a` disables every active swap. On a memory-constrained host " +
+			"this pushes data back into RAM, potentially triggering OOM-killer. Prefer " +
+			"disabling specific devices/files (`swapoff /swapfile`) and verify memory headroom " +
+			"with `free -m` first.",
+		Check: checkZC1434,
+	})
+}
+
+func checkZC1434(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "swapoff" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-a" || arg.String() == "--all" {
+			return []Violation{{
+				KataID: "ZC1434",
+				Message: "`swapoff -a` disables ALL swap areas — risks OOM on memory-constrained " +
+					"hosts. Disable specific swaps (`swapoff /swapfile`) after checking `free -m`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 430 Katas = 0.4.30
-const Version = "0.4.30"
+// 431 Katas = 0.4.31
+const Version = "0.4.31"


### PR DESCRIPTION
ZC1434 — `swapoff -a` disables all swap. Memory-constrained hosts can OOM. Severity: Warning