### PR TITLE
feat: ZC1532 — warn on screen -dm / tmux new-session -d

### DIFF
--- a/pkg/katas/katatests/zc1532_test.go
+++ b/pkg/katas/katatests/zc1532_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1532(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — screen -S mysession",
+			input:    `screen -S mysession`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — tmux attach",
+			input:    `tmux attach-session -t work`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — screen -S name -dm cmd",
+			input: `screen -S work -dm /usr/local/bin/worker`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1532",
+					Message: "`screen -dm` backgrounds work outside systemd — no journal, no cgroup, common persistence technique. Use a systemd unit instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — tmux new-session -d -s name cmd",
+			input: `tmux new-session -d -s work /usr/local/bin/worker`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1532",
+					Message: "`tmux new-session -d` backgrounds work outside systemd — no journal, no cgroup, common persistence technique. Use a systemd unit instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1532")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1532.go
+++ b/pkg/katas/zc1532.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1532",
+		Title:    "Warn on `screen -dm` / `tmux new-session -d` — detached long-running session",
+		Severity: SeverityWarning,
+		Description: "Starting a detached screen/tmux session from a script puts a long-running " +
+			"process outside the systemd supervisory tree: no logs in the journal, no cgroup " +
+			"accounting, no restart-on-failure, no OOM scoring. It is also a common post- " +
+			"compromise persistence technique because the session survives the initial shell " +
+			"exit and hides in `ps -ef` as a short tmux/screen helper. For real long-running " +
+			"work, write a systemd unit (user or system) and start it with `systemctl " +
+			"[--user] start`.",
+		Check: checkZC1532,
+	})
+}
+
+func checkZC1532(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value == "screen" {
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "-dm" || v == "-dmS" {
+				return zc1532Violation(cmd, "screen "+v)
+			}
+		}
+	}
+	if ident.Value == "tmux" && len(cmd.Arguments) >= 2 && cmd.Arguments[0].String() == "new-session" {
+		for _, arg := range cmd.Arguments[1:] {
+			if arg.String() == "-d" {
+				return zc1532Violation(cmd, "tmux new-session -d")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1532Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1532",
+		Message: "`" + what + "` backgrounds work outside systemd — no journal, no cgroup, " +
+			"common persistence technique. Use a systemd unit instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 528 Katas = 0.5.28
-const Version = "0.5.28"
+// 529 Katas = 0.5.29
+const Version = "0.5.29"


### PR DESCRIPTION
## Summary
- Flags `screen -dm`/`-dmS` and `tmux new-session -d`
- Detached long-running processes run outside systemd — no journal/cgroup/restart
- Common persistence pattern
- Suggest systemd unit (user or system)
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.29 (529 katas)