### PR TITLE
feat: ZC1537 — error on lvremove/vgremove/pvremove -f (LVM destroy)

### DIFF
--- a/pkg/katas/katatests/zc1537_test.go
+++ b/pkg/katas/katatests/zc1537_test.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1537(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — lvremove vg/lv",
+			input:    `lvremove vg0/lv0`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — lvremove -f vg/lv",
+			input: `lvremove -f vg0/lv0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1537",
+					Message: "`lvremove -f` skips the confirmation — a typo in the volume name destroys every filesystem on top of it.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — vgremove -f vg",
+			input: `vgremove -f vg0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1537",
+					Message: "`vgremove -f` skips the confirmation — a typo in the volume name destroys every filesystem on top of it.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — pvremove -ff pv",
+			input: `pvremove -ff /devicenode`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1537",
+					Message: "`pvremove -ff` skips the confirmation — a typo in the volume name destroys every filesystem on top of it.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1537")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1537.go
+++ b/pkg/katas/zc1537.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1537",
+		Title:    "Error on `lvremove -f` / `vgremove -f` / `pvremove -f` — force-destroys LVM metadata",
+		Severity: SeverityError,
+		Description: "The `-f`/`--force` flag on the LVM destructive commands skips the " +
+			"confirmation prompt that protects against a typo in the volume name. If the " +
+			"target variable resolves to the wrong VG/LV/PV (empty, unset, different host), " +
+			"a single line destroys every filesystem on top of that LVM stack. Leave the " +
+			"prompt in and pipe `yes` to it only when you have explicitly confirmed the " +
+			"target immediately beforehand.",
+		Check: checkZC1537,
+	})
+}
+
+func checkZC1537(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "lvremove" && ident.Value != "vgremove" && ident.Value != "pvremove" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-f" || v == "-ff" || v == "--force" {
+			return []Violation{{
+				KataID: "ZC1537",
+				Message: "`" + ident.Value + " " + v + "` skips the confirmation — a typo in " +
+					"the volume name destroys every filesystem on top of it.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 533 Katas = 0.5.33
-const Version = "0.5.33"
+// 534 Katas = 0.5.34
+const Version = "0.5.34"


### PR DESCRIPTION
## Summary
- Flags `lvremove|vgremove|pvremove -f|-ff|--force`
- Skips confirmation; wrong target variable destroys every filesystem on the stack
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.34 (534 katas)