### PR TITLE
feat: ZC1474 — warn on ssh-keygen -N "" (passwordless SSH key)

### DIFF
--- a/pkg/katas/katatests/zc1474_test.go
+++ b/pkg/katas/katatests/zc1474_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1474(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ssh-keygen -N passphrase",
+			input:    `ssh-keygen -N secretpass -f key`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ssh-keygen without -N",
+			input:    `ssh-keygen -t ed25519 -f key`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  `invalid — ssh-keygen -N "" -f key`,
+			input: `ssh-keygen -N "" -f key`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1474",
+					Message: "`ssh-keygen -N \"\"` generates a passwordless key — anything that reads the file can use it. Use a passphrase or ssh-agent/HSM.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — ssh-keygen -N '' -f key`,
+			input: `ssh-keygen -N '' -f key`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1474",
+					Message: "`ssh-keygen -N \"\"` generates a passwordless key — anything that reads the file can use it. Use a passphrase or ssh-agent/HSM.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1474")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1474.go
+++ b/pkg/katas/zc1474.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1474",
+		Title:    "Warn on `ssh-keygen -N \"\"` — generates passwordless SSH key",
+		Severity: SeverityWarning,
+		Description: "Generating an SSH key with an empty passphrase (`-N \"\"`) leaves the key " +
+			"usable by anything that can read the file. Combined with a weak umask or a backup " +
+			"that follows the file, this is a common lateral-movement vector. Use a real " +
+			"passphrase, or delegate key storage to `ssh-agent` / a hardware token.",
+		Check: checkZC1474,
+	})
+}
+
+func checkZC1474(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ssh-keygen" {
+		return nil
+	}
+
+	var prevN bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevN {
+			prevN = false
+			if v == `""` || v == `''` || v == "" {
+				return []Violation{{
+					KataID:  "ZC1474",
+					Message: "`ssh-keygen -N \"\"` generates a passwordless key — anything that reads the file can use it. Use a passphrase or ssh-agent/HSM.",
+					Line:    cmd.Token.Line,
+					Column:  cmd.Token.Column,
+					Level:   SeverityWarning,
+				}}
+			}
+		}
+		if v == "-N" {
+			prevN = true
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 470 Katas = 0.4.70
-const Version = "0.4.70"
+// 471 Katas = 0.4.71
+const Version = "0.4.71"


### PR DESCRIPTION
## Summary
- Flags `ssh-keygen -N ""` and `ssh-keygen -N ''`
- Passwordless private key is usable by anything that reads the file — common lateral-movement vector
- Suggest passphrase, askpass, PKCS11, or HSM-backed key

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.71 (471 katas)