### PR TITLE
feat: ZC1510 — error on auditctl -e 0 / -D (disables kernel audit)

### DIFF
--- a/pkg/katas/katatests/zc1510_test.go
+++ b/pkg/katas/katatests/zc1510_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1510(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — auditctl -w /etc/passwd",
+			input:    `auditctl -w /etc/passwd -p wa`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — auditctl -e 1",
+			input:    `auditctl -e 1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — auditctl -e 0",
+			input: `auditctl -e 0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1510",
+					Message: "`auditctl -e 0` disables audit subsystem — anti-forensics tactic. Use `-e 2` for a reboot-locked maintenance window instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — auditctl -D",
+			input: `auditctl -D`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1510",
+					Message: "`auditctl -D` deletes every audit rule — anti-forensics tactic. Use `-e 2` for a reboot-locked maintenance window instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1510")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1510.go
+++ b/pkg/katas/zc1510.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1510",
+		Title:    "Error on `auditctl -e 0` / `auditctl -D` — disables kernel audit logging",
+		Severity: SeverityError,
+		Description: "`auditctl -e 0` switches the Linux audit subsystem off, and `auditctl -D` " +
+			"deletes every audit rule, including the ones that monitor `/etc/shadow`, `execve`, " +
+			"and privilege escalations. Both are textbook anti-forensics steps. If you need to " +
+			"temporarily quiet audit for a maintenance window, use `-e 2` (lock enabled + " +
+			"immutable) to require a reboot for any further change and document the action.",
+		Check: checkZC1510,
+	})
+}
+
+func checkZC1510(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "auditctl" {
+		return nil
+	}
+
+	var prevE bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-D" {
+			return zc1510Violation(cmd, "-D", "deletes every audit rule")
+		}
+		if prevE {
+			prevE = false
+			if v == "0" {
+				return zc1510Violation(cmd, "-e 0", "disables audit subsystem")
+			}
+		}
+		if v == "-e" {
+			prevE = true
+		}
+	}
+	return nil
+}
+
+func zc1510Violation(cmd *ast.SimpleCommand, flag, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1510",
+		Message: "`auditctl " + flag + "` " + what + " — anti-forensics tactic. Use `-e 2` " +
+			"for a reboot-locked maintenance window instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 506 Katas = 0.5.6
-const Version = "0.5.6"
+// 507 Katas = 0.5.7
+const Version = "0.5.7"


### PR DESCRIPTION
## Summary
- Flags `auditctl -e 0` (disable audit) and `auditctl -D` (delete all rules)
- Textbook anti-forensics — clears monitoring of execve, /etc/shadow, etc.
- Severity: Error — suggest `-e 2` (locked) for legitimate maintenance

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.7 (507 katas)