### PR TITLE
feat: ZC1508 — style: ldd can execute the binary; prefer objdump/readelf

### DIFF
--- a/pkg/katas/katatests/zc1508_test.go
+++ b/pkg/katas/katatests/zc1508_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1508(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — objdump -p",
+			input:    `objdump -p /bin/ls`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — readelf -d",
+			input:    `readelf -d /bin/ls`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ldd /bin/ls",
+			input: `ldd /bin/ls`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1508",
+					Message: "`ldd` on glibc can execute the target binary. Use `objdump -p` or `readelf -d` to inspect ELF dependencies safely.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ldd /tmp/downloaded.bin",
+			input: `ldd /tmp/downloaded.bin`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1508",
+					Message: "`ldd` on glibc can execute the target binary. Use `objdump -p` or `readelf -d` to inspect ELF dependencies safely.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1508")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1508.go
+++ b/pkg/katas/zc1508.go
@@ -1,0 +1,47 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1508",
+		Title:    "Style: `ldd <binary>` may execute the binary — use `objdump -p` / `readelf -d` for untrusted files",
+		Severity: SeverityStyle,
+		Description: "On glibc, `ldd` is implemented by setting `LD_TRACE_LOADED_OBJECTS=1` and " +
+			"invoking the binary. A malicious ELF with a custom interpreter (`PT_INTERP`) or " +
+			"constructors can therefore run code when `ldd` is pointed at it. `objdump -p " +
+			"<file> | grep NEEDED` or `readelf -d <file>` give the same shared-library list " +
+			"without executing the binary.",
+		Check: checkZC1508,
+	})
+}
+
+func checkZC1508(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ldd" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1508",
+		Message: "`ldd` on glibc can execute the target binary. Use `objdump -p` or " +
+			"`readelf -d` to inspect ELF dependencies safely.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 504 Katas = 0.5.4
-const Version = "0.5.4"
+// 505 Katas = 0.5.5
+const Version = "0.5.5"


### PR DESCRIPTION
## Summary
- Flags any `ldd <file>` invocation
- glibc ldd runs the binary with `LD_TRACE_LOADED_OBJECTS=1` — malicious ELF with custom interpreter or constructors can execute code
- Suggest `objdump -p | grep NEEDED` or `readelf -d`
- Severity: Style

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.5 (505 katas)