### PR TITLE
feat: ZC1464 — warn on iptables -F / -P INPUT ACCEPT (firewall weakening)

### DIFF
--- a/pkg/katas/katatests/zc1464_test.go
+++ b/pkg/katas/katatests/zc1464_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1464(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — iptables -A INPUT -j DROP",
+			input:    `iptables -A INPUT -j DROP`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — iptables -P INPUT DROP",
+			input:    `iptables -P INPUT DROP`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — iptables-save > backup",
+			input:    `iptables -S`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — iptables -F (flush all)",
+			input: `iptables -F`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1464",
+					Message: "Firewall hardening weakened (flushing all firewall rules). Keep default-drop and use atomic reload.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — iptables -P INPUT ACCEPT",
+			input: `iptables -P INPUT ACCEPT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1464",
+					Message: "Firewall hardening weakened (default-ACCEPT policy on INPUT chain). Keep default-drop and use atomic reload.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ip6tables -F",
+			input: `ip6tables -F`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1464",
+					Message: "Firewall hardening weakened (flushing all firewall rules). Keep default-drop and use atomic reload.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1464")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1464.go
+++ b/pkg/katas/zc1464.go
@@ -1,0 +1,64 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1464",
+		Title:    "Warn on `iptables -F` / `-P INPUT ACCEPT` — flushes or opens the host firewall",
+		Severity: SeverityWarning,
+		Description: "Flushing all rules (`-F`) or setting the default INPUT/FORWARD policy to " +
+			"ACCEPT leaves the host with no network filter. This is rarely correct outside a " +
+			"first-boot provisioning script, and is a frequent post-compromise persistence step. " +
+			"Use `iptables-save`/`iptables-restore` for atomic reloads and keep a default-drop " +
+			"policy on all hook chains.",
+		Check: checkZC1464,
+	})
+}
+
+func checkZC1464(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "iptables" && ident.Value != "ip6tables" && ident.Value != "nft" {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, arg := range cmd.Arguments {
+		args = append(args, arg.String())
+	}
+
+	// Catch: `iptables -F` (no chain) — flushes everything
+	// Catch: `iptables -P INPUT ACCEPT` / `-P FORWARD ACCEPT`
+	for i, a := range args {
+		if a == "-F" || a == "--flush" {
+			return violateZC1464(cmd, "flushing all firewall rules")
+		}
+		if (a == "-P" || a == "--policy") && i+2 < len(args) && args[i+2] == "ACCEPT" {
+			chain := args[i+1]
+			if chain == "INPUT" || chain == "FORWARD" {
+				return violateZC1464(cmd, "default-ACCEPT policy on "+chain+" chain")
+			}
+		}
+	}
+	return nil
+}
+
+func violateZC1464(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID:  "ZC1464",
+		Message: "Firewall hardening weakened (" + what + "). Keep default-drop and use atomic reload.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 460 Katas = 0.4.60
-const Version = "0.4.60"
+// 461 Katas = 0.4.61
+const Version = "0.4.61"


### PR DESCRIPTION
## Summary
- Flags `iptables -F` (flush all) and `iptables -P INPUT/FORWARD ACCEPT` (default-accept policy)
- Covers `iptables`, `ip6tables`, and `nft`
- Rules with explicit chain scoping (`iptables -F INPUT`) could be legitimate — out of scope for now

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.61 (461 katas)