### PR TITLE
feat: ZC1525 — warn on ping -f (re-add, PR 542 was prematurely closed)

### DIFF
--- a/pkg/katas/katatests/zc1525_test.go
+++ b/pkg/katas/katatests/zc1525_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1525(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ping -c 4 host",
+			input:    `ping -c 4 example.com`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ping -f host",
+			input: `ping -f example.com`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1525",
+					Message: "`ping -f` (flood) bypasses the rate limit — saturates slow links. Scope tightly and document.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ping6 -f host",
+			input: `ping6 -f 2001:db8::1`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1525",
+					Message: "`ping6 -f` (flood) bypasses the rate limit — saturates slow links. Scope tightly and document.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1525")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1525.go
+++ b/pkg/katas/zc1525.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1525",
+		Title:    "Warn on `ping -f` — flood ping sends packets as fast as possible",
+		Severity: SeverityWarning,
+		Description: "`ping -f` (flood mode) removes the one-per-second rate limit and sends " +
+			"ICMP echo requests in a tight loop. It's a root-only builtin specifically because " +
+			"it can saturate a slow link or overload a low-end host. Legitimate uses exist " +
+			"(latency benchmarking, stress testing known-internal targets), but in a script " +
+			"aimed at arbitrary hosts it is a noisy traffic generator. Scope tightly and " +
+			"document.",
+		Check: checkZC1525,
+	})
+}
+
+func checkZC1525(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ping" && ident.Value != "ping6" && ident.Value != "fping" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-f" {
+			return []Violation{{
+				KataID: "ZC1525",
+				Message: "`" + ident.Value + " -f` (flood) bypasses the rate limit — saturates " +
+					"slow links. Scope tightly and document.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 522 Katas = 0.5.22
-const Version = "0.5.22"
+// 523 Katas = 0.5.23
+const Version = "0.5.23"


### PR DESCRIPTION
## Summary
- Re-adds ZC1525 (flood ping detection) after PR 542 was prematurely closed during the typos fix on PR 543
- Same kata body: flags `ping|ping6|fping -f`
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.23 (523 katas)