### PR TITLE
feat: ZC1523 — error on tar -C / (extract into root)

### DIFF
--- a/pkg/katas/katatests/zc1523_test.go
+++ b/pkg/katas/katatests/zc1523_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1523(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — tar xf foo.tar -C /tmp/stage",
+			input:    `tar xf foo.tar -C /tmp/stage`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — tar xf foo.tar -C /",
+			input: `tar xf foo.tar -C /`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1523",
+					Message: "`tar -C /` extracts into the filesystem root — overwrites any path that happens to be inside the archive. Stage, inspect, then copy.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1523")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1523.go
+++ b/pkg/katas/zc1523.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1523",
+		Title:    "Error on `tar -C /` — extracting an archive into the filesystem root",
+		Severity: SeverityError,
+		Description: "Extracting a tarball directly into `/` overwrites any file it carries a " +
+			"matching path for. Combined with a malicious tarball that contains entries like " +
+			"`etc/pam.d/sshd` or `usr/bin/ls`, this is a full system compromise disguised as a " +
+			"software install. Always extract into a staging directory, inspect contents, then " +
+			"copy specific files into place.",
+		Check: checkZC1523,
+	})
+}
+
+func checkZC1523(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "tar" && ident.Value != "bsdtar" {
+		return nil
+	}
+
+	var prevC bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevC {
+			prevC = false
+			if v == "/" {
+				return []Violation{{
+					KataID: "ZC1523",
+					Message: "`tar -C /` extracts into the filesystem root — overwrites any " +
+						"path that happens to be inside the archive. Stage, inspect, then copy.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityError,
+				}}
+			}
+		}
+		if v == "-C" || v == "--directory" {
+			prevC = true
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 519 Katas = 0.5.19
-const Version = "0.5.19"
+// 520 Katas = 0.5.20
+const Version = "0.5.20"


### PR DESCRIPTION
## Summary
- Flags `tar|bsdtar -C /` / `--directory /`
- Malicious archive paths like `etc/pam.d/sshd` would overwrite system files
- Suggest stage-inspect-copy workflow
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.20 (520 katas)