### PR TITLE
feat: ZC1560 — error on pip install --trusted-host (MITM PyPI index)

### DIFF
--- a/pkg/katas/katatests/zc1560_test.go
+++ b/pkg/katas/katatests/zc1560_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1560(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — pip install foo",
+			input:    `pip install foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — pip install --index-url https://x foo",
+			input:    `pip install --index-url https://pypi.example.com foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — pip install --trusted-host pypi.example.com foo",
+			input: `pip install --trusted-host pypi.example.com foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1560",
+					Message: "`pip --trusted-host` skips TLS verification and allows plain-HTTP for that index. Fix the CA trust and keep --index-url on https://.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — pip3 install foo --trusted-host pypi.org",
+			input: `pip3 install foo --trusted-host pypi.org`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1560",
+					Message: "`pip --trusted-host` skips TLS verification and allows plain-HTTP for that index. Fix the CA trust and keep --index-url on https://.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1560")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1560.go
+++ b/pkg/katas/zc1560.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1560",
+		Title:    "Error on `pip install --trusted-host` — accepts MITM / plain-HTTP PyPI index",
+		Severity: SeverityError,
+		Description: "`--trusted-host` tells pip to skip TLS certificate verification for the " +
+			"specified host and to allow plain-HTTP URLs from that host. Any MITM on the path " +
+			"can substitute packages on install, and a typo in the host name means every " +
+			"subsequent `install` from the mis-spelled host is unauthenticated. Fix the CA " +
+			"trust (install the real corporate CA) instead of silencing pip, and keep the " +
+			"default `--index-url https://...` over the TLS-verified endpoint.",
+		Check: checkZC1560,
+	})
+}
+
+func checkZC1560(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "pip" && ident.Value != "pip3" && ident.Value != "pipx" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "--trusted-host" {
+			return []Violation{{
+				KataID: "ZC1560",
+				Message: "`pip --trusted-host` skips TLS verification and allows plain-HTTP " +
+					"for that index. Fix the CA trust and keep --index-url on https://.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 556 Katas = 0.5.56
-const Version = "0.5.56"
+// 557 Katas = 0.5.57
+const Version = "0.5.57"


### PR DESCRIPTION
## Summary
- Flags `pip|pip3|pipx install --trusted-host <host>`
- Skips TLS verification + allows plain-HTTP for the host
- Suggest fixing CA trust, keep index-url on `https://`
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.57 (557 katas)