### PR TITLE
feat: ZC1567 — warn on python -m http.server without --bind 127.0.0.1

### DIFF
--- a/pkg/katas/katatests/zc1567_test.go
+++ b/pkg/katas/katatests/zc1567_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1567(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — python -m http.server --bind 127.0.0.1",
+			input:    `python -m http.server --bind 127.0.0.1 8080`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — python -m http.server -b 127.0.0.1",
+			input:    `python -m http.server -b 127.0.0.1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — python -m venv myenv",
+			input:    `python -m venv myenv`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — python -m http.server",
+			input: `python -m http.server`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1567",
+					Message: "`python -m http.server` without `--bind` defaults to 0.0.0.0 — exposes the cwd to every network the host sees. Add `--bind 127.0.0.1`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — python3 -m http.server 8080",
+			input: `python3 -m http.server 8080`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1567",
+					Message: "`python -m http.server` without `--bind` defaults to 0.0.0.0 — exposes the cwd to every network the host sees. Add `--bind 127.0.0.1`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — python2 -m SimpleHTTPServer",
+			input: `python2 -m SimpleHTTPServer`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1567",
+					Message: "`python -m http.server` without `--bind` defaults to 0.0.0.0 — exposes the cwd to every network the host sees. Add `--bind 127.0.0.1`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1567")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1567.go
+++ b/pkg/katas/zc1567.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1567",
+		Title:    "Warn on `python -m http.server` without `--bind 127.0.0.1` — serves to all interfaces",
+		Severity: SeverityWarning,
+		Description: "`python -m http.server` (and the legacy `SimpleHTTPServer`) default to " +
+			"`0.0.0.0`, exposing the current directory's contents to every network the host " +
+			"is on. Tmp scratch files, `.env`, SSH keys, or a `node_modules` tree with private " +
+			"config all become reachable from anywhere on the LAN (or the internet, on a VPS). " +
+			"Pass `--bind 127.0.0.1` (or `--bind ::1`) unless you really need external access " +
+			"and know what is in the cwd.",
+		Check: checkZC1567,
+	})
+}
+
+func checkZC1567(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "python" && ident.Value != "python2" && ident.Value != "python3" {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, a.String())
+	}
+
+	// python -m http.server  or  python -m SimpleHTTPServer
+	var isServer bool
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-m" && (args[i+1] == "http.server" || args[i+1] == "SimpleHTTPServer") {
+			isServer = true
+			break
+		}
+	}
+	if !isServer {
+		return nil
+	}
+
+	for _, a := range args {
+		if a == "--bind" || a == "-b" {
+			return nil
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1567",
+		Message: "`python -m http.server` without `--bind` defaults to 0.0.0.0 — exposes the " +
+			"cwd to every network the host sees. Add `--bind 127.0.0.1`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 563 Katas = 0.5.63
-const Version = "0.5.63"
+// 564 Katas = 0.5.64
+const Version = "0.5.64"


### PR DESCRIPTION
## Summary
- Flags `python|python2|python3 -m http.server` (or `SimpleHTTPServer`) without `--bind` or `-b`
- Default 0.0.0.0 exposes cwd on every network
- Suggest `--bind 127.0.0.1`
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.64 (564 katas)