### PR TITLE
feat: ZC1531 — warn on wget -t 0 (infinite retries hang script)

### DIFF
--- a/pkg/katas/katatests/zc1531_test.go
+++ b/pkg/katas/katatests/zc1531_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1531(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — wget -t 5 https://host",
+			input:    `wget -t 5 https://host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — wget -t 0 https://host",
+			input: `wget -t 0 https://host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1531",
+					Message: "`wget -t 0` retries forever — script hangs on dead endpoint. Use finite `-t 5` plus `--timeout=<seconds>`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1531")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1531.go
+++ b/pkg/katas/zc1531.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1531",
+		Title:    "Warn on `wget -t 0` — infinite retries, hangs on a dead endpoint",
+		Severity: SeverityWarning,
+		Description: "`wget -t 0` (or `--tries=0`) means retry forever. Paired with `-w` (wait " +
+			"between retries) and a dead endpoint, the script hangs until killed — in a cron " +
+			"job, every subsequent invocation piles up and eventually the UID's process limit " +
+			"trips. Use a finite retry count (`-t 5`) plus `--timeout=<seconds>` to cap total " +
+			"wall time.",
+		Check: checkZC1531,
+	})
+}
+
+func checkZC1531(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "wget" {
+		return nil
+	}
+
+	var prevT bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevT {
+			prevT = false
+			if v == "0" {
+				return []Violation{{
+					KataID: "ZC1531",
+					Message: "`wget -t 0` retries forever — script hangs on dead endpoint. " +
+						"Use finite `-t 5` plus `--timeout=<seconds>`.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+		if v == "-t" {
+			prevT = true
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 527 Katas = 0.5.27
-const Version = "0.5.27"
+// 528 Katas = 0.5.28
+const Version = "0.5.28"


### PR DESCRIPTION
## Summary
- Flags `wget -t 0`
- Retry forever paired with dead endpoint hangs script / piles up cron invocations
- Suggest finite `-t 5` + `--timeout`
- Parser limitation: `--tries=0` long form swallowed upstream
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.28 (528 katas)