### PR TITLE
feat: ZC1501 — style: docker-compose (hyphen) → docker compose (space)

### DIFF
--- a/pkg/katas/katatests/zc1501_test.go
+++ b/pkg/katas/katatests/zc1501_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1501(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker compose up",
+			input:    `docker compose up -d`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker-compose up",
+			input: `docker-compose up -d`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1501",
+					Message: "`docker-compose` is the deprecated Python V1 binary. Use `docker compose` (space-separated subcommand) for the bundled V2 plugin.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — docker-compose down",
+			input: `docker-compose down --volumes`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1501",
+					Message: "`docker-compose` is the deprecated Python V1 binary. Use `docker compose` (space-separated subcommand) for the bundled V2 plugin.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1501")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1501.go
+++ b/pkg/katas/zc1501.go
@@ -1,0 +1,43 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1501",
+		Title:    "Style: `docker-compose` (hyphen) — use `docker compose` (space, built-in plugin)",
+		Severity: SeverityStyle,
+		Description: "`docker-compose` is the Python Compose V1 binary. Docker stopped shipping " +
+			"it with Docker Desktop in 2023 and Compose V2 is now the first-class `docker " +
+			"compose` subcommand. Scripts that invoke `docker-compose` silently degrade on " +
+			"fresh installs and miss V2-only options (`--profile`, `--wait`, richer env " +
+			"interpolation). Call `docker compose` (space) or pin the V2 binary explicitly.",
+		Check: checkZC1501,
+	})
+}
+
+func checkZC1501(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker-compose" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1501",
+		Message: "`docker-compose` is the deprecated Python V1 binary. Use `docker compose` " +
+			"(space-separated subcommand) for the bundled V2 plugin.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 497 Katas = 0.4.97
-const Version = "0.4.97"
+// 498 Katas = 0.4.98
+const Version = "0.4.98"


### PR DESCRIPTION
## Summary
- Flags `docker-compose <subcommand>` — deprecated Python V1 binary
- Suggest `docker compose <subcommand>` (space-separated V2 plugin)
- Severity: Style

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.98 (498 katas)