### PR TITLE
feat: ZC1479 — error on ssh StrictHostKeyChecking=no / UserKnownHostsFile=/dev/null

### DIFF
--- a/pkg/katas/katatests/zc1479_test.go
+++ b/pkg/katas/katatests/zc1479_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1479(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ssh user@host",
+			input:    `ssh user@host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ssh -o StrictHostKeyChecking=accept-new",
+			input:    `ssh -o StrictHostKeyChecking=accept-new user@host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ssh -o StrictHostKeyChecking=no",
+			input: `ssh -o StrictHostKeyChecking=no user@host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1479",
+					Message: "`StrictHostKeyChecking=no` disables SSH host-key verification — first MITM owns the connection. Pin the fingerprint in known_hosts instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — scp -oStrictHostKeyChecking=no (joined)",
+			input: `scp -oStrictHostKeyChecking=no file user@host:`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1479",
+					Message: "`StrictHostKeyChecking=no` disables SSH host-key verification — first MITM owns the connection. Pin the fingerprint in known_hosts instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ssh -oUserKnownHostsFile=/dev/null",
+			input: `ssh -oUserKnownHostsFile=/dev/null user@host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1479",
+					Message: "`UserKnownHostsFile=/dev/null` disables SSH host-key verification — first MITM owns the connection. Pin the fingerprint in known_hosts instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1479")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1479.go
+++ b/pkg/katas/zc1479.go
@@ -1,0 +1,79 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1479",
+		Title:    "Error on `ssh/scp -o StrictHostKeyChecking=no` / `UserKnownHostsFile=/dev/null`",
+		Severity: SeverityError,
+		Description: "Setting `StrictHostKeyChecking=no` or pointing `UserKnownHostsFile` at " +
+			"`/dev/null` makes the client accept any server key on the first (and every) " +
+			"connection, stripping the protection against MITM that SSH is designed to provide. " +
+			"For ephemeral CI targets, pin the host key in `known_hosts` with `ssh-keyscan` and " +
+			"verify the fingerprint out of band, or use `StrictHostKeyChecking=accept-new` at " +
+			"most.",
+		Check: checkZC1479,
+	})
+}
+
+func checkZC1479(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ssh" && ident.Value != "scp" && ident.Value != "sftp" {
+		return nil
+	}
+
+	check := func(spec string) []Violation {
+		s := strings.TrimSpace(strings.ToLower(spec))
+		if s == "stricthostkeychecking=no" {
+			return zc1479Violation(cmd, "StrictHostKeyChecking=no")
+		}
+		if s == "userknownhostsfile=/dev/null" {
+			return zc1479Violation(cmd, "UserKnownHostsFile=/dev/null")
+		}
+		return nil
+	}
+
+	var prevO bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevO {
+			prevO = false
+			if res := check(v); res != nil {
+				return res
+			}
+		}
+		if v == "-o" {
+			prevO = true
+			continue
+		}
+		if strings.HasPrefix(v, "-o") {
+			if res := check(v[2:]); res != nil {
+				return res
+			}
+		}
+	}
+	return nil
+}
+
+func zc1479Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID:  "ZC1479",
+		Message: "`" + what + "` disables SSH host-key verification — first MITM owns the connection. Pin the fingerprint in known_hosts instead.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 475 Katas = 0.4.75
-const Version = "0.4.75"
+// 476 Katas = 0.4.76
+const Version = "0.4.76"


### PR DESCRIPTION
## Summary
- Flags `ssh|scp|sftp -o StrictHostKeyChecking=no` or `UserKnownHostsFile=/dev/null` (space or joined forms)
- Severity: Error — MITM protection gone
- Complements ZC1228 (which accepts any host-key policy) by flagging the specifically-insecure value

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.76 (476 katas)