### PR TITLE
feat: ZC1469 — error on dnf/yum --nogpgcheck / rpm --nosignature

### DIFF
--- a/pkg/katas/katatests/zc1469_test.go
+++ b/pkg/katas/katatests/zc1469_test.go
@@ -1,0 +1,82 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1469(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — dnf install curl",
+			input:    `dnf install curl`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — rpm -i package.rpm",
+			input:    `rpm -i package.rpm`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — dnf install --nogpgcheck foo",
+			input: `dnf install --nogpgcheck foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1469",
+					Message: "Package signature verification disabled (dnf --nogpgcheck) — any mirror / MITM becomes immediate root.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — yum install --nogpgcheck foo",
+			input: `yum install --nogpgcheck foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1469",
+					Message: "Package signature verification disabled (yum --nogpgcheck) — any mirror / MITM becomes immediate root.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — rpm -i --nosignature foo.rpm",
+			input: `rpm -i --nosignature foo.rpm`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1469",
+					Message: "Package signature verification disabled (rpm --nosignature) — any mirror / MITM becomes immediate root.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — zypper install --no-gpg-checks foo",
+			input: `zypper install --no-gpg-checks foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1469",
+					Message: "Package signature verification disabled (zypper --no-gpg-checks) — any mirror / MITM becomes immediate root.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1469")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1469.go
+++ b/pkg/katas/zc1469.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1469",
+		Title:    "Error on `dnf/yum --nogpgcheck` or `rpm --nosignature` (unsigned RPM install)",
+		Severity: SeverityError,
+		Description: "`--nogpgcheck` / `--nosignature` / `--nodigest` disable RPM package " +
+			"signature and digest verification. This turns every mirror, cache, or MITM into a " +
+			"direct root compromise. Always keep GPG/signature checking on; sign internal repos " +
+			"with your own key.",
+		Check: checkZC1469,
+	})
+}
+
+func checkZC1469(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "dnf", "yum", "microdnf", "zypper":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "--nogpgcheck" || v == "--no-gpg-checks" {
+				return zc1469Violation(cmd, ident.Value+" "+v)
+			}
+		}
+	case "rpm", "rpmbuild":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "--nosignature" || v == "--nodigest" || v == "--nofiledigest" ||
+				v == "--noverify" || v == "--nochecksum" {
+				return zc1469Violation(cmd, ident.Value+" "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1469Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1469",
+		Message: "Package signature verification disabled (" + what + ") — any mirror / MITM " +
+			"becomes immediate root.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 465 Katas = 0.4.65
-const Version = "0.4.65"
+// 466 Katas = 0.4.66
+const Version = "0.4.66"


### PR DESCRIPTION
## Summary
- Flags dnf/yum/microdnf/zypper with `--nogpgcheck` or `--no-gpg-checks`
- Flags rpm/rpmbuild with `--nosignature`, `--nodigest`, `--nofiledigest`, `--noverify`, `--nochecksum`
- Severity: Error — direct MITM-to-root

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.66 (466 katas)