### PR TITLE
feat: ZC1467 — error on sysctl kernel.core_pattern pipe / kernel.modprobe override

### DIFF
--- a/pkg/katas/katatests/zc1467_test.go
+++ b/pkg/katas/katatests/zc1467_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1467(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sysctl -w vm.swappiness=10",
+			input:    `sysctl -w vm.swappiness=10`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — sysctl -w kernel.core_pattern=core",
+			input:    `sysctl -w kernel.core_pattern=core`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — sysctl -w kernel.modprobe=/sbin/modprobe",
+			input:    `sysctl -w kernel.modprobe=/sbin/modprobe`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — sysctl -w 'kernel.core_pattern=|/tmp/x'",
+			input: `sysctl -w 'kernel.core_pattern=|/tmp/x'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1467",
+					Message: "Kernel hijack vector (kernel.core_pattern pipe handler) — next crash / module load runs attacker-supplied binary as root.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — sysctl -w kernel.modprobe=/tmp/foo",
+			input: `sysctl -w kernel.modprobe=/tmp/foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1467",
+					Message: "Kernel hijack vector (kernel.modprobe override) — next crash / module load runs attacker-supplied binary as root.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1467")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1467.go
+++ b/pkg/katas/zc1467.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1467",
+		Title:    "Warn on `sysctl -w kernel.core_pattern=|...` / `kernel.modprobe=...` (kernel hijack)",
+		Severity: SeverityError,
+		Description: "Writing `kernel.core_pattern` to a pipe handler or `kernel.modprobe` to a " +
+			"user-writable path is a textbook privilege-escalation trick: the next crashing " +
+			"setuid process (or the next auto-load of an absent module) executes the supplied " +
+			"binary as root. Keep `core_pattern` set to `core` or `systemd-coredump` and leave " +
+			"`kernel.modprobe` at the distro default (`/sbin/modprobe`).",
+		Check: checkZC1467,
+	})
+}
+
+func checkZC1467(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "sysctl" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := stripOuterQuotes(arg.String())
+		// Accept both `key=value` and `-w key=value` — `-w` shows up as its own arg.
+		k, val, ok := strings.Cut(v, "=")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		val = stripOuterQuotes(val)
+		if k == "kernel.core_pattern" && strings.HasPrefix(val, "|") {
+			return zc1467Violation(cmd, "kernel.core_pattern pipe handler")
+		}
+		if k == "kernel.modprobe" && val != "" && val != "/sbin/modprobe" {
+			return zc1467Violation(cmd, "kernel.modprobe override")
+		}
+	}
+	return nil
+}
+
+func stripOuterQuotes(s string) string {
+	if len(s) >= 2 {
+		first, last := s[0], s[len(s)-1]
+		if (first == '\'' && last == '\'') || (first == '"' && last == '"') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+func zc1467Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1467",
+		Message: "Kernel hijack vector (" + what + ") — next crash / module load runs " +
+			"attacker-supplied binary as root.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 463 Katas = 0.4.63
-const Version = "0.4.63"
+// 464 Katas = 0.4.64
+const Version = "0.4.64"


### PR DESCRIPTION
## Summary
- Flags `sysctl -w kernel.core_pattern='|/tmp/x'` — pipe handler becomes root on next crash of a setuid process
- Flags `sysctl -w kernel.modprobe=/tmp/foo` — swap the auto-module loader with attacker-controlled binary
- Severity: Error (direct privesc vector)

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.64 (464 katas)