### PR TITLE
feat: ZC1483 — warn on pip install --break-system-packages (PEP 668 bypass)

### DIFF
--- a/pkg/katas/katatests/zc1483_test.go
+++ b/pkg/katas/katatests/zc1483_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1483(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — pip install in venv",
+			input:    `pip install requests`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — pip install --user",
+			input:    `pip install --user requests`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — pip install --break-system-packages",
+			input: `pip install --break-system-packages requests`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1483",
+					Message: "`--break-system-packages` installs into distro-managed paths and collides with apt/dnf. Use a venv, pipx, or uv/poetry instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — pip3 install --break-system-packages",
+			input: `pip3 install --break-system-packages foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1483",
+					Message: "`--break-system-packages` installs into distro-managed paths and collides with apt/dnf. Use a venv, pipx, or uv/poetry instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1483")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1483.go
+++ b/pkg/katas/zc1483.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1483",
+		Title:    "Warn on `pip install --break-system-packages` — bypasses PEP 668 externally-managed guard",
+		Severity: SeverityWarning,
+		Description: "`--break-system-packages` tells pip to ignore the distro's PEP 668 marker " +
+			"and install into `/usr/lib/python*`, overwriting files the package manager owns. " +
+			"The next `apt`/`dnf` upgrade clobbers or gets clobbered by the pip-installed " +
+			"version, and you now have two sources of truth for Python dependencies. Install " +
+			"into a virtualenv (`python -m venv`), use `pipx` for application scripts, or use " +
+			"`uv` / `poetry` for project dependencies.",
+		Check: checkZC1483,
+	})
+}
+
+func checkZC1483(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "pip" && ident.Value != "pip3" && ident.Value != "pipx" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--break-system-packages" {
+			return []Violation{{
+				KataID: "ZC1483",
+				Message: "`--break-system-packages` installs into distro-managed paths and " +
+					"collides with apt/dnf. Use a venv, pipx, or uv/poetry instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 479 Katas = 0.4.79
-const Version = "0.4.79"
+// 480 Katas = 0.4.80
+const Version = "0.4.80"


### PR DESCRIPTION
## Summary
- Flags `pip|pip3|pipx install --break-system-packages`
- Bypasses PEP 668 externally-managed guard → collides with apt/dnf-managed Python files
- Suggest venv / pipx / uv / poetry instead
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.80 (480 katas)