### PR TITLE
feat: ZC1509 — warn on trap ''/- on fatal signals (cleanup skipped)

### DIFF
--- a/pkg/katas/katatests/zc1509_test.go
+++ b/pkg/katas/katatests/zc1509_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1509(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — trap 'cleanup' EXIT",
+			input:    `trap 'cleanup' EXIT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — trap 'cleanup' TERM",
+			input:    `trap 'cleanup' TERM`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — trap '' TERM",
+			input: `trap '' TERM`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1509",
+					Message: "`trap '' TERM` silences a fatal signal — cleanup handlers never run. Keep at least a cleanup trap on EXIT.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — trap - SIGINT",
+			input: `trap - SIGINT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1509",
+					Message: "`trap - SIGINT` silences a fatal signal — cleanup handlers never run. Keep at least a cleanup trap on EXIT.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1509")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1509.go
+++ b/pkg/katas/zc1509.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1509",
+		Title:    "Warn on `trap '' TERM` / `trap - TERM` — ignores/resets fatal signal",
+		Severity: SeverityWarning,
+		Description: "`trap '' <signal>` makes the signal uninterruptible. `trap - <signal>` " +
+			"restores the default disposition, which on `TERM`/`INT`/`HUP` means the script " +
+			"exits without running any cleanup handler. Both forms are routinely used to " +
+			"harden long-running scripts against accidental `Ctrl-C`, but also to hide from " +
+			"`kill` during incident response. Keep the explicit cleanup handler on at least " +
+			"`EXIT` so state is always unwound.",
+		Check: checkZC1509,
+	})
+}
+
+func checkZC1509(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "trap" {
+		return nil
+	}
+
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	handler := cmd.Arguments[0].String()
+	if handler != "''" && handler != `""` && handler != "-" {
+		return nil
+	}
+	// Signals after the handler.
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		switch v {
+		case "TERM", "SIGTERM", "INT", "SIGINT", "HUP", "SIGHUP",
+			"QUIT", "SIGQUIT":
+			return []Violation{{
+				KataID: "ZC1509",
+				Message: "`trap " + handler + " " + v + "` silences a fatal signal — cleanup " +
+					"handlers never run. Keep at least a cleanup trap on EXIT.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 505 Katas = 0.5.5
-const Version = "0.5.5"
+// 506 Katas = 0.5.6
+const Version = "0.5.6"


### PR DESCRIPTION
## Summary
- Flags `trap '' SIGTERM|SIGINT|SIGHUP|SIGQUIT|TERM|INT|HUP|QUIT` and `trap - <same>`
- Disables cleanup on fatal signals — state leaks, tmp files pile up
- Keep explicit cleanup trap on `EXIT` at minimum
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.6 (506 katas)