### PR TITLE
feat: ZC1456 — warn on `docker run -v /:...`

### DIFF
--- a/pkg/katas/katatests/zc1456_test.go
+++ b/pkg/katas/katatests/zc1456_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1456(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker run -v local mount",
+			input:    `docker run -v data:/app alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker run -v /:/host",
+			input: `docker run -v /:/host alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1456",
+					Message: "`-v /:...` mounts the host root into the container — trivial container escape. Scope to specific paths.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1456")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1456.go
+++ b/pkg/katas/zc1456.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1456",
+		Title:    "Avoid `docker run -v /:...` — bind-mounts host root into container",
+		Severity: SeverityError,
+		Description: "Mounting `/` (host root) into a container gives the container read/write " +
+			"access to the entire host filesystem — a trivial container escape. Mount only the " +
+			"specific host paths the container needs, using `:ro` for read-only where possible.",
+		Check: checkZC1456,
+	})
+}
+
+func checkZC1456(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+
+	var prevV bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevV {
+			prevV = false
+			// v should be host:container or host:container:opts
+			if strings.HasPrefix(v, "/:") || v == "/" {
+				return []Violation{{
+					KataID: "ZC1456",
+					Message: "`-v /:...` mounts the host root into the container — trivial " +
+						"container escape. Scope to specific paths.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityError,
+				}}
+			}
+		}
+		if v == "-v" || v == "--volume" {
+			prevV = true
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 452 Katas = 0.4.52
-const Version = "0.4.52"
+// 453 Katas = 0.4.53
+const Version = "0.4.53"


### PR DESCRIPTION
ZC1456 — Mounting / into container is a trivial escape. Scope to needed paths. Severity: Error