### PR TITLE
feat: ZC1527 — warn on crontab - (overwrites user cron from stdin)

### DIFF
--- a/pkg/katas/katatests/zc1527_test.go
+++ b/pkg/katas/katatests/zc1527_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1527(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — crontab -l",
+			input:    `crontab -l`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — crontab file",
+			input:    `crontab /etc/cron.d/myfile`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — crontab -",
+			input: `crontab -`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1527",
+					Message: "`crontab -` overwrites the user's crontab from stdin — silently drops existing rows. Use /etc/cron.d/ files or a diff/merge workflow.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — crontab -u svc -",
+			input: `crontab -u svc -`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1527",
+					Message: "`crontab -` overwrites the user's crontab from stdin — silently drops existing rows. Use /etc/cron.d/ files or a diff/merge workflow.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1527")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1527.go
+++ b/pkg/katas/zc1527.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1527",
+		Title:    "Warn on `crontab -` — replaces cron from stdin, overwrites without diff",
+		Severity: SeverityWarning,
+		Description: "`crontab -` (or `crontab -u <user> -`) reads a full crontab from stdin and " +
+			"replaces the user's existing entries wholesale. Any manual tweak, oncall " +
+			"override, or colleague's row is silently deleted. Paired with `curl | crontab -` " +
+			"it is a common persistence one-liner. Use `crontab -l > /tmp/old && ... " +
+			"crontab -e` with an explicit diff/merge, or ship cron entries via " +
+			"`/etc/cron.d/*` managed by config tooling.",
+		Check: checkZC1527,
+	})
+}
+
+func checkZC1527(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "crontab" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-" {
+			return []Violation{{
+				KataID: "ZC1527",
+				Message: "`crontab -` overwrites the user's crontab from stdin — silently " +
+					"drops existing rows. Use /etc/cron.d/ files or a diff/merge workflow.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 523 Katas = 0.5.23
-const Version = "0.5.23"
+// 524 Katas = 0.5.24
+const Version = "0.5.24"


### PR DESCRIPTION
## Summary
- Flags `crontab -` and `crontab -u <user> -`
- Wholesale replacement of user crontab — drops existing rows, common persistence one-liner
- Suggest /etc/cron.d/ or read-modify-write
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.24 (524 katas)