### PR TITLE
feat: ZC1536 — warn on iptables -j DNAT/REDIRECT (traffic rewrite)

### DIFF
--- a/pkg/katas/katatests/zc1536_test.go
+++ b/pkg/katas/katatests/zc1536_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1536(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — iptables -L (list)",
+			input:    `iptables -L`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — iptables -A INPUT -j DROP",
+			input:    `iptables -A INPUT -j DROP`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — iptables -I PREROUTING ... -j DNAT",
+			input: `iptables -t nat -I PREROUTING -p tcp -j DNAT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1536",
+					Message: "`iptables -j DNAT` rewrites packet destination — silent redirect surface. Use declarative nftables/firewalld config.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — iptables -A OUTPUT ... -j REDIRECT",
+			input: `iptables -t nat -A OUTPUT -p tcp -j REDIRECT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1536",
+					Message: "`iptables -j REDIRECT` rewrites packet destination — silent redirect surface. Use declarative nftables/firewalld config.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1536")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1536.go
+++ b/pkg/katas/zc1536.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1536",
+		Title:    "Warn on `iptables -j DNAT` / `-j REDIRECT` — rewrites traffic destination",
+		Severity: SeverityWarning,
+		Description: "`-j DNAT` and `-j REDIRECT` in an iptables rule rewrite the destination " +
+			"address/port of matching packets. That is how you transparently proxy, but also " +
+			"how you silently redirect a victim's connections to an attacker-controlled port. " +
+			"Scripts that touch NAT rules should be carefully reviewed; prefer declarative " +
+			"network config (nftables ruleset, NetworkManager connection, firewalld service) " +
+			"and store rule provenance.",
+		Check: checkZC1536,
+	})
+}
+
+func checkZC1536(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "iptables" && ident.Value != "ip6tables" {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, a.String())
+	}
+
+	// Must see an add/insert verb to avoid flagging -L listings.
+	var hasAdd bool
+	for _, a := range args {
+		if a == "-A" || a == "-I" || a == "-R" || a == "--append" ||
+			a == "--insert" || a == "--replace" {
+			hasAdd = true
+			break
+		}
+	}
+	if !hasAdd {
+		return nil
+	}
+
+	for i, a := range args {
+		if a == "-j" && i+1 < len(args) {
+			tgt := args[i+1]
+			if tgt == "DNAT" || tgt == "REDIRECT" || tgt == "NETMAP" {
+				return []Violation{{
+					KataID: "ZC1536",
+					Message: "`iptables -j " + tgt + "` rewrites packet destination — " +
+						"silent redirect surface. Use declarative nftables/firewalld config.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 532 Katas = 0.5.32
-const Version = "0.5.32"
+// 533 Katas = 0.5.33
+const Version = "0.5.33"


### PR DESCRIPTION
## Summary
- Flags `iptables|ip6tables -A|-I|-R ... -j DNAT|REDIRECT|NETMAP`
- NAT targets rewrite packet destination — silent redirect surface
- Suggest declarative nftables/firewalld config
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.33 (533 katas)