### PR TITLE
feat: ZC1465 — warn on setenforce 0 (disables SELinux enforcement)

### DIFF
--- a/pkg/katas/katatests/zc1465_test.go
+++ b/pkg/katas/katatests/zc1465_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1465(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — setenforce 1",
+			input:    `setenforce 1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — setenforce Enforcing",
+			input:    `setenforce Enforcing`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — setenforce 0",
+			input: `setenforce 0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1465",
+					Message: "`setenforce 0` disables SELinux enforcement host-wide. Fix the AVC with `audit2allow` instead and keep enforcing mode on.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — setenforce Permissive",
+			input: `setenforce Permissive`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1465",
+					Message: "`setenforce 0` disables SELinux enforcement host-wide. Fix the AVC with `audit2allow` instead and keep enforcing mode on.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1465")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1465.go
+++ b/pkg/katas/zc1465.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1465",
+		Title:    "Warn on `setenforce 0` — disables SELinux enforcement",
+		Severity: SeverityWarning,
+		Description: "`setenforce 0` switches SELinux to permissive mode, silencing every policy " +
+			"decision into an audit log line instead of a deny. It is the textbook post-" +
+			"compromise persistence step and also a common \"fix\" that papers over an actual " +
+			"policy bug. Address the specific AVC with `audit2allow` instead, and leave " +
+			"`setenforce 1` (enforcing) in production.",
+		Check: checkZC1465,
+	})
+}
+
+func checkZC1465(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "setenforce" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	v := cmd.Arguments[0].String()
+	if v == "0" || v == "Permissive" || v == "permissive" {
+		return []Violation{{
+			KataID: "ZC1465",
+			Message: "`setenforce 0` disables SELinux enforcement host-wide. Fix the AVC with " +
+				"`audit2allow` instead and keep enforcing mode on.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 461 Katas = 0.4.61
-const Version = "0.4.61"
+// 462 Katas = 0.4.62
+const Version = "0.4.62"


### PR DESCRIPTION
## Summary
- Flags `setenforce 0` / `setenforce Permissive` — disables SELinux enforcing mode host-wide
- Suggestion: use `audit2allow` for the specific AVC instead of going permissive

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.62 (462 katas)