### PR TITLE
feat: ZC1475 — warn on setcap granting dangerous capabilities (privesc)

### DIFF
--- a/pkg/katas/katatests/zc1475_test.go
+++ b/pkg/katas/katatests/zc1475_test.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1475(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — setcap cap_net_bind_service",
+			input:    `setcap cap_net_bind_service+ep /usr/bin/node`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — setcap cap_sys_admin+ep",
+			input: `setcap cap_sys_admin+ep /usr/bin/foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1475",
+					Message: "`setcap` granting dangerous capability `cap_sys_admin` makes the binary a privesc vector for any executing user. Scope narrower or use a dedicated service user.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — setcap cap_dac_override+ep",
+			input: `setcap cap_dac_override+ep /usr/bin/filedump`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1475",
+					Message: "`setcap` granting dangerous capability `cap_dac_override` makes the binary a privesc vector for any executing user. Scope narrower or use a dedicated service user.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — setcap cap_setuid+ep",
+			input: `setcap 'cap_setuid=+ep' /usr/bin/maybebad`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1475",
+					Message: "`setcap` granting dangerous capability `cap_setuid` makes the binary a privesc vector for any executing user. Scope narrower or use a dedicated service user.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1475")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1475.go
+++ b/pkg/katas/zc1475.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1475",
+		Title:    "Warn on `setcap` granting dangerous capabilities to a binary (privesc)",
+		Severity: SeverityWarning,
+		Description: "Adding CAP_SYS_ADMIN, CAP_DAC_OVERRIDE, CAP_DAC_READ_SEARCH, CAP_SYS_PTRACE, " +
+			"or CAP_SETUID to a binary lets any user who can execute it perform operations " +
+			"roughly equivalent to root — read any file, change any UID, attach ptrace to root " +
+			"processes. Scope the capability as narrowly as possible (e.g. CAP_NET_BIND_SERVICE) " +
+			"or run the binary under a dedicated service user with a systemd unit.",
+		Check: checkZC1475,
+	})
+}
+
+var setcapDangerous = []string{
+	"cap_sys_admin",
+	"cap_dac_override",
+	"cap_dac_read_search",
+	"cap_sys_ptrace",
+	"cap_sys_module",
+	"cap_setuid",
+	"cap_setgid",
+	"cap_chown",
+}
+
+func checkZC1475(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "setcap" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := strings.ToLower(stripOuterQuotes(arg.String()))
+		for _, cap := range setcapDangerous {
+			if strings.Contains(v, cap) {
+				return []Violation{{
+					KataID: "ZC1475",
+					Message: "`setcap` granting dangerous capability `" + cap + "` makes the " +
+						"binary a privesc vector for any executing user. Scope narrower or use a " +
+						"dedicated service user.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 471 Katas = 0.4.71
-const Version = "0.4.71"
+// 472 Katas = 0.4.72
+const Version = "0.4.72"


### PR DESCRIPTION
## Summary
- Flags `setcap` granting `cap_sys_admin`, `cap_dac_override`, `cap_dac_read_search`, `cap_sys_ptrace`, `cap_sys_module`, `cap_setuid`, `cap_setgid`, or `cap_chown`
- Case-insensitive, handles single-quoted capability specs and comma-separated lists
- Severity: Warning — binary becomes privesc vector for any executing user

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.72 (472 katas)