### PR TITLE
feat: ZC1529 — warn on fsck -y (auto-yes can destroy salvageable data)

### DIFF
--- a/pkg/katas/katatests/zc1529_test.go
+++ b/pkg/katas/katatests/zc1529_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1529(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — fsck -n $disk (dry run)",
+			input:    `fsck -n $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — fsck -p $disk (preen)",
+			input:    `fsck -p $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — fsck -y $disk",
+			input: `fsck -y $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1529",
+					Message: "`fsck -y` answers yes to every repair prompt — can destroy salvageable data. Prefer `-n` (dry-run) or `-p` (preen).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — fsck.ext4 -y $disk",
+			input: `fsck.ext4 -y $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1529",
+					Message: "`fsck.ext4 -y` answers yes to every repair prompt — can destroy salvageable data. Prefer `-n` (dry-run) or `-p` (preen).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1529")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1529.go
+++ b/pkg/katas/zc1529.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1529",
+		Title:    "Warn on `fsck -y` / `fsck.<fs> -y` — auto-answer yes can corrupt",
+		Severity: SeverityWarning,
+		Description: "`fsck -y` answers `yes` to every repair prompt. For the happy case it is a " +
+			"timesaver, but on a filesystem with unusual corruption (bad sector storm, mangled " +
+			"journal after power loss) the automatic answer can turn salvageable data into " +
+			"`lost+found` entries or zero it outright. In scripts, prefer `fsck -n` for a " +
+			"dry-run and let a human adjudicate a real repair, or run with `-p` (preen: only " +
+			"safe automatic fixes).",
+		Check: checkZC1529,
+	})
+}
+
+func checkZC1529(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "fsck" && !strings.HasPrefix(ident.Value, "fsck.") &&
+		ident.Value != "e2fsck" && ident.Value != "xfs_repair" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-y" {
+			return []Violation{{
+				KataID: "ZC1529",
+				Message: "`" + ident.Value + " -y` answers yes to every repair prompt — can " +
+					"destroy salvageable data. Prefer `-n` (dry-run) or `-p` (preen).",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 525 Katas = 0.5.25
-const Version = "0.5.25"
+// 526 Katas = 0.5.26
+const Version = "0.5.26"


### PR DESCRIPTION
## Summary
- Flags `fsck -y` / `fsck.<fs> -y` / `e2fsck -y` / `xfs_repair -y`
- Auto-answer yes can turn salvageable data into lost+found
- Suggest `-n` (dry-run) or `-p` (preen)
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.26 (526 katas)