### PR TITLE
feat: ZC1545 — warn on docker system prune with -a or --volumes

### DIFF
--- a/pkg/katas/katatests/zc1545_test.go
+++ b/pkg/katas/katatests/zc1545_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1545(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker image prune",
+			input:    `docker image prune`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — docker system prune (no -a / --volumes)",
+			input:    `docker system prune -f`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker system prune -af --volumes",
+			input: `docker system prune -af --volumes`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1545",
+					Message: "`docker system prune` with `-a`/`--volumes` drops unused volumes — stopped stacks lose their databases. Scope the prune.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — docker volume prune -a",
+			input: `docker volume prune -a`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1545",
+					Message: "`docker volume prune` with `-a`/`--volumes` drops unused volumes — stopped stacks lose their databases. Scope the prune.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1545")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1545.go
+++ b/pkg/katas/zc1545.go
@@ -1,0 +1,68 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1545",
+		Title:    "Warn on `docker system prune -af --volumes` — drops unused volumes too",
+		Severity: SeverityWarning,
+		Description: "`docker system prune -af --volumes` removes stopped containers, unused " +
+			"networks, dangling images — and every volume not currently attached to a running " +
+			"container. On a host where `docker-compose down` is used casually (shutdown " +
+			"before a laptop close, for example), the matching database volume looks " +
+			"\"unused\" to prune and goes with it. Drop `--volumes` from routine cleanup, or " +
+			"target specific prune scopes (`docker image prune`, `docker container prune`).",
+		Check: checkZC1545,
+	})
+}
+
+func checkZC1545(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" && ident.Value != "nerdctl" {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, a.String())
+	}
+
+	if len(args) < 2 {
+		return nil
+	}
+	// docker system prune / volume prune
+	if !((args[0] == "system" && args[1] == "prune") ||
+		(args[0] == "volume" && args[1] == "prune")) {
+		return nil
+	}
+
+	var hasAllVolumes bool
+	for _, a := range args[2:] {
+		if a == "--volumes" || a == "-a" || a == "--all" ||
+			a == "-af" || a == "-fa" || a == "--all --volumes" {
+			hasAllVolumes = true
+		}
+	}
+	if !hasAllVolumes {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1545",
+		Message: "`" + ident.Value + " " + args[0] + " prune` with `-a`/`--volumes` drops " +
+			"unused volumes — stopped stacks lose their databases. Scope the prune.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 541 Katas = 0.5.41
-const Version = "0.5.41"
+// 542 Katas = 0.5.42
+const Version = "0.5.42"


### PR DESCRIPTION
## Summary
- Flags `docker|podman|nerdctl system prune` or `volume prune` with `-a`/`-af`/`--all`/`--volumes`
- Drops unused volumes — stopped compose stacks lose their DBs
- Suggest scoped prune (image/container/network)
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.42 (542 katas)