### PR TITLE
feat: ZC1558 — warn on usermod/gpasswd adding to privileged groups

### DIFF
--- a/pkg/katas/katatests/zc1558_test.go
+++ b/pkg/katas/katatests/zc1558_test.go
@@ -1,0 +1,77 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1558(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — usermod -aG audio alice",
+			input:    `usermod -aG audio alice`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — usermod -aG wheel alice",
+			input: `usermod -aG wheel alice`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1558",
+					Message: "Adding user to `wheel` grants persistent admin-level access — use a scoped sudoers.d drop-in via configuration management.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — usermod -aG docker alice",
+			input: `usermod -aG docker alice`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1558",
+					Message: "Adding user to `docker` grants persistent admin-level access — use a scoped sudoers.d drop-in via configuration management.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — gpasswd -a alice sudo",
+			input: `gpasswd -a alice sudo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1558",
+					Message: "Adding user to `sudo` grants persistent admin-level access — use a scoped sudoers.d drop-in via configuration management.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — usermod -aG audio,wheel alice (mixed)",
+			input: `usermod -aG audio,wheel alice`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1558",
+					Message: "Adding user to `wheel` grants persistent admin-level access — use a scoped sudoers.d drop-in via configuration management.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1558")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1558.go
+++ b/pkg/katas/zc1558.go
@@ -1,0 +1,87 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1558",
+		Title:    "Warn on `usermod -aG wheel|sudo|root|adm` — silent privilege group escalation",
+		Severity: SeverityWarning,
+		Description: "Adding a user to `wheel`, `sudo`, `root`, `adm`, `docker`, or `libvirt` " +
+			"from a script grants persistent admin-level access without the review a sudoers " +
+			"drop-in or PAM profile would get. `docker` and `libvirt` in particular are " +
+			"equivalent to root (spawn privileged containers / raw disk access). Use a " +
+			"sudoers.d file scoped to specific commands and audit changes in configuration " +
+			"management.",
+		Check: checkZC1558,
+	})
+}
+
+var privGroups = map[string]struct{}{
+	"wheel":   {},
+	"sudo":    {},
+	"root":    {},
+	"adm":     {},
+	"docker":  {},
+	"libvirt": {},
+	"lxd":     {},
+	"kvm":     {},
+	"disk":    {},
+}
+
+func checkZC1558(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "usermod" && ident.Value != "gpasswd" && ident.Value != "adduser" {
+		return nil
+	}
+
+	// Look for the group argument after -aG / -G / -a
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, a.String())
+	}
+
+	for i, a := range args {
+		if (a == "-aG" || a == "-Ga" || a == "-G" || a == "--groups" || a == "--append") &&
+			i+1 < len(args) {
+			groups := strings.Split(args[i+1], ",")
+			for _, g := range groups {
+				g = strings.TrimSpace(g)
+				if _, bad := privGroups[g]; bad {
+					return zc1558Violation(cmd, g)
+				}
+			}
+		}
+	}
+	// gpasswd -a user <group>  => -a then user then group
+	if ident.Value == "gpasswd" && len(args) >= 3 && args[0] == "-a" {
+		g := args[2]
+		if _, bad := privGroups[g]; bad {
+			return zc1558Violation(cmd, g)
+		}
+	}
+	return nil
+}
+
+func zc1558Violation(cmd *ast.SimpleCommand, group string) []Violation {
+	return []Violation{{
+		KataID: "ZC1558",
+		Message: "Adding user to `" + group + "` grants persistent admin-level access — use a " +
+			"scoped sudoers.d drop-in via configuration management.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 554 Katas = 0.5.54
-const Version = "0.5.54"
+// 555 Katas = 0.5.55
+const Version = "0.5.55"


### PR DESCRIPTION
## Summary
- Flags `usermod -aG|-G`, `gpasswd -a`, `adduser --groups` when target group is privileged
- Groups: wheel, sudo, root, adm, docker, libvirt, lxd, kvm, disk
- Suggest scoped sudoers.d drop-in via configuration management
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.55 (555 katas)