### PR TITLE
feat: ZC1559 — warn on ssh-copy-id -f / StrictHostKeyChecking=no (TOFU push)

### DIFF
--- a/pkg/katas/katatests/zc1559_test.go
+++ b/pkg/katas/katatests/zc1559_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1559(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ssh-copy-id user@host",
+			input:    `ssh-copy-id user@host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ssh-copy-id -i ~/.ssh/id_ed25519.pub user@host",
+			input:    `ssh-copy-id -i ~/.ssh/id_ed25519.pub user@host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ssh-copy-id -f user@host",
+			input: `ssh-copy-id -f user@host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1559",
+					Message: "`ssh-copy-id -f` pushes a long-term credential without host-key verification. Verify the fingerprint out of band first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ssh-copy-id -o StrictHostKeyChecking=no user@host",
+			input: `ssh-copy-id -o StrictHostKeyChecking=no user@host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1559",
+					Message: "`ssh-copy-id -o StrictHostKeyChecking=no` pushes a long-term credential without host-key verification. Verify the fingerprint out of band first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1559")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1559.go
+++ b/pkg/katas/zc1559.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1559",
+		Title:    "Warn on `ssh-copy-id -f` / `-o StrictHostKeyChecking=no` — trust-on-first-use key push",
+		Severity: SeverityWarning,
+		Description: "`ssh-copy-id` opens an SSH connection to deposit the caller's public key. " +
+			"With `-f` it overwrites existing `authorized_keys` without prompting; with " +
+			"`-o StrictHostKeyChecking=no` it does not verify the host key. Together they " +
+			"push a long-term credential at a host the script has never authenticated — a " +
+			"network MITM lands a permanent backdoor. Verify the target host's fingerprint " +
+			"out of band before pushing keys.",
+		Check: checkZC1559,
+	})
+}
+
+func checkZC1559(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ssh-copy-id" {
+		return nil
+	}
+
+	var prevO bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-f" {
+			return zc1559Violation(cmd, "-f")
+		}
+		if prevO {
+			prevO = false
+			s := strings.TrimSpace(strings.ToLower(v))
+			if s == "stricthostkeychecking=no" || s == "userknownhostsfile=/dev/null" {
+				return zc1559Violation(cmd, "-o "+v)
+			}
+		}
+		if v == "-o" {
+			prevO = true
+		}
+	}
+	return nil
+}
+
+func zc1559Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1559",
+		Message: "`ssh-copy-id " + what + "` pushes a long-term credential without host-key " +
+			"verification. Verify the fingerprint out of band first.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 555 Katas = 0.5.55
-const Version = "0.5.55"
+// 556 Katas = 0.5.56
+const Version = "0.5.56"


### PR DESCRIPTION
## Summary
- Flags `ssh-copy-id -f` and `ssh-copy-id -o StrictHostKeyChecking=no` / `UserKnownHostsFile=/dev/null`
- Pushes long-term credential without host verification → permanent backdoor on MITM
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.56 (556 katas)