### PR TITLE
feat: ZC1482 — error on docker login -p / --password= (password in process list)

### DIFF
--- a/pkg/katas/katatests/zc1482_test.go
+++ b/pkg/katas/katatests/zc1482_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1482(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker login --password-stdin",
+			input:    `docker login --password-stdin -u user registry`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — docker push (not login)",
+			input:    `docker push -p registry/image`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker login -p pass",
+			input: `docker login -u user -p secretpass registry`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1482",
+					Message: "`-p secretpass` puts the password in ps / /proc / history. Use `--password-stdin` piped from a secrets file or credential helper.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — docker login --password=pass",
+			input: `docker login --password=secretpass -u user`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1482",
+					Message: "`--password=secretpass` puts the password in ps / /proc / history. Use `--password-stdin` piped from a secrets file or credential helper.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — helm registry login -p",
+			input: `helm registry login -u user -p secret example.com`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1482",
+					Message: "`-p secret` puts the password in ps / /proc / history. Use `--password-stdin` piped from a secrets file or credential helper.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1482")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1482.go
+++ b/pkg/katas/zc1482.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1482",
+		Title:    "Error on `docker login -p` / `--password=` — credential in process list",
+		Severity: SeverityError,
+		Description: "Passing the registry password on the command line puts it in the output of " +
+			"`ps`, `/proc/<pid>/cmdline`, and the shell history. On a shared CI runner or a host " +
+			"with unprivileged users, that is an immediate leak. Use `--password-stdin` and " +
+			"pipe the secret in from `cat /run/secrets/foo` or a credential helper.",
+		Check: checkZC1482,
+	})
+}
+
+func checkZC1482(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" && ident.Value != "buildah" &&
+		ident.Value != "skopeo" && ident.Value != "helm" {
+		return nil
+	}
+
+	// Must see `login` subcommand anywhere.
+	var sawLogin bool
+	var prevP bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "login" {
+			sawLogin = true
+			continue
+		}
+		if !sawLogin {
+			continue
+		}
+		if prevP {
+			return zc1482Violation(cmd, "-p "+v)
+		}
+		if v == "-p" {
+			prevP = true
+			continue
+		}
+		if strings.HasPrefix(v, "--password=") {
+			return zc1482Violation(cmd, v)
+		}
+	}
+	return nil
+}
+
+func zc1482Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1482",
+		Message: "`" + what + "` puts the password in ps / /proc / history. Use " +
+			"`--password-stdin` piped from a secrets file or credential helper.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 478 Katas = 0.4.78
-const Version = "0.4.78"
+// 479 Katas = 0.4.79
+const Version = "0.4.79"


### PR DESCRIPTION
## Summary
- Flags `docker|podman|buildah|skopeo|helm` after `login` subcommand with `-p VALUE` or `--password=VALUE`
- Severity: Error — password lands in ps/proc/history
- Suggest `--password-stdin` piped from `/run/secrets` or a credential helper

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.79 (479 katas)