### PR TITLE
feat: ZC1553 — style: use Zsh ${(U)var} instead of tr case-class

### DIFF
--- a/pkg/katas/katatests/zc1553_test.go
+++ b/pkg/katas/katatests/zc1553_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1553(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — tr -d '[:space:]'",
+			input:    `tr -d '[:space:]'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — tr -s ' '",
+			input:    `tr -s ' '`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — tr '[:lower:]' '[:upper:]'",
+			input: `tr '[:lower:]' '[:upper:]'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1553",
+					Message: "`tr` for case conversion — use Zsh `${(U)var}` / `${(L)var}` to avoid the fork/exec and portability hazard.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — tr a-z A-Z",
+			input: `tr a-z A-Z`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1553",
+					Message: "`tr` for case conversion — use Zsh `${(U)var}` / `${(L)var}` to avoid the fork/exec and portability hazard.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — tr '[:upper:]' '[:lower:]'",
+			input: `tr '[:upper:]' '[:lower:]'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1553",
+					Message: "`tr` for case conversion — use Zsh `${(U)var}` / `${(L)var}` to avoid the fork/exec and portability hazard.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1553")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1553.go
+++ b/pkg/katas/zc1553.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1553",
+		Title:    "Style: use Zsh `${(U)var}` / `${(L)var}` instead of `tr '[:lower:]' '[:upper:]'`",
+		Severity: SeverityStyle,
+		Description: "Zsh provides `${(U)var}` and `${(L)var}` parameter-expansion flags for " +
+			"case conversion in-process. Spawning `tr` for this forks/execs per call (noticeable " +
+			"in a hot loop), relies on the external `tr` being POSIX-compliant (BusyBox and old " +
+			"macOS differ), and round-trips the data through a pipe. Drop `tr` for the " +
+			"built-in: `upper=${(U)lower}` / `lower=${(L)upper}`.",
+		Check: checkZC1553,
+	})
+}
+
+func checkZC1553(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "tr" {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, strings.Trim(a.String(), "'\""))
+	}
+
+	// Need at least the from/to sets.
+	if len(args) < 2 {
+		return nil
+	}
+	var from, to string
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			continue
+		}
+		if from == "" {
+			from = a
+		} else if to == "" {
+			to = a
+			break
+		}
+	}
+
+	isUpper := func(s string) bool { return s == "[:upper:]" || s == "A-Z" }
+	isLower := func(s string) bool { return s == "[:lower:]" || s == "a-z" }
+	if (isLower(from) && isUpper(to)) || (isUpper(from) && isLower(to)) {
+		return []Violation{{
+			KataID: "ZC1553",
+			Message: "`tr` for case conversion — use Zsh `${(U)var}` / `${(L)var}` to avoid " +
+				"the fork/exec and portability hazard.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityStyle,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 549 Katas = 0.5.49
-const Version = "0.5.49"
+// 550 Katas = 0.5.50
+const Version = "0.5.50"


### PR DESCRIPTION
## Summary
- Flags `tr '[:lower:]' '[:upper:]'` / `tr a-z A-Z` (and reverse direction)
- Zsh parameter-expansion flags `${(U)var}` / `${(L)var}` avoid the fork/exec
- Also sidesteps BusyBox/macOS `tr` portability quirks
- Severity: Style

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.50 (550 katas)