### PR TITLE
feat: ZC1438 — warn on `systemctl mask`

### DIFF
--- a/pkg/katas/katatests/zc1438_test.go
+++ b/pkg/katas/katatests/zc1438_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1438(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — systemctl disable",
+			input:    `systemctl disable some.service`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — systemctl mask",
+			input: `systemctl mask some.service`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1438",
+					Message: "`systemctl mask` permanently blocks service start. If this is a policy choice, document the `unmask` path. For a softer block, use `disable`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1438")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1438.go
+++ b/pkg/katas/zc1438.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1438",
+		Title:    "`systemctl mask` permanently prevents service start — document the unmask path",
+		Severity: SeverityWarning,
+		Description: "`systemctl mask unit` symlinks the unit to `/dev/null`, preventing any " +
+			"start (manual, dependency, or at boot). Even `systemctl start` fails with 'Unit is " +
+			"masked.'. The reverse `systemctl unmask` is easy to forget. Document the unmask in " +
+			"provisioning scripts or use `disable` (which still allows manual start).",
+		Check: checkZC1438,
+	})
+}
+
+func checkZC1438(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "systemctl" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "mask" {
+			return []Violation{{
+				KataID: "ZC1438",
+				Message: "`systemctl mask` permanently blocks service start. If this is a " +
+					"policy choice, document the `unmask` path. For a softer block, use `disable`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 434 Katas = 0.4.34
-const Version = "0.4.34"
+// 435 Katas = 0.4.35
+const Version = "0.4.35"


### PR DESCRIPTION
ZC1438 — `systemctl mask` symlinks unit to /dev/null, blocks manual start. Document unmask path. Severity: Warning

100-kata session milestone reached.