### PR TITLE
feat: ZC1491 — warn on export LD_PRELOAD / LD_LIBRARY_PATH / LD_AUDIT

### DIFF
--- a/pkg/katas/katatests/zc1491_test.go
+++ b/pkg/katas/katatests/zc1491_test.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1491(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — export PATH=/usr/bin",
+			input:    `export PATH=/usr/bin`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — export LD_PRELOAD=/tmp/evil.so",
+			input: `export LD_PRELOAD=/tmp/evil.so`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1491",
+					Message: "`export LD_PRELOAD=...` forces every subsequent binary to load a custom library — classic privesc/persistence. Scope to a single invocation if needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — export LD_LIBRARY_PATH=/opt/untrusted",
+			input: `export LD_LIBRARY_PATH=/opt/untrusted`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1491",
+					Message: "`export LD_LIBRARY_PATH=...` forces every subsequent binary to load a custom library — classic privesc/persistence. Scope to a single invocation if needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — export LD_AUDIT=/tmp/audit.so",
+			input: `export LD_AUDIT=/tmp/audit.so`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1491",
+					Message: "`export LD_AUDIT=...` forces every subsequent binary to load a custom library — classic privesc/persistence. Scope to a single invocation if needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1491")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1491.go
+++ b/pkg/katas/zc1491.go
@@ -1,0 +1,62 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1491",
+		Title:    "Warn on `export LD_PRELOAD=...` / `LD_LIBRARY_PATH=...` — library injection",
+		Severity: SeverityWarning,
+		Description: "Setting `LD_PRELOAD` in a script forces every subsequent dynamically-linked " +
+			"command to load the specified shared object first, a classic post-compromise " +
+			"privesc and persistence technique. Setting `LD_LIBRARY_PATH` to a writable path is " +
+			"a gentler variant of the same class. Legitimate uses exist (perf profiling, " +
+			"asan instrumentation) but should be scoped to a single invocation and the path " +
+			"pinned to a read-only location.",
+		Check: checkZC1491,
+	})
+}
+
+func checkZC1491(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "LD_PRELOAD=") && len(v) > len("LD_PRELOAD=") {
+			return zc1491Violation(cmd, "LD_PRELOAD")
+		}
+		if strings.HasPrefix(v, "LD_LIBRARY_PATH=") && len(v) > len("LD_LIBRARY_PATH=") {
+			return zc1491Violation(cmd, "LD_LIBRARY_PATH")
+		}
+		if strings.HasPrefix(v, "LD_AUDIT=") && len(v) > len("LD_AUDIT=") {
+			return zc1491Violation(cmd, "LD_AUDIT")
+		}
+	}
+	return nil
+}
+
+func zc1491Violation(cmd *ast.SimpleCommand, varName string) []Violation {
+	return []Violation{{
+		KataID: "ZC1491",
+		Message: "`export " + varName + "=...` forces every subsequent binary to load a custom " +
+			"library — classic privesc/persistence. Scope to a single invocation if needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 487 Katas = 0.4.87
-const Version = "0.4.87"
+// 488 Katas = 0.4.88
+const Version = "0.4.88"


### PR DESCRIPTION
## Summary
- Flags `export LD_PRELOAD=...`, `export LD_LIBRARY_PATH=...`, `export LD_AUDIT=...`
- Library-injection vector — every subsequent dynamic binary loads attacker-chosen .so
- Severity: Warning
- Parser limitation: typeset/declare parse as DeclarationStatement, out of scope

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.88 (488 katas)