### PR TITLE
feat: ZC1566 — error on gem -P NoSecurity/LowSecurity

### DIFF
--- a/pkg/katas/katatests/zc1566_test.go
+++ b/pkg/katas/katatests/zc1566_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1566(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — gem install rails",
+			input:    `gem install rails`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — gem install -P HighSecurity",
+			input:    `gem install -P HighSecurity rails`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — gem install -P NoSecurity",
+			input: `gem install -P NoSecurity rails`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1566",
+					Message: "`gem -P NoSecurity` skips signature verification — MITM or account compromise becomes RCE at install. Use HighSecurity.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — gem install --trust-policy LowSecurity",
+			input: `gem install --trust-policy LowSecurity rails`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1566",
+					Message: "`gem -P LowSecurity` skips signature verification — MITM or account compromise becomes RCE at install. Use HighSecurity.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1566")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1566.go
+++ b/pkg/katas/zc1566.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1566",
+		Title:    "Error on `gem install -P NoSecurity|LowSecurity` / `--trust-policy NoSecurity`",
+		Severity: SeverityError,
+		Description: "RubyGems' trust policy decides what signatures the installer accepts. " +
+			"`NoSecurity` skips signature verification entirely; `LowSecurity` warns but still " +
+			"installs unsigned gems. On a registry MITM or a hijacked maintainer account those " +
+			"policies turn into arbitrary code execution at gem-install time. Use `HighSecurity` " +
+			"(reject all but fully-signed) or `MediumSecurity` for hybrid repos.",
+		Check: checkZC1566,
+	})
+}
+
+func checkZC1566(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "gem" {
+		return nil
+	}
+
+	var prevP bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevP {
+			prevP = false
+			if v == "NoSecurity" || v == "LowSecurity" {
+				return []Violation{{
+					KataID: "ZC1566",
+					Message: "`gem -P " + v + "` skips signature verification — MITM or " +
+						"account compromise becomes RCE at install. Use HighSecurity.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityError,
+				}}
+			}
+		}
+		if v == "-P" || v == "--trust-policy" {
+			prevP = true
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 562 Katas = 0.5.62
-const Version = "0.5.62"
+// 563 Katas = 0.5.63
+const Version = "0.5.63"


### PR DESCRIPTION
## Summary
- Flags `gem install -P NoSecurity|LowSecurity` and `--trust-policy NoSecurity|LowSecurity`
- Skips signature verification → MITM / hijacked account becomes RCE at install
- Suggest HighSecurity
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.63 (563 katas)