### PR TITLE
feat: ZC1541 — error on apk add --allow-untrusted (unsigned pkg)

### DIFF
--- a/pkg/katas/katatests/zc1541_test.go
+++ b/pkg/katas/katatests/zc1541_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1541(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — apk add curl",
+			input:    `apk add curl`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — apk add --allow-untrusted local.apk",
+			input: `apk add --allow-untrusted ./local.apk`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1541",
+					Message: "`apk --allow-untrusted` skips signature verification on the package — MITM-to-root on Alpine. Sign and place key in /etc/apk/keys/.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1541")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1541.go
+++ b/pkg/katas/zc1541.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1541",
+		Title:    "Error on `apk add --allow-untrusted` — installs unsigned Alpine packages",
+		Severity: SeverityError,
+		Description: "`apk add --allow-untrusted` skips signature verification on the package " +
+			"being installed. On Alpine that is a direct MITM-to-root path: any mirror, " +
+			"cache, or typo-squat can slip a replacement `.apk` and the daemon starts running " +
+			"attacker code on next restart. Sign internal packages with your own key in " +
+			"`/etc/apk/keys/` and keep verification on.",
+		Check: checkZC1541,
+	})
+}
+
+func checkZC1541(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "apk" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "--allow-untrusted" {
+			return []Violation{{
+				KataID: "ZC1541",
+				Message: "`apk --allow-untrusted` skips signature verification on the " +
+					"package — MITM-to-root on Alpine. Sign and place key in /etc/apk/keys/.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 537 Katas = 0.5.37
-const Version = "0.5.37"
+// 538 Katas = 0.5.38
+const Version = "0.5.38"


### PR DESCRIPTION
## Summary
- Flags `apk` with `--allow-untrusted`
- Alpine signature bypass — MITM-to-root
- Suggest signing + `/etc/apk/keys/`
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.38 (538 katas)