### PR TITLE
feat: ZC1533 — warn on setsid <cmd> (detaches from TTY, escapes supervision)

### DIFF
--- a/pkg/katas/katatests/zc1533_test.go
+++ b/pkg/katas/katatests/zc1533_test.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1533(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:  "invalid — setsid /usr/local/bin/worker",
+			input: `setsid /usr/local/bin/worker`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1533",
+					Message: "`setsid` detaches the child from the TTY / session — escapes supervision. Prefer a systemd unit; document a detach if one is genuinely needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — setsid -f /usr/local/bin/worker",
+			input: `setsid -f /usr/local/bin/worker`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1533",
+					Message: "`setsid` detaches the child from the TTY / session — escapes supervision. Prefer a systemd unit; document a detach if one is genuinely needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1533")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1533.go
+++ b/pkg/katas/zc1533.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1533",
+		Title:    "Warn on `setsid <cmd>` — detaches from controlling TTY, escapes supervision",
+		Severity: SeverityWarning,
+		Description: "`setsid` starts a new session and process group. Combined with `-f` " +
+			"(`--fork`) the child is fully detached from the invoking shell: `SIGHUP` from " +
+			"logout does not reach it, the tty hang-up no longer terminates it, and it falls " +
+			"off the script's job table. That is legitimate for daemonising a long-running " +
+			"helper (though systemd does this better) and is also a standard persistence " +
+			"mechanism. Prefer a systemd unit; if you must detach, document why.",
+		Check: checkZC1533,
+	})
+}
+
+func checkZC1533(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "setsid" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1533",
+		Message: "`setsid` detaches the child from the TTY / session — escapes supervision. " +
+			"Prefer a systemd unit; document a detach if one is genuinely needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 529 Katas = 0.5.29
-const Version = "0.5.29"
+// 530 Katas = 0.5.30
+const Version = "0.5.30"


### PR DESCRIPTION
## Summary
- Flags any `setsid <cmd>` invocation
- Detaches from TTY/session — SIGHUP won't reach child, falls off job table
- Legit for daemonising but systemd does it better; also persistence pattern
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.30 (530 katas)