### PR TITLE
feat: ZC1500 — warn on systemctl edit in scripts (editor hang)

### DIFF
--- a/pkg/katas/katatests/zc1500_test.go
+++ b/pkg/katas/katatests/zc1500_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1500(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — systemctl status sshd",
+			input:    `systemctl status sshd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — systemctl edit --no-edit sshd",
+			input:    `systemctl edit --no-edit sshd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — systemctl edit sshd",
+			input: `systemctl edit sshd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1500",
+					Message: "`systemctl edit` opens $EDITOR and waits for the user. Use a drop-in `/etc/systemd/system/<unit>.d/*.conf` + `daemon-reload` in scripts.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — systemctl edit --full myapp.service",
+			input: `systemctl edit --full myapp.service`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1500",
+					Message: "`systemctl edit` opens $EDITOR and waits for the user. Use a drop-in `/etc/systemd/system/<unit>.d/*.conf` + `daemon-reload` in scripts.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1500")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1500.go
+++ b/pkg/katas/zc1500.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1500",
+		Title:    "Warn on `systemctl edit <unit>` in scripts — requires interactive editor",
+		Severity: SeverityWarning,
+		Description: "`systemctl edit <unit>` (without `--no-edit` and without a piped `EDITOR`) " +
+			"opens `$EDITOR` on a tmpfile and waits for the user. In a non-interactive script " +
+			"this either hangs until timeout or silently succeeds with no change, depending on " +
+			"how the editor handles a closed stdin. For scripted unit tweaks, drop a `.conf` " +
+			"drop-in under `/etc/systemd/system/<unit>.d/` and call `systemctl daemon-reload`.",
+		Check: checkZC1500,
+	})
+}
+
+func checkZC1500(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "systemctl" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "edit" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--no-edit" || v == "--runtime" {
+			// Still odd, but at least doesn't spin on an editor. Let it pass.
+			return nil
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1500",
+		Message: "`systemctl edit` opens $EDITOR and waits for the user. Use a drop-in " +
+			"`/etc/systemd/system/<unit>.d/*.conf` + `daemon-reload` in scripts.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 496 Katas = 0.4.96
-const Version = "0.4.96"
+// 497 Katas = 0.4.97
+const Version = "0.4.97"


### PR DESCRIPTION
## Summary
- Flags `systemctl edit <unit>` without `--no-edit` or `--runtime`
- Opens $EDITOR and waits for user — hangs in non-interactive scripts
- Suggest drop-in `.conf` under `/etc/systemd/system/<unit>.d/` + `daemon-reload`
- Severity: Warning

**500-kata milestone reached.**

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.97 (497 katas)