### PR TITLE
feat: ZC1435 — warn on `killall -9`

### DIFF
--- a/pkg/katas/katatests/zc1435_test.go
+++ b/pkg/katas/katatests/zc1435_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1435(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — killall plain",
+			input:    `killall myproc`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — killall -9",
+			input: `killall -9 myproc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1435",
+					Message: "`killall -9 name` force-kills every matching process, including unrelated instances on multi-user or containerized hosts. Start with -TERM, or kill by PID after `pgrep`/`pidof`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1435")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1435.go
+++ b/pkg/katas/zc1435.go
@@ -1,0 +1,47 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1435",
+		Title:    "Avoid `killall -9` / `killall -KILL` — force-kill by process name",
+		Severity: SeverityWarning,
+		Description: "`killall -9 name` sends SIGKILL to every process matching `name` — in " +
+			"multi-user or containerized environments, this can hit unrelated processes that " +
+			"happen to share the name. Prefer `killall -TERM` first (graceful), or kill by PID " +
+			"after locating with `pgrep` / `pidof`.",
+		Check: checkZC1435,
+	})
+}
+
+func checkZC1435(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "killall" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-9" || v == "-KILL" || v == "-s" {
+			return []Violation{{
+				KataID: "ZC1435",
+				Message: "`killall -9 name` force-kills every matching process, including " +
+					"unrelated instances on multi-user or containerized hosts. Start with -TERM, " +
+					"or kill by PID after `pgrep`/`pidof`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 431 Katas = 0.4.31
-const Version = "0.4.31"
+// 432 Katas = 0.4.32
+const Version = "0.4.32"


### PR DESCRIPTION
ZC1435 — killall -9 kills all matching processes by name, risky in multi-user/container hosts. Severity: Warning