### PR TITLE
feat: ZC1485 — warn on openssl s_client forcing legacy TLS (-ssl3/-tls1)

### DIFF
--- a/pkg/katas/katatests/zc1485_test.go
+++ b/pkg/katas/katatests/zc1485_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1485(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — openssl s_client -tls1_3",
+			input:    `openssl s_client -tls1_3 -connect host:443`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — openssl x509 (not s_client/s_server)",
+			input:    `openssl x509 -ssl3 -noout`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — openssl s_client -ssl3",
+			input: `openssl s_client -ssl3 -connect host:443`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1485",
+					Message: "`openssl s_client -ssl3` forces a legacy / disabled TLS version (downgrade-attack surface). Update the remote instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — openssl s_client -tls1",
+			input: `openssl s_client -tls1 -connect host:443`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1485",
+					Message: "`openssl s_client -tls1` forces a legacy / disabled TLS version (downgrade-attack surface). Update the remote instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — openssl s_server -tls1_1",
+			input: `openssl s_server -tls1_1 -cert cert.pem`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1485",
+					Message: "`openssl s_server -tls1_1` forces a legacy / disabled TLS version (downgrade-attack surface). Update the remote instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1485")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1485.go
+++ b/pkg/katas/zc1485.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1485",
+		Title:    "Warn on `openssl s_client -ssl3 / -tls1 / -tls1_1` — legacy TLS",
+		Severity: SeverityWarning,
+		Description: "Forcing SSLv3, TLSv1.0, or TLSv1.1 connects with protocols that have known " +
+			"downgrade and bit-flip attacks (POODLE, BEAST). These are disabled by default in " +
+			"every maintained OpenSSL build. If the remote only speaks an old protocol, the " +
+			"right fix is to update the remote, not downgrade your client.",
+		Check: checkZC1485,
+	})
+}
+
+func checkZC1485(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "openssl" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	if sub != "s_client" && sub != "s_server" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "-ssl2" || v == "-ssl3" || v == "-tls1" || v == "-tls1_1" ||
+			v == "-no_tls1_2" || v == "-no_tls1_3" {
+			return []Violation{{
+				KataID: "ZC1485",
+				Message: "`openssl " + sub + " " + v + "` forces a legacy / disabled TLS " +
+					"version (downgrade-attack surface). Update the remote instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 481 Katas = 0.4.81
-const Version = "0.4.81"
+// 482 Katas = 0.4.82
+const Version = "0.4.82"


### PR DESCRIPTION
## Summary
- Flags `openssl s_client|s_server` with `-ssl2`, `-ssl3`, `-tls1`, `-tls1_1`, `-no_tls1_2`, or `-no_tls1_3`
- Forces a protocol with known downgrade/bit-flip attacks (POODLE, BEAST)
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.82 (482 katas)