### PR TITLE
feat: ZC1524 — warn on sysctl -e/-q (silently skip unknown keys)

### DIFF
--- a/pkg/katas/katatests/zc1524_test.go
+++ b/pkg/katas/katatests/zc1524_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1524(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sysctl -p",
+			input:    `sysctl -p /etc/sysctl.d/99-hardening.conf`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — sysctl -e -p",
+			input: `sysctl -e -p /etc/sysctl.d/99-hardening.conf`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1524",
+					Message: "`sysctl -e` suppresses error output — typos in sysctl.d/ conffiles silently skip. Remove and surface the real error.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — sysctl -q",
+			input: `sysctl -q -p /etc/sysctl.d/99-hardening.conf`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1524",
+					Message: "`sysctl -q` suppresses error output — typos in sysctl.d/ conffiles silently skip. Remove and surface the real error.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1524")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1524.go
+++ b/pkg/katas/zc1524.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1524",
+		Title:    "Warn on `sysctl -e` / `sysctl -q` — silently skip unknown keys, hide config drift",
+		Severity: SeverityWarning,
+		Description: "`sysctl -e` and `-q` suppress error output for unknown keys or failed " +
+			"writes. That is how a typo in `/etc/sysctl.d/99-hardening.conf` goes unnoticed " +
+			"for months — the hardening didn't actually take effect because the key name was " +
+			"wrong. Drop `-e`/`-q` in scripts and let errors bubble up; fix the offending " +
+			"conffile instead.",
+		Check: checkZC1524,
+	})
+}
+
+func checkZC1524(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "sysctl" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-e" || v == "-q" || v == "-eq" || v == "-qe" {
+			return []Violation{{
+				KataID: "ZC1524",
+				Message: "`sysctl " + v + "` suppresses error output — typos in sysctl.d/ " +
+					"conffiles silently skip. Remove and surface the real error.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 520 Katas = 0.5.20
-const Version = "0.5.20"
+// 521 Katas = 0.5.21
+const Version = "0.5.21"


### PR DESCRIPTION
## Summary
- Flags `sysctl -e`, `-q`, `-eq`, `-qe`
- Suppresses error output — typos in sysctl.d/ silently skip, hardening never takes
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.21 (521 katas)