### PR TITLE
feat: ZC1526 — error on wipefs -a (+ typos fixes for ZC1507/ZC1514)

### DIFF
--- a/pkg/katas/katatests/zc1514_test.go
+++ b/pkg/katas/katatests/zc1514_test.go
@@ -24,7 +24,7 @@ func TestZC1514(t *testing.T) {
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1514",
-					Message: "`useradd -p <hash>` puts the crypted password in ps / /proc / history. Use `chpasswd --crypt-method=SHA512` from stdin.",
+					Message: "`useradd -p <hash>` puts the hashed password in ps / /proc / history. Use `chpasswd --crypt-method=SHA512` from stdin.",
 					Line:    1,
 					Column:  1,
 				},
@@ -36,7 +36,7 @@ func TestZC1514(t *testing.T) {
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1514",
-					Message: "`usermod -p <hash>` puts the crypted password in ps / /proc / history. Use `chpasswd --crypt-method=SHA512` from stdin.",
+					Message: "`usermod -p <hash>` puts the hashed password in ps / /proc / history. Use `chpasswd --crypt-method=SHA512` from stdin.",
 					Line:    1,
 					Column:  1,
 				},

--- a/pkg/katas/katatests/zc1526_test.go
+++ b/pkg/katas/katatests/zc1526_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1526(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — wipefs --no-act",
+			input:    `wipefs --no-act $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — wipefs -a disk",
+			input: `wipefs -a $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1526",
+					Message: "`wipefs -a` erases every filesystem signature — unrecoverable. Run with `--no-act` first, or use `sgdisk --zap-all` for scoped deletion.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — wipefs -af disk",
+			input: `wipefs -af $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1526",
+					Message: "`wipefs -a` erases every filesystem signature — unrecoverable. Run with `--no-act` first, or use `sgdisk --zap-all` for scoped deletion.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1526")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1507.go
+++ b/pkg/katas/zc1507.go
@@ -40,7 +40,7 @@ func checkZC1507(node ast.Node) []Violation {
 	for _, arg := range cmd.Arguments {
 		v := arg.String()
 		if v == "-a" || v == "-l" || v == "--archive" || v == "--links" ||
-			strings.HasPrefix(v, "-a") && strings.ContainsAny(v[1:], "lavxHAX") {
+			strings.HasPrefix(v, "-a") && strings.ContainsAny(v[1:], "lavx") {
 			hasSymlinkMode = true
 		}
 		if v == "--safe-links" || v == "--copy-unsafe-links" || v == "--no-links" ||

--- a/pkg/katas/zc1514.go
+++ b/pkg/katas/zc1514.go
@@ -9,8 +9,8 @@ func init() {
 		ID:       "ZC1514",
 		Title:    "Error on `useradd -p <hash>` / `usermod -p <hash>` — password hash on cmdline",
 		Severity: SeverityError,
-		Description: "`-p` takes an already-crypt(3)-ed password and writes it to `/etc/shadow`. " +
-			"That crypted form is in `ps`, `/proc/<pid>/cmdline`, and shell history for as " +
+		Description: "`-p` takes an already-hashed password (crypt(3) format) and writes it " +
+			"to `/etc/shadow`. That hash is in `ps`, `/proc/<pid>/cmdline`, and history for as " +
 			"long as the process runs — enough time for a co-tenant to grab it and start an " +
 			"offline crack. Use `chpasswd` with `--crypt-method=SHA512` reading from stdin, " +
 			"or write `/etc/shadow` via a configuration-management tool with proper file " +
@@ -39,7 +39,7 @@ func checkZC1514(node ast.Node) []Violation {
 		if prevP && v != "" && v[0] != '-' {
 			return []Violation{{
 				KataID: "ZC1514",
-				Message: "`" + ident.Value + " -p <hash>` puts the crypted password in ps / " +
+				Message: "`" + ident.Value + " -p <hash>` puts the hashed password in ps / " +
 					"/proc / history. Use `chpasswd --crypt-method=SHA512` from stdin.",
 				Line:   cmd.Token.Line,
 				Column: cmd.Token.Column,

--- a/pkg/katas/zc1526.go
+++ b/pkg/katas/zc1526.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1526",
+		Title:    "Error on `wipefs -a` / `wipefs -af` — erases filesystem signatures (unrecoverable)",
+		Severity: SeverityError,
+		Description: "`wipefs -a` overwrites every filesystem, partition table, and RAID signature " +
+			"it finds on the target. Unlike `rm`, there is no retention anywhere — the only " +
+			"recovery path is a disk image backup taken beforehand. If the target variable is " +
+			"wrong (typo, empty, resolves to the wrong `/dev/sdX`), this bricks the disk. " +
+			"Always run with `--no-act` first or prefer `sgdisk --zap-all` for partition-table " +
+			"scope.",
+		Check: checkZC1526,
+	})
+}
+
+func checkZC1526(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "wipefs" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-a" || v == "-af" || v == "-fa" || v == "--all" {
+			return []Violation{{
+				KataID: "ZC1526",
+				Message: "`wipefs -a` erases every filesystem signature — unrecoverable. Run " +
+					"with `--no-act` first, or use `sgdisk --zap-all` for scoped deletion.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 521 Katas = 0.5.21
-const Version = "0.5.21"
+// 522 Katas = 0.5.22
+const Version = "0.5.22"


### PR DESCRIPTION
## Summary
- Adds ZC1526: flags `wipefs -a|-af|-fa|--all` — unrecoverable signature erase, Error severity
- Fixes typos CI failures on main:
  - ZC1514: "crypted password" → "hashed password" (typos flags "crypted" as "encrypted")
  - ZC1507: drop "HAX" from rsync letter-set mnemonic (typos flags it as HEX typo)

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.22 (522 katas)