### PR TITLE
feat: ZC1548 — warn on helm --disable-openapi-validation

### DIFF
--- a/pkg/katas/katatests/zc1548_test.go
+++ b/pkg/katas/katatests/zc1548_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1548(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — helm install foo chart",
+			input:    `helm install foo bitnami/nginx`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — helm install foo chart --disable-openapi-validation",
+			input: `helm install foo bitnami/nginx --disable-openapi-validation`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1548",
+					Message: "`helm --disable-openapi-validation` hides bad manifests until the controller crashes. Fix the schema deviation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — helm upgrade foo chart --disable-openapi-validation",
+			input: `helm upgrade foo bitnami/nginx --disable-openapi-validation`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1548",
+					Message: "`helm --disable-openapi-validation` hides bad manifests until the controller crashes. Fix the schema deviation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1548")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1548.go
+++ b/pkg/katas/zc1548.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1548",
+		Title:    "Warn on `helm install/upgrade --disable-openapi-validation` — skips schema check",
+		Severity: SeverityWarning,
+		Description: "`--disable-openapi-validation` tells Helm to skip the OpenAPI schema check " +
+			"the API server would apply. Malformed CRD instances or Deployments with " +
+			"invalid spec fields then silently land in etcd, only failing when the " +
+			"controller tries to reconcile — usually 3am, usually in prod. Keep the " +
+			"validation on; fix the schema deviation instead.",
+		Check: checkZC1548,
+	})
+}
+
+func checkZC1548(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "helm" {
+		return nil
+	}
+
+	var sawVerb bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "install" || v == "upgrade" || v == "template" {
+			sawVerb = true
+			continue
+		}
+		if !sawVerb {
+			continue
+		}
+		if v == "--disable-openapi-validation" {
+			return []Violation{{
+				KataID: "ZC1548",
+				Message: "`helm --disable-openapi-validation` hides bad manifests until the " +
+					"controller crashes. Fix the schema deviation.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 544 Katas = 0.5.44
-const Version = "0.5.44"
+// 545 Katas = 0.5.45
+const Version = "0.5.45"


### PR DESCRIPTION
## Summary
- Flags `helm install|upgrade|template ... --disable-openapi-validation`
- Skips schema check — bad manifests land in etcd, controller fails at reconcile time
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.45 (545 katas)