### PR TITLE
feat: ZC1519 — warn on ulimit -u unlimited (fork bomb surface)

### DIFF
--- a/pkg/katas/katatests/zc1519_test.go
+++ b/pkg/katas/katatests/zc1519_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1519(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ulimit -u 4096",
+			input:    `ulimit -u 4096`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ulimit -n unlimited (different limit)",
+			input:    `ulimit -n unlimited`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ulimit -u unlimited",
+			input: `ulimit -u unlimited`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1519",
+					Message: "`ulimit -u unlimited` removes the user process cap — fork bomb surface. Pick a realistic number or set it via /etc/security/limits.d/.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1519")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1519.go
+++ b/pkg/katas/zc1519.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1519",
+		Title:    "Warn on `ulimit -u unlimited` — removes user process cap, enables fork bombs",
+		Severity: SeverityWarning,
+		Description: "`ulimit -u` caps the number of processes a UID can run; `unlimited` removes " +
+			"that cap. Combined with a bug in a background loop (or a literal fork bomb via " +
+			"`:(){ :|:& };:`) it pegs the scheduler until the machine has to be cold-booted. " +
+			"Pick a realistic number (distro defaults around 4096 for interactive sessions) or " +
+			"set it in `/etc/security/limits.d/` so it is persistent and visible.",
+		Check: checkZC1519,
+	})
+}
+
+func checkZC1519(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ulimit" {
+		return nil
+	}
+
+	var prevU bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevU {
+			prevU = false
+			if v == "unlimited" {
+				return []Violation{{
+					KataID: "ZC1519",
+					Message: "`ulimit -u unlimited` removes the user process cap — fork bomb " +
+						"surface. Pick a realistic number or set it via /etc/security/limits.d/.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+		if v == "-u" {
+			prevU = true
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 515 Katas = 0.5.15
-const Version = "0.5.15"
+// 516 Katas = 0.5.16
+const Version = "0.5.16"


### PR DESCRIPTION
## Summary
- Flags `ulimit -u unlimited`
- Removes user process cap — fork bomb risk
- Suggest realistic cap, or persistent settings via `/etc/security/limits.d/`
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.16 (516 katas)