### PR TITLE
feat: ZC1466 — warn on disabling the host firewall

### DIFF
--- a/pkg/katas/katatests/zc1466_test.go
+++ b/pkg/katas/katatests/zc1466_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1466(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ufw allow 22",
+			input:    `ufw allow 22`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — systemctl start firewalld",
+			input:    `systemctl start firewalld`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ufw disable",
+			input: `ufw disable`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1466",
+					Message: "Host firewall disabled (ufw disable). Keep it on and open specific ports.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — systemctl stop firewalld",
+			input: `systemctl stop firewalld`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1466",
+					Message: "Host firewall disabled (systemctl stop firewalld). Keep it on and open specific ports.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — systemctl mask ufw.service",
+			input: `systemctl mask ufw.service`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1466",
+					Message: "Host firewall disabled (systemctl mask ufw.service). Keep it on and open specific ports.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1466")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1466.go
+++ b/pkg/katas/zc1466.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1466",
+		Title:    "Warn on disabling the host firewall (`ufw disable` / `systemctl stop firewalld`)",
+		Severity: SeverityWarning,
+		Description: "Disabling the host firewall leaves every listening port reachable from " +
+			"every network the host is on. This is a common \"just make it work\" shortcut that " +
+			"has shipped to production more than once. Keep the firewall running and open the " +
+			"specific port with `ufw allow <port>` / `firewall-cmd --add-port=<port>/tcp`.",
+		Check: checkZC1466,
+	})
+}
+
+func checkZC1466(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value == "ufw" && len(cmd.Arguments) >= 1 {
+		if cmd.Arguments[0].String() == "disable" {
+			return violateZC1466(cmd, "ufw disable")
+		}
+	}
+
+	if ident.Value == "systemctl" && len(cmd.Arguments) >= 2 {
+		verb := cmd.Arguments[0].String()
+		unit := cmd.Arguments[1].String()
+		if (verb == "stop" || verb == "disable" || verb == "mask") &&
+			(unit == "firewalld" || unit == "firewalld.service" ||
+				unit == "ufw" || unit == "ufw.service" ||
+				unit == "nftables" || unit == "nftables.service" ||
+				unit == "iptables" || unit == "iptables.service") {
+			return violateZC1466(cmd, "systemctl "+verb+" "+unit)
+		}
+	}
+
+	return nil
+}
+
+func violateZC1466(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID:  "ZC1466",
+		Message: "Host firewall disabled (" + what + "). Keep it on and open specific ports.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 462 Katas = 0.4.62
-const Version = "0.4.62"
+// 463 Katas = 0.4.63
+const Version = "0.4.63"


### PR DESCRIPTION
## Summary
- Flags `ufw disable` — hard off for UFW
- Flags `systemctl stop|disable|mask` for `firewalld`, `ufw`, `nftables`, `iptables` (with or without `.service`)
- Leaves `systemctl start|enable` alone

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.63 (463 katas)