### PR TITLE
feat: ZC1564 — warn on manual wall-clock change (date -s / timedatectl / hwclock)

### DIFF
--- a/pkg/katas/katatests/zc1564_test.go
+++ b/pkg/katas/katatests/zc1564_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1564(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — date (read)",
+			input:    `date`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — timedatectl status",
+			input:    `timedatectl status`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — date -s 2025-01-01",
+			input: `date -s 2025-01-01`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1564",
+					Message: "`date -s` sets the wall clock manually — breaks TLS certs, cron catch-up, and systemd timer math. Use timesyncd/chrony/ntpd.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — timedatectl set-time",
+			input: `timedatectl set-time 2025-01-01`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1564",
+					Message: "`timedatectl set-time` sets the wall clock manually — breaks TLS certs, cron catch-up, and systemd timer math. Use timesyncd/chrony/ntpd.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — hwclock -w",
+			input: `hwclock -w`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1564",
+					Message: "`hwclock -w` sets the wall clock manually — breaks TLS certs, cron catch-up, and systemd timer math. Use timesyncd/chrony/ntpd.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1564")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1564.go
+++ b/pkg/katas/zc1564.go
@@ -1,0 +1,64 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1564",
+		Title:    "Warn on `date -s` / `timedatectl set-time` — manual clock change breaks TLS / cron",
+		Severity: SeverityWarning,
+		Description: "Setting the system clock by hand (`date -s`, `timedatectl set-time`, " +
+			"`hwclock --set`) moves wall-clock time enough to invalidate short-lived TLS " +
+			"certificates, reset `cron`'s missed-job catch-up, and confuse `systemd.timer` " +
+			"units that depend on monotonic math. Use `systemd-timesyncd` / `chrony` / `ntpd` " +
+			"for routine correction; reserve manual set for first-boot bootstrap or air-gapped " +
+			"recovery and document the action.",
+		Check: checkZC1564,
+	})
+}
+
+func checkZC1564(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value == "date" {
+		for _, arg := range cmd.Arguments {
+			if arg.String() == "-s" || arg.String() == "--set" {
+				return zc1564Violation(cmd, "date -s")
+			}
+		}
+	}
+	if ident.Value == "timedatectl" && len(cmd.Arguments) >= 1 &&
+		cmd.Arguments[0].String() == "set-time" {
+		return zc1564Violation(cmd, "timedatectl set-time")
+	}
+	if ident.Value == "hwclock" {
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "--set" || v == "-w" || v == "--systohc" {
+				return zc1564Violation(cmd, "hwclock "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1564Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1564",
+		Message: "`" + what + "` sets the wall clock manually — breaks TLS certs, cron " +
+			"catch-up, and systemd timer math. Use timesyncd/chrony/ntpd.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 560 Katas = 0.5.60
-const Version = "0.5.60"
+// 561 Katas = 0.5.61
+const Version = "0.5.61"


### PR DESCRIPTION
## Summary
- Flags `date -s`, `timedatectl set-time`, `hwclock -w|--set|--systohc`
- Breaks TLS validity, cron catch-up, systemd timer math
- Suggest timesyncd / chrony / ntpd
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.61 (561 katas)