### PR TITLE
feat: ZC1556 — error on openssl enc with broken cipher (DES/RC4/3DES/BF/RC2/CAST)

### DIFF
--- a/pkg/katas/katatests/zc1556_test.go
+++ b/pkg/katas/katatests/zc1556_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1556(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — openssl enc -aes-256-gcm",
+			input:    `openssl enc -aes-256-gcm -in file -out enc`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — openssl enc -chacha20-poly1305",
+			input:    `openssl enc -chacha20-poly1305 -in file -out enc`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — openssl enc -des",
+			input: `openssl enc -des -in file -out enc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1556",
+					Message: "`openssl enc -des` is a broken or deprecated cipher. Use `-aes-256-gcm` / `-chacha20-poly1305`, or `age` / `gpg` for files.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — openssl enc -rc4",
+			input: `openssl enc -rc4 -in file -out enc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1556",
+					Message: "`openssl enc -rc4` is a broken or deprecated cipher. Use `-aes-256-gcm` / `-chacha20-poly1305`, or `age` / `gpg` for files.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — openssl enc -des-ede3-cbc",
+			input: `openssl enc -des-ede3-cbc -in file -out enc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1556",
+					Message: "`openssl enc -des-ede3-cbc` is a broken or deprecated cipher. Use `-aes-256-gcm` / `-chacha20-poly1305`, or `age` / `gpg` for files.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1556")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1556.go
+++ b/pkg/katas/zc1556.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1556",
+		Title:    "Error on `openssl enc -des` / `-rc4` / `-3des` — broken symmetric cipher",
+		Severity: SeverityError,
+		Description: "DES, RC4, and 3DES are all broken or on-deprecation-path: DES's 56-bit key " +
+			"fell to commodity brute-force decades ago, RC4 has practical biased-output attacks, " +
+			"and 3DES suffers the Sweet32 birthday collision when reused for more than ~32GB. " +
+			"None of them provide authenticity either. Use `-aes-256-gcm` or `-chacha20-poly1305`, " +
+			"or move up to a dedicated tool (`age`, `gpg`, `libsodium`).",
+		Check: checkZC1556,
+	})
+}
+
+func checkZC1556(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "openssl" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "enc" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := strings.ToLower(arg.String())
+		switch v {
+		case "-des", "-des-cbc", "-des-ecb",
+			"-des3", "-des-ede", "-des-ede-cbc", "-des-ede3", "-des-ede3-cbc",
+			"-rc4", "-rc4-40",
+			"-bf", "-bf-cbc",
+			"-rc2", "-rc2-cbc",
+			"-cast", "-cast5-cbc":
+			return []Violation{{
+				KataID: "ZC1556",
+				Message: "`openssl enc " + v + "` is a broken or deprecated cipher. Use " +
+					"`-aes-256-gcm` / `-chacha20-poly1305`, or `age` / `gpg` for files.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 552 Katas = 0.5.52
-const Version = "0.5.52"
+// 553 Katas = 0.5.53
+const Version = "0.5.53"


### PR DESCRIPTION
## Summary
- Flags `openssl enc` with `-des`, `-des-ede`, `-des-ede3`, `-rc4`, `-bf`, `-rc2`, `-cast`, etc.
- All are broken or deprecated; none provide authenticity
- Suggest `-aes-256-gcm` / `-chacha20-poly1305`, or `age` / `gpg`
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.53 (553 katas)