### PR TITLE
feat: ZC1493 — warn on watch -n 0 (zero interval spins CPU)

### DIFF
--- a/pkg/katas/katatests/zc1493_test.go
+++ b/pkg/katas/katatests/zc1493_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1493(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — watch ls",
+			input:    `watch ls`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — watch -n 1 df",
+			input:    `watch -n 1 df`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — watch -n 0.5 df",
+			input:    `watch -n 0.5 df`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — watch -n 0 df",
+			input: `watch -n 0 df`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1493",
+					Message: "`watch -n 0` pins a core at 100% and saturates the terminal. Use a realistic interval or an event-driven API (inotifywait / journalctl -f).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — watch -n0 df (joined)",
+			input: `watch -n0 df`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1493",
+					Message: "`watch -n -n0` pins a core at 100% and saturates the terminal. Use a realistic interval or an event-driven API (inotifywait / journalctl -f).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1493")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1493.go
+++ b/pkg/katas/zc1493.go
@@ -1,0 +1,64 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1493",
+		Title:    "Warn on `watch -n 0` — zero-interval watch spins CPU",
+		Severity: SeverityWarning,
+		Description: "`watch -n 0` (or `-n 0.0` / `-n .0`) tells `watch` to re-run the command " +
+			"with no delay, which immediately pins a core to 100% and usually saturates the " +
+			"terminal emulator too. Pick a realistic interval (`-n 1`, `-n 2`, `-n 0.5`) — or " +
+			"if you truly want tight polling, use a dedicated event API (`inotifywait`, " +
+			"`systemd.path` unit, `journalctl -f`).",
+		Check: checkZC1493,
+	})
+}
+
+func checkZC1493(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "watch" {
+		return nil
+	}
+
+	var prevN bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevN {
+			prevN = false
+			if v == "0" || v == "0.0" || v == "0.00" || v == ".0" || v == ".00" {
+				return zc1493Violation(cmd, v)
+			}
+		}
+		if v == "-n" || v == "--interval" {
+			prevN = true
+			continue
+		}
+		if v == "-n0" || v == "-n0.0" || v == "--interval=0" || v == "--interval=0.0" {
+			return zc1493Violation(cmd, v)
+		}
+	}
+	return nil
+}
+
+func zc1493Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1493",
+		Message: "`watch -n " + what + "` pins a core at 100% and saturates the terminal. " +
+			"Use a realistic interval or an event-driven API (inotifywait / journalctl -f).",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 489 Katas = 0.4.89
-const Version = "0.4.89"
+// 490 Katas = 0.4.90
+const Version = "0.4.90"


### PR DESCRIPTION
## Summary
- Flags `watch -n 0` / `watch -n 0.0` / `watch -n .0` / `watch -n0`
- Zero interval spins a CPU core at 100% and saturates the terminal
- Suggest realistic interval or event-driven API (`inotifywait`, `systemd.path`, `journalctl -f`)
- Parser limitation: `--interval=0` long form is swallowed upstream

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.90 (490 katas)