### PR TITLE
feat: ZC1460 — warn on docker run --security-opt seccomp/apparmor=unconfined

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,3 +1,5 @@
 [default.extend-words]
 # DoubleBracketExpression abbreviated as dbe in AST node names
 dbe = "dbe"
+# mke2fs is the canonical GNU ext2/3/4 filesystem creation tool
+mke2fs = "mke2fs"

--- a/pkg/katas/katatests/zc1460_test.go
+++ b/pkg/katas/katatests/zc1460_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1460(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker run with no security-opt",
+			input:    `docker run alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — docker run --security-opt=no-new-privileges",
+			input:    `docker run --security-opt=no-new-privileges alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker run --security-opt seccomp=unconfined (space form)",
+			input: `docker run --security-opt seccomp=unconfined alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1460",
+					Message: "Disabling seccomp or AppArmor removes the main syscall/MAC filter that blocks container escapes. Keep the default profile.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — docker run --security-opt=apparmor=unconfined (equals form)",
+			input: `docker run --security-opt=apparmor=unconfined alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1460",
+					Message: "Disabling seccomp or AppArmor removes the main syscall/MAC filter that blocks container escapes. Keep the default profile.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1460")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1460.go
+++ b/pkg/katas/zc1460.go
@@ -1,0 +1,78 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1460",
+		Title:    "Warn on `docker run --security-opt seccomp=unconfined` / `apparmor=unconfined`",
+		Severity: SeverityWarning,
+		Description: "Disabling seccomp or AppArmor removes the syscall / MAC filter that blocks " +
+			"most container escape exploits. Only disable these in a known-safe development " +
+			"context; production workloads should keep the default profile or ship a stricter " +
+			"custom profile.",
+		Check: checkZC1460,
+	})
+}
+
+func checkZC1460(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+
+	var prevOpt bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+
+		if strings.HasPrefix(v, "--security-opt=") {
+			val := strings.TrimPrefix(v, "--security-opt=")
+			if isUnconfined(val) {
+				return violateZC1460(cmd)
+			}
+			continue
+		}
+
+		if prevOpt {
+			prevOpt = false
+			if isUnconfined(v) {
+				return violateZC1460(cmd)
+			}
+		}
+		if v == "--security-opt" {
+			prevOpt = true
+		}
+	}
+
+	return nil
+}
+
+func isUnconfined(v string) bool {
+	return v == "seccomp=unconfined" ||
+		v == "apparmor=unconfined" ||
+		v == "seccomp:unconfined" ||
+		v == "apparmor:unconfined"
+}
+
+func violateZC1460(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1460",
+		Message: "Disabling seccomp or AppArmor removes the main syscall/MAC filter that " +
+			"blocks container escapes. Keep the default profile.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 456 Katas = 0.4.56
-const Version = "0.4.56"
+// 457 Katas = 0.4.57
+const Version = "0.4.57"


### PR DESCRIPTION
## Summary
- Flags `docker run --security-opt seccomp=unconfined` or `apparmor=unconfined` — disables the syscall/MAC filter that stops most container escape exploits
- Supports both `--security-opt=VALUE` and `--security-opt VALUE` forms (docker, podman)
- Also whitelists `mke2fs` in `_typos.toml` (legitimate GNU ext2/3/4 tool surfaced by ZC1424 in prior PR CI)

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.57 (457 katas)