### PR TITLE
feat: ZC1436 — `sysctl -w` is ephemeral

### DIFF
--- a/pkg/katas/katatests/zc1436_test.go
+++ b/pkg/katas/katatests/zc1436_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1436(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sysctl -p (reload from config)",
+			input:    `sysctl -p`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — sysctl -w (ephemeral)",
+			input: `sysctl -w vm.swappiness=10`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1436",
+					Message: "`sysctl -w` setting is lost on reboot. Persist in `/etc/sysctl.d/*.conf` and reload with `sysctl --system`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1436")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1436.go
+++ b/pkg/katas/zc1436.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1436",
+		Title:    "`sysctl -w` is ephemeral — persist in `/etc/sysctl.d/*.conf` for surviving reboots",
+		Severity: SeverityInfo,
+		Description: "`sysctl -w key=value` sets a kernel parameter until the next reboot. For " +
+			"configuration that must survive reboots, write a file in `/etc/sysctl.d/` and apply " +
+			"with `sysctl --system`. Using only `-w` in provisioning scripts creates silent drift.",
+		Check: checkZC1436,
+	})
+}
+
+func checkZC1436(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sysctl" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-w" || arg.String() == "--write" {
+			return []Violation{{
+				KataID: "ZC1436",
+				Message: "`sysctl -w` setting is lost on reboot. Persist in `/etc/sysctl.d/*.conf` " +
+					"and reload with `sysctl --system`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityInfo,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 432 Katas = 0.4.32
-const Version = "0.4.32"
+// 433 Katas = 0.4.33
+const Version = "0.4.33"


### PR DESCRIPTION
ZC1436 — `sysctl -w` doesn't survive reboot. Persist via /etc/sysctl.d/. Severity: Info