### PR TITLE
feat: ZC1494 — warn on tcpdump -w without -Z (pcap as root)

### DIFF
--- a/pkg/katas/katatests/zc1494_test.go
+++ b/pkg/katas/katatests/zc1494_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1494(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — tcpdump without -w (stdout)",
+			input:    `tcpdump -i eth0 port 443`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — tcpdump -w capture.pcap -Z tcpdump",
+			input:    `tcpdump -i eth0 -w capture.pcap -Z tcpdump`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — tcpdump -i eth0 -w capture.pcap",
+			input: `tcpdump -i eth0 -w capture.pcap`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1494",
+					Message: "`tcpdump -w` without `-Z <user>` writes the pcap as root and never drops privileges. Add `-Z tcpdump` (or a dedicated capture user).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1494")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1494.go
+++ b/pkg/katas/zc1494.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1494",
+		Title:    "Warn on `tcpdump -w <file>` without `-Z <user>` — capture file owned by root",
+		Severity: SeverityWarning,
+		Description: "`tcpdump` needs root (or CAP_NET_RAW) to open the raw socket, but once the " +
+			"socket is open it should drop privileges with `-Z <user>` before writing the pcap. " +
+			"Without `-Z`, the capture file is owned by root, any bpf filter bug is exercised " +
+			"with root privileges, and on a shared host the pcap can land with permissions that " +
+			"leak sensitive traffic to other users. Pair `-w` with `-Z tcpdump` (or a dedicated " +
+			"capture user).",
+		Check: checkZC1494,
+	})
+}
+
+func checkZC1494(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "tcpdump" {
+		return nil
+	}
+
+	hasW := false
+	hasZ := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-w" || v == "--write-file" {
+			hasW = true
+		}
+		if v == "-Z" || v == "--relinquish-privileges" {
+			hasZ = true
+		}
+	}
+	if !hasW || hasZ {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1494",
+		Message: "`tcpdump -w` without `-Z <user>` writes the pcap as root and never drops " +
+			"privileges. Add `-Z tcpdump` (or a dedicated capture user).",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 490 Katas = 0.4.90
-const Version = "0.4.90"
+// 491 Katas = 0.4.91
+const Version = "0.4.91"


### PR DESCRIPTION
## Summary
- Flags `tcpdump -w <file>` without matching `-Z <user>`
- Without -Z, capture file is owned by root and filter runs with root privileges
- Suggest `-Z tcpdump` (or dedicated capture user)
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.91 (491 katas)