### PR TITLE
feat: ZC1481 — warn on disabling shell history (unset HISTFILE)

### DIFF
--- a/pkg/katas/katatests/zc1481_test.go
+++ b/pkg/katas/katatests/zc1481_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1481(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — unset TMPDIR",
+			input:    `unset TMPDIR`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — export HISTFILE=~/.zsh_history",
+			input:    `export HISTFILE=~/.zsh_history`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — unset HISTFILE",
+			input: `unset HISTFILE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1481",
+					Message: "`unset HISTFILE` disables shell history — textbook post-compromise tactic. Legitimate alternative: `HISTCONTROL=ignorespace` plus leading-space prefix.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — export HISTFILE=/dev/null",
+			input: `export HISTFILE=/dev/null`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1481",
+					Message: "`HISTFILE=/dev/null` disables shell history — textbook post-compromise tactic. Legitimate alternative: `HISTCONTROL=ignorespace` plus leading-space prefix.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — export HISTSIZE=0",
+			input: `export HISTSIZE=0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1481",
+					Message: "`HISTSIZE=0` disables shell history — textbook post-compromise tactic. Legitimate alternative: `HISTCONTROL=ignorespace` plus leading-space prefix.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1481")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1481.go
+++ b/pkg/katas/zc1481.go
@@ -1,0 +1,68 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1481",
+		Title:    "Warn on `unset HISTFILE` / `export HISTFILE=/dev/null` — disables shell history",
+		Severity: SeverityWarning,
+		Description: "Disabling shell history (`unset HISTFILE`, `HISTFILE=/dev/null`, " +
+			"`HISTSIZE=0`) is a classic stepping stone for hiding post-compromise activity. " +
+			"Legitimate scripts almost never need this — if you are pasting a secret on the " +
+			"command line, use `HISTCONTROL=ignorespace` and prefix the line with a space, or " +
+			"read the value from a file / stdin.",
+		Check: checkZC1481,
+	})
+}
+
+func checkZC1481(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "unset":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "HISTFILE" || v == "HISTSIZE" || v == "SAVEHIST" || v == "HISTCMD" {
+				return zc1481Violation(cmd, "unset "+v)
+			}
+		}
+	case "export", "typeset":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if strings.HasPrefix(v, "HISTFILE=") {
+				val := strings.TrimPrefix(v, "HISTFILE=")
+				if val == "" || val == "/dev/null" || val == "''" || val == `""` {
+					return zc1481Violation(cmd, v)
+				}
+			}
+			if v == "HISTSIZE=0" || v == "SAVEHIST=0" {
+				return zc1481Violation(cmd, v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1481Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1481",
+		Message: "`" + what + "` disables shell history — textbook post-compromise tactic. " +
+			"Legitimate alternative: `HISTCONTROL=ignorespace` plus leading-space prefix.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 477 Katas = 0.4.77
-const Version = "0.4.77"
+// 478 Katas = 0.4.78
+const Version = "0.4.78"


### PR DESCRIPTION
## Summary
- Flags `unset HISTFILE|HISTSIZE|SAVEHIST|HISTCMD`
- Flags `export HISTFILE=/dev/null` / `=''` / empty, and `HISTSIZE=0` / `SAVEHIST=0`
- Severity: Warning — commonly used to hide post-compromise activity

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.78 (478 katas)