### PR TITLE
feat: ZC1470 — error on git http.sslVerify=false (MITM-to-root on clone)

### DIFF
--- a/pkg/katas/katatests/zc1470_test.go
+++ b/pkg/katas/katatests/zc1470_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1470(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — git clone https",
+			input:    `git clone https://example.com/x.git`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — git config http.sslVerify true",
+			input:    `git config http.sslVerify true`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — git config http.sslVerify false",
+			input: `git config http.sslVerify false`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1470",
+					Message: "`http.sslVerify=false` disables TLS verification — any MITM swaps the clone for attacker code. Fix the CA instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — git config --global http.sslVerify false",
+			input: `git config --global http.sslVerify false`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1470",
+					Message: "`http.sslVerify=false` disables TLS verification — any MITM swaps the clone for attacker code. Fix the CA instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — git -c http.sslVerify=false clone",
+			input: `git -c http.sslVerify=false clone https://example.com/x.git`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1470",
+					Message: "`http.sslVerify=false` disables TLS verification — any MITM swaps the clone for attacker code. Fix the CA instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1470")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1470.go
+++ b/pkg/katas/zc1470.go
@@ -1,0 +1,82 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1470",
+		Title:    "Error on `git config http.sslVerify false` / `git -c http.sslVerify=false`",
+		Severity: SeverityError,
+		Description: "Disabling `http.sslVerify` in git means every subsequent fetch / clone " +
+			"accepts any TLS certificate — MITM trivially replaces the tree you are cloning with " +
+			"attacker-controlled code. Fix the broken CA instead: install the certificate, " +
+			"point at the right store with `GIT_SSL_CAINFO`, or use an SSH transport.",
+		Check: checkZC1470,
+	})
+}
+
+func checkZC1470(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "git" {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, a.String())
+	}
+
+	// Form A: `git config [--global|--local|--system] http.sslVerify false`
+	for i := 0; i < len(args); i++ {
+		if args[i] == "config" {
+			// Walk following args, skip scope flag if present.
+			j := i + 1
+			for j < len(args) && strings.HasPrefix(args[j], "--") && args[j] != "--" {
+				j++
+			}
+			if j+1 < len(args) && strings.EqualFold(args[j], "http.sslVerify") {
+				if strings.EqualFold(args[j+1], "false") || args[j+1] == "0" {
+					return zc1470Violation(cmd)
+				}
+			}
+		}
+	}
+
+	// Form B: `git -c http.sslVerify=false ...`
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-c" && i+1 < len(args) {
+			kv := args[i+1]
+			if k, v, ok := strings.Cut(kv, "="); ok {
+				if strings.EqualFold(k, "http.sslVerify") &&
+					(strings.EqualFold(v, "false") || v == "0") {
+					return zc1470Violation(cmd)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func zc1470Violation(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1470",
+		Message: "`http.sslVerify=false` disables TLS verification — any MITM swaps the " +
+			"clone for attacker code. Fix the CA instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 466 Katas = 0.4.66
-const Version = "0.4.66"
+// 467 Katas = 0.4.67
+const Version = "0.4.67"


### PR DESCRIPTION
## Summary
- Flags `git config [--global|--local|--system] http.sslVerify false`
- Flags `git -c http.sslVerify=false <cmd>` (one-shot)
- Case-insensitive on config key; accepts `false` and `0`
- Severity: Error — clone becomes attacker code on MITM

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.67 (467 katas)