### PR TITLE
feat: ZC1497 — error on useradd/usermod -u 0 (creates second root)

### DIFF
--- a/pkg/katas/katatests/zc1497_test.go
+++ b/pkg/katas/katatests/zc1497_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1497(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — useradd alice",
+			input:    `useradd alice`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — useradd -u 1001 alice",
+			input:    `useradd -u 1001 alice`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — useradd -u 0 svc",
+			input: `useradd -u 0 svc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1497",
+					Message: "Creating a user with UID 0 produces a second root account — classic persistence technique. Use sudo rules tied to a non-0 UID instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — usermod -u0 backup",
+			input: `usermod -u0 backup`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1497",
+					Message: "Creating a user with UID 0 produces a second root account — classic persistence technique. Use sudo rules tied to a non-0 UID instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1497")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1497.go
+++ b/pkg/katas/zc1497.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1497",
+		Title:    "Error on `useradd -u 0` / `usermod -u 0` — creates a second root account",
+		Severity: SeverityError,
+		Description: "Creating a user with UID 0 makes them a second root — indistinguishable " +
+			"from `root` for every access decision, but hiding behind a non-obvious username " +
+			"(`backup`, `service`, `svc-updater`). This is a textbook persistence technique. " +
+			"If you need privileged but auditable operations, grant sudo rules tied to a " +
+			"specific non-0 UID and log via sudo's session plugin.",
+		Check: checkZC1497,
+	})
+}
+
+func checkZC1497(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "useradd" && ident.Value != "usermod" && ident.Value != "adduser" {
+		return nil
+	}
+
+	var prevU bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevU {
+			prevU = false
+			if v == "0" {
+				return zc1497Violation(cmd)
+			}
+		}
+		if v == "-u" || v == "--uid" {
+			prevU = true
+		}
+		if v == "-u0" || v == "--uid=0" {
+			return zc1497Violation(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1497Violation(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1497",
+		Message: "Creating a user with UID 0 produces a second root account — classic " +
+			"persistence technique. Use sudo rules tied to a non-0 UID instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 493 Katas = 0.4.93
-const Version = "0.4.93"
+// 494 Katas = 0.4.94
+const Version = "0.4.94"


### PR DESCRIPTION
## Summary
- Flags `useradd|usermod|adduser -u 0` / `-u0` / `--uid=0`
- UID 0 == root for all kernel access decisions — classic persistence technique
- Suggest sudo rules tied to a non-0 UID
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.94 (494 katas)