### PR TITLE
feat: ZC1538 — error on zpool destroy -f / zfs destroy -rR

### DIFF
--- a/pkg/katas/katatests/zc1538_test.go
+++ b/pkg/katas/katatests/zc1538_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1538(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — zpool list",
+			input:    `zpool list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — zfs list",
+			input:    `zfs list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — zfs destroy mydataset (no -r)",
+			input:    `zfs destroy tank/data/old`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — zpool destroy -f tank",
+			input: `zpool destroy -f tank`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1538",
+					Message: "`zpool destroy -f` irrecoverably destroys the ZFS pool/dataset and every snapshot on it. Require explicit target confirmation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — zfs destroy -rR tank/data",
+			input: `zfs destroy -rR tank/data`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1538",
+					Message: "`zfs destroy -rR` irrecoverably destroys the ZFS pool/dataset and every snapshot on it. Require explicit target confirmation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1538")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1538.go
+++ b/pkg/katas/zc1538.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1538",
+		Title:    "Error on `zpool destroy -f` / `zfs destroy -rR` — recursive ZFS destruction",
+		Severity: SeverityError,
+		Description: "`zpool destroy -f` nukes a whole ZFS pool including every dataset, " +
+			"snapshot, and clone on it. `zfs destroy -r` recurses into descendant datasets; " +
+			"`-R` additionally drops descendant clones. Unlike `rm`, the space is freed " +
+			"immediately and there is no recycle bin. Always require `zfs list`/`zpool list` " +
+			"+ explicit target confirmation in the same script block, and prefer snapshot-" +
+			"based rollback for recoverable workflows.",
+		Check: checkZC1538,
+	})
+}
+
+func checkZC1538(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value == "zpool" && len(cmd.Arguments) >= 2 &&
+		cmd.Arguments[0].String() == "destroy" {
+		for _, arg := range cmd.Arguments[1:] {
+			if arg.String() == "-f" {
+				return zc1538Violation(cmd, "zpool destroy -f")
+			}
+		}
+	}
+	if ident.Value == "zfs" && len(cmd.Arguments) >= 2 &&
+		cmd.Arguments[0].String() == "destroy" {
+		for _, arg := range cmd.Arguments[1:] {
+			v := arg.String()
+			if v == "-r" || v == "-R" || v == "-rR" || v == "-Rr" ||
+				v == "-rf" || v == "-fr" {
+				return zc1538Violation(cmd, "zfs destroy "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1538Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1538",
+		Message: "`" + what + "` irrecoverably destroys the ZFS pool/dataset and every " +
+			"snapshot on it. Require explicit target confirmation.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 534 Katas = 0.5.34
-const Version = "0.5.34"
+// 535 Katas = 0.5.35
+const Version = "0.5.35"


### PR DESCRIPTION
## Summary
- Flags `zpool destroy -f <pool>` and `zfs destroy -r|-R|-rR|-Rr|-rf|-fr <dataset>`
- Irrecoverable destruction of ZFS data, no recycle bin
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.35 (535 katas)