### PR TITLE
feat: ZC1458 — warn on `docker run --user root/0`

### DIFF
--- a/pkg/katas/katatests/zc1458_test.go
+++ b/pkg/katas/katatests/zc1458_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1458(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker run --user nobody",
+			input:    `docker run --user 1000 alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker run --user root",
+			input: `docker run --user root alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1458",
+					Message: "Explicit root UID inside a container lets container-escape bugs become host root. Use a non-root USER in the image.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — docker run --user 0",
+			input: `docker run --user 0 alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1458",
+					Message: "Explicit root UID inside a container lets container-escape bugs become host root. Use a non-root USER in the image.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1458")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1458.go
+++ b/pkg/katas/zc1458.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1458",
+		Title:    "Warn on explicit `docker run --user root` / `--user 0`",
+		Severity: SeverityWarning,
+		Description: "Running as UID 0 inside a container means a break-out bug leaves the " +
+			"attacker as root on the host (absent user namespaces). Build images with a " +
+			"non-root `USER` directive and avoid overriding to root at runtime.",
+		Check: checkZC1458,
+	})
+}
+
+func checkZC1458(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+
+	var prevU bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevU {
+			prevU = false
+			if v == "root" || v == "0" || strings.HasPrefix(v, "0:") || strings.HasPrefix(v, "root:") {
+				return []Violation{{
+					KataID: "ZC1458",
+					Message: "Explicit root UID inside a container lets container-escape bugs " +
+						"become host root. Use a non-root USER in the image.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+		if v == "-u" || v == "--user" {
+			prevU = true
+		}
+	}
+
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 454 Katas = 0.4.54
-const Version = "0.4.54"
+// 455 Katas = 0.4.55
+const Version = "0.4.55"


### PR DESCRIPTION
ZC1458 — Explicit root inside container = host root on escape. Use non-root USER. Severity: Warning

120-kata session milestone.