### PR TITLE
feat: ZC1505 — warn on dpkg --force-confnew/--force-confold (silent conffile)

### DIFF
--- a/pkg/katas/katatests/zc1505_test.go
+++ b/pkg/katas/katatests/zc1505_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1505(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — dpkg -i pkg.deb",
+			input:    `dpkg -i pkg.deb`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — dpkg -i --force-confnew pkg.deb",
+			input: `dpkg -i --force-confnew pkg.deb`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1505",
+					Message: "`--force-confnew` silently picks maintainer or local conffile — legit /etc changes disappear or new defaults are ignored. Use ucf/etckeeper.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — dpkg -i pkg.deb --force-confold",
+			input: `dpkg -i pkg.deb --force-confold`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1505",
+					Message: "`--force-confold` silently picks maintainer or local conffile — legit /etc changes disappear or new defaults are ignored. Use ucf/etckeeper.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1505")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1505.go
+++ b/pkg/katas/zc1505.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1505",
+		Title:    "Warn on `dpkg --force-confnew` / `--force-confold` — silently overrides /etc changes",
+		Severity: SeverityWarning,
+		Description: "`--force-confnew` replaces any locally-modified config file with the " +
+			"maintainer version; `--force-confold` keeps the local file and drops the new " +
+			"defaults on the floor. Either way dpkg silently picks a side without prompting, " +
+			"so a legitimate /etc tweak (hardening, compliance override) can vanish or a " +
+			"security-relevant config update can be ignored. Review the conffile diff per " +
+			"upgrade (`ucf` / `etckeeper`) rather than hard-coding the decision.",
+		Check: checkZC1505,
+	})
+}
+
+func checkZC1505(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "dpkg" && ident.Value != "apt" && ident.Value != "apt-get" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "--force-conf") ||
+			strings.HasPrefix(v, "-oDpkg::Options::=--force-conf") ||
+			strings.HasPrefix(v, "-o=Dpkg::Options::=--force-conf") {
+			return []Violation{{
+				KataID: "ZC1505",
+				Message: "`" + v + "` silently picks maintainer or local conffile — legit /etc " +
+					"changes disappear or new defaults are ignored. Use ucf/etckeeper.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 501 Katas = 0.5.1
-const Version = "0.5.1"
+// 502 Katas = 0.5.2
+const Version = "0.5.2"


### PR DESCRIPTION
## Summary
- Flags `dpkg|apt|apt-get` with `--force-conf{new,old,def,miss,ask}` or embedded via `-oDpkg::Options::=--force-conf*`
- Silently picks maintainer or local conffile — hides /etc drift
- Suggest ucf / etckeeper review per upgrade
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.2 (502 katas)