### PR TITLE
feat: ZC1496 — error on reading /dev/mem / /dev/kmem / /dev/port

### DIFF
--- a/pkg/katas/katatests/zc1496_test.go
+++ b/pkg/katas/katatests/zc1496_test.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1496(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — strings /bin/ls",
+			input:    `strings /bin/ls`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — strings /dev/mem",
+			input: `strings /dev/mem`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1496",
+					Message: "Reading `/dev/mem` leaks kernel / physical memory. Use kdump + crash on a crash-kernel image if you need a dump.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — xxd /dev/port",
+			input: `xxd /dev/port`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1496",
+					Message: "Reading `/dev/port` leaks kernel / physical memory. Use kdump + crash on a crash-kernel image if you need a dump.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — cat /dev/kmem",
+			input: `cat /dev/kmem`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1496",
+					Message: "Reading `/dev/kmem` leaks kernel / physical memory. Use kdump + crash on a crash-kernel image if you need a dump.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1496")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1496.go
+++ b/pkg/katas/zc1496.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1496",
+		Title:    "Error on reading `/dev/mem` / `/dev/kmem` / `/dev/port` — leaks physical memory",
+		Severity: SeverityError,
+		Description: "These device nodes map physical memory, kernel memory, and x86 I/O ports. " +
+			"Reading them (with `strings`, `xxd`, `cat`, or `dd`) exposes kernel state, keys, " +
+			"and any other live secret on the box. Modern kernels gate `/dev/mem` behind " +
+			"`CONFIG_STRICT_DEVMEM` but most distros also carry `CAP_SYS_RAWIO` on installed " +
+			"debugging tools, so the protection is fragile. If you really need a memory dump, " +
+			"use `kdump` + `crash` on a proper crash-kernel image.",
+		Check: checkZC1496,
+	})
+}
+
+func checkZC1496(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "strings" && ident.Value != "xxd" && ident.Value != "cat" &&
+		ident.Value != "dd" && ident.Value != "od" && ident.Value != "hexdump" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "/dev/mem" || v == "/dev/kmem" || v == "/dev/port" ||
+			v == "if=/dev/mem" || v == "if=/dev/kmem" {
+			return []Violation{{
+				KataID: "ZC1496",
+				Message: "Reading `" + v + "` leaks kernel / physical memory. Use kdump + " +
+					"crash on a crash-kernel image if you need a dump.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 492 Katas = 0.4.92
-const Version = "0.4.92"
+// 493 Katas = 0.4.93
+const Version = "0.4.93"


### PR DESCRIPTION
## Summary
- Flags `strings|xxd|cat|dd|od|hexdump` targeting `/dev/mem`, `/dev/kmem`, `/dev/port`
- Leaks kernel / physical memory — keys, TLS session material, secrets
- Severity: Error
- Parser limitation: `dd if=/dev/kmem` panics upstream, out of scope

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.93 (493 katas)