### PR TITLE
feat: ZC1534 — warn on dmesg -c (wipes kernel ring buffer)

### DIFF
--- a/pkg/katas/katatests/zc1534_test.go
+++ b/pkg/katas/katatests/zc1534_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1534(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — dmesg -T",
+			input:    `dmesg -T`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — dmesg -c",
+			input: `dmesg -c`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1534",
+					Message: "`dmesg -c` wipes the kernel ring buffer — subsequent readers see no OOM/panic/audit messages. Read without clearing.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — dmesg -C",
+			input: `dmesg -C`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1534",
+					Message: "`dmesg -C` wipes the kernel ring buffer — subsequent readers see no OOM/panic/audit messages. Read without clearing.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1534")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1534.go
+++ b/pkg/katas/zc1534.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1534",
+		Title:    "Warn on `dmesg -c` / `--clear` — wipes kernel ring buffer",
+		Severity: SeverityWarning,
+		Description: "`dmesg -c` reads and then clears the kernel ring buffer. Any subsequent " +
+			"reader sees an empty log, so OOM kills, driver panics, and audit messages that " +
+			"landed between the wipe and the incident response are gone. It is also an " +
+			"anti-forensics step in post-exploitation playbooks. Use `dmesg` (no flags) for a " +
+			"read, and let the journal retention policy handle rotation.",
+		Check: checkZC1534,
+	})
+}
+
+func checkZC1534(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "dmesg" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-c" || v == "-C" || v == "--clear" || v == "--read-clear" {
+			return []Violation{{
+				KataID: "ZC1534",
+				Message: "`dmesg " + v + "` wipes the kernel ring buffer — subsequent " +
+					"readers see no OOM/panic/audit messages. Read without clearing.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 530 Katas = 0.5.30
-const Version = "0.5.30"
+// 531 Katas = 0.5.31
+const Version = "0.5.31"


### PR DESCRIPTION
## Summary
- Flags `dmesg -c|-C|--clear|--read-clear`
- Wipes kernel ring buffer — OOM/panic/audit messages lost
- Anti-forensics pattern
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.31 (531 katas)