### PR TITLE
feat: ZC1440 — warn on `usermod -G` without `-a`

### DIFF
--- a/pkg/katas/katatests/zc1440_test.go
+++ b/pkg/katas/katatests/zc1440_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1440(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — usermod -aG (append)",
+			input:    `usermod -aG docker alice`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — usermod -L (lock)",
+			input:    `usermod -L alice`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — usermod -G (replace)",
+			input: `usermod -G docker alice`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1440",
+					Message: "`usermod -G` without `-a` overwrites supplementary groups. Use `-aG` to append — existing memberships are preserved.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1440")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1440.go
+++ b/pkg/katas/zc1440.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1440",
+		Title:    "`usermod -G group user` replaces supplementary groups — use `-aG` to append",
+		Severity: SeverityWarning,
+		Description: "`usermod -G group user` overwrites the user's supplementary group list — " +
+			"any prior group memberships are removed. Users commonly add themselves to `docker` " +
+			"or `wheel` via `-G` and inadvertently lose `sudo`/`audio`/other memberships. Always " +
+			"pair with `-a` (`-aG`) to append instead of replace.",
+		Check: checkZC1440,
+	})
+}
+
+func checkZC1440(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "usermod" {
+		return nil
+	}
+
+	hasG := false
+	hasA := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "-G", "--groups":
+			hasG = true
+		case "-a", "--append":
+			hasA = true
+		case "-aG", "-Ga":
+			return nil // safe combined flag
+		}
+	}
+	if hasG && !hasA {
+		return []Violation{{
+			KataID: "ZC1440",
+			Message: "`usermod -G` without `-a` overwrites supplementary groups. Use `-aG` to " +
+				"append — existing memberships are preserved.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 436 Katas = 0.4.36
-const Version = "0.4.36"
+// 437 Katas = 0.4.37
+const Version = "0.4.37"


### PR DESCRIPTION
ZC1440 — `usermod -G` replaces supplementary groups. Use `-aG` to append. Severity: Warning