### PR TITLE
feat: ZC1487 — warn on history -c (Bash-ism / post-compromise tactic)

### DIFF
--- a/pkg/katas/katatests/zc1487_test.go
+++ b/pkg/katas/katatests/zc1487_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1487(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — history (list)",
+			input:    `history`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — history 10",
+			input:    `history 10`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — history -c",
+			input: `history -c`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1487",
+					Message: "`history -c` is a Bash-ism for clearing history — does nothing in Zsh and is a classic post-compromise tactic elsewhere.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — history -d 1",
+			input: `history -d 1`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1487",
+					Message: "`history -d` is a Bash-ism for clearing history — does nothing in Zsh and is a classic post-compromise tactic elsewhere.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1487")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1487.go
+++ b/pkg/katas/zc1487.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1487",
+		Title:    "Warn on `history -c` — clears shell history (and is a Bash-ism under Zsh)",
+		Severity: SeverityWarning,
+		Description: "`history -c` clears the in-memory history buffer in Bash. It is a standard " +
+			"post-compromise anti-forensics step. It is also a Bash-ism: in Zsh, `history` " +
+			"takes completely different arguments, so a copy-pasted `history -c` silently no-ops " +
+			"and leaves the author thinking history was cleared when it was not. If you really " +
+			"need to rotate history in a Zsh script, unset `HISTFILE` before the sensitive " +
+			"block or redirect to `/dev/null` explicitly.",
+		Check: checkZC1487,
+	})
+}
+
+func checkZC1487(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "history" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-c" || v == "-d" {
+			return []Violation{{
+				KataID: "ZC1487",
+				Message: "`history " + v + "` is a Bash-ism for clearing history — does " +
+					"nothing in Zsh and is a classic post-compromise tactic elsewhere.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 483 Katas = 0.4.83
-const Version = "0.4.83"
+// 484 Katas = 0.4.84
+const Version = "0.4.84"


### PR DESCRIPTION
## Summary
- Flags `history -c` and `history -d` — clears history in Bash; silently no-ops in Zsh
- Dual relevance: post-compromise anti-forensics in Bash, programmer-surprise bug in Zsh
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.84 (484 katas)