### PR TITLE
feat: ZC1562 — warn on env -u of PATH / LD_* vars

### DIFF
--- a/pkg/katas/katatests/zc1562_test.go
+++ b/pkg/katas/katatests/zc1562_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1562(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — env cmd",
+			input:    `env cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — env -u TMPDIR cmd",
+			input:    `env -u TMPDIR cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — env -u PATH cmd",
+			input: `env -u PATH cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1562",
+					Message: "`env -u PATH` clears a security-relevant variable mid-run. Use `env -i` to sanitise, or set the right value explicitly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — env -u LD_PRELOAD cmd",
+			input: `env -u LD_PRELOAD cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1562",
+					Message: "`env -u LD_PRELOAD` clears a security-relevant variable mid-run. Use `env -i` to sanitise, or set the right value explicitly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1562")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1562.go
+++ b/pkg/katas/zc1562.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1562",
+		Title:    "Warn on `env -u PATH` / `-u LD_LIBRARY_PATH` — clears security-relevant env",
+		Severity: SeverityWarning,
+		Description: "`env -u PATH` unsets the caller's `PATH` before running the child, forcing " +
+			"the child to fall back to the hard-coded search list (`/bin:/usr/bin` on glibc). " +
+			"That bypasses PATH hardening done by the parent shell (e.g. a sanitised PATH " +
+			"under `sudo`). Unsetting `LD_PRELOAD` / `LD_LIBRARY_PATH` mid-stream is also " +
+			"usually the caller trying to shake off an earlier `export`. Either use `env -i` " +
+			"to sanitise completely, or explicitly set the variables the child should see.",
+		Check: checkZC1562,
+	})
+}
+
+func checkZC1562(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "env" {
+		return nil
+	}
+
+	var prevU bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevU {
+			prevU = false
+			switch v {
+			case "PATH", "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT":
+				return []Violation{{
+					KataID: "ZC1562",
+					Message: "`env -u " + v + "` clears a security-relevant variable mid-run. " +
+						"Use `env -i` to sanitise, or set the right value explicitly.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+		if v == "-u" || v == "--unset" {
+			prevU = true
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 558 Katas = 0.5.58
-const Version = "0.5.58"
+// 559 Katas = 0.5.59
+const Version = "0.5.59"


### PR DESCRIPTION
## Summary
- Flags `env -u PATH|LD_PRELOAD|LD_LIBRARY_PATH|LD_AUDIT <cmd>`
- Clears security-relevant variables, often to shake off sudo/parent hardening
- Suggest `env -i` for full sanitisation or explicit value
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.59 (559 katas)