### PR TITLE
feat: ZC1551 — warn on helm install/upgrade --skip-crds

### DIFF
--- a/pkg/katas/katatests/zc1551_test.go
+++ b/pkg/katas/katatests/zc1551_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1551(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — helm install chart",
+			input:    `helm install foo bitnami/nginx`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — helm install chart --skip-crds",
+			input: `helm install foo bitnami/nginx --skip-crds`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1551",
+					Message: "`helm --skip-crds` installs .Release objects without their CRDs — custom resources fail validation. Install CRDs first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — helm upgrade chart --skip-crds",
+			input: `helm upgrade foo bitnami/nginx --skip-crds`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1551",
+					Message: "`helm --skip-crds` installs .Release objects without their CRDs — custom resources fail validation. Install CRDs first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1551")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1551.go
+++ b/pkg/katas/zc1551.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1551",
+		Title:    "Warn on `helm install/upgrade --skip-crds` — chart CRs land before their CRDs",
+		Severity: SeverityWarning,
+		Description: "`--skip-crds` tells Helm to install only the `.Release` objects and skip " +
+			"the CustomResourceDefinition manifests under `crds/`. Without the CRDs present, " +
+			"any `.Release` object that references a custom resource is rejected by the API " +
+			"server at validation time, or — worse — fails later when a reconciler tries to " +
+			"watch a type that does not exist. Use the default (install CRDs) on first roll- " +
+			"out; if you need split lifecycle, install CRDs manually (`kubectl apply -f " +
+			"chart/crds/`) before the `helm install`.",
+		Check: checkZC1551,
+	})
+}
+
+func checkZC1551(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "helm" {
+		return nil
+	}
+
+	var sawVerb bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "install" || v == "upgrade" {
+			sawVerb = true
+			continue
+		}
+		if !sawVerb {
+			continue
+		}
+		if v == "--skip-crds" {
+			return []Violation{{
+				KataID: "ZC1551",
+				Message: "`helm --skip-crds` installs .Release objects without their CRDs — " +
+					"custom resources fail validation. Install CRDs first.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 547 Katas = 0.5.47
-const Version = "0.5.47"
+// 548 Katas = 0.5.48
+const Version = "0.5.48"


### PR DESCRIPTION
## Summary
- Flags `helm install|upgrade ... --skip-crds`
- CRDs missing → custom resources fail validation
- Suggest default behaviour, or pre-install CRDs with kubectl
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.48 (548 katas)