### PR TITLE
feat: ZC1520 — warn on vared in scripts (Zsh interactive editor)

### DIFF
--- a/pkg/katas/katatests/zc1520_test.go
+++ b/pkg/katas/katatests/zc1520_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1520(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — read varname",
+			input:    `read varname`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — vared myvar",
+			input: `vared myvar`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1520",
+					Message: "`vared` requires a TTY — in a non-interactive script it errors or hangs. Use `read`, stdin, or environment variables for scripted input.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1520")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1520.go
+++ b/pkg/katas/zc1520.go
@@ -1,0 +1,43 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1520",
+		Title:    "Warn on `vared <var>` in scripts — reads interactively, hangs non-interactive",
+		Severity: SeverityWarning,
+		Description: "`vared` is the Zsh interactive line-editor builtin that lets the user edit " +
+			"the value of a variable in place. In a non-interactive script (cron job, CI " +
+			"runner, ssh-with-command) `vared` has no TTY, so the script either errors out or " +
+			"hangs waiting for input that never arrives. For scripted input, read the value " +
+			"from stdin (`read varname`), a file, or an environment variable.",
+		Check: checkZC1520,
+	})
+}
+
+func checkZC1520(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "vared" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1520",
+		Message: "`vared` requires a TTY — in a non-interactive script it errors or hangs. " +
+			"Use `read`, stdin, or environment variables for scripted input.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 516 Katas = 0.5.16
-const Version = "0.5.16"
+// 517 Katas = 0.5.17
+const Version = "0.5.17"


### PR DESCRIPTION
## Summary
- Flags `vared` in any invocation
- Zsh interactive line-editor builtin — hangs without TTY
- Suggest `read`, stdin, or env var for scripted input
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.17 (517 katas)