### PR TITLE
feat: ZC1492 — style: prefer systemd timers over at for deferred jobs

### DIFF
--- a/pkg/katas/katatests/zc1492_test.go
+++ b/pkg/katas/katatests/zc1492_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1492(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — at -l (list jobs)",
+			input:    `at -l`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — at -r 3 (remove job)",
+			input:    `at -r 3`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — at now + 1 hour",
+			input: `at now + 1 hour`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1492",
+					Message: "`at` schedules via atd with no unit file — harder to audit. Prefer `systemd-run --on-calendar=` or a `.timer` unit.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — at -f script.sh midnight",
+			input: `at -f script.sh midnight`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1492",
+					Message: "`at` schedules via atd with no unit file — harder to audit. Prefer `systemd-run --on-calendar=` or a `.timer` unit.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1492")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1492.go
+++ b/pkg/katas/zc1492.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1492",
+		Title:    "Style: `at` / `batch` for deferred execution — prefer systemd timers for auditability",
+		Severity: SeverityStyle,
+		Description: "`at` and `batch` schedule one-shot deferred jobs via `atd`. The job payload " +
+			"lands in `/var/spool/at*/` with no unit file or dependency graph, which makes it " +
+			"harder to review in fleet audits, easier to miss in a compromise triage, and one of " +
+			"the less-watched places adversaries stash persistence. Prefer `systemd-run " +
+			"--on-calendar=` or a proper `.timer` unit with a corresponding `.service`.",
+		Check: checkZC1492,
+	})
+}
+
+func checkZC1492(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "at" {
+		return nil
+	}
+
+	// Skip list/remove/query forms: -l, -r, -c, -q
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-l" || v == "-r" || v == "-c" || v == "-q" ||
+			v == "--list" || v == "--remove" {
+			return nil
+		}
+	}
+
+	// Any remaining `at <time>` or `at -f <script> <time>` invocation.
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1492",
+		Message: "`at` schedules via atd with no unit file — harder to audit. Prefer " +
+			"`systemd-run --on-calendar=` or a `.timer` unit.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 488 Katas = 0.4.88
-const Version = "0.4.88"
+// 489 Katas = 0.4.89
+const Version = "0.4.89"


### PR DESCRIPTION
## Summary
- Flags `at <time>` and `at -f <script> <time>` — deferred-execution via atd, no unit file
- Ignores `at -l|-r|-c|-q` (list/remove/query forms)
- Suggest `systemd-run --on-calendar=...` or a `.timer` unit
- Severity: Style

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.89 (489 katas)