### PR TITLE
feat: ZC1443 — warn on `terraform destroy` without `-target`

### DIFF
--- a/pkg/katas/katatests/zc1443_test.go
+++ b/pkg/katas/katatests/zc1443_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1443(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — terraform plan",
+			input:    `terraform plan`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — terraform destroy",
+			input: `terraform destroy`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1443",
+					Message: "`terraform destroy` without `-target` removes every resource in state. Scope with `-target=...` or gate behind interactive confirmation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1443")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1443.go
+++ b/pkg/katas/zc1443.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1443",
+		Title:    "Dangerous: `terraform destroy` / `apply -destroy` without `-target`",
+		Severity: SeverityWarning,
+		Description: "`terraform destroy` (or `terraform apply -destroy`) without a `-target` " +
+			"removes every resource in state — entire environments, databases, volumes, DNS, " +
+			"everything. Always prefer targeted destroy or scope via workspaces. Consider " +
+			"guarding state-destroying commands behind an interactive confirmation.",
+		Check: checkZC1443,
+	})
+}
+
+func checkZC1443(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || (ident.Value != "terraform" && ident.Value != "tofu") {
+		return nil
+	}
+
+	hasDestroy := false
+	hasTarget := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "destroy" || v == "-destroy" {
+			hasDestroy = true
+		}
+		if strings.HasPrefix(v, "-target") || v == "-target" {
+			hasTarget = true
+		}
+	}
+	if hasDestroy && !hasTarget {
+		return []Violation{{
+			KataID: "ZC1443",
+			Message: "`terraform destroy` without `-target` removes every resource in state. " +
+				"Scope with `-target=...` or gate behind interactive confirmation.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 439 Katas = 0.4.39
-const Version = "0.4.39"
+// 440 Katas = 0.4.40
+const Version = "0.4.40"


### PR DESCRIPTION
ZC1443 — `terraform destroy` without -target wipes everything in state. Severity: Warning