### PR TITLE
feat: ZC1543 — warn on go install @latest / cargo install --git unpinned

### DIFF
--- a/pkg/katas/katatests/zc1543_test.go
+++ b/pkg/katas/katatests/zc1543_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1543(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — go install pkg@v1.2.3",
+			input:    `go install github.com/foo/bar@v1.2.3`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — cargo install --git url --rev sha",
+			input:    `cargo install --git https://example.com/foo --rev abc123 foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — cargo install foo (crates.io pin via crate version)",
+			input:    `cargo install foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — go install pkg@latest",
+			input: `go install github.com/foo/bar@latest`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1543",
+					Message: "`go install github.com/foo/bar@latest` is unpinned — HEAD-of-default can change between runs. Pin to a version tag or commit hash for reproducibility.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — cargo install --git url (no rev)",
+			input: `cargo install --git https://example.com/foo foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1543",
+					Message: "`cargo install --git (no --rev/--tag/--branch)` is unpinned — HEAD-of-default can change between runs. Pin to a version tag or commit hash for reproducibility.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1543")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1543.go
+++ b/pkg/katas/zc1543.go
@@ -1,0 +1,82 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1543",
+		Title:    "Warn on `go install pkg@latest` / `cargo install --git <url>` without rev pin",
+		Severity: SeverityWarning,
+		Description: "`go install pkg@latest` and `cargo install --git <url>` without `--rev` / " +
+			"`--tag` / `--branch` resolve to whatever HEAD is at install time. The next CI " +
+			"run can pull a different commit — great for supply-chain attackers to inject " +
+			"post-breach, bad for reproducibility. Pin to a specific version tag (`pkg@v1.2.3`) " +
+			"or a commit hash (`cargo install --rev abc123 --git ...`).",
+		Check: checkZC1543,
+	})
+}
+
+func checkZC1543(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, a.String())
+	}
+
+	// go install ...@latest / no @
+	if ident.Value == "go" && len(args) >= 2 && args[0] == "install" {
+		for _, a := range args[1:] {
+			if strings.HasPrefix(a, "-") {
+				continue
+			}
+			if strings.HasSuffix(a, "@latest") || strings.HasSuffix(a, "@master") ||
+				strings.HasSuffix(a, "@main") {
+				return zc1543Violation(cmd, "go install "+a)
+			}
+			if !strings.Contains(a, "@") && strings.Contains(a, "/") {
+				return zc1543Violation(cmd, "go install "+a+" (no @version)")
+			}
+		}
+	}
+
+	// cargo install --git <url>  with no --rev / --tag / --branch
+	if ident.Value == "cargo" && len(args) >= 2 && args[0] == "install" {
+		var hasGit, hasPin bool
+		for _, a := range args[1:] {
+			if a == "--git" {
+				hasGit = true
+			}
+			if a == "--rev" || a == "--tag" || a == "--branch" || a == "--locked" {
+				hasPin = true
+			}
+		}
+		if hasGit && !hasPin {
+			return zc1543Violation(cmd, "cargo install --git (no --rev/--tag/--branch)")
+		}
+	}
+	return nil
+}
+
+func zc1543Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1543",
+		Message: "`" + what + "` is unpinned — HEAD-of-default can change between runs. Pin " +
+			"to a version tag or commit hash for reproducibility.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 539 Katas = 0.5.39
-const Version = "0.5.39"
+// 540 Katas = 0.5.40
+const Version = "0.5.40"


### PR DESCRIPTION
## Summary
- Flags `go install <pkg>@latest|@master|@main` and `go install <pkg>` with no `@version`
- Flags `cargo install --git <url>` without `--rev` / `--tag` / `--branch` / `--locked`
- Unpinned = different build per CI run, supply-chain attack surface
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.40 (540 katas)