### PR TITLE
feat: ZC1512 — style: service <unit> <verb> → systemctl <verb> <unit>

### DIFF
--- a/pkg/katas/katatests/zc1512_test.go
+++ b/pkg/katas/katatests/zc1512_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1512(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — systemctl restart sshd",
+			input:    `systemctl restart sshd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — service with unrecognized verb",
+			input:    `service --help`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — service sshd restart",
+			input: `service sshd restart`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1512",
+					Message: "`service sshd restart` — prefer `systemctl restart sshd` for consistency with other systemd commands.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — service nginx reload",
+			input: `service nginx reload`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1512",
+					Message: "`service nginx reload` — prefer `systemctl reload nginx` for consistency with other systemd commands.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1512")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1512.go
+++ b/pkg/katas/zc1512.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1512",
+		Title:    "Style: `service <unit> <verb>` — use `systemctl <verb> <unit>` on systemd hosts",
+		Severity: SeverityStyle,
+		Description: "`service` is the SysV init compatibility wrapper. On a systemd-managed " +
+			"host (every mainstream distro since ~2016) it translates to `systemctl` anyway, " +
+			"but reverses argument order, loses `--user` scope, ignores unit templating, and " +
+			"can't restart sockets or timers. Prefer `systemctl start|stop|restart|reload " +
+			"<unit>` for consistency across scripts and interactive shells.",
+		Check: checkZC1512,
+	})
+}
+
+func checkZC1512(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "service" {
+		return nil
+	}
+
+	// Needs at least <unit> <verb>.
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	verb := cmd.Arguments[1].String()
+	switch verb {
+	case "start", "stop", "restart", "reload", "status", "force-reload", "try-restart":
+	default:
+		return nil
+	}
+
+	unit := cmd.Arguments[0].String()
+	return []Violation{{
+		KataID: "ZC1512",
+		Message: "`service " + unit + " " + verb + "` — prefer `systemctl " + verb + " " +
+			unit + "` for consistency with other systemd commands.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 508 Katas = 0.5.8
-const Version = "0.5.8"
+// 509 Katas = 0.5.9
+const Version = "0.5.9"


### PR DESCRIPTION
## Summary
- Flags `service <unit> start|stop|restart|reload|status|force-reload|try-restart`
- Suggests equivalent `systemctl <verb> <unit>` — unified with socket/timer/user-scope support
- Severity: Style

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.9 (509 katas)