### PR TITLE
feat: ZC1495 — warn on ulimit -c unlimited (setuid memory leak via core dumps)

### DIFF
--- a/pkg/katas/katatests/zc1495_test.go
+++ b/pkg/katas/katatests/zc1495_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1495(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ulimit -n 10240",
+			input:    `ulimit -n 10240`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ulimit -c 0 (disable)",
+			input:    `ulimit -c 0`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ulimit -c unlimited",
+			input: `ulimit -c unlimited`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1495",
+					Message: "`ulimit -c unlimited` exposes setuid-process memory via core dumps. Leave the distro default and use systemd-coredump if you need post-mortems.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1495")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1495.go
+++ b/pkg/katas/zc1495.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1495",
+		Title:    "Warn on `ulimit -c unlimited` — enables core dumps from setuid binaries",
+		Severity: SeverityWarning,
+		Description: "`ulimit -c unlimited` enables unbounded core dumps for the current shell " +
+			"and its children. On a system with `fs.suid_dumpable=2` and a world-readable " +
+			"coredump directory, a setuid process that segfaults leaks its memory into a file " +
+			"any user can read — Dirty COW-class keys, TLS session material, kerberos tickets. " +
+			"Leave core dumps at the distro default (usually 0) and use systemd-coredump with " +
+			"access controls if you genuinely need post-mortems.",
+		Check: checkZC1495,
+	})
+}
+
+func checkZC1495(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ulimit" {
+		return nil
+	}
+
+	var coreFlag bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-c" {
+			coreFlag = true
+			continue
+		}
+		if coreFlag && v == "unlimited" {
+			return []Violation{{
+				KataID: "ZC1495",
+				Message: "`ulimit -c unlimited` exposes setuid-process memory via core dumps. " +
+					"Leave the distro default and use systemd-coredump if you need post-mortems.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+		coreFlag = false
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 491 Katas = 0.4.91
-const Version = "0.4.91"
+// 492 Katas = 0.4.92
+const Version = "0.4.92"


### PR DESCRIPTION
## Summary
- Flags `ulimit -c unlimited`
- Combined with `fs.suid_dumpable=2` and a world-readable coredump dir, setuid crashes leak memory
- Suggest distro default + systemd-coredump with access controls
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.92 (492 katas)