### PR TITLE
feat: ZC1507 — warn on rsync -a / -l without --safe-links (symlink escape)

### DIFF
--- a/pkg/katas/katatests/zc1507_test.go
+++ b/pkg/katas/katatests/zc1507_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1507(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — rsync without archive / -l",
+			input:    `rsync -rv src/ dst/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — rsync -a --safe-links src/ dst/",
+			input:    `rsync -a --safe-links src/ dst/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — rsync --no-links src/ dst/",
+			input:    `rsync -a --no-links src/ dst/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — rsync -a src/ dst/",
+			input: `rsync -a src/ dst/`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1507",
+					Message: "`rsync` preserving symlinks without `--safe-links` follows ones pointing outside the source tree — path traversal vector. Add `--safe-links` or `--copy-unsafe-links`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — rsync -al src/ dst/",
+			input: `rsync -al src/ dst/`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1507",
+					Message: "`rsync` preserving symlinks without `--safe-links` follows ones pointing outside the source tree — path traversal vector. Add `--safe-links` or `--copy-unsafe-links`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1507")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1507.go
+++ b/pkg/katas/zc1507.go
@@ -1,0 +1,64 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1507",
+		Title:    "Warn on `rsync -l` / default symlink handling — follows escaping symlinks",
+		Severity: SeverityWarning,
+		Description: "By default rsync copies symlinks as-is but does not prevent one from " +
+			"pointing outside the source tree. When the destination is rooted elsewhere (or " +
+			"the receiver creates a file at the symlink's resolved path) this becomes a path " +
+			"traversal primitive. Use `--safe-links` to skip symlinks pointing outside the " +
+			"transfer set, or `--copy-unsafe-links` to materialise them as regular files.",
+		Check: checkZC1507,
+	})
+}
+
+func checkZC1507(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "rsync" {
+		return nil
+	}
+
+	// Trigger only when rsync is actually asked to handle symlinks:
+	// -l (preserve symlinks) or -a (archive, which includes -l).
+	var hasSymlinkMode, hasSafeHandling bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-a" || v == "-l" || v == "--archive" || v == "--links" ||
+			strings.HasPrefix(v, "-a") && strings.ContainsAny(v[1:], "lavxHAX") {
+			hasSymlinkMode = true
+		}
+		if v == "--safe-links" || v == "--copy-unsafe-links" || v == "--no-links" ||
+			v == "--munge-links" {
+			hasSafeHandling = true
+		}
+	}
+	if !hasSymlinkMode || hasSafeHandling {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1507",
+		Message: "`rsync` preserving symlinks without `--safe-links` follows ones pointing " +
+			"outside the source tree — path traversal vector. Add `--safe-links` or " +
+			"`--copy-unsafe-links`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 503 Katas = 0.5.3
-const Version = "0.5.3"
+// 504 Katas = 0.5.4
+const Version = "0.5.4"


### PR DESCRIPTION
## Summary
- Flags `rsync` with `-a` / `-l` / `--links` but no `--safe-links` / `--copy-unsafe-links` / `--no-links` / `--munge-links`
- Default symlink preservation allows traversal when a symlink points outside the source tree
- Parser limitation: `--archive` long form is swallowed upstream
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.4 (504 katas)