### PR TITLE
feat: ZC1449 — warn on dnf/yum install without -y

### DIFF
--- a/pkg/katas/katatests/zc1449_test.go
+++ b/pkg/katas/katatests/zc1449_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1449(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — dnf install -y",
+			input:    `dnf install -y vim`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — dnf install no -y",
+			input: `dnf install vim`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1449",
+					Message: "`dnf` without `-y` hangs on confirmation. Add `-y` for unattended runs.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — yum install no -y",
+			input: `yum install httpd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1449",
+					Message: "`yum` without `-y` hangs on confirmation. Add `-y` for unattended runs.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1449")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1449.go
+++ b/pkg/katas/zc1449.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1449",
+		Title:    "`dnf`/`yum` install without `-y` hangs in non-interactive scripts",
+		Severity: SeverityWarning,
+		Description: "In CI/Dockerfiles, `dnf install pkg` or `yum install pkg` prompts for " +
+			"confirmation and stalls. Always pass `-y` (or `--assumeyes`) for unattended runs. " +
+			"Also consider `--nodocs` and `--setopt=install_weak_deps=False` for slim images.",
+		Check: checkZC1449,
+	})
+}
+
+func checkZC1449(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "dnf" && ident.Value != "yum" && ident.Value != "microdnf" {
+		return nil
+	}
+
+	hasInstall := false
+	hasYes := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "install" || v == "upgrade" || v == "update" || v == "remove" {
+			hasInstall = true
+		}
+		if v == "-y" || v == "--assumeyes" {
+			hasYes = true
+		}
+	}
+	if hasInstall && !hasYes {
+		return []Violation{{
+			KataID: "ZC1449",
+			Message: "`" + ident.Value + "` without `-y` hangs on confirmation. Add `-y` for " +
+				"unattended runs.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 445 Katas = 0.4.45
-const Version = "0.4.45"
+// 446 Katas = 0.4.46
+const Version = "0.4.46"


### PR DESCRIPTION
ZC1449 — dnf/yum install without -y hangs on prompt in scripts. Severity: Warning