### PR TITLE
feat: ZC1522 — warn on ip route add default / route add default

### DIFF
--- a/pkg/katas/katatests/zc1522_test.go
+++ b/pkg/katas/katatests/zc1522_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1522(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ip route add 10.0.0.0/24 dev eth1",
+			input:    `ip route add 10.0.0.0/24 dev eth1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ip route show default",
+			input:    `ip route show default`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ip route add default via 1.2.3.4",
+			input: `ip route add default via 1.2.3.4`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1522",
+					Message: "`ip route add default` silently reroutes every non-local packet through the new gateway — MITM surface or CI footgun. Use NetworkManager/networkd config.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — route add default gw 1.2.3.4",
+			input: `route add default gw 1.2.3.4`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1522",
+					Message: "`route add default` silently reroutes every non-local packet through the new gateway — MITM surface or CI footgun. Use NetworkManager/networkd config.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1522")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1522.go
+++ b/pkg/katas/zc1522.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1522",
+		Title:    "Warn on `ip route add default` / `route add default` — changes default gateway",
+		Severity: SeverityWarning,
+		Description: "Setting a new default route in a script silently redirects every non-local " +
+			"packet through the specified gateway. That is exactly the knob an attacker turns " +
+			"to MITM a whole host after a foothold, and it is also a common accidental foot- " +
+			"gun in CI runners (gateway in the runner network ≠ gateway in production). Use " +
+			"NetworkManager / systemd-networkd config files for persistent routes, and " +
+			"document any runtime change with a comment explaining why.",
+		Check: checkZC1522,
+	})
+}
+
+func checkZC1522(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, a.String())
+	}
+
+	// `ip route add default ...`
+	if ident.Value == "ip" && len(args) >= 3 &&
+		args[0] == "route" && args[1] == "add" && args[2] == "default" {
+		return zc1522Violation(cmd, "ip route add default")
+	}
+	// `route add default ...`
+	if ident.Value == "route" && len(args) >= 2 &&
+		args[0] == "add" && args[1] == "default" {
+		return zc1522Violation(cmd, "route add default")
+	}
+	return nil
+}
+
+func zc1522Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1522",
+		Message: "`" + what + "` silently reroutes every non-local packet through the new " +
+			"gateway — MITM surface or CI footgun. Use NetworkManager/networkd config.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 518 Katas = 0.5.18
-const Version = "0.5.18"
+// 519 Katas = 0.5.19
+const Version = "0.5.19"


### PR DESCRIPTION
## Summary
- Flags `ip route add default ...` and `route add default ...`
- Changing default gateway reroutes everything — MITM or CI misconfig
- Suggest NetworkManager / networkd config files
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.19 (519 katas)