### PR TITLE
feat: ZC1535 — warn on ip link promisc on / ifconfig promisc

### DIFF
--- a/pkg/katas/katatests/zc1535_test.go
+++ b/pkg/katas/katatests/zc1535_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1535(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ip link set eth0 up",
+			input:    `ip link set eth0 up`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ip link set eth0 promisc off",
+			input:    `ip link set eth0 promisc off`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ip link set eth0 promisc on",
+			input: `ip link set eth0 promisc on`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1535",
+					Message: "Interface put into promiscuous mode — sniffer-in-place. Re-disable after capture, or grant tcpdump CAP_NET_RAW instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ifconfig eth0 promisc",
+			input: `ifconfig eth0 promisc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1535",
+					Message: "Interface put into promiscuous mode — sniffer-in-place. Re-disable after capture, or grant tcpdump CAP_NET_RAW instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1535")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1535.go
+++ b/pkg/katas/zc1535.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1535",
+		Title:    "Warn on `ip link set <iface> promisc on` — enables packet capture",
+		Severity: SeverityWarning,
+		Description: "Putting an interface into promiscuous mode tells the NIC to deliver every " +
+			"frame to userspace, not just frames addressed to this host. Legitimate for tools " +
+			"like tcpdump/tshark (which turn it on themselves) but running it from a script " +
+			"and leaving it on is a sniffer-in-place — traffic from other hosts on the same " +
+			"broadcast domain lands in anyone's `tshark -i`. Re-disable as soon as capture is " +
+			"done, and prefer giving tcpdump `CAP_NET_RAW` so the mode is scoped to a single " +
+			"invocation.",
+		Check: checkZC1535,
+	})
+}
+
+func checkZC1535(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ip" && ident.Value != "ifconfig" {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, a.String())
+	}
+
+	// ip link set <iface> promisc on
+	if ident.Value == "ip" {
+		for i := 0; i+4 < len(args); i++ {
+			if args[i] == "link" && args[i+1] == "set" && args[i+3] == "promisc" && args[i+4] == "on" {
+				return zc1535Violation(cmd)
+			}
+		}
+	}
+	// ifconfig <iface> promisc
+	if ident.Value == "ifconfig" {
+		for _, a := range args {
+			if a == "promisc" {
+				return zc1535Violation(cmd)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1535Violation(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1535",
+		Message: "Interface put into promiscuous mode — sniffer-in-place. Re-disable after " +
+			"capture, or grant tcpdump CAP_NET_RAW instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 531 Katas = 0.5.31
-const Version = "0.5.31"
+// 532 Katas = 0.5.32
+const Version = "0.5.32"


### PR DESCRIPTION
## Summary
- Flags `ip link set <iface> promisc on` and `ifconfig <iface> promisc`
- Sniffer-in-place pattern — re-disable after capture
- Suggest `CAP_NET_RAW` on tcpdump for scoped use
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.32 (532 katas)