### PR TITLE
feat: ZC1513 — style: make install without DESTDIR (unmanaged)

### DIFF
--- a/pkg/katas/katatests/zc1513_test.go
+++ b/pkg/katas/katatests/zc1513_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1513(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — make",
+			input:    `make`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — make DESTDIR=/tmp/pkg install",
+			input:    `make DESTDIR=/tmp/pkg install`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — make install",
+			input: `make install`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1513",
+					Message: "`make install` without `DESTDIR=` leaves no package-manager record. Set `DESTDIR=/tmp/pkgroot` and wrap in checkinstall / fpm, or use stow.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — gmake install",
+			input: `gmake install`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1513",
+					Message: "`make install` without `DESTDIR=` leaves no package-manager record. Set `DESTDIR=/tmp/pkgroot` and wrap in checkinstall / fpm, or use stow.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1513")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1513.go
+++ b/pkg/katas/zc1513.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1513",
+		Title:    "Style: `make install` without `DESTDIR=` — unmanaged system-wide install",
+		Severity: SeverityStyle,
+		Description: "`make install` drops files directly into `$(prefix)` with no package " +
+			"manager tracking. Upgrades can leave stale files behind, uninstalls rely on " +
+			"`make uninstall` being accurate, and the operation typically needs `sudo`. For " +
+			"local builds, set `DESTDIR=/tmp/pkgroot` + wrap in `checkinstall` / `fpm` / " +
+			"distro packaging, or use `stow` / `xstow` to manage symlinks under `/usr/local`.",
+		Check: checkZC1513,
+	})
+}
+
+func checkZC1513(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "make" && ident.Value != "gmake" {
+		return nil
+	}
+
+	hasInstall := false
+	hasDestdir := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "install" {
+			hasInstall = true
+		}
+		if len(v) >= 8 && v[:8] == "DESTDIR=" {
+			hasDestdir = true
+		}
+	}
+	if !hasInstall || hasDestdir {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1513",
+		Message: "`make install` without `DESTDIR=` leaves no package-manager record. Set " +
+			"`DESTDIR=/tmp/pkgroot` and wrap in checkinstall / fpm, or use stow.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 509 Katas = 0.5.9
-const Version = "0.5.9"
+// 510 Katas = 0.5.10
+const Version = "0.5.10"


### PR DESCRIPTION
## Summary
- Flags `make install` or `gmake install` without `DESTDIR=` var
- Suggests DESTDIR + checkinstall/fpm or stow for /usr/local
- Severity: Style

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.10 (510 katas)