### PR TITLE
feat: ZC1461 — avoid docker run --pid=host (shared host PID ns)

### DIFF
--- a/pkg/katas/katatests/zc1461_test.go
+++ b/pkg/katas/katatests/zc1461_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1461(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker run without --pid",
+			input:    `docker run alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — docker run --pid=container:other",
+			input:    `docker run --pid=container:abc alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker run --pid=host (equals form)",
+			input: `docker run --pid=host alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1461",
+					Message: "`--pid=host` shares the host PID namespace — container can signal and inspect every host process. Avoid outside debug tools.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — podman run --pid host (space form)",
+			input: `podman run --pid host alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1461",
+					Message: "`--pid=host` shares the host PID namespace — container can signal and inspect every host process. Avoid outside debug tools.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1461")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1461.go
+++ b/pkg/katas/zc1461.go
@@ -1,0 +1,64 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1461",
+		Title:    "Avoid `docker run --pid=host` — shares host PID namespace with the container",
+		Severity: SeverityWarning,
+		Description: "`--pid=host` lets the container see every host process and send signals to " +
+			"them, including sending SIGKILL to init-managed daemons or attaching a debugger to " +
+			"host-side processes. Use only for diagnostic tools (e.g. strace/perf containers) and " +
+			"never for general workloads.",
+		Check: checkZC1461,
+	})
+}
+
+func checkZC1461(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+
+	var prevPid bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+
+		if v == "--pid=host" {
+			return violateZC1461(cmd)
+		}
+		if prevPid {
+			prevPid = false
+			if v == "host" {
+				return violateZC1461(cmd)
+			}
+		}
+		if v == "--pid" {
+			prevPid = true
+		}
+	}
+
+	return nil
+}
+
+func violateZC1461(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1461",
+		Message: "`--pid=host` shares the host PID namespace — container can signal and " +
+			"inspect every host process. Avoid outside debug tools.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 457 Katas = 0.4.57
-const Version = "0.4.57"
+// 458 Katas = 0.4.58
+const Version = "0.4.58"


### PR DESCRIPTION
## Summary
- Flags `docker run --pid=host` / `docker run --pid host` — container can see and signal every host process (including init)
- Applies to `docker` and `podman`
- Ignores container-scoped forms like `--pid=container:abc`

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.58 (458 katas)