### PR TITLE
feat: ZC1546 — warn on kubectl delete --force --grace-period=0

### DIFF
--- a/pkg/katas/katatests/zc1546_test.go
+++ b/pkg/katas/katatests/zc1546_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1546(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — kubectl delete pod foo",
+			input:    `kubectl delete pod foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — kubectl delete pod foo --force (grace-period not 0)",
+			input:    `kubectl delete pod foo --force`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — kubectl delete pod foo --force --grace-period=0",
+			input: `kubectl delete pod foo --force --grace-period=0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1546",
+					Message: "`kubectl delete --force --grace-period=0` skips PreStop hooks and kubelet drain — corrupts StatefulSet state. Use standard delete.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — oc delete pod foo --force --grace-period=0",
+			input: `oc delete pod foo --force --grace-period=0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1546",
+					Message: "`kubectl delete --force --grace-period=0` skips PreStop hooks and kubelet drain — corrupts StatefulSet state. Use standard delete.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1546")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1546.go
+++ b/pkg/katas/zc1546.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1546",
+		Title:    "Warn on `kubectl delete --force --grace-period=0` — skips PreStop, corrupts state",
+		Severity: SeverityWarning,
+		Description: "`kubectl delete --force --grace-period=0` tells the API server to remove " +
+			"the resource from etcd without waiting for the kubelet to run PreStop hooks or " +
+			"drain the pod. For a StatefulSet pod this routinely corrupts the backing PV " +
+			"(database mid-flush, file lock left held) and the replacement pod refuses to " +
+			"start. Use standard delete and let the graceful shutdown run; only reach for " +
+			"`--force` when the node itself is gone.",
+		Check: checkZC1546,
+	})
+}
+
+func checkZC1546(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kubectl" && ident.Value != "oc" {
+		return nil
+	}
+
+	var sawDelete, hasForce, hasGrace0 bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "delete" {
+			sawDelete = true
+		}
+		if !sawDelete {
+			continue
+		}
+		if v == "--force" {
+			hasForce = true
+		}
+		if v == "--grace-period=0" {
+			hasGrace0 = true
+		}
+	}
+	if sawDelete && hasForce && hasGrace0 {
+		return []Violation{{
+			KataID: "ZC1546",
+			Message: "`kubectl delete --force --grace-period=0` skips PreStop hooks and kubelet " +
+				"drain — corrupts StatefulSet state. Use standard delete.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 542 Katas = 0.5.42
-const Version = "0.5.42"
+// 543 Katas = 0.5.43
+const Version = "0.5.43"


### PR DESCRIPTION
## Summary
- Flags `kubectl|oc delete ... --force --grace-period=0`
- Skips PreStop hooks and kubelet drain — corrupts StatefulSet state
- Suggest plain `kubectl delete` unless node is dead
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.43 (543 katas)