### PR TITLE
feat: ZC1530 — warn on pkill -f (full-cmdline match, easy to over-kill)

### DIFF
--- a/pkg/katas/katatests/zc1530_test.go
+++ b/pkg/katas/katatests/zc1530_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1530(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — pkill sshd (process name)",
+			input:    `pkill sshd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — pkill -U 1000 java",
+			input:    `pkill -U 1000 java`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — pkill -f server",
+			input: `pkill -f server`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1530",
+					Message: "`pkill -f` matches the full command line — easy to over-kill. Drop `-f`, scope with `-U/-G/-P`, or anchor the pattern with ^/$.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1530")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1530.go
+++ b/pkg/katas/zc1530.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1530",
+		Title:    "Warn on `pkill -f <pattern>` — matches full command line, easy to over-kill",
+		Severity: SeverityWarning,
+		Description: "`pkill -f` matches the pattern against the full command line, not just " +
+			"the process name. A pattern like `-f server` also matches the `grep -- server` " +
+			"in a user's shell history or any backup tool named `server-backup`. For routine " +
+			"use, drop `-f` (matches process name only) or scope with `-U <uid>` / `-G " +
+			"<gid>` / `-P <ppid>`. When you must match the command line, pin it with `^` / `$` " +
+			"anchors in the pattern.",
+		Check: checkZC1530,
+	})
+}
+
+func checkZC1530(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "pkill" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-f" {
+			return []Violation{{
+				KataID: "ZC1530",
+				Message: "`pkill -f` matches the full command line — easy to over-kill. Drop " +
+					"`-f`, scope with `-U/-G/-P`, or anchor the pattern with ^/$.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 526 Katas = 0.5.26
-const Version = "0.5.26"
+// 527 Katas = 0.5.27
+const Version = "0.5.27"


### PR DESCRIPTION
## Summary
- Flags `pkill -f`
- Matches full command line, not process name — catches unintended targets
- Suggest drop `-f`, scope with `-U/-G/-P`, or anchor pattern with `^`/`$`
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.27 (527 katas)