### PR TITLE
feat: ZC1447 — prefer iproute2 over net-tools

### DIFF
--- a/pkg/katas/katatests/zc1447_test.go
+++ b/pkg/katas/katatests/zc1447_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1447(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ip addr",
+			input:    `ip addr show`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ifconfig",
+			input: `ifconfig eth0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1447",
+					Message: "`ifconfig` is deprecated. Use `ip addr` / `ip link` / `ip route` from iproute2.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — netstat",
+			input: `netstat -tuln`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1447",
+					Message: "`netstat` is deprecated. Use `ss` from iproute2 (same flags, faster output).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1447")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1447.go
+++ b/pkg/katas/zc1447.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1447",
+		Title:    "Avoid deprecated `ifconfig` / `netstat` — prefer `ip` / `ss`",
+		Severity: SeverityStyle,
+		Description: "On modern Linux, `ifconfig` and `netstat` (from net-tools) are deprecated " +
+			"in favor of the iproute2 suite: `ip addr`, `ip link`, `ip route`, `ss`. net-tools " +
+			"is not installed by default on many distros (Alpine, Fedora Cloud, minimal images), " +
+			"so scripts break. Use iproute2 commands for portability.",
+		Check: checkZC1447,
+	})
+}
+
+func checkZC1447(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "ifconfig":
+		return []Violation{{
+			KataID:  "ZC1447",
+			Message: "`ifconfig` is deprecated. Use `ip addr` / `ip link` / `ip route` from iproute2.",
+			Line:    cmd.Token.Line,
+			Column:  cmd.Token.Column,
+			Level:   SeverityStyle,
+		}}
+	case "netstat":
+		return []Violation{{
+			KataID:  "ZC1447",
+			Message: "`netstat` is deprecated. Use `ss` from iproute2 (same flags, faster output).",
+			Line:    cmd.Token.Line,
+			Column:  cmd.Token.Column,
+			Level:   SeverityStyle,
+		}}
+	case "route":
+		return []Violation{{
+			KataID:  "ZC1447",
+			Message: "`route` is deprecated. Use `ip route`.",
+			Line:    cmd.Token.Line,
+			Column:  cmd.Token.Column,
+			Level:   SeverityStyle,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 443 Katas = 0.4.43
-const Version = "0.4.43"
+// 444 Katas = 0.4.44
+const Version = "0.4.44"


### PR DESCRIPTION
ZC1447 — net-tools deprecated, not installed by default on modern distros. Use ip/ss. Severity: Style