### PR TITLE
feat: ZC1437 — warn on `dmesg -c`/`-C`

### DIFF
--- a/pkg/katas/katatests/zc1437_test.go
+++ b/pkg/katas/katatests/zc1437_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1437(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — dmesg -T (human time)",
+			input:    `dmesg -T`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — dmesg -c",
+			input: `dmesg -c`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1437",
+					Message: "`dmesg -c`/`-C` clears the kernel ring buffer — subsequent debugging loses earlier messages. Use plain `dmesg` or `journalctl -k`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1437")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1437.go
+++ b/pkg/katas/zc1437.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1437",
+		Title:    "`dmesg -c` / `-C` clears the kernel ring buffer — destroys evidence",
+		Severity: SeverityWarning,
+		Description: "`dmesg -c` prints the ring buffer and then **clears** it. `dmesg -C` clears " +
+			"without printing. Any later debugging loses the earlier messages. Prefer plain " +
+			"`dmesg` for read-only inspection, or `journalctl -k` with a time filter.",
+		Check: checkZC1437,
+	})
+}
+
+func checkZC1437(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "dmesg" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-c" || v == "-C" || v == "--clear" || v == "--read-clear" {
+			return []Violation{{
+				KataID: "ZC1437",
+				Message: "`dmesg -c`/`-C` clears the kernel ring buffer — subsequent debugging " +
+					"loses earlier messages. Use plain `dmesg` or `journalctl -k`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 433 Katas = 0.4.33
-const Version = "0.4.33"
+// 434 Katas = 0.4.34
+const Version = "0.4.34"


### PR DESCRIPTION
ZC1437 — `dmesg -c` clears kernel ring buffer after reading, destroying debug evidence. Severity: Warning