### PR TITLE
feat: ZC1518 — warn on bash -p (privileged, skips env sanitisation)

### DIFF
--- a/pkg/katas/katatests/zc1518_test.go
+++ b/pkg/katas/katatests/zc1518_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1518(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — bash -c 'cmd'",
+			input:    `bash -c 'true'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — bash -p -c 'cmd'",
+			input: `bash -p -c 'true'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1518",
+					Message: "`bash -p` keeps the privileged environment on a setuid wrapper — almost never needed, audit and remove.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1518")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1518.go
+++ b/pkg/katas/zc1518.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1518",
+		Title:    "Warn on `bash -p` — privileged mode (skips env sanitisation on setuid)",
+		Severity: SeverityWarning,
+		Description: "`bash -p` (and `-o privileged`) tells bash not to drop its effective UID/GID " +
+			"and not to sanitize the environment when started on a setuid wrapper. It is " +
+			"explicitly the flag you use to keep `BASH_ENV`, `SHELLOPTS`, and similar " +
+			"attacker-controlled variables active while running as a more privileged user. " +
+			"Almost no legitimate script needs `-p`; audit and remove.",
+		Check: checkZC1518,
+	})
+}
+
+func checkZC1518(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "bash" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-p" {
+			return []Violation{{
+				KataID: "ZC1518",
+				Message: "`bash -p` keeps the privileged environment on a setuid wrapper — " +
+					"almost never needed, audit and remove.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 514 Katas = 0.5.14
-const Version = "0.5.14"
+// 515 Katas = 0.5.15
+const Version = "0.5.15"


### PR DESCRIPTION
## Summary
- Flags `bash -p`
- Keeps privileged env on setuid wrapper — preserves `BASH_ENV` / `SHELLOPTS` attacker input
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.15 (515 katas)