### PR TITLE
feat: ZC1498 — warn on mount -o remount,rw / (read-only root bypass)

### DIFF
--- a/pkg/katas/katatests/zc1498_test.go
+++ b/pkg/katas/katatests/zc1498_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1498(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — mount /mnt/data /mnt/backup",
+			input:    `mount /mnt/data /mnt/backup`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — mount -o ro,remount /",
+			input:    `mount -o ro,remount /`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — mount -o remount,rw /",
+			input: `mount -o remount,rw /`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1498",
+					Message: "`mount -o remount,rw /` makes a read-only system path writable — use ostree / systemd-sysext or fix /etc/fstab.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — mount -o rw,remount /boot",
+			input: `mount -o rw,remount /boot`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1498",
+					Message: "`mount -o remount,rw /boot` makes a read-only system path writable — use ostree / systemd-sysext or fix /etc/fstab.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1498")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1498.go
+++ b/pkg/katas/zc1498.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1498",
+		Title:    "Warn on `mount -o remount,rw /` — makes read-only root filesystem writable",
+		Severity: SeverityWarning,
+		Description: "Remounting the root filesystem read-write is either an intentional config " +
+			"change that belongs in `/etc/fstab` (in which case this script is the wrong place) " +
+			"or a post-compromise step for persisting changes on an immutable / verity-backed " +
+			"root. On distros that ship with RO root (Fedora Silverblue, Chrome OS, appliance " +
+			"images) this also breaks rollback guarantees. Use `systemd-sysext` or " +
+			"`ostree admin deploy` for legitimate modifications.",
+		Check: checkZC1498,
+	})
+}
+
+func checkZC1498(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "mount" {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, a.String())
+	}
+
+	var hasRemount, hasRW bool
+	var target string
+	for i, a := range args {
+		if a == "-o" && i+1 < len(args) {
+			opts := strings.Split(args[i+1], ",")
+			for _, o := range opts {
+				if o == "remount" {
+					hasRemount = true
+				}
+				if o == "rw" {
+					hasRW = true
+				}
+			}
+		}
+		if (a == "/" || a == "/root" || a == "/boot") && !strings.HasPrefix(a, "-") {
+			target = a
+		}
+	}
+	if hasRemount && hasRW && target != "" {
+		return []Violation{{
+			KataID: "ZC1498",
+			Message: "`mount -o remount,rw " + target + "` makes a read-only system path " +
+				"writable — use ostree / systemd-sysext or fix /etc/fstab.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 494 Katas = 0.4.94
-const Version = "0.4.94"
+// 495 Katas = 0.4.95
+const Version = "0.4.95"


### PR DESCRIPTION
## Summary
- Flags `mount -o remount,rw /` / `rw,remount /` (and `/root`, `/boot`)
- Breaks rollback guarantees on immutable distros (Silverblue, Chrome OS, appliance images)
- Suggest systemd-sysext or ostree admin deploy
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.95 (495 katas)