### PR TITLE
feat: ZC1515 — warn on md5sum/sha1sum for integrity (collision-vulnerable)

### DIFF
--- a/pkg/katas/katatests/zc1515_test.go
+++ b/pkg/katas/katatests/zc1515_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1515(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sha256sum file",
+			input:    `sha256sum file.tar.gz`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — b2sum file",
+			input:    `b2sum file.tar.gz`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — md5sum file",
+			input: `md5sum file.tar.gz`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1515",
+					Message: "`md5sum` is collision-vulnerable — don't use for integrity checks. Use `sha256sum` / `sha512sum` / `b2sum` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — sha1sum file",
+			input: `sha1sum file.tar.gz`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1515",
+					Message: "`sha1sum` is collision-vulnerable — don't use for integrity checks. Use `sha256sum` / `sha512sum` / `b2sum` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1515")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1515.go
+++ b/pkg/katas/zc1515.go
@@ -1,0 +1,43 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1515",
+		Title:    "Warn on `md5sum` / `sha1sum` for integrity check — collision-vulnerable",
+		Severity: SeverityWarning,
+		Description: "MD5 and SHA-1 are broken for collision resistance: public attacks cheaply " +
+			"craft two different files with the same hash. For verifying a download against a " +
+			"published checksum, or for comparing archives against a manifest, use " +
+			"`sha256sum` / `sha512sum` / `b2sum` instead. MD5 is still fine for non-adversarial " +
+			"cache keys but almost every invocation in scripts is the integrity case.",
+		Check: checkZC1515,
+	})
+}
+
+func checkZC1515(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "md5sum" && ident.Value != "sha1sum" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1515",
+		Message: "`" + ident.Value + "` is collision-vulnerable — don't use for integrity " +
+			"checks. Use `sha256sum` / `sha512sum` / `b2sum` instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 511 Katas = 0.5.11
-const Version = "0.5.11"
+// 512 Katas = 0.5.12
+const Version = "0.5.12"


### PR DESCRIPTION
## Summary
- Flags `md5sum` and `sha1sum`
- Both broken for collision resistance — not safe for integrity verification
- Suggest `sha256sum` / `sha512sum` / `b2sum`
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.12 (512 katas)