### PR TITLE
feat: ZC1453 — warn on `sudo pip/npm/gem` (lang pkg mgr as root)

### DIFF
--- a/pkg/katas/katatests/zc1453_test.go
+++ b/pkg/katas/katatests/zc1453_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1453(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sudo apt-get install",
+			input:    `sudo apt-get install -y curl`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — sudo pip install",
+			input: `sudo pip install requests`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1453",
+					Message: "`sudo pip` runs a language package manager as root. Prefer `--user`, a virtualenv/venv, or a version manager (nvm/pyenv/rbenv).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — sudo npm install -g",
+			input: `sudo npm install -g ts-node`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1453",
+					Message: "`sudo npm` runs a language package manager as root. Prefer `--user`, a virtualenv/venv, or a version manager (nvm/pyenv/rbenv).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1453")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1453.go
+++ b/pkg/katas/zc1453.go
@@ -1,0 +1,47 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1453",
+		Title:    "Avoid `sudo pip` / `sudo npm` / `sudo gem` — language package managers as root",
+		Severity: SeverityWarning,
+		Description: "Running a language package manager as root installs third-party code with " +
+			"full privileges, may overwrite distro-managed libs, and can execute arbitrary " +
+			"install-time hooks as root. Use `--user`, a virtualenv/venv, or a version manager " +
+			"(nvm, pyenv, rbenv) instead.",
+		Check: checkZC1453,
+	})
+}
+
+func checkZC1453(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sudo" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "pip", "pip3", "npm", "yarn", "pnpm", "gem", "cpan", "luarocks":
+			return []Violation{{
+				KataID: "ZC1453",
+				Message: "`sudo " + v + "` runs a language package manager as root. Prefer " +
+					"`--user`, a virtualenv/venv, or a version manager (nvm/pyenv/rbenv).",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 449 Katas = 0.4.49
-const Version = "0.4.49"
+// 450 Katas = 0.4.50
+const Version = "0.4.50"


### PR DESCRIPTION
ZC1453 — sudo + language package managers runs install-hooks as root. Use --user/venv/version mgr. Severity: Warning

450-kata milestone.