### PR TITLE
feat: ZC1511 — error on nmcli wifi/vpn secret on cmdline

### DIFF
--- a/pkg/katas/katatests/zc1511_test.go
+++ b/pkg/katas/katatests/zc1511_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1511(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — nmcli con up myssid",
+			input:    `nmcli con up myssid`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — nmcli --ask",
+			input:    `nmcli con up myssid --ask`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — nmcli con mod myssid 802-11-wireless-security.psk mypassword",
+			input: `nmcli con mod myssid 802-11-wireless-security.psk mypassword`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1511",
+					Message: "`nmcli` passed `802-11-wireless-security.psk <secret>` on the command line — ends up in ps/history. Use `--ask` or a keyfile profile.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — nmcli con mod vpn vpn.secrets.password pw",
+			input: `nmcli con mod myvpn vpn.secrets.password vpnpass`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1511",
+					Message: "`nmcli` passed `vpn.secrets.password <secret>` on the command line — ends up in ps/history. Use `--ask` or a keyfile profile.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1511")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1511.go
+++ b/pkg/katas/zc1511.go
@@ -1,0 +1,68 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1511",
+		Title:    "Error on `nmcli ... <wireless/vpn secret>` on command line",
+		Severity: SeverityError,
+		Description: "Passing Wi-Fi pre-shared keys or VPN secrets as positional `nmcli` args " +
+			"puts them in `ps`, shell history, and `/proc/<pid>/cmdline`. Let NetworkManager " +
+			"store the secret for you via `--ask` (interactive prompt, no TTY echo) or use " +
+			"`keyfile` connection profiles under `/etc/NetworkManager/system-connections/` " +
+			"with mode 0600.",
+		Check: checkZC1511,
+	})
+}
+
+var nmcliSecretKeys = []string{
+	"802-11-wireless-security.psk",
+	"wifi-sec.psk",
+	"wifi.psk",
+	"vpn.secrets.password",
+	"ipsec-secret",
+	"openvpn-password",
+	"802-1x.password",
+}
+
+func checkZC1511(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "nmcli" {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, a.String())
+	}
+
+	for i, a := range args {
+		low := strings.ToLower(a)
+		for _, key := range nmcliSecretKeys {
+			if low == key && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				return []Violation{{
+					KataID: "ZC1511",
+					Message: "`nmcli` passed `" + key + " <secret>` on the command line — " +
+						"ends up in ps/history. Use `--ask` or a keyfile profile.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityError,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 507 Katas = 0.5.7
-const Version = "0.5.7"
+// 508 Katas = 0.5.8
+const Version = "0.5.8"


### PR DESCRIPTION
## Summary
- Flags `nmcli` followed by `802-11-wireless-security.psk`, `wifi-sec.psk`, `wifi.psk`, `vpn.secrets.password`, `ipsec-secret`, `openvpn-password`, or `802-1x.password` + a plaintext secret
- Secret appears in ps/history/cmdline
- Suggest `--ask` or keyfile profile
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.8 (508 katas)