### PR TITLE
feat: ZC1477 — warn on printf "$var" (format-string attack)

### DIFF
--- a/pkg/katas/katatests/zc1477_test.go
+++ b/pkg/katas/katatests/zc1477_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1477(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — printf '%s\\n' \"$x\"",
+			input:    `printf '%s\n' "$x"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — printf \"%s\\n\" \"$x\"",
+			input:    `printf "%s\n" "$x"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — printf 'hello world'",
+			input:    `printf 'hello world'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — printf \"$x\"",
+			input: `printf "$x"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1477",
+					Message: "`printf` format string contains a variable — `%` inside `$var` is reparsed as a format specifier. Use `printf '%s' \"$var\"` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — printf \"$(cmd)\"",
+			input: `printf "$(cmd)"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1477",
+					Message: "`printf` format string contains a variable — `%` inside `$var` is reparsed as a format specifier. Use `printf '%s' \"$var\"` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1477")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1477.go
+++ b/pkg/katas/zc1477.go
@@ -1,0 +1,66 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1477",
+		Title:    "Warn on `printf \"$var\"` — variable in format-string position (printf-fmt attack)",
+		Severity: SeverityWarning,
+		Description: "The first argument to `printf` is a format string. Interpolating a shell " +
+			"variable into it means any `%` sequence inside the variable is interpreted as a " +
+			"format specifier — at best producing garbage, at worst crashing with " +
+			"`%s`-out-of-bounds reads or writing attacker-controlled data with `%n`. Always " +
+			"use a literal format string: `printf '%s\\n' \"$var\"`.",
+		Check: checkZC1477,
+	})
+}
+
+func checkZC1477(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "printf" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	first := cmd.Arguments[0].String()
+	raw := stripOuterQuotes(first)
+
+	// Single-quoted strings don't interpolate; treat them as safe even if `$` is present.
+	if strings.HasPrefix(first, "'") && strings.HasSuffix(first, "'") {
+		return nil
+	}
+
+	// Look for an unescaped `$` (variable, command substitution, or arithmetic).
+	for i := 0; i < len(raw); i++ {
+		if raw[i] == '\\' {
+			i++
+			continue
+		}
+		if raw[i] == '$' {
+			return []Violation{{
+				KataID: "ZC1477",
+				Message: "`printf` format string contains a variable — `%` inside `$var` is " +
+					"reparsed as a format specifier. Use `printf '%s' \"$var\"` instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 473 Katas = 0.4.73
-const Version = "0.4.73"
+// 474 Katas = 0.4.74
+const Version = "0.4.74"


### PR DESCRIPTION
## Summary
- Flags `printf "$var"`, `printf "$(cmd)"`, `printf "$x text"` — any unquoted variable in format position
- Leaves single-quoted format strings alone (no interpolation possible)
- Suggest `printf '%s\n' "$var"`

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.74 (474 katas)