### PR TITLE
feat: ZC1514 — error on useradd/usermod -p <hash> (crypted password on cmdline)

### DIFF
--- a/pkg/katas/katatests/zc1514_test.go
+++ b/pkg/katas/katatests/zc1514_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1514(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — useradd alice",
+			input:    `useradd alice`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — useradd -p hash alice",
+			input: `useradd -p $6$salt$hashhashhash alice`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1514",
+					Message: "`useradd -p <hash>` puts the crypted password in ps / /proc / history. Use `chpasswd --crypt-method=SHA512` from stdin.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — usermod -p hash bob",
+			input: `usermod -p $6$salt$hashhash bob`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1514",
+					Message: "`usermod -p <hash>` puts the crypted password in ps / /proc / history. Use `chpasswd --crypt-method=SHA512` from stdin.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1514")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1514.go
+++ b/pkg/katas/zc1514.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1514",
+		Title:    "Error on `useradd -p <hash>` / `usermod -p <hash>` — password hash on cmdline",
+		Severity: SeverityError,
+		Description: "`-p` takes an already-crypt(3)-ed password and writes it to `/etc/shadow`. " +
+			"That crypted form is in `ps`, `/proc/<pid>/cmdline`, and shell history for as " +
+			"long as the process runs — enough time for a co-tenant to grab it and start an " +
+			"offline crack. Use `chpasswd` with `--crypt-method=SHA512` reading from stdin, " +
+			"or write `/etc/shadow` via a configuration-management tool with proper file " +
+			"permissions.",
+		Check: checkZC1514,
+	})
+}
+
+func checkZC1514(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "useradd" && ident.Value != "usermod" && ident.Value != "adduser" {
+		return nil
+	}
+
+	var prevP bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevP && v != "" && v[0] != '-' {
+			return []Violation{{
+				KataID: "ZC1514",
+				Message: "`" + ident.Value + " -p <hash>` puts the crypted password in ps / " +
+					"/proc / history. Use `chpasswd --crypt-method=SHA512` from stdin.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+		prevP = (v == "-p" || v == "--password")
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 510 Katas = 0.5.10
-const Version = "0.5.10"
+// 511 Katas = 0.5.11
+const Version = "0.5.11"


### PR DESCRIPTION
## Summary
- Flags `useradd|usermod|adduser -p <hash>`
- Hash visible in ps / /proc / history — co-tenant can grab and crack offline
- Suggest `chpasswd --crypt-method=SHA512` from stdin
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.11 (511 katas)