### PR TITLE
feat: ZC1441 — warn on `docker prune -af`

### DIFF
--- a/pkg/katas/katatests/zc1441_test.go
+++ b/pkg/katas/katatests/zc1441_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1441(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker ps",
+			input:    `docker ps`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — docker prune (no -af)",
+			input:    `docker system prune`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker system prune -af",
+			input: `docker system prune -a -f`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1441",
+					Message: "`docker prune -af` / `-a --force` deletes all unused resources without prompt. Scope with `--filter` or target one resource type.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — docker prune -af combined",
+			input: `docker prune -af`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1441",
+					Message: "`docker prune -af` / `-a --force` deletes all unused resources without prompt. Scope with `--filter` or target one resource type.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1441")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1441.go
+++ b/pkg/katas/zc1441.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1441",
+		Title:    "Warn on `docker system prune -af` / `-a --force` (or similar podman/k8s)",
+		Severity: SeverityWarning,
+		Description: "`docker system prune -af` deletes every unused image, container, network, " +
+			"and (with `--volumes`) volume. On shared CI runners or build hosts this obliterates " +
+			"cached layers and slows future builds. Scope prunes with `--filter \"until=168h\"` " +
+			"or target one resource type at a time.",
+		Check: checkZC1441,
+	})
+}
+
+func checkZC1441(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+
+	seenPrune := false
+	seenA := false
+	seenF := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "prune":
+			seenPrune = true
+		case "-a", "--all":
+			seenA = true
+		case "-f", "--force":
+			seenF = true
+		case "-af", "-fa":
+			seenA = true
+			seenF = true
+		}
+	}
+	if seenPrune && seenA && seenF {
+		return []Violation{{
+			KataID: "ZC1441",
+			Message: "`docker prune -af` / `-a --force` deletes all unused resources without " +
+				"prompt. Scope with `--filter` or target one resource type.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 437 Katas = 0.4.37
-const Version = "0.4.37"
+// 438 Katas = 0.4.38
+const Version = "0.4.38"


### PR DESCRIPTION
ZC1441 — `docker prune -af` deletes unused images/containers/networks. Scope with --filter. Severity: Warning