### PR TITLE
feat: ZC1454 — warn on `docker/podman run --privileged`

### DIFF
--- a/pkg/katas/katatests/zc1454_test.go
+++ b/pkg/katas/katatests/zc1454_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1454(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker run alpine",
+			input:    `docker run alpine echo hi`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker run --privileged",
+			input: `docker run --privileged alpine sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1454",
+					Message: "`--privileged` disables container isolation — effectively host root. Use `--cap-add` + `--device` for narrow permissions.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1454")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1454.go
+++ b/pkg/katas/zc1454.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1454",
+		Title:    "Avoid `docker/podman run --privileged` — disables most container isolation",
+		Severity: SeverityError,
+		Description: "`--privileged` disables the seccomp profile, grants all Linux capabilities, " +
+			"and lets the container access all host devices. It is effectively equivalent to " +
+			"running the process as host root. Add specific capabilities with `--cap-add` and " +
+			"bind-mount specific devices with `--device` instead.",
+		Check: checkZC1454,
+	})
+}
+
+func checkZC1454(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+
+	hasRun := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "run" || v == "exec" || v == "create" {
+			hasRun = true
+		}
+		if hasRun && v == "--privileged" {
+			return []Violation{{
+				KataID: "ZC1454",
+				Message: "`--privileged` disables container isolation — effectively host root. " +
+					"Use `--cap-add` + `--device` for narrow permissions.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 450 Katas = 0.4.50
-const Version = "0.4.50"
+// 451 Katas = 0.4.51
+const Version = "0.4.51"


### PR DESCRIPTION
ZC1454 — --privileged disables container isolation. Use --cap-add/--device. Severity: Error