### PR TITLE
feat: ZC1521 — style: strace/ltrace without -e filter

### DIFF
--- a/pkg/katas/katatests/zc1521_test.go
+++ b/pkg/katas/katatests/zc1521_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1521(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — strace -e trace=openat cmd",
+			input:    `strace -e trace=openat ls`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — strace -f cmd",
+			input: `strace -f ls`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1521",
+					Message: "`strace` without `-e` captures every syscall including secrets in read/write buffers. Scope with `-e trace=<set>`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — strace cmd (bare)",
+			input: `strace ls`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1521",
+					Message: "`strace` without `-e` captures every syscall including secrets in read/write buffers. Scope with `-e trace=<set>`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1521")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1521.go
+++ b/pkg/katas/zc1521.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1521",
+		Title:    "Style: `strace` without `-e` filter — captures every syscall (incl. secrets, huge output)",
+		Severity: SeverityStyle,
+		Description: "Unfiltered `strace` records every syscall the process makes: every " +
+			"`read()`/`write()` buffer, every `connect()` sockaddr, every `open()` path. That " +
+			"includes passwords read from stdin, session tokens written to TLS sockets, and " +
+			"any memory a `write()` buffer happens to point at. Scope with `-e trace=<set>` " +
+			"(e.g. `trace=openat,connect`) and strip sensitive content with `-e abbrev=all`.",
+		Check: checkZC1521,
+	})
+}
+
+func checkZC1521(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "strace" && ident.Value != "ltrace" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	// Any filter flag present → skip.
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-e" || v == "--trace" || v == "--trace-path" || v == "-P" {
+			return nil
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1521",
+		Message: "`" + ident.Value + "` without `-e` captures every syscall including secrets " +
+			"in read/write buffers. Scope with `-e trace=<set>`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 517 Katas = 0.5.17
-const Version = "0.5.17"
+// 518 Katas = 0.5.18
+const Version = "0.5.18"


### PR DESCRIPTION
## Summary
- Flags `strace` / `ltrace` without `-e|--trace|--trace-path|-P` filter
- Captures every syscall — secrets in read/write buffers, auth tokens, passwords
- Suggest `-e trace=<set>` + `-e abbrev=all`
- Severity: Style

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.18 (518 katas)