### PR TITLE
feat: ZC1472 — error on aws s3 --acl public-read / public-read-write

### DIFF
--- a/pkg/katas/katatests/zc1472_test.go
+++ b/pkg/katas/katatests/zc1472_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1472(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — aws s3 cp file bucket without ACL",
+			input:    `aws s3 cp file s3://bucket/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — aws s3 cp --acl private",
+			input:    `aws s3 cp file s3://bucket/ --acl private`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — aws s3 cp --acl public-read",
+			input: `aws s3 cp file s3://bucket/ --acl public-read`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1472",
+					Message: "Canned ACL `public-read` makes the object (often the bucket) world-readable. Use a scoped bucket policy instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — aws s3 sync --acl=public-read-write",
+			input: `aws s3 sync ./ s3://bucket/ --acl=public-read-write`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1472",
+					Message: "Canned ACL `public-read-write` makes the object (often the bucket) world-readable. Use a scoped bucket policy instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — aws s3api put-bucket-acl --acl public-read",
+			input: `aws s3api put-bucket-acl --bucket foo --acl public-read`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1472",
+					Message: "Canned ACL `public-read` makes the object (often the bucket) world-readable. Use a scoped bucket policy instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1472")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1472.go
+++ b/pkg/katas/zc1472.go
@@ -1,0 +1,69 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1472",
+		Title:    "Error on `aws s3 --acl public-read` / `public-read-write` (public bucket)",
+		Severity: SeverityError,
+		Description: "Using the `public-read` or `public-read-write` canned ACL when uploading, " +
+			"syncing, or setting a bucket policy makes the object (and often the bucket) readable " +
+			"by anyone on the internet. Prefer bucket policies scoped to specific principals, or " +
+			"CloudFront with Origin Access Identity if you truly need public read.",
+		Check: checkZC1472,
+	})
+}
+
+func checkZC1472(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "aws" {
+		return nil
+	}
+
+	// Must see `s3` or `s3api` service argument anywhere before `--acl`.
+	var sawService bool
+	var prevAcl bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "s3" || v == "s3api" {
+			sawService = true
+		}
+		if !sawService {
+			continue
+		}
+		if prevAcl {
+			prevAcl = false
+			if v == "public-read" || v == "public-read-write" {
+				return zc1472Violation(cmd, v)
+			}
+		}
+		if v == "--acl" {
+			prevAcl = true
+		}
+		if v == "--acl=public-read" || v == "--acl=public-read-write" {
+			return zc1472Violation(cmd, v[len("--acl="):])
+		}
+	}
+	return nil
+}
+
+func zc1472Violation(cmd *ast.SimpleCommand, acl string) []Violation {
+	return []Violation{{
+		KataID:  "ZC1472",
+		Message: "Canned ACL `" + acl + "` makes the object (often the bucket) world-readable. Use a scoped bucket policy instead.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 468 Katas = 0.4.68
-const Version = "0.4.68"
+// 469 Katas = 0.4.69
+const Version = "0.4.69"


### PR DESCRIPTION
## Summary
- Flags canned ACLs `public-read` / `public-read-write` on `aws s3 cp|sync|mv|cp|presign` and `aws s3api put-bucket-acl / put-object-acl`
- Handles both `--acl VALUE` and `--acl=VALUE` forms
- Severity: Error — public-internet data exposure

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.69 (469 katas)