### PR TITLE
feat: ZC1486 — warn on curl -2 / -3 (forces broken SSLv2/SSLv3)

### DIFF
--- a/pkg/katas/katatests/zc1486_test.go
+++ b/pkg/katas/katatests/zc1486_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1486(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — curl https://host",
+			input:    `curl https://host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — curl -1 (TLSv1+)",
+			input:    `curl -1 https://host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — curl -2 (SSLv2)",
+			input: `curl -2 https://host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1486",
+					Message: "`curl -2` forces SSLv2/SSLv3 — removed from modern TLS libraries and subject to POODLE. Fix the server instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — curl -3 (SSLv3)",
+			input: `curl -3 https://host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1486",
+					Message: "`curl -3` forces SSLv2/SSLv3 — removed from modern TLS libraries and subject to POODLE. Fix the server instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1486")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1486.go
+++ b/pkg/katas/zc1486.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1486",
+		Title:    "Warn on `curl -2` / `-3` — forces broken SSLv2 / SSLv3",
+		Severity: SeverityWarning,
+		Description: "`curl -2` (SSLv2) and `-3` (SSLv3) force protocols that are removed from " +
+			"every current TLS library. `-2` matches no working server; `-3` leaves you open to " +
+			"POODLE. If the remote really needs an old protocol the fix is on the server, not " +
+			"the client.",
+		Check: checkZC1486,
+	})
+}
+
+func checkZC1486(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "curl" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-2" || v == "-3" {
+			return []Violation{{
+				KataID: "ZC1486",
+				Message: "`curl " + v + "` forces SSLv2/SSLv3 — removed from modern TLS " +
+					"libraries and subject to POODLE. Fix the server instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 482 Katas = 0.4.82
-const Version = "0.4.82"
+// 483 Katas = 0.4.83
+const Version = "0.4.83"


### PR DESCRIPTION
## Summary
- Flags `curl -2` (SSLv2) and `curl -3` (SSLv3)
- Severity: Warning — protocols removed from modern TLS libraries, POODLE-vulnerable
- Parser limitation: long forms (`--tlsv1.0`, `--tls-max 1.1`) are swallowed before reaching the check

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.83 (483 katas)