### PR TITLE
feat: ZC1462 — avoid docker run --ipc=host (shared host IPC ns)

### DIFF
--- a/pkg/katas/katatests/zc1462_test.go
+++ b/pkg/katas/katatests/zc1462_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1462(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker run without --ipc",
+			input:    `docker run alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — docker run --ipc=shareable",
+			input:    `docker run --ipc=shareable alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker run --ipc=host (equals form)",
+			input: `docker run --ipc=host alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1462",
+					Message: "`--ipc=host` shares host shared memory and SysV IPC with the container — trivial data theft and side-channel vector. Use the default private IPC.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — podman run --ipc host (space form)",
+			input: `podman run --ipc host alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1462",
+					Message: "`--ipc=host` shares host shared memory and SysV IPC with the container — trivial data theft and side-channel vector. Use the default private IPC.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1462")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1462.go
+++ b/pkg/katas/zc1462.go
@@ -1,0 +1,64 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1462",
+		Title:    "Avoid `docker run --ipc=host` — shares host IPC namespace (/dev/shm, SysV IPC)",
+		Severity: SeverityWarning,
+		Description: "`--ipc=host` makes the container share `/dev/shm` and the SysV IPC keyspace " +
+			"with the host. Any process on the host can read/write the container's shared memory " +
+			"(and vice-versa), making side-channel and data-theft attacks trivial. Use the default " +
+			"private IPC namespace unless two containers explicitly need to share IPC.",
+		Check: checkZC1462,
+	})
+}
+
+func checkZC1462(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+
+	var prevIpc bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+
+		if v == "--ipc=host" {
+			return violateZC1462(cmd)
+		}
+		if prevIpc {
+			prevIpc = false
+			if v == "host" {
+				return violateZC1462(cmd)
+			}
+		}
+		if v == "--ipc" {
+			prevIpc = true
+		}
+	}
+
+	return nil
+}
+
+func violateZC1462(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1462",
+		Message: "`--ipc=host` shares host shared memory and SysV IPC with the container — " +
+			"trivial data theft and side-channel vector. Use the default private IPC.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 458 Katas = 0.4.58
-const Version = "0.4.58"
+// 459 Katas = 0.4.59
+const Version = "0.4.59"


### PR DESCRIPTION
## Summary
- Flags `docker run --ipc=host` / `--ipc host` — shares `/dev/shm` and SysV IPC with the host (side-channel, data theft)
- Applies to `docker` and `podman`
- Ignores other modes (`shareable`, `private`, `container:X`)

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.59 (459 katas)