### PR TITLE
feat: ZC1570 — warn on smbclient/mount.cifs -N (anonymous SMB)

### DIFF
--- a/pkg/katas/katatests/zc1570_test.go
+++ b/pkg/katas/katatests/zc1570_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1570(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — smbclient -U user //server/share",
+			input:    `smbclient -U user //server/share`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — smbclient -N //server/share",
+			input: `smbclient -N //server/share`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1570",
+					Message: "`smbclient -N` is anonymous SMB access — any host on-net can read the share. Use credentials=<file> 0600 or -k.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — mount.cifs -N //server/share /mnt",
+			input: `mount.cifs -N //server/share /mnt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1570",
+					Message: "`mount.cifs -N` is anonymous SMB access — any host on-net can read the share. Use credentials=<file> 0600 or -k.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1570")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1570.go
+++ b/pkg/katas/zc1570.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1570",
+		Title:    "Warn on `smbclient -N` / `mount.cifs guest` — anonymous SMB share access",
+		Severity: SeverityWarning,
+		Description: "`smbclient -N` skips authentication entirely (anonymous / null session); " +
+			"`mount.cifs` with `guest,username=` or `-o guest` does the same at the mount " +
+			"layer. Any host on the network segment can then read the share. If the share is " +
+			"truly public (software mirror, build cache) wrap in a read-only filesystem and " +
+			"document it; otherwise require Kerberos (`-k`) or pass credentials via " +
+			"`credentials=<file>` with 0600 perms.",
+		Check: checkZC1570,
+	})
+}
+
+func checkZC1570(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "smbclient" && ident.Value != "mount.cifs" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-N" || v == "--no-pass" {
+			return []Violation{{
+				KataID: "ZC1570",
+				Message: "`" + ident.Value + " " + v + "` is anonymous SMB access — any " +
+					"host on-net can read the share. Use credentials=<file> 0600 or -k.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 566 Katas = 0.5.66
-const Version = "0.5.66"
+// 567 Katas = 0.5.67
+const Version = "0.5.67"


### PR DESCRIPTION
## Summary
- Flags `smbclient|mount.cifs -N`
- Null-session SMB — any host on-net reads the share
- Suggest credentials= file 0600 or Kerberos -k
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.67 (567 katas)