### PR TITLE
feat: ZC1459 — warn on docker run --cap-add dangerous capabilities

### DIFF
--- a/pkg/katas/katatests/zc1459_test.go
+++ b/pkg/katas/katatests/zc1459_test.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1459(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker run --cap-add=NET_BIND_SERVICE",
+			input:    `docker run --cap-add=NET_BIND_SERVICE alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker run --cap-add=SYS_ADMIN (equals form)",
+			input: `docker run --cap-add=SYS_ADMIN alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1459",
+					Message: "Dangerous Linux capability granted — breaks the container's security boundary. Prefer `--cap-drop=ALL` and add back only minimum needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — docker run --cap-add SYS_PTRACE (space form)",
+			input: `docker run --cap-add SYS_PTRACE alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1459",
+					Message: "Dangerous Linux capability granted — breaks the container's security boundary. Prefer `--cap-drop=ALL` and add back only minimum needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — podman run --cap-add=ALL",
+			input: `podman run --cap-add=ALL alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1459",
+					Message: "Dangerous Linux capability granted — breaks the container's security boundary. Prefer `--cap-drop=ALL` and add back only minimum needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1459")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1459.go
+++ b/pkg/katas/zc1459.go
@@ -1,0 +1,83 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1459",
+		Title:    "Warn on `docker run --cap-add=SYS_ADMIN` / other dangerous capabilities",
+		Severity: SeverityWarning,
+		Description: "Granting `SYS_ADMIN`, `SYS_PTRACE`, `SYS_MODULE`, `NET_ADMIN`, or `ALL` " +
+			"capabilities effectively disables the container's security boundary — most " +
+			"container escapes rely on exactly these. Drop all capabilities and add back only " +
+			"the specific ones the workload needs (usually none).",
+		Check: checkZC1459,
+	})
+}
+
+var dangerousCaps = map[string]struct{}{
+	"SYS_ADMIN":       {},
+	"SYS_PTRACE":      {},
+	"SYS_MODULE":      {},
+	"SYS_RAWIO":       {},
+	"NET_ADMIN":       {},
+	"DAC_READ_SEARCH": {},
+	"ALL":             {},
+}
+
+func checkZC1459(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+
+	var prevCap bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+
+		// Split form: --cap-add=VALUE
+		if strings.HasPrefix(v, "--cap-add=") {
+			val := strings.TrimPrefix(v, "--cap-add=")
+			if _, bad := dangerousCaps[strings.ToUpper(val)]; bad {
+				return violateZC1459(cmd)
+			}
+			continue
+		}
+
+		// Space form: --cap-add VALUE
+		if prevCap {
+			prevCap = false
+			if _, bad := dangerousCaps[strings.ToUpper(v)]; bad {
+				return violateZC1459(cmd)
+			}
+		}
+		if v == "--cap-add" {
+			prevCap = true
+		}
+	}
+
+	return nil
+}
+
+func violateZC1459(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1459",
+		Message: "Dangerous Linux capability granted — breaks the container's security " +
+			"boundary. Prefer `--cap-drop=ALL` and add back only minimum needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 455 Katas = 0.4.55
-const Version = "0.4.55"
+// 456 Katas = 0.4.56
+const Version = "0.4.56"


### PR DESCRIPTION
## Summary
- Flags `docker run --cap-add=SYS_ADMIN` (or SYS_PTRACE / SYS_MODULE / SYS_RAWIO / NET_ADMIN / DAC_READ_SEARCH / ALL) which breaks the container security boundary
- Handles both `--cap-add=VALUE` and `--cap-add VALUE` forms
- Applies to `docker` and `podman`

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.56 (456 katas)