### PR TITLE
feat: ZC1442 — warn on `kubectl delete --all`

### DIFF
--- a/pkg/katas/katatests/zc1442_test.go
+++ b/pkg/katas/katatests/zc1442_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1442(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — kubectl get pods",
+			input:    `kubectl get pods`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — kubectl delete specific pod",
+			input:    `kubectl delete pod myapp-abc123`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — kubectl delete --all pods",
+			input: `kubectl delete pods --all`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1442",
+					Message: "`kubectl delete --all` (or `-A`) deletes resources cluster-wide. Dry-run with `--dry-run=client -o yaml` first, and scope with `-n` namespace.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1442")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1442.go
+++ b/pkg/katas/zc1442.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1442",
+		Title:    "Dangerous: `kubectl delete --all` / `--all-namespaces` deletes cluster resources",
+		Severity: SeverityError,
+		Description: "`kubectl delete --all pods` (in the current namespace) or " +
+			"`-A`/`--all-namespaces` scopes delete operations across the whole cluster. A typo " +
+			"on the resource type can wipe deployments, services, secrets, or even CRDs. " +
+			"Always use `--dry-run=client` first, then apply with `-n` explicit namespace.",
+		Check: checkZC1442,
+	})
+}
+
+func checkZC1442(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kubectl" && ident.Value != "oc" {
+		return nil
+	}
+
+	hasDelete := false
+	hasAll := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "delete" {
+			hasDelete = true
+		}
+		if v == "--all" || v == "-A" || v == "--all-namespaces" {
+			hasAll = true
+		}
+	}
+	if hasDelete && hasAll {
+		return []Violation{{
+			KataID: "ZC1442",
+			Message: "`kubectl delete --all` (or `-A`) deletes resources cluster-wide. Dry-run " +
+				"with `--dry-run=client -o yaml` first, and scope with `-n` namespace.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityError,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 438 Katas = 0.4.38
-const Version = "0.4.38"
+// 439 Katas = 0.4.39
+const Version = "0.4.39"


### PR DESCRIPTION
ZC1442 — `kubectl delete --all` / `-A` deletes cluster-wide. Dry-run first, scope namespace. Severity: Error