### PR TITLE
feat: ZC1542 — error on snap install --dangerous (unsigned snap)

### DIFF
--- a/pkg/katas/katatests/zc1542_test.go
+++ b/pkg/katas/katatests/zc1542_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1542(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — snap install firefox",
+			input:    `snap install firefox`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — snap install --dangerous local.snap",
+			input: `snap install --dangerous ./local.snap`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1542",
+					Message: "`snap install --dangerous` installs an assertion-unverified snap — any .snap on disk can register system services. Use --devmode or the store.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1542")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1542.go
+++ b/pkg/katas/zc1542.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1542",
+		Title:    "Error on `snap install --dangerous` — installs unsigned snap",
+		Severity: SeverityError,
+		Description: "`snap install --dangerous` tells snapd to install a snap that is not " +
+			"assertion-verified. That bypass is named after the risk: any `.snap` file on disk " +
+			"can register system services, confinement profiles, and hooks, running as whatever " +
+			"user the snap declares. Use `--devmode` for developer work (still verified) or " +
+			"ship the snap through the store / a private brand store for production rollouts.",
+		Check: checkZC1542,
+	})
+}
+
+func checkZC1542(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "snap" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "--dangerous" {
+			return []Violation{{
+				KataID: "ZC1542",
+				Message: "`snap install --dangerous` installs an assertion-unverified snap — " +
+					"any .snap on disk can register system services. Use --devmode or the " +
+					"store.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 538 Katas = 0.5.38
-const Version = "0.5.38"
+// 539 Katas = 0.5.39
+const Version = "0.5.39"


### PR DESCRIPTION
## Summary
- Flags `snap install --dangerous`
- Bypasses assertion verification — any .snap can register system services
- Suggest `--devmode` for dev, store / private brand store for prod
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.39 (539 katas)