### PR TITLE
feat: ZC1552 — warn on openssl dhparam/genrsa < 2048 bits

### DIFF
--- a/pkg/katas/katatests/zc1552_test.go
+++ b/pkg/katas/katatests/zc1552_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1552(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — openssl genrsa 2048",
+			input:    `openssl genrsa 2048`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — openssl dhparam 4096",
+			input:    `openssl dhparam 4096`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — openssl x509 (not key-producing)",
+			input:    `openssl x509 -in cert.pem -noout`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — openssl genrsa 1024",
+			input: `openssl genrsa 1024`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1552",
+					Message: "`openssl genrsa 1024` uses a weak key/param size — modern baselines require 2048+. Use 2048 or 3072/4096 for long-lived keys.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — openssl dhparam 512",
+			input: `openssl dhparam 512`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1552",
+					Message: "`openssl dhparam 512` uses a weak key/param size — modern baselines require 2048+. Use 2048 or 3072/4096 for long-lived keys.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1552")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1552.go
+++ b/pkg/katas/zc1552.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"strconv"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1552",
+		Title:    "Warn on `openssl dhparam <2048` / `genrsa <2048` — weak key/parameter size",
+		Severity: SeverityWarning,
+		Description: "Generating DH parameters or RSA keys shorter than 2048 bits is below every " +
+			"modern compliance baseline (NIST SP 800-57, BSI TR-02102, Mozilla Server Side TLS). " +
+			"A 1024-bit RSA modulus or DH group is within reach of academic precomputation " +
+			"(Logjam) and a 512-bit one was broken on commodity hardware in the 1990s. Use " +
+			"2048 as a floor and 3072 / 4096 for long-lived keys.",
+		Check: checkZC1552,
+	})
+}
+
+func checkZC1552(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "openssl" {
+		return nil
+	}
+
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	if sub != "dhparam" && sub != "genrsa" && sub != "gendsa" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n < 2048 {
+			return []Violation{{
+				KataID: "ZC1552",
+				Message: "`openssl " + sub + " " + v + "` uses a weak key/param size — " +
+					"modern baselines require 2048+. Use 2048 or 3072/4096 for long-lived keys.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 548 Katas = 0.5.48
-const Version = "0.5.48"
+// 549 Katas = 0.5.49
+const Version = "0.5.49"


### PR DESCRIPTION
## Summary
- Flags `openssl dhparam|genrsa|gendsa` with size < 2048
- Below every modern compliance baseline
- Suggest 2048 floor, 3072/4096 for long-lived
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.49 (549 katas)