### PR TITLE
feat: ZC1568 — error on useradd/usermod -o (non-unique UID)

### DIFF
--- a/pkg/katas/katatests/zc1568_test.go
+++ b/pkg/katas/katatests/zc1568_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1568(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — useradd -u 1000 alice",
+			input:    `useradd -u 1000 alice`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — useradd -o -u 1000 alice",
+			input: `useradd -o -u 1000 alice`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1568",
+					Message: "`useradd -o` assigns a non-unique UID — the two accounts share kernel identity, indistinguishable in audit. Use a fresh UID.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — usermod -o -u 500 bob",
+			input: `usermod -o -u 500 bob`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1568",
+					Message: "`usermod -o` assigns a non-unique UID — the two accounts share kernel identity, indistinguishable in audit. Use a fresh UID.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1568")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1568.go
+++ b/pkg/katas/zc1568.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1568",
+		Title:    "Error on `useradd -o` / `usermod -o` — allows non-unique UID (alias user)",
+		Severity: SeverityError,
+		Description: "`-o` (or `--non-unique`) lets `useradd` / `usermod` assign a UID that is " +
+			"already in use. The new account has the same kernel identity as the existing one " +
+			"but its own login name, password, shell, and home dir. It is indistinguishable in " +
+			"`ps` / audit / file ACLs, so a compromise of either account is a compromise of " +
+			"both. Pick a fresh UID instead.",
+		Check: checkZC1568,
+	})
+}
+
+func checkZC1568(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "useradd" && ident.Value != "usermod" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-o" || v == "--non-unique" {
+			return []Violation{{
+				KataID: "ZC1568",
+				Message: "`" + ident.Value + " -o` assigns a non-unique UID — the two " +
+					"accounts share kernel identity, indistinguishable in audit. Use a " +
+					"fresh UID.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 564 Katas = 0.5.64
-const Version = "0.5.64"
+// 565 Katas = 0.5.65
+const Version = "0.5.65"


### PR DESCRIPTION
## Summary
- Flags `useradd|usermod -o` — shares UID with existing account
- Audit/ACL indistinguishable — compromise of either is both
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.65 (565 katas)