### PR TITLE
feat: ZC1504 — warn on git push --mirror (overwrites every remote ref)

### DIFF
--- a/pkg/katas/katatests/zc1504_test.go
+++ b/pkg/katas/katatests/zc1504_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1504(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — git push origin main",
+			input:    `git push origin main`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — git push --all origin",
+			input:    `git push --all origin`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — git push --mirror origin",
+			input: `git push --mirror origin`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1504",
+					Message: "`git push --mirror` overwrites every remote ref and deletes ones missing locally. Use an explicit refspec or `--all` for everyday pushes.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — git push origin --mirror",
+			input: `git push origin --mirror`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1504",
+					Message: "`git push --mirror` overwrites every remote ref and deletes ones missing locally. Use an explicit refspec or `--all` for everyday pushes.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1504")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1504.go
+++ b/pkg/katas/zc1504.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1504",
+		Title:    "Warn on `git push --mirror` — overwrites every remote ref",
+		Severity: SeverityWarning,
+		Description: "`git push --mirror` pushes every ref under `refs/` and deletes any remote " +
+			"ref that is not present locally. Running it against a shared origin instantly " +
+			"wipes everyone else's branches and tags. Legitimate uses are mirror-to-mirror " +
+			"replication where the source is the authoritative tree; for everyday pushes use " +
+			"an explicit refspec or `git push --all`.",
+		Check: checkZC1504,
+	})
+}
+
+func checkZC1504(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "git" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "push" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--mirror" {
+			return []Violation{{
+				KataID: "ZC1504",
+				Message: "`git push --mirror` overwrites every remote ref and deletes ones " +
+					"missing locally. Use an explicit refspec or `--all` for everyday pushes.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 500 Katas = 0.5.0
-const Version = "0.5.0"
+// 501 Katas = 0.5.1
+const Version = "0.5.1"


### PR DESCRIPTION
## Summary
- Flags `git push --mirror` (flag before or after remote name)
- Deletes remote refs missing locally — wipes shared origin's branches/tags
- Legit for mirror replication with authoritative source; use explicit refspec or `--all` for regular pushes
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.1 (501 katas)