### PR TITLE
feat: ZC1528 — warn on chage -M 99999 / -E -1 (disables password aging)

### DIFF
--- a/pkg/katas/katatests/zc1528_test.go
+++ b/pkg/katas/katatests/zc1528_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1528(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — chage -M 90 alice",
+			input:    `chage -M 90 alice`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — chage -l alice",
+			input:    `chage -l alice`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — chage -M 99999 alice",
+			input: `chage -M 99999 alice`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1528",
+					Message: "`chage -M 99999` disables password aging — removes automatic lockout. Use a PAM profile instead of per-user chage.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — chage -E -1 alice",
+			input: `chage -E -1 alice`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1528",
+					Message: "`chage -E -1` disables password aging — removes automatic lockout. Use a PAM profile instead of per-user chage.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1528")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1528.go
+++ b/pkg/katas/zc1528.go
@@ -1,0 +1,69 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1528",
+		Title:    "Warn on `chage -M 99999` / `-E -1` — disables password aging / expiry",
+		Severity: SeverityWarning,
+		Description: "`chage -M 99999` sets the max password age to roughly 273 years (effectively " +
+			"never). `chage -E -1` clears the account expiration date. Both silently remove an " +
+			"automatic lockout mechanism a compromised credential would otherwise hit. If " +
+			"passwords genuinely should not expire (SSO, cert-based auth), encode that in a " +
+			"PAM profile rather than per-user `chage`.",
+		Check: checkZC1528,
+	})
+}
+
+func checkZC1528(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "chage" {
+		return nil
+	}
+
+	var prevM, prevE bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevM {
+			prevM = false
+			if v == "99999" || v == "-1" || v == "0" {
+				return zc1528Violation(cmd, "-M "+v)
+			}
+		}
+		if prevE {
+			prevE = false
+			if v == "-1" {
+				return zc1528Violation(cmd, "-E -1")
+			}
+		}
+		switch v {
+		case "-M", "--maxdays":
+			prevM = true
+		case "-E", "--expiredate":
+			prevE = true
+		}
+	}
+	return nil
+}
+
+func zc1528Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1528",
+		Message: "`chage " + what + "` disables password aging — removes automatic lockout. " +
+			"Use a PAM profile instead of per-user chage.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 524 Katas = 0.5.24
-const Version = "0.5.24"
+// 525 Katas = 0.5.25
+const Version = "0.5.25"


### PR DESCRIPTION
## Summary
- Flags `chage -M 99999|-1|0` and `chage -E -1`
- Silently removes automatic lockout mechanism
- Suggest PAM profile for SSO/cert-auth case
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.25 (525 katas)