### PR TITLE
feat: ZC1506 — warn on newgrp in scripts (spawns new shell, breaks flow)

### DIFF
--- a/pkg/katas/katatests/zc1506_test.go
+++ b/pkg/katas/katatests/zc1506_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1506(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sg audio -c cmd",
+			input:    `sg audio -c 'ls /var/log'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — newgrp audio",
+			input: `newgrp audio`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1506",
+					Message: "`newgrp` starts a new shell — script either hangs or exits. Use `sg <group> -c <cmd>` or systemd `SupplementaryGroups=`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1506")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1506.go
+++ b/pkg/katas/zc1506.go
@@ -1,0 +1,43 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1506",
+		Title:    "Warn on `newgrp <group>` in scripts — spawns a new shell, breaks control flow",
+		Severity: SeverityWarning,
+		Description: "`newgrp` starts a new login shell with the requested primary group. Inside " +
+			"a non-interactive script that shell inherits no commands, so the script either " +
+			"hangs waiting for the user or exits immediately depending on stdin. If the script " +
+			"genuinely needs temporarily-augmented group access, call `sg <group> -c <cmd>` " +
+			"or, in a service context, use `SupplementaryGroups=` in the unit file.",
+		Check: checkZC1506,
+	})
+}
+
+func checkZC1506(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "newgrp" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1506",
+		Message: "`newgrp` starts a new shell — script either hangs or exits. Use " +
+			"`sg <group> -c <cmd>` or systemd `SupplementaryGroups=`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 502 Katas = 0.5.2
-const Version = "0.5.2"
+// 503 Katas = 0.5.3
+const Version = "0.5.3"


### PR DESCRIPTION
## Summary
- Flags `newgrp <group>` — spawns new shell, non-interactive script hangs/exits
- Suggest `sg <group> -c <cmd>` for one-shot, or systemd `SupplementaryGroups=` for services
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.3 (503 katas)