### PR TITLE
feat: ZC1550 — warn on apt-mark hold (blocks package updates)

### DIFF
--- a/pkg/katas/katatests/zc1550_test.go
+++ b/pkg/katas/katatests/zc1550_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1550(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — apt-mark unhold pkg",
+			input:    `apt-mark unhold openssh-server`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — apt-mark showhold",
+			input:    `apt-mark showhold`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — apt-mark hold pkg",
+			input: `apt-mark hold openssh-server`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1550",
+					Message: "`apt-mark hold` pins the package — blocks future CVE fixes. Document the reason and schedule an unhold review.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — apt-mark hold multiple pkgs",
+			input: `apt-mark hold openssh-server libc6`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1550",
+					Message: "`apt-mark hold` pins the package — blocks future CVE fixes. Document the reason and schedule an unhold review.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1550")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1550.go
+++ b/pkg/katas/zc1550.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1550",
+		Title:    "Warn on `apt-mark hold <pkg>` — pins a package, blocks security updates",
+		Severity: SeverityWarning,
+		Description: "`apt-mark hold` tells apt to leave the package at its current version on " +
+			"`apt upgrade` and `unattended-upgrades`. That is occasionally correct (pinning a " +
+			"kernel variant for a driver, or a broken-upstream version) but silently keeps the " +
+			"package vulnerable to every subsequent CVE. Document the reason in a comment, " +
+			"schedule a review, and prefer `apt-mark unhold` + `apt upgrade <pkg>` over leaving " +
+			"the pin in place indefinitely.",
+		Check: checkZC1550,
+	})
+}
+
+func checkZC1550(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "apt-mark" && ident.Value != "dpkg" {
+		return nil
+	}
+
+	if ident.Value == "apt-mark" && len(cmd.Arguments) >= 2 &&
+		cmd.Arguments[0].String() == "hold" {
+		return []Violation{{
+			KataID: "ZC1550",
+			Message: "`apt-mark hold` pins the package — blocks future CVE fixes. Document " +
+				"the reason and schedule an unhold review.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+
+	// `echo "<pkg> hold" | dpkg --set-selections` is the legacy equivalent; flag when
+	// dpkg is called with --set-selections.
+	if ident.Value == "dpkg" {
+		for _, arg := range cmd.Arguments {
+			if arg.String() == "--set-selections" {
+				return []Violation{{
+					KataID: "ZC1550",
+					Message: "`dpkg --set-selections` with a `hold` entry pins a package — " +
+						"blocks future CVE fixes. Use apt-mark hold and document.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 546 Katas = 0.5.46
-const Version = "0.5.46"
+// 547 Katas = 0.5.47
+const Version = "0.5.47"


### PR DESCRIPTION
## Summary
- Flags `apt-mark hold <pkg>` — silently blocks future CVE fixes
- Also flags `dpkg --set-selections` (legacy equivalent), when parser preserves it
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.47 (547 katas)