### PR TITLE
feat: ZC1451 — warn on `pip install` without --user/venv

### DIFF
--- a/pkg/katas/katatests/zc1451_test.go
+++ b/pkg/katas/katatests/zc1451_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1451(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — pip install --user",
+			input:    `pip install --user requests`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — pip install (system-wide)",
+			input: `pip install requests`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1451",
+					Message: "`pip install` without `--user` or an active venv targets system Python. Use `python -m venv` / `uv` / `--user` for scoped installs.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1451")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1451.go
+++ b/pkg/katas/zc1451.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1451",
+		Title:    "Avoid `pip install` without `--user` or virtualenv",
+		Severity: SeverityWarning,
+		Description: "`pip install pkg` (no `--user`, no active venv) targets the system Python, " +
+			"potentially breaking system tools or requiring sudo. On modern Linux this now fails " +
+			"with PEP 668 `externally-managed-environment`. Always use a virtualenv (`python -m " +
+			"venv`, `uv`, `poetry`) or `--user` for scoped installs.",
+		Check: checkZC1451,
+	})
+}
+
+func checkZC1451(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "pip" && ident.Value != "pip3" {
+		return nil
+	}
+
+	hasInstall := false
+	hasUser := false
+	hasBreakSystem := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "install" {
+			hasInstall = true
+		}
+		if v == "--user" {
+			hasUser = true
+		}
+		if v == "--break-system-packages" {
+			hasBreakSystem = true
+		}
+	}
+	if hasInstall && !hasUser && !hasBreakSystem {
+		return []Violation{{
+			KataID: "ZC1451",
+			Message: "`pip install` without `--user` or an active venv targets system Python. " +
+				"Use `python -m venv` / `uv` / `--user` for scoped installs.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 447 Katas = 0.4.47
-const Version = "0.4.47"
+// 448 Katas = 0.4.48
+const Version = "0.4.48"


### PR DESCRIPTION
ZC1451 — System-wide pip install pollutes system Python / fails under PEP 668. Use venv or --user. Severity: Warning