### PR TITLE
feat: ZC1516 — error on umask 000 / 0 (world-writable new files)

### DIFF
--- a/pkg/katas/katatests/zc1516_test.go
+++ b/pkg/katas/katatests/zc1516_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1516(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — umask 022",
+			input:    `umask 022`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — umask 077",
+			input:    `umask 077`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — umask 000 (parser normalizes to 0)",
+			input: `umask 000`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1516",
+					Message: "`umask 0` leaves new files world-readable and world-writable. Use `022` for public software, `077` for secrets handling.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — umask 0",
+			input: `umask 0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1516",
+					Message: "`umask 0` leaves new files world-readable and world-writable. Use `022` for public software, `077` for secrets handling.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1516")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1516.go
+++ b/pkg/katas/zc1516.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1516",
+		Title:    "Error on `umask 000` / `umask 0` — new files / directories world-writable",
+		Severity: SeverityError,
+		Description: "`umask 000` means every file created after this line inherits mode 0666 " +
+			"and every directory inherits 0777 — world-readable, world-writable, no " +
+			"authorization layer. On a multi-user host (build runner, shared workstation) this " +
+			"leaks secrets through the filesystem and invites tampering. Pick a sensible " +
+			"umask (`022` for public software, `077` for secrets handling).",
+		Check: checkZC1516,
+	})
+}
+
+func checkZC1516(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "umask" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	v := cmd.Arguments[0].String()
+	if v == "0" || v == "00" || v == "000" || v == "0000" {
+		return []Violation{{
+			KataID: "ZC1516",
+			Message: "`umask " + v + "` leaves new files world-readable and world-writable. " +
+				"Use `022` for public software, `077` for secrets handling.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityError,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 512 Katas = 0.5.12
-const Version = "0.5.12"
+// 513 Katas = 0.5.13
+const Version = "0.5.13"


### PR DESCRIPTION
## Summary
- Flags `umask 0`, `umask 00`, `umask 000`, `umask 0000`
- New files mode 0666, new dirs 0777 — world-writable
- Suggest 022 (public) or 077 (secrets)
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.13 (513 katas)