### PR TITLE
feat: ZC1547 — warn on kubectl apply --prune --all (untracked delete)

### DIFF
--- a/pkg/katas/katatests/zc1547_test.go
+++ b/pkg/katas/katatests/zc1547_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1547(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — kubectl apply -f manifests/",
+			input:    `kubectl apply -f manifests/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — kubectl apply --prune -l app=x -f manifests/",
+			input:    `kubectl apply --prune -l app=x -f manifests/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — kubectl apply --prune --all -f m/",
+			input: `kubectl apply --prune --all -f m/`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1547",
+					Message: "`kubectl apply --prune --all` deletes every matching resource not in the manifest — manifest typo wipes other teams' resources. Scope with a narrow `-l <selector>`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — kubectl apply --prune -A -f m/",
+			input: `kubectl apply --prune -A -f m/`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1547",
+					Message: "`kubectl apply --prune --all` deletes every matching resource not in the manifest — manifest typo wipes other teams' resources. Scope with a narrow `-l <selector>`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1547")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1547.go
+++ b/pkg/katas/zc1547.go
@@ -1,0 +1,64 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1547",
+		Title:    "Warn on `kubectl apply --prune --all` — deletes resources missing from manifest",
+		Severity: SeverityWarning,
+		Description: "`kubectl apply --prune --all` (or `--prune -l <selector>`) deletes every " +
+			"cluster resource whose label matches but which is not in the manifest you just " +
+			"applied. In a partial-repo deploy or a manifest typo, that can delete production " +
+			"Deployments, Services, or Secrets another team owns. Pair `--prune` with a " +
+			"narrow `-l` selector unique to your stack, or use a GitOps controller (Argo CD, " +
+			"Flux) that scopes prune to its own Application.",
+		Check: checkZC1547,
+	})
+}
+
+func checkZC1547(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kubectl" && ident.Value != "oc" {
+		return nil
+	}
+
+	var sawApply, hasPrune, hasAll bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "apply" {
+			sawApply = true
+		}
+		if !sawApply {
+			continue
+		}
+		if v == "--prune" {
+			hasPrune = true
+		}
+		if v == "--all" || v == "-A" || v == "--all-namespaces" {
+			hasAll = true
+		}
+	}
+	if sawApply && hasPrune && hasAll {
+		return []Violation{{
+			KataID: "ZC1547",
+			Message: "`kubectl apply --prune --all` deletes every matching resource not in the " +
+				"manifest — manifest typo wipes other teams' resources. Scope with a " +
+				"narrow `-l <selector>`.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 543 Katas = 0.5.43
-const Version = "0.5.43"
+// 544 Katas = 0.5.44
+const Version = "0.5.44"


### PR DESCRIPTION
## Summary
- Flags `kubectl|oc apply --prune --all` or `--prune -A` or `--prune --all-namespaces`
- Manifest typo wipes other teams' resources
- Suggest narrow `-l <selector>` or GitOps controller scope
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.44 (544 katas)