### PR TITLE
feat: ZC1463 — avoid docker run --userns=host (disables user-ns remap)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,5 +1,7 @@
 [default.extend-words]
 # DoubleBracketExpression abbreviated as dbe in AST node names
 dbe = "dbe"
+
+[default.extend-identifiers]
 # mke2fs is the canonical GNU ext2/3/4 filesystem creation tool
 mke2fs = "mke2fs"

--- a/pkg/katas/katatests/zc1463_test.go
+++ b/pkg/katas/katatests/zc1463_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1463(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker run without --userns",
+			input:    `docker run alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — docker run --userns=keep-id",
+			input:    `podman run --userns=keep-id alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker run --userns=host",
+			input: `docker run --userns=host alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1463",
+					Message: "`--userns=host` disables user-namespace remap — UID 0 in the container == UID 0 on the host. Leave the default remap on.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — podman run --userns host",
+			input: `podman run --userns host alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1463",
+					Message: "`--userns=host` disables user-namespace remap — UID 0 in the container == UID 0 on the host. Leave the default remap on.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1463")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1463.go
+++ b/pkg/katas/zc1463.go
@@ -1,0 +1,64 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1463",
+		Title:    "Avoid `docker run --userns=host` — disables user-namespace remapping",
+		Severity: SeverityWarning,
+		Description: "`--userns=host` turns off the user-namespace remap, meaning UID 0 in the " +
+			"container maps to UID 0 on the host. Combined with any of the `--cap-add`, " +
+			"`--privileged`, or bind-mount footguns, this becomes a direct host-root escalation. " +
+			"Leave the default (container-side remap) enabled.",
+		Check: checkZC1463,
+	})
+}
+
+func checkZC1463(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+
+	var prevNs bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+
+		if v == "--userns=host" {
+			return violateZC1463(cmd)
+		}
+		if prevNs {
+			prevNs = false
+			if v == "host" {
+				return violateZC1463(cmd)
+			}
+		}
+		if v == "--userns" {
+			prevNs = true
+		}
+	}
+
+	return nil
+}
+
+func violateZC1463(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1463",
+		Message: "`--userns=host` disables user-namespace remap — UID 0 in the container == " +
+			"UID 0 on the host. Leave the default remap on.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 459 Katas = 0.4.59
-const Version = "0.4.59"
+// 460 Katas = 0.4.60
+const Version = "0.4.60"


### PR DESCRIPTION
## Summary
- Flags `docker run --userns=host` / `--userns host` — disables UID remap, makes UID 0 in container == UID 0 on host
- Applies to `docker` and `podman`
- Ignores container-scoped values (`keep-id`, `private`, etc.)
- Moves `mke2fs` typos entry from `extend-words` to `extend-identifiers` so the `mke` digit-prefix no longer flags as typo of `make`

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.60 (460 katas)