### PR TITLE
feat: ZC1448 — warn on `apt-get install` without `-y`

### DIFF
--- a/pkg/katas/katatests/zc1448_test.go
+++ b/pkg/katas/katatests/zc1448_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1448(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — apt-get install -y",
+			input:    `apt-get install -y curl`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — apt-get update (not install)",
+			input:    `apt-get update`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — apt-get install without -y",
+			input: `apt-get install curl`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1448",
+					Message: "`apt-get install`/`apt install` without `-y` hangs on the interactive prompt in scripts. Add `-y` and set DEBIAN_FRONTEND=noninteractive.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1448")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1448.go
+++ b/pkg/katas/zc1448.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1448",
+		Title:    "`apt-get install` / `apt install` without `-y` hangs in non-interactive scripts",
+		Severity: SeverityWarning,
+		Description: "In provisioning scripts, `apt-get install foo` (no `-y`) waits for " +
+			"interactive confirmation and stalls CI/Dockerfiles indefinitely. Always pass `-y` " +
+			"(or `--yes`), and for unattended upgrades also set " +
+			"`DEBIAN_FRONTEND=noninteractive` in the environment.",
+		Check: checkZC1448,
+	})
+}
+
+func checkZC1448(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "apt-get" && ident.Value != "apt" {
+		return nil
+	}
+
+	hasInstall := false
+	hasYes := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "install" || v == "upgrade" || v == "dist-upgrade" || v == "full-upgrade" {
+			hasInstall = true
+		}
+		if v == "-y" || v == "--yes" || v == "--assume-yes" {
+			hasYes = true
+		}
+	}
+	if hasInstall && !hasYes {
+		return []Violation{{
+			KataID: "ZC1448",
+			Message: "`apt-get install`/`apt install` without `-y` hangs on the interactive " +
+				"prompt in scripts. Add `-y` and set DEBIAN_FRONTEND=noninteractive.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 444 Katas = 0.4.44
-const Version = "0.4.44"
+// 445 Katas = 0.4.45
+const Version = "0.4.45"


### PR DESCRIPTION
ZC1448 — apt-get install without -y hangs on prompt in scripts. Severity: Warning

110-kata session milestone.