### PR TITLE
feat: ZC1549 — error on unzip -d / (extract into root)

### DIFF
--- a/pkg/katas/katatests/zc1549_test.go
+++ b/pkg/katas/katatests/zc1549_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1549(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — unzip to /tmp/stage",
+			input:    `unzip foo.zip -d /tmp/stage`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — unzip -o to /opt/app",
+			input:    `unzip -o foo.zip -d /opt/app`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — unzip -d /",
+			input: `unzip foo.zip -d /`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1549",
+					Message: "`unzip -d /` extracts into a system path — any archive entry overwrites matching system file. Stage, inspect, copy.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — unzip -o file -d /boot",
+			input: `unzip -o foo.zip -d /boot`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1549",
+					Message: "`unzip -d /boot` extracts into a system path — any archive entry overwrites matching system file. Stage, inspect, copy.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1549")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1549.go
+++ b/pkg/katas/zc1549.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1549",
+		Title:    "Error on `unzip -d /` / `unzip -o ... -d /` — extract archive into filesystem root",
+		Severity: SeverityError,
+		Description: "Unzipping directly into `/` (or `/root`, `/boot`) overwrites any system file " +
+			"whose path matches an entry in the archive. A malicious zip that carries " +
+			"`etc/passwd`, `usr/bin/ls`, or `root/.ssh/authorized_keys` turns a seemingly " +
+			"harmless extract into full system compromise. Stage to a scratch directory, " +
+			"inspect contents, then copy or install specific files.",
+		Check: checkZC1549,
+	})
+}
+
+func checkZC1549(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "unzip" && ident.Value != "busybox" {
+		return nil
+	}
+
+	var prevD bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevD {
+			prevD = false
+			if v == "/" || v == "/root" || v == "/boot" {
+				return []Violation{{
+					KataID: "ZC1549",
+					Message: "`unzip -d " + v + "` extracts into a system path — any archive " +
+						"entry overwrites matching system file. Stage, inspect, copy.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityError,
+				}}
+			}
+		}
+		if v == "-d" {
+			prevD = true
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 545 Katas = 0.5.45
-const Version = "0.5.45"
+// 546 Katas = 0.5.46
+const Version = "0.5.46"


### PR DESCRIPTION
## Summary
- Flags `unzip -d /`, `-d /root`, `-d /boot` (and `busybox unzip` variant)
- Malicious archive paths would overwrite system files
- Suggest stage-inspect-copy workflow
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.46 (546 katas)