### PR TITLE
feat: ZC1480 — warn on terraform apply/destroy skipping plan review

### DIFF
--- a/pkg/katas/katatests/zc1480_test.go
+++ b/pkg/katas/katatests/zc1480_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1480(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — terraform plan",
+			input:    `terraform plan`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — terraform apply (interactive)",
+			input:    `terraform apply`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — terraform apply -auto-approve",
+			input: `terraform apply -auto-approve`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1480",
+					Message: "`terraform apply -auto-approve` skips plan review. Gate behind a branch/env check or require manual approval.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — terraform destroy --auto-approve",
+			input: `terraform destroy --auto-approve`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1480",
+					Message: "`terraform destroy --auto-approve` skips plan review. Gate behind a branch/env check or require manual approval.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — tofu apply -auto-approve",
+			input: `tofu apply -auto-approve`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1480",
+					Message: "`tofu apply -auto-approve` skips plan review. Gate behind a branch/env check or require manual approval.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1480")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1480.go
+++ b/pkg/katas/zc1480.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1480",
+		Title:    "Warn on `terraform apply -auto-approve` / `destroy -auto-approve` in scripts",
+		Severity: SeverityWarning,
+		Description: "Running `terraform apply -auto-approve` or `destroy -auto-approve` from a " +
+			"shell script skips the plan-review step that exists to catch schema drift, " +
+			"accidental `-replace`, and resources being deleted. Fine for throwaway CI against " +
+			"a PR environment, but dangerous against shared state. Prefer running `plan` + " +
+			"`apply` with an out-file and human approval, or scope the auto-apply to specific " +
+			"branches/environments.",
+		Check: checkZC1480,
+	})
+}
+
+func checkZC1480(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "terraform" && ident.Value != "terragrunt" && ident.Value != "tofu" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	if sub != "apply" && sub != "destroy" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "-auto-approve" || v == "--auto-approve" ||
+			v == "-auto-approve=true" || v == "--auto-approve=true" {
+			return []Violation{{
+				KataID: "ZC1480",
+				Message: "`" + ident.Value + " " + sub + " " + v + "` skips plan review. " +
+					"Gate behind a branch/env check or require manual approval.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 476 Katas = 0.4.76
-const Version = "0.4.76"
+// 477 Katas = 0.4.77
+const Version = "0.4.77"


### PR DESCRIPTION
## Summary
- Flags `terraform|terragrunt|tofu apply` or `destroy` with `-auto-approve` or `--auto-approve` (incl. `=true` form)
- Skips the plan-review step that catches schema drift, accidental `-replace`, and resource deletion
- Severity: Warning — fine for throwaway CI, dangerous against shared state

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.77 (477 katas)