### PR TITLE
feat: ZC1471 — error on kubectl/helm/oc --insecure-skip-tls-verify

### DIFF
--- a/pkg/katas/katatests/zc1471_test.go
+++ b/pkg/katas/katatests/zc1471_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1471(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — kubectl get pods",
+			input:    `kubectl get pods`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — helm install nginx bitnami/nginx",
+			input:    `helm install nginx bitnami/nginx`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — kubectl get pods --insecure-skip-tls-verify",
+			input: `kubectl get pods --insecure-skip-tls-verify`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1471",
+					Message: "`--insecure-skip-tls-verify` turns off API-server certificate verification — MITM steals every secret. Fix the CA bundle instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — helm install --insecure-skip-tls-verify=true foo",
+			input: `helm install --insecure-skip-tls-verify=true foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1471",
+					Message: "`--insecure-skip-tls-verify` turns off API-server certificate verification — MITM steals every secret. Fix the CA bundle instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — oc login --insecure-skip-tls-verify=true",
+			input: `oc login --insecure-skip-tls-verify=true https://cluster`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1471",
+					Message: "`--insecure-skip-tls-verify` turns off API-server certificate verification — MITM steals every secret. Fix the CA bundle instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1471")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1471.go
+++ b/pkg/katas/zc1471.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1471",
+		Title:    "Error on `kubectl/helm --insecure-skip-tls-verify` (cluster MITM)",
+		Severity: SeverityError,
+		Description: "`--insecure-skip-tls-verify` tells kubectl / helm to accept any certificate " +
+			"from the API server. Against a production cluster, this hands every secret and " +
+			"admission payload to a MITM. Fix the trust chain: point `--certificate-authority` " +
+			"at the right CA bundle, or restore `KUBECONFIG` with the cluster's embedded CA.",
+		Check: checkZC1471,
+	})
+}
+
+func checkZC1471(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kubectl" && ident.Value != "helm" && ident.Value != "oc" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--insecure-skip-tls-verify" ||
+			v == "--insecure-skip-tls-verify=true" ||
+			v == "--kube-insecure-skip-tls-verify" {
+			return []Violation{{
+				KataID: "ZC1471",
+				Message: "`--insecure-skip-tls-verify` turns off API-server certificate " +
+					"verification — MITM steals every secret. Fix the CA bundle instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 467 Katas = 0.4.67
-const Version = "0.4.67"
+// 468 Katas = 0.4.68
+const Version = "0.4.68"


### PR DESCRIPTION
## Summary
- Flags `kubectl|helm|oc` with `--insecure-skip-tls-verify` (flag-after-subcommand) or `--insecure-skip-tls-verify=true`
- Parser limitation: flag-before-subcommand is swallowed as command name, so that form is out of scope
- Severity: Error — cluster secrets leak to MITM

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.68 (468 katas)