### PR TITLE
feat: ZC1455 — warn on `docker run --net=host`

### DIFF
--- a/pkg/katas/katatests/zc1455_test.go
+++ b/pkg/katas/katatests/zc1455_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1455(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker run isolated",
+			input:    `docker run -p 8080:80 alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker run --net=host",
+			input: `docker run --net=host alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1455",
+					Message: "`--net=host` / `--network=host` lets the container reach host-local services. Use `-p` for explicit publishes or dedicated container networks.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1455")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1455.go
+++ b/pkg/katas/zc1455.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1455",
+		Title:    "Avoid `docker run --net=host` / `--network=host` — disables network isolation",
+		Severity: SeverityWarning,
+		Description: "Host networking gives the container direct access to the host's network " +
+			"stack, including localhost services. A vulnerable container can reach services " +
+			"meant to be local-only. Use `-p hostport:containerport` for specific publishes and " +
+			"dedicated networks for inter-container traffic.",
+		Check: checkZC1455,
+	})
+}
+
+func checkZC1455(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--net=host" || v == "--network=host" || v == "-net=host" {
+			return []Violation{{
+				KataID: "ZC1455",
+				Message: "`--net=host` / `--network=host` lets the container reach host-local " +
+					"services. Use `-p` for explicit publishes or dedicated container networks.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 451 Katas = 0.4.51
-const Version = "0.4.51"
+// 452 Katas = 0.4.52
+const Version = "0.4.52"


### PR DESCRIPTION
ZC1455 — Host network namespace gives container full host network access. Use -p for explicit publishes. Severity: Warning