### PR TITLE
feat: ZC1452 — warn on `npm install -g`

### DIFF
--- a/pkg/katas/katatests/zc1452_test.go
+++ b/pkg/katas/katatests/zc1452_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1452(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — npm install local",
+			input:    `npm install react`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — npm install -g",
+			input: `npm install -g typescript`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1452",
+					Message: "`npm install -g` installs system-wide. Prefer project-local install or `npx`/`pnpm dlx` for one-off tools.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1452")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1452.go
+++ b/pkg/katas/zc1452.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1452",
+		Title:    "Avoid `npm install -g` — global installs need root, break under multiple Node versions",
+		Severity: SeverityStyle,
+		Description: "`npm install -g` places packages in a system-wide prefix (typically " +
+			"`/usr/local`). That requires sudo, conflicts with Node version managers (nvm, " +
+			"asdf, volta), and is rarely what you want in a project. Prefer project-local " +
+			"installs (`npm i`), or `pnpm dlx`/`npx` for one-off tools.",
+		Check: checkZC1452,
+	})
+}
+
+func checkZC1452(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "npm" && ident.Value != "yarn" && ident.Value != "pnpm" {
+		return nil
+	}
+
+	hasInstall := false
+	hasGlobal := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "install" || v == "i" || v == "add" {
+			hasInstall = true
+		}
+		if v == "-g" || v == "--global" {
+			hasGlobal = true
+		}
+	}
+	if hasInstall && hasGlobal {
+		return []Violation{{
+			KataID: "ZC1452",
+			Message: "`" + ident.Value + " install -g` installs system-wide. Prefer project-local " +
+				"install or `npx`/`pnpm dlx` for one-off tools.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityStyle,
+		}}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 448 Katas = 0.4.48
-const Version = "0.4.48"
+// 449 Katas = 0.4.49
+const Version = "0.4.49"


### PR DESCRIPTION
ZC1452 — Global npm/yarn/pnpm install needs sudo, breaks with nvm. Use project-local or npx. Severity: Style