### PR TITLE
feat: ZC1478 — warn on mktemp -u (TOCTOU race)

### DIFF
--- a/pkg/katas/katatests/zc1478_test.go
+++ b/pkg/katas/katatests/zc1478_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1478(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — mktemp (default)",
+			input:    `mktemp`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — mktemp -d",
+			input:    `mktemp -d`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — mktemp -u",
+			input: `mktemp -u`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1478",
+					Message: "`mktemp -u` returns a unique name but does not create the file — TOCTOU race. Let `mktemp` create the file (or use `-d` for a directory).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — mktemp -u -t foo.XXXX",
+			input: `mktemp -u -t foo.XXXX`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1478",
+					Message: "`mktemp -u` returns a unique name but does not create the file — TOCTOU race. Let `mktemp` create the file (or use `-d` for a directory).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1478")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1478.go
+++ b/pkg/katas/zc1478.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1478",
+		Title:    "Avoid `mktemp -u` — returns a name without creating the file (TOCTOU)",
+		Severity: SeverityWarning,
+		Description: "`mktemp -u` allocates a unique name but does not create the file, leaving " +
+			"a classic time-of-check to time-of-use race: a second process (possibly attacker- " +
+			"controlled on a multi-user host or shared CI runner) can claim the name before you " +
+			"redirect into it. Drop `-u` and operate on the file `mktemp` creates for you, or " +
+			"use `mktemp -d` if you need a directory path.",
+		Check: checkZC1478,
+	})
+}
+
+func checkZC1478(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "mktemp" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-u" || v == "--dry-run" {
+			return []Violation{{
+				KataID: "ZC1478",
+				Message: "`mktemp -u` returns a unique name but does not create the file — " +
+					"TOCTOU race. Let `mktemp` create the file (or use `-d` for a directory).",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 474 Katas = 0.4.74
-const Version = "0.4.74"
+// 475 Katas = 0.4.75
+const Version = "0.4.75"


### PR DESCRIPTION
## Summary
- Flags `mktemp -u` (allocates name without creating the file → TOCTOU)
- Suggests dropping `-u` or using `mktemp -d` for a directory
- Parser limitation: `--dry-run` is swallowed as command name, so only the `-u` short form is in scope

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.75 (475 katas)