### PR TITLE
feat: ZC1444 — warn on `redis-cli FLUSHALL`/`FLUSHDB`

### DIFF
--- a/pkg/katas/katatests/zc1444_test.go
+++ b/pkg/katas/katatests/zc1444_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1444(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — redis-cli GET",
+			input:    `redis-cli GET foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — redis-cli FLUSHALL",
+			input: `redis-cli FLUSHALL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1444",
+					Message: "`redis-cli FLUSHALL`/`FLUSHDB` wipes Redis data. Disable via `rename-command` in redis.conf on production, or require explicit confirmation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — redis-cli FLUSHDB",
+			input: `redis-cli FLUSHDB`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1444",
+					Message: "`redis-cli FLUSHALL`/`FLUSHDB` wipes Redis data. Disable via `rename-command` in redis.conf on production, or require explicit confirmation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1444")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1444.go
+++ b/pkg/katas/zc1444.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1444",
+		Title:    "Dangerous: `redis-cli FLUSHALL` / `FLUSHDB` — wipes Redis data",
+		Severity: SeverityError,
+		Description: "`FLUSHALL` deletes every key in every database; `FLUSHDB` clears the current " +
+			"DB. Running against production is usually catastrophic. Either rename the command " +
+			"in `redis.conf` (`rename-command FLUSHALL \"\"`) or require an explicit " +
+			"confirmation in scripts.",
+		Check: checkZC1444,
+	})
+}
+
+func checkZC1444(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "redis-cli" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := strings.ToUpper(arg.String())
+		if v == "FLUSHALL" || v == "FLUSHDB" {
+			return []Violation{{
+				KataID: "ZC1444",
+				Message: "`redis-cli FLUSHALL`/`FLUSHDB` wipes Redis data. Disable via " +
+					"`rename-command` in redis.conf on production, or require explicit confirmation.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 440 Katas = 0.4.40
-const Version = "0.4.40"
+// 441 Katas = 0.4.41
+const Version = "0.4.41"


### PR DESCRIPTION
ZC1444 — Redis flush commands wipe data. Rename in redis.conf or require confirmation. Severity: Error