### PR TITLE
feat: ZC1540 — error on cryptsetup erase / luksErase (LUKS header)

### DIFF
--- a/pkg/katas/katatests/zc1540_test.go
+++ b/pkg/katas/katatests/zc1540_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1540(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — cryptsetup luksOpen",
+			input:    `cryptsetup luksOpen $DEV mapname`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — cryptsetup luksRemoveKey",
+			input:    `cryptsetup luksRemoveKey $DEV`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — cryptsetup erase $DEV",
+			input: `cryptsetup erase $DEV`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1540",
+					Message: "`cryptsetup erase` wipes the LUKS header — ciphertext becomes unrecoverable. Back up the header first, or use luksRemoveKey/luksKillSlot for single-slot rotation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — cryptsetup luksErase $DEV",
+			input: `cryptsetup luksErase $DEV`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1540",
+					Message: "`cryptsetup luksErase` wipes the LUKS header — ciphertext becomes unrecoverable. Back up the header first, or use luksRemoveKey/luksKillSlot for single-slot rotation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1540")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1540.go
+++ b/pkg/katas/zc1540.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1540",
+		Title:    "Error on `cryptsetup erase` / `luksErase` — destroys LUKS header, data unrecoverable",
+		Severity: SeverityError,
+		Description: "`cryptsetup erase` (alias `luksErase`) overwrites the LUKS header and " +
+			"every key slot. Without the header the ciphertext on the device is unrecoverable " +
+			"— even the original passphrase cannot unlock it. Keep a `cryptsetup " +
+			"luksHeaderBackup` image somewhere safe before running erase, and prefer " +
+			"`luksRemoveKey`/`luksKillSlot` when only rotating one slot.",
+		Check: checkZC1540,
+	})
+}
+
+func checkZC1540(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "cryptsetup" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "erase" || v == "luksErase" {
+			return []Violation{{
+				KataID: "ZC1540",
+				Message: "`cryptsetup " + v + "` wipes the LUKS header — ciphertext becomes " +
+					"unrecoverable. Back up the header first, or use luksRemoveKey/" +
+					"luksKillSlot for single-slot rotation.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 536 Katas = 0.5.36
-const Version = "0.5.36"
+// 537 Katas = 0.5.37
+const Version = "0.5.37"


### PR DESCRIPTION
## Summary
- Flags `cryptsetup erase` and `cryptsetup luksErase`
- Destroys LUKS header — ciphertext unrecoverable even with original passphrase
- Suggest luksHeaderBackup first, or luksRemoveKey/luksKillSlot for single-slot
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.37 (537 katas)