### PR TITLE
feat: ZC1473 — warn on openssl req/genrsa -nodes (unencrypted private key)

### DIFF
--- a/pkg/katas/katatests/zc1473_test.go
+++ b/pkg/katas/katatests/zc1473_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1473(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — openssl req with -aes256",
+			input:    `openssl req -newkey rsa:4096 -aes256 -keyout key.pem -out csr.pem`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — openssl x509 (not key-producing)",
+			input:    `openssl x509 -in cert.pem -noout -subject`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — openssl req -nodes",
+			input: `openssl req -newkey rsa:4096 -nodes -keyout key.pem -out csr.pem`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1473",
+					Message: "`-nodes` writes the private key to disk unencrypted. Use `-aes256` (or an HSM/TPM) and keep the passphrase in a secrets store.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — openssl genrsa with -noenc",
+			input: `openssl genrsa -noenc -out key.pem 4096`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1473",
+					Message: "`-noenc` writes the private key to disk unencrypted. Use `-aes256` (or an HSM/TPM) and keep the passphrase in a secrets store.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1473")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1473.go
+++ b/pkg/katas/zc1473.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1473",
+		Title:    "Warn on `openssl req ... -nodes` / `genrsa` without passphrase — unencrypted private key",
+		Severity: SeverityWarning,
+		Description: "`-nodes` tells OpenSSL not to encrypt the private key that is written to " +
+			"disk. The file ends up at whatever filesystem permissions the umask dictates, and " +
+			"any subsequent backup / container image / rsync picks up a usable key with no " +
+			"passphrase. Use `-aes256` / `-aes-256-cbc` and keep the passphrase in a secrets " +
+			"store, or rely on a hardware-backed key via PKCS#11 / TPM.",
+		Check: checkZC1473,
+	})
+}
+
+func checkZC1473(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "openssl" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	// Only flag on subcommands that actually produce a private key file.
+	if sub != "req" && sub != "genrsa" && sub != "genpkey" && sub != "ecparam" &&
+		sub != "dsaparam" && sub != "pkcs12" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "-nodes" || v == "-noenc" {
+			return []Violation{{
+				KataID: "ZC1473",
+				Message: "`" + v + "` writes the private key to disk unencrypted. Use `-aes256` " +
+					"(or an HSM/TPM) and keep the passphrase in a secrets store.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 469 Katas = 0.4.69
-const Version = "0.4.69"
+// 470 Katas = 0.4.70
+const Version = "0.4.70"


### PR DESCRIPTION
## Summary
- Flags `openssl req|genrsa|genpkey|ecparam|dsaparam|pkcs12 -nodes` or `-noenc`
- Writes private key unencrypted to disk — next backup/image/rsync picks up a usable key
- Suggest `-aes256` + secrets-store passphrase, or hardware-backed key

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.70 (470 katas)