### PR TITLE
feat: ZC1503 — error on groupadd/groupmod -g 0 (duplicate root group) [500-kata milestone]

### DIFF
--- a/pkg/katas/katatests/zc1503_test.go
+++ b/pkg/katas/katatests/zc1503_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1503(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — groupadd mygroup",
+			input:    `groupadd mygroup`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — groupadd -g 2000 mygroup",
+			input:    `groupadd -g 2000 mygroup`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — groupadd -g 0 fakeroot",
+			input: `groupadd -g 0 fakeroot`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1503",
+					Message: "Creating a group with GID 0 duplicates the `root` group — hidden privesc. Pick an unused GID (see `getent group`) and scope via sudoers/polkit.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — groupmod -g0 service",
+			input: `groupmod -g0 service`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1503",
+					Message: "Creating a group with GID 0 duplicates the `root` group — hidden privesc. Pick an unused GID (see `getent group`) and scope via sudoers/polkit.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1503")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1503.go
+++ b/pkg/katas/zc1503.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1503",
+		Title:    "Error on `groupadd -g 0` / `groupmod -g 0` — creates duplicate root group",
+		Severity: SeverityError,
+		Description: "Creating or renaming a group to GID 0 gives its members the same privileges " +
+			"as members of `root` for every file that grants permissions to GID 0. Combined " +
+			"with `usermod -G 0 <user>` it becomes an invisible privilege escalation path. " +
+			"Distro tooling already reserves GID 0 for `root`; pick a sensible unused GID " +
+			"(`getent group` gives the list) and scope access via sudoers or polkit.",
+		Check: checkZC1503,
+	})
+}
+
+func checkZC1503(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "groupadd" && ident.Value != "groupmod" && ident.Value != "addgroup" {
+		return nil
+	}
+
+	var prevG bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevG {
+			prevG = false
+			if v == "0" {
+				return zc1503Violation(cmd)
+			}
+		}
+		if v == "-g" || v == "--gid" {
+			prevG = true
+		}
+		if v == "-g0" || v == "--gid=0" {
+			return zc1503Violation(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1503Violation(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1503",
+		Message: "Creating a group with GID 0 duplicates the `root` group — hidden privesc. " +
+			"Pick an unused GID (see `getent group`) and scope via sudoers/polkit.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 499 Katas = 0.4.99
-const Version = "0.4.99"
+// 500 Katas = 0.5.0
+const Version = "0.5.0"


### PR DESCRIPTION
## Summary
- Flags `groupadd|groupmod|addgroup -g 0` / `-g0` / `--gid=0`
- Duplicates the `root` group — hidden privesc when combined with usermod -G 0
- Suggest unused GID via `getent group` + sudoers/polkit scoping
- Severity: Error

**Repo reaches 500 katas with this PR — version bumps to 0.5.0 (halfway to the v1.0 Marketplace launch target).**

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.0 (500 katas)