### PR TITLE
feat: ZC1557 — error on kubeadm reset -f (wipes k8s control-plane state)

### DIFF
--- a/pkg/katas/katatests/zc1557_test.go
+++ b/pkg/katas/katatests/zc1557_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1557(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — kubeadm init",
+			input:    `kubeadm init`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — kubeadm reset (no -f)",
+			input:    `kubeadm reset`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — kubeadm reset -f",
+			input: `kubeadm reset -f`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1557",
+					Message: "`kubeadm reset -f` skips the confirmation and wipes /etc/kubernetes / kubelet state. Drain and remove the node first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — kubeadm reset --force",
+			input: `kubeadm reset --force`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1557",
+					Message: "`kubeadm reset -f` skips the confirmation and wipes /etc/kubernetes / kubelet state. Drain and remove the node first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1557")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1557.go
+++ b/pkg/katas/zc1557.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1557",
+		Title:    "Error on `kubeadm reset -f` / `--force` — wipes Kubernetes control-plane state",
+		Severity: SeverityError,
+		Description: "`kubeadm reset` stops kubelet, tears down static-pod manifests, clears " +
+			"`/etc/kubernetes`, and (with `-f`) skips the confirmation that protects a mistyped " +
+			"target. On a control-plane node it also breaks every tenant that relied on that " +
+			"etcd quorum. Drain first, remove the node from the cluster, then run reset " +
+			"interactively to confirm.",
+		Check: checkZC1557,
+	})
+}
+
+func checkZC1557(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kubeadm" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "reset" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "-f" || v == "--force" {
+			return []Violation{{
+				KataID: "ZC1557",
+				Message: "`kubeadm reset -f` skips the confirmation and wipes " +
+					"/etc/kubernetes / kubelet state. Drain and remove the node first.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 553 Katas = 0.5.53
-const Version = "0.5.53"
+// 554 Katas = 0.5.54
+const Version = "0.5.54"


### PR DESCRIPTION
## Summary
- Flags `kubeadm reset -f` and `kubeadm reset --force`
- Wipes /etc/kubernetes, breaks etcd quorum on control-plane nodes
- Suggest drain → remove node → interactive reset
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.54 (554 katas)