### PR TITLE
feat: ZC1502 — warn on grep "$var" without -- (flag injection)

### DIFF
--- a/pkg/katas/katatests/zc1502_test.go
+++ b/pkg/katas/katatests/zc1502_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1502(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — grep literal pattern",
+			input:    `grep "hello" file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — grep -- \"$var\" (end-of-flags marker)",
+			input:    `grep -- "$pattern" file.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — grep \"$var\" file (no --)",
+			input: `grep "$pattern" file.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1502",
+					Message: "Variable `\"$pattern\"` used as pattern without `--` end-of-flags marker — attacker-controlled leading `-` becomes a flag. Write `grep -- \"$var\"`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — rg $pattern files (unquoted)",
+			input: `rg $pattern files`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1502",
+					Message: "Variable `$pattern` used as pattern without `--` end-of-flags marker — attacker-controlled leading `-` becomes a flag. Write `grep -- \"$var\"`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1502")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1502.go
+++ b/pkg/katas/zc1502.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1502",
+		Title:    "Warn on `grep \"$var\" file` without `--` — flag injection when `$var` starts with `-`",
+		Severity: SeverityWarning,
+		Description: "Without a `--` end-of-flags marker, `grep` (and most POSIX tools) treats " +
+			"any argument that starts with `-` as a flag. If `$var` comes from user input or a " +
+			"fuzzed filename, an attacker can pass `--include=*secret*` or `-f /etc/shadow` " +
+			"and get grep to read paths the script author never intended. Always write " +
+			"`grep -- \"$var\" file` or use a grep-compatible library with explicit pattern API.",
+		Check: checkZC1502,
+	})
+}
+
+func checkZC1502(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "grep" && ident.Value != "egrep" && ident.Value != "fgrep" &&
+		ident.Value != "rg" && ident.Value != "ag" {
+		return nil
+	}
+
+	hasDashDash := false
+	firstVarArg := ""
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--" {
+			hasDashDash = true
+			break
+		}
+		// First variable-like pattern argument (no surrounding single quote means interpolation)
+		if firstVarArg == "" && (strings.HasPrefix(v, "\"$") || strings.HasPrefix(v, "$")) {
+			firstVarArg = v
+		}
+	}
+
+	if firstVarArg == "" || hasDashDash {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1502",
+		Message: "Variable `" + firstVarArg + "` used as pattern without `--` end-of-flags " +
+			"marker — attacker-controlled leading `-` becomes a flag. Write `grep -- \"$var\"`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 498 Katas = 0.4.98
-const Version = "0.4.98"
+// 499 Katas = 0.4.99
+const Version = "0.4.99"


### PR DESCRIPTION
## Summary
- Flags `grep|egrep|fgrep|rg|ag "$var" file` (or unquoted `$var`) without `--` end-of-flags marker
- Attacker-controlled `$var` starting with `-` becomes a flag (e.g. `-f /etc/shadow`)
- Suggest `grep -- "$var" file`
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.4.99 (499 katas)