### PR TITLE
feat: ZC1488 — warn on ssh -R/-L/-D bound to 0.0.0.0 (all-interface tunnel)

### DIFF
--- a/pkg/katas/katatests/zc1488_test.go
+++ b/pkg/katas/katatests/zc1488_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1488(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ssh -R 2222:localhost:22 host (default bind)",
+			input:    `ssh -R 2222:localhost:22 host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ssh -R 127.0.0.1:2222:localhost:22 host",
+			input:    `ssh -R 127.0.0.1:2222:localhost:22 host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ssh -R 0.0.0.0:2222:localhost:22 host",
+			input: `ssh -R 0.0.0.0:2222:localhost:22 host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1488",
+					Message: "SSH reverse tunnel bound to all interfaces (`0.0.0.0:2222:localhost:22`) — forwarded port reachable from any network. Bind to a specific IP.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ssh -D 0.0.0.0:1080 host (dynamic SOCKS)",
+			input: `ssh -D 0.0.0.0:1080 host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1488",
+					Message: "SSH reverse tunnel bound to all interfaces (`0.0.0.0:1080`) — forwarded port reachable from any network. Bind to a specific IP.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1488")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1488.go
+++ b/pkg/katas/zc1488.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1488",
+		Title:    "Warn on `ssh -R 0.0.0.0:...` / `*:...` — reverse tunnel bound to all interfaces",
+		Severity: SeverityWarning,
+		Description: "The default for `ssh -R` binds the remote listener to `localhost`. Pointing " +
+			"it at `0.0.0.0` or `*` (or an explicit public IP) exposes the forwarded port to the " +
+			"whole network, including anything else that has reached the jump host. For " +
+			"persistent ops tunnels, pin the bind address to a specific private interface and " +
+			"require `GatewayPorts clientspecified` server-side.",
+		Check: checkZC1488,
+	})
+}
+
+func checkZC1488(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ssh" && ident.Value != "autossh" {
+		return nil
+	}
+
+	var prevForward bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevForward {
+			prevForward = false
+			if strings.HasPrefix(v, "0.0.0.0:") || strings.HasPrefix(v, "*:") ||
+				strings.HasPrefix(v, "::") {
+				return []Violation{{
+					KataID: "ZC1488",
+					Message: "SSH reverse tunnel bound to all interfaces (`" + v + "`) — " +
+						"forwarded port reachable from any network. Bind to a specific IP.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+		if v == "-R" || v == "-L" || v == "-D" {
+			prevForward = true
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 484 Katas = 0.4.84
-const Version = "0.4.84"
+// 485 Katas = 0.4.85
+const Version = "0.4.85"


### PR DESCRIPTION
## Summary
- Flags `ssh|autossh -R|-L|-D <bind>:...` when `<bind>` is `0.0.0.0`, `*`, or `::`
- Default for ssh port-forward is localhost — binding to all interfaces exposes the forwarded port
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.85 (485 katas)