### PR TITLE
feat: ZC1569 — error on nvme format/sanitize (SSD unrecoverable erase)

### DIFF
--- a/pkg/katas/katatests/zc1569_test.go
+++ b/pkg/katas/katatests/zc1569_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1569(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — nvme list",
+			input:    `nvme list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — nvme id-ctrl $DISK",
+			input:    `nvme id-ctrl $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — nvme format -s1 $DISK",
+			input: `nvme format -s1 $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1569",
+					Message: "`nvme format -s1` unrecoverably erases the namespace in seconds. Do not run from automation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — nvme format -s2 $DISK",
+			input: `nvme format -s2 $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1569",
+					Message: "`nvme format -s2` unrecoverably erases the namespace in seconds. Do not run from automation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — nvme sanitize -a 4 $DISK",
+			input: `nvme sanitize -a 4 $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1569",
+					Message: "`nvme sanitize -a` unrecoverably erases the namespace in seconds. Do not run from automation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1569")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1569.go
+++ b/pkg/katas/zc1569.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1569",
+		Title:    "Error on `nvme format -s1` / `-s2` — cryptographic or full-block SSD erase",
+		Severity: SeverityError,
+		Description: "`nvme format -s1` does a cryptographic erase of the target namespace; " +
+			"`-s2` (or the full-NVMe sanitize) rewrites every block. Both are unrecoverable " +
+			"in seconds. On a typo in the device variable — or a script that iterates over " +
+			"`/dev/nvme*n*` and catches the wrong namespace — the wrong disk is gone by the " +
+			"time the operator notices. Run interactively on verified targets, or not at all " +
+			"from automation.",
+		Check: checkZC1569,
+	})
+}
+
+func checkZC1569(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "nvme" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	if sub != "format" && sub != "sanitize" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "-s1" || v == "-s2" || v == "--ses=1" || v == "--ses=2" ||
+			v == "-a" || v == "--sanact" {
+			return []Violation{{
+				KataID: "ZC1569",
+				Message: "`nvme " + sub + " " + v + "` unrecoverably erases the namespace in " +
+					"seconds. Do not run from automation.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 565 Katas = 0.5.65
-const Version = "0.5.65"
+// 566 Katas = 0.5.66
+const Version = "0.5.66"


### PR DESCRIPTION
## Summary
- Flags `nvme format -s1|-s2` and `nvme sanitize -a`
- Seconds-to-unrecoverable erase; wrong-device typo is fatal
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.66 (566 katas)