### PR TITLE
feat: ZC1563 — warn on swapoff -a (disables all swap)

### DIFF
--- a/pkg/katas/katatests/zc1563_test.go
+++ b/pkg/katas/katatests/zc1563_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1563(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — swapon -a",
+			input:    `swapon -a`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — swapoff specific file",
+			input:    `swapoff /swapfile`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — swapoff -a",
+			input: `swapoff -a`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1563",
+					Message: "`swapoff -a` disables all swap devices — next memory-hungry process hits OOM. Document the trade-off if kubelet requires it.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1563")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1563.go
+++ b/pkg/katas/zc1563.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1563",
+		Title:    "Warn on `swapoff -a` — disables swap (memory pressure, potential OOM)",
+		Severity: SeverityWarning,
+		Description: "`swapoff -a` turns off every active swap device. Kubelet installers do " +
+			"this because kubelet refuses to run with swap, but leaving it in a general-purpose " +
+			"script means the next memory-hungry process on the host hits the OOM killer " +
+			"instead of paging. If the goal is kubelet-friendly, also remove the swap entry " +
+			"from `/etc/fstab` and document the trade-off; otherwise keep swap on.",
+		Check: checkZC1563,
+	})
+}
+
+func checkZC1563(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "swapoff" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-a" || arg.String() == "--all" {
+			return []Violation{{
+				KataID: "ZC1563",
+				Message: "`swapoff -a` disables all swap devices — next memory-hungry process " +
+					"hits OOM. Document the trade-off if kubelet requires it.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 559 Katas = 0.5.59
-const Version = "0.5.59"
+// 560 Katas = 0.5.60
+const Version = "0.5.60"


### PR DESCRIPTION
## Summary
- Flags `swapoff -a` / `swapoff --all`
- Ignores `swapoff <specific-file>` and `swapon -a`
- Common in kubelet installers but hides memory pressure elsewhere
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.60 (560 katas)