### PR TITLE
feat: ZC1439 — warn on `sysctl ip_forward=1`

### DIFF
--- a/pkg/katas/katatests/zc1439_test.go
+++ b/pkg/katas/katatests/zc1439_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1439(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sysctl vm.swappiness=10",
+			input:    `sysctl vm.swappiness=10`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — sysctl ip_forward=1",
+			input: `sysctl net.ipv4.ip_forward=1`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1439",
+					Message: "Enabling `ip_forward` turns the host into a router. Verify firewall posture (iptables/nftables) and persist the setting in `/etc/sysctl.d/`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1439")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1439.go
+++ b/pkg/katas/zc1439.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1439",
+		Title:    "Enabling IP forwarding in a script — document firewall posture",
+		Severity: SeverityWarning,
+		Description: "Setting `net.ipv4.ip_forward=1` (or `-w`-ing a sysctl to the same effect) " +
+			"turns the host into a router. Without matching iptables/nftables rules this can " +
+			"silently expose services between interfaces. If intentional (VPN, container host, " +
+			"NAT gateway), pair with explicit firewall rules and persist via `/etc/sysctl.d/`.",
+		Check: checkZC1439,
+	})
+}
+
+func checkZC1439(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sysctl" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "ip_forward=1") ||
+			strings.Contains(v, "forwarding=1") ||
+			strings.Contains(v, "ip_forward =1") {
+			return []Violation{{
+				KataID: "ZC1439",
+				Message: "Enabling `ip_forward` turns the host into a router. Verify firewall " +
+					"posture (iptables/nftables) and persist the setting in `/etc/sysctl.d/`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 435 Katas = 0.4.35
-const Version = "0.4.35"
+// 436 Katas = 0.4.36
+const Version = "0.4.36"


### PR DESCRIPTION
ZC1439 — Enabling ip_forward makes the host a router. Verify firewall. Severity: Warning