### PR TITLE
feat: ZC1517 — warn on print -P "$var" (Zsh prompt-escape injection)

### DIFF
--- a/pkg/katas/katatests/zc1517_test.go
+++ b/pkg/katas/katatests/zc1517_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1517(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — print -P with literal",
+			input:    `print -P "%F{red}hello%f"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — print without -P",
+			input:    `print "$var"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — print -P with single-quoted var (no interpolation)",
+			input:    `print -P '$var'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — print -P \"$var\"",
+			input: `print -P "$var"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1517",
+					Message: "`print -P \"$var\"` expands prompt escapes inside the variable — use `${(V)var}` / `${(q-)var}` to neutralize metacharacters, or drop -P.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — print -P $msg (unquoted)",
+			input: `print -P $msg`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1517",
+					Message: "`print -P $msg` expands prompt escapes inside the variable — use `${(V)var}` / `${(q-)var}` to neutralize metacharacters, or drop -P.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1517")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1517.go
+++ b/pkg/katas/zc1517.go
@@ -1,0 +1,69 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1517",
+		Title:    "Warn on `print -P \"$var\"` — prompt-escape injection via user-controlled string",
+		Severity: SeverityWarning,
+		Description: "`print -P` enables prompt-escape expansion (`%F`, `%K`, `%B`, `%S`, plus " +
+			"arbitrary command substitution via `%{...%}`). Interpolating a shell variable " +
+			"means any of those sequences inside the variable are expanded — at best messing " +
+			"up terminal state, at worst running the attacker's command via `%(e:...)` or " +
+			"similar. Either drop `-P` or wrap the variable with `${(q-)var}` / `${(V)var}` " +
+			"to neutralize metacharacters before printing.",
+		Check: checkZC1517,
+	})
+}
+
+func checkZC1517(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "print" {
+		return nil
+	}
+
+	hasP := false
+	var varArg string
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-P" {
+			hasP = true
+			continue
+		}
+		if !hasP || varArg != "" {
+			continue
+		}
+		// Look for interpolation:  "$x" or $x (double-quoted or unquoted).
+		raw := v
+		if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
+			raw = raw[1 : len(raw)-1]
+		}
+		if strings.Contains(raw, "$") && !(len(v) >= 2 && v[0] == '\'' && v[len(v)-1] == '\'') {
+			varArg = v
+		}
+	}
+	if !hasP || varArg == "" {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1517",
+		Message: "`print -P " + varArg + "` expands prompt escapes inside the variable — use " +
+			"`${(V)var}` / `${(q-)var}` to neutralize metacharacters, or drop -P.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 513 Katas = 0.5.13
-const Version = "0.5.13"
+// 514 Katas = 0.5.14
+const Version = "0.5.14"


### PR DESCRIPTION
## Summary
- Flags `print -P "$var"` or `print -P $var` — variable interpolated into prompt-expanded position
- Variable content can inject `%F`/`%K`/`%{cmd%}` → terminal state corruption or command execution
- Suggest `${(V)var}` / `${(q-)var}` neutralisation, or drop `-P`
- Zsh-specific
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.14 (514 katas)