### PR TITLE
feat: ZC1544 — warn on dnf copr enable / add-apt-repository (unvetted)

### DIFF
--- a/pkg/katas/katatests/zc1544_test.go
+++ b/pkg/katas/katatests/zc1544_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1544(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — dnf install curl",
+			input:    `dnf install curl`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — dnf copr enable user/repo",
+			input: `dnf copr enable user/repo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1544",
+					Message: "`dnf copr enable` pulls from a single-contributor repo — no distro security team. Pin the build, verify key fingerprint, mirror internally.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — add-apt-repository ppa:user/repo",
+			input: `add-apt-repository ppa:user/repo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1544",
+					Message: "`add-apt-repository` pulls from a single-contributor repo — no distro security team. Pin the build, verify key fingerprint, mirror internally.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1544")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1544.go
+++ b/pkg/katas/zc1544.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1544",
+		Title:    "Warn on `dnf copr enable` / `add-apt-repository ppa:` — unvetted third-party repo",
+		Severity: SeverityWarning,
+		Description: "Enabling a COPR project or an Ubuntu PPA pulls packages signed by a single " +
+			"community contributor — there is no distro security team or reproducible-builds " +
+			"guarantee behind that key. Any future compromise of that contributor's account " +
+			"ships a rootkit to every box that ran this line. If you need the package badly " +
+			"enough, pin to a specific `build-id`, verify the key fingerprint out of band, " +
+			"and mirror to an internal repository.",
+		Check: checkZC1544,
+	})
+}
+
+func checkZC1544(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value == "dnf" && len(cmd.Arguments) >= 2 &&
+		cmd.Arguments[0].String() == "copr" && cmd.Arguments[1].String() == "enable" {
+		return zc1544Violation(cmd, "dnf copr enable")
+	}
+	if ident.Value == "add-apt-repository" {
+		return zc1544Violation(cmd, "add-apt-repository")
+	}
+	return nil
+}
+
+func zc1544Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1544",
+		Message: "`" + what + "` pulls from a single-contributor repo — no distro security " +
+			"team. Pin the build, verify key fingerprint, mirror internally.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 540 Katas = 0.5.40
-const Version = "0.5.40"
+// 541 Katas = 0.5.41
+const Version = "0.5.41"


### PR DESCRIPTION
## Summary
- Flags `dnf copr enable <repo>` and `add-apt-repository <repo>`
- Third-party repos signed by single contributor — no distro security team
- Suggest pinning build, verifying fingerprint, mirroring internally
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.41 (541 katas)