### PR TITLE
feat: ZC1555 — error on chmod/chown/chgrp on /etc/shadow / sudoers

### DIFF
--- a/pkg/katas/katatests/zc1555_test.go
+++ b/pkg/katas/katatests/zc1555_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1555(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — chmod on own file",
+			input:    `chmod 600 /tmp/myfile`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — chown on /etc/nginx",
+			input:    `chown root:root /etc/nginx/nginx.conf`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — chmod 666 /etc/shadow",
+			input: `chmod 666 /etc/shadow`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1555",
+					Message: "`chmod ... /etc/shadow` races the distro-managed tool — use passwd/chage/visudo or a config-management drop-in.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — chown root:root /etc/sudoers",
+			input: `chown root:root /etc/sudoers`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1555",
+					Message: "`chown ... /etc/sudoers` races the distro-managed tool — use passwd/chage/visudo or a config-management drop-in.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — chgrp shadow /etc/gshadow",
+			input: `chgrp shadow /etc/gshadow`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1555",
+					Message: "`chgrp ... /etc/gshadow` races the distro-managed tool — use passwd/chage/visudo or a config-management drop-in.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1555")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1555.go
+++ b/pkg/katas/zc1555.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1555",
+		Title:    "Error on `chmod` / `chown` on `/etc/shadow` or `/etc/sudoers` (managed files)",
+		Severity: SeverityError,
+		Description: "`/etc/shadow`, `/etc/gshadow`, `/etc/sudoers`, and `/etc/passwd` have " +
+			"specific ownership and mode invariants that the distro `passwd`, `chage`, and " +
+			"`visudo` tools maintain atomically with file locking. Direct `chmod`/`chown` races " +
+			"those tools, can leave the file world-readable mid-modification (leaking the " +
+			"shadow file), and will be clobbered on the next `shadow -p` run. Use the proper " +
+			"wrapper, or ship a configuration-management drop-in.",
+		Check: checkZC1555,
+	})
+}
+
+func checkZC1555(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "chmod" && ident.Value != "chown" && ident.Value != "chgrp" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "/etc/shadow", "/etc/gshadow", "/etc/sudoers", "/etc/passwd",
+			"/etc/shadow-", "/etc/gshadow-", "/etc/passwd-", "/etc/sudoers-":
+			return []Violation{{
+				KataID: "ZC1555",
+				Message: "`" + ident.Value + " ... " + v + "` races the distro-managed tool — " +
+					"use passwd/chage/visudo or a config-management drop-in.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 551 Katas = 0.5.51
-const Version = "0.5.51"
+// 552 Katas = 0.5.52
+const Version = "0.5.52"


### PR DESCRIPTION
## Summary
- Flags `chmod|chown|chgrp` targeting `/etc/{shadow,gshadow,sudoers,passwd}` + backup variants
- Direct ops race distro tools (passwd/chage/visudo) and can leak shadow content
- Suggest proper wrapper / config-management drop-in
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.52 (552 katas)