### PR TITLE
feat: ZC1450 — warn on pacman/zypper without non-interactive flag

### DIFF
--- a/pkg/katas/katatests/zc1450_test.go
+++ b/pkg/katas/katatests/zc1450_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1450(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — pacman -Ss (search)",
+			input:    `pacman -Ss vim`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — pacman -S without --noconfirm",
+			input: `pacman -S vim`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1450",
+					Message: "`pacman -S` without `--noconfirm` hangs in scripts.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — zypper install without -n",
+			input: `zypper install vim`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1450",
+					Message: "`zypper install` without `--non-interactive` (`-n`) hangs in scripts.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1450")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1450.go
+++ b/pkg/katas/zc1450.go
@@ -44,11 +44,11 @@ func checkZC1450(node ast.Node) []Violation {
 		}
 		if hasInstall && !hasNoConfirm {
 			return []Violation{{
-				KataID: "ZC1450",
+				KataID:  "ZC1450",
 				Message: "`pacman -S` without `--noconfirm` hangs in scripts.",
-				Line:   cmd.Token.Line,
-				Column: cmd.Token.Column,
-				Level:  SeverityWarning,
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityWarning,
 			}}
 		}
 	case "zypper":
@@ -65,11 +65,11 @@ func checkZC1450(node ast.Node) []Violation {
 		}
 		if hasInstall && !hasN {
 			return []Violation{{
-				KataID: "ZC1450",
+				KataID:  "ZC1450",
 				Message: "`zypper install` without `--non-interactive` (`-n`) hangs in scripts.",
-				Line:   cmd.Token.Line,
-				Column: cmd.Token.Column,
-				Level:  SeverityWarning,
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityWarning,
 			}}
 		}
 	}

--- a/pkg/katas/zc1450.go
+++ b/pkg/katas/zc1450.go
@@ -1,0 +1,78 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1450",
+		Title:    "`pacman -S` / `zypper install` without non-interactive flag hangs in scripts",
+		Severity: SeverityWarning,
+		Description: "Arch's `pacman -S` waits on confirmation unless `--noconfirm` is passed. " +
+			"SUSE's `zypper install` needs `--non-interactive` (or `-n`). Both stall CI pipelines " +
+			"and Dockerfiles without these flags.",
+		Check: checkZC1450,
+	})
+}
+
+func checkZC1450(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "pacman":
+		hasInstall := false
+		hasNoConfirm := false
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if strings.HasPrefix(v, "-S") && !strings.HasPrefix(v, "-Ss") && !strings.HasPrefix(v, "-Si") {
+				hasInstall = true
+			}
+			if v == "--noconfirm" {
+				hasNoConfirm = true
+			}
+		}
+		if hasInstall && !hasNoConfirm {
+			return []Violation{{
+				KataID: "ZC1450",
+				Message: "`pacman -S` without `--noconfirm` hangs in scripts.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	case "zypper":
+		hasInstall := false
+		hasN := false
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "install" || v == "in" || v == "update" || v == "up" {
+				hasInstall = true
+			}
+			if v == "-n" || v == "--non-interactive" {
+				hasN = true
+			}
+		}
+		if hasInstall && !hasN {
+			return []Violation{{
+				KataID: "ZC1450",
+				Message: "`zypper install` without `--non-interactive` (`-n`) hangs in scripts.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 446 Katas = 0.4.46
-const Version = "0.4.46"
+// 447 Katas = 0.4.47
+const Version = "0.4.47"


### PR DESCRIPTION
ZC1450 — pacman -S needs --noconfirm, zypper needs -n, else scripts hang. Severity: Warning