### PR TITLE
feat: ZC1468 — error on apt --allow-unauthenticated / --force-yes

### DIFF
--- a/pkg/katas/katatests/zc1468_test.go
+++ b/pkg/katas/katatests/zc1468_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1468(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — apt-get install curl",
+			input:    `apt-get install curl`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — apt-get install -y curl",
+			input:    `apt-get install -y curl`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — apt-get install --allow-unauthenticated curl",
+			input: `apt-get install --allow-unauthenticated curl`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1468",
+					Message: "APT installing unsigned or override-policy packages (--allow-unauthenticated) — disables signature verification, MITM-to-root trivial.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — apt-get install --force-yes foo",
+			input: `apt-get install --force-yes foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1468",
+					Message: "APT installing unsigned or override-policy packages (--force-yes) — disables signature verification, MITM-to-root trivial.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — apt install --allow-downgrades foo",
+			input: `apt install --allow-downgrades foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1468",
+					Message: "APT installing unsigned or override-policy packages (--allow-downgrades) — disables signature verification, MITM-to-root trivial.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1468")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1468.go
+++ b/pkg/katas/zc1468.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1468",
+		Title:    "Error on apt `--allow-unauthenticated` / `--force-yes` — installs unsigned packages",
+		Severity: SeverityError,
+		Description: "`--allow-unauthenticated` and the deprecated `--force-yes` disable APT's " +
+			"package-signature verification, turning any MITM or typo-squat into arbitrary " +
+			"code execution as root. Always sign internal packages and leave verification on.",
+		Check: checkZC1468,
+	})
+}
+
+func checkZC1468(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "apt" && ident.Value != "apt-get" && ident.Value != "aptitude" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--allow-unauthenticated" ||
+			v == "--force-yes" ||
+			v == "--allow-downgrades" ||
+			v == "--allow-remove-essential" ||
+			v == "--allow-change-held-packages" {
+			return []Violation{{
+				KataID: "ZC1468",
+				Message: "APT installing unsigned or override-policy packages (" + v + ") — " +
+					"disables signature verification, MITM-to-root trivial.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 464 Katas = 0.4.64
-const Version = "0.4.64"
+// 465 Katas = 0.4.65
+const Version = "0.4.65"


### PR DESCRIPTION
## Summary
- Flags apt/apt-get/aptitude when run with `--allow-unauthenticated`, `--force-yes`, `--allow-downgrades`, `--allow-remove-essential`, or `--allow-change-held-packages`
- Severity: Error (disables package signature verification → direct MITM-to-root)

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.65 (465 katas)