### PR TITLE
feat: ZC1565 — style: prefer command -v over whereis/locate

### DIFF
--- a/pkg/katas/katatests/zc1565_test.go
+++ b/pkg/katas/katatests/zc1565_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1565(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — command -v cmd",
+			input:    `command -v git`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — whereis git",
+			input: `whereis git`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1565",
+					Message: "`whereis` is index-based and stale-prone. Use `command -v <cmd>` for runtime existence checks.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — locate foo",
+			input: `locate foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1565",
+					Message: "`locate` is index-based and stale-prone. Use `command -v <cmd>` for runtime existence checks.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1565")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1565.go
+++ b/pkg/katas/zc1565.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1565",
+		Title:    "Style: use `command -v` instead of `whereis` / `locate` for command existence",
+		Severity: SeverityStyle,
+		Description: "`whereis` searches a hard-coded list of binary/manual/source directories " +
+			"and returns everything it finds, including stale paths on custom `$PATH` layouts. " +
+			"`locate` relies on a cron-maintained index that may be hours or days stale. For " +
+			"a scripted \"does this command exist?\" check, `command -v <cmd>` respects the " +
+			"current `$PATH`, returns the selected resolution, and has no index-refresh " +
+			"coupling.",
+		Check: checkZC1565,
+	})
+}
+
+func checkZC1565(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "whereis" && ident.Value != "locate" && ident.Value != "mlocate" &&
+		ident.Value != "plocate" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1565",
+		Message: "`" + ident.Value + "` is index-based and stale-prone. Use `command -v " +
+			"<cmd>` for runtime existence checks.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 561 Katas = 0.5.61
-const Version = "0.5.61"
+// 562 Katas = 0.5.62
+const Version = "0.5.62"


### PR DESCRIPTION
## Summary
- Flags `whereis|locate|mlocate|plocate` used in scripts
- Stale-index-prone; `command -v` is the right runtime existence check
- Severity: Style

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.62 (562 katas)