### PR TITLE
feat: ZC1554 — warn on unzip -o / tar --overwrite (silent overwrite)

### DIFF
--- a/pkg/katas/katatests/zc1554_test.go
+++ b/pkg/katas/katatests/zc1554_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1554(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — unzip without -o",
+			input:    `unzip file.zip`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — tar xf without --overwrite",
+			input:    `tar xf foo.tar`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — unzip -o file.zip",
+			input: `unzip -o file.zip`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1554",
+					Message: "`unzip -o` overwrites existing files without prompting. Extract to a staging directory, diff, then move.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — tar xf foo.tar --overwrite",
+			input: `tar xf foo.tar --overwrite`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1554",
+					Message: "`tar --overwrite` discards existing files during extract. Use a staging directory and diff before rolling forward.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1554")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1554.go
+++ b/pkg/katas/zc1554.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1554",
+		Title:    "Warn on `unzip -o` / `tar ... --overwrite` — silent overwrite during extract",
+		Severity: SeverityWarning,
+		Description: "`unzip -o` overwrites existing files without prompting; `tar --overwrite` " +
+			"does the same for tarballs. In a directory that already contains user work or a " +
+			"previous release, a newer archive silently wins, discarding in-flight edits and " +
+			"custom config. Extract to a fresh staging directory, diff, then move specific " +
+			"files into place.",
+		Check: checkZC1554,
+	})
+}
+
+func checkZC1554(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value == "unzip" {
+		for _, arg := range cmd.Arguments {
+			if arg.String() == "-o" {
+				return []Violation{{
+					KataID: "ZC1554",
+					Message: "`unzip -o` overwrites existing files without prompting. Extract " +
+						"to a staging directory, diff, then move.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+	if ident.Value == "tar" || ident.Value == "bsdtar" {
+		for _, arg := range cmd.Arguments {
+			if arg.String() == "--overwrite" {
+				return []Violation{{
+					KataID: "ZC1554",
+					Message: "`tar --overwrite` discards existing files during extract. Use a " +
+						"staging directory and diff before rolling forward.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 550 Katas = 0.5.50
-const Version = "0.5.50"
+// 551 Katas = 0.5.51
+const Version = "0.5.51"


### PR DESCRIPTION
## Summary
- Flags `unzip -o` and `tar --overwrite` / `bsdtar --overwrite`
- Silent overwrite discards in-flight edits and custom config
- Suggest staging directory + diff + selective copy
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.51 (551 katas)