### PR TITLE
feat: ZC1539 — warn on parted -s <disk> <destructive-op>

### DIFF
--- a/pkg/katas/katatests/zc1539_test.go
+++ b/pkg/katas/katatests/zc1539_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1539(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — parted -s DISK print",
+			input:    `parted -s $DISK print`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — parted DISK mklabel (interactive)",
+			input:    `parted $DISK mklabel gpt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — parted -s DISK mklabel gpt",
+			input: `parted -s $DISK mklabel gpt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1539",
+					Message: "`parted -s <disk> mklabel` bypasses the confirmation prompt — a typo in the disk variable silently repartitions the wrong device.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — parted -s DISK rm 1",
+			input: `parted -s $DISK rm 1`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1539",
+					Message: "`parted -s <disk> rm` bypasses the confirmation prompt — a typo in the disk variable silently repartitions the wrong device.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1539")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1539.go
+++ b/pkg/katas/zc1539.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1539",
+		Title:    "Warn on `parted -s <disk> <destructive-op>` — script mode bypasses confirmation",
+		Severity: SeverityWarning,
+		Description: "`parted -s` (script mode) answers the `data will be destroyed` prompt " +
+			"with `yes`. Combined with `mklabel`, `mkpart`, `rm`, or `resizepart` on the " +
+			"wrong device variable it silently repartitions or zeros the partition table on a " +
+			"disk the author never intended. Require an explicit `parted <disk> print` check " +
+			"plus an out-of-band confirmation before the destructive call.",
+		Check: checkZC1539,
+	})
+}
+
+func checkZC1539(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "parted" {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, a.String())
+	}
+
+	var hasScript bool
+	for _, a := range args {
+		if a == "-s" {
+			hasScript = true
+		}
+	}
+	if !hasScript {
+		return nil
+	}
+	for _, a := range args {
+		switch a {
+		case "mklabel", "mkpart", "rm", "resizepart", "mkpartfs":
+			return []Violation{{
+				KataID: "ZC1539",
+				Message: "`parted -s <disk> " + a + "` bypasses the confirmation prompt — a " +
+					"typo in the disk variable silently repartitions the wrong device.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 535 Katas = 0.5.35
-const Version = "0.5.35"
+// 536 Katas = 0.5.36
+const Version = "0.5.36"


### PR DESCRIPTION
## Summary
- Flags `parted -s` paired with `mklabel`, `mkpart`, `rm`, `resizepart`, or `mkpartfs`
- Script mode bypasses confirmation prompt — typo in disk variable silently repartitions
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.36 (536 katas)