### PR TITLE
feat: ZC1561 — error on systemctl isolate rescue/emergency.target

### DIFF
--- a/pkg/katas/katatests/zc1561_test.go
+++ b/pkg/katas/katatests/zc1561_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1561(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — systemctl isolate multi-user.target",
+			input:    `systemctl isolate multi-user.target`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — systemctl start nginx.service",
+			input:    `systemctl start nginx.service`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — systemctl isolate rescue.target",
+			input: `systemctl isolate rescue.target`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1561",
+					Message: "`systemctl isolate rescue.target` kills SSH and most services — console-only recovery. Do not run from a script.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — systemctl isolate emergency.target",
+			input: `systemctl isolate emergency.target`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1561",
+					Message: "`systemctl isolate emergency.target` kills SSH and most services — console-only recovery. Do not run from a script.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1561")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1561.go
+++ b/pkg/katas/zc1561.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1561",
+		Title:    "Error on `systemctl isolate rescue.target` / `emergency.target` from a script",
+		Severity: SeverityError,
+		Description: "`systemctl isolate rescue.target` drops the host into single-user rescue " +
+			"mode; `emergency.target` goes even further, leaving only the root shell on the " +
+			"console. Both terminate networking, SSH sessions, and most services. On a remote " +
+			"host the script loses its own connection mid-run, and anyone relying on the box " +
+			"is cut off without warning. Reserve these for console recovery, not script flow.",
+		Check: checkZC1561,
+	})
+}
+
+func checkZC1561(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "systemctl" {
+		return nil
+	}
+
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "isolate" {
+		return nil
+	}
+	target := cmd.Arguments[1].String()
+	switch target {
+	case "rescue.target", "emergency.target", "rescue", "emergency":
+		return []Violation{{
+			KataID: "ZC1561",
+			Message: "`systemctl isolate " + target + "` kills SSH and most services — " +
+				"console-only recovery. Do not run from a script.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityError,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 557 Katas = 0.5.57
-const Version = "0.5.57"
+// 558 Katas = 0.5.58
+const Version = "0.5.58"


### PR DESCRIPTION
## Summary
- Flags `systemctl isolate rescue|emergency|rescue.target|emergency.target`
- Kills SSH + networking + most services — script self-disconnects remotely
- Reserve for console recovery, not script flow
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.58 (558 katas)