### PR TITLE
feat: ZC1571 — style: ntpdate / sntp deprecated (use chronyc / timesyncd)

### DIFF
--- a/pkg/katas/katatests/zc1571_test.go
+++ b/pkg/katas/katatests/zc1571_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1571(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — chronyc makestep",
+			input:    `chronyc makestep`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ntpdate pool.ntp.org",
+			input: `ntpdate pool.ntp.org`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1571",
+					Message: "`ntpdate` is deprecated and races any running chrony/timesyncd. Use `chronyc makestep` or `systemctl restart systemd-timesyncd`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — sntp -sS pool.ntp.org",
+			input: `sntp -sS pool.ntp.org`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1571",
+					Message: "`sntp` is deprecated and races any running chrony/timesyncd. Use `chronyc makestep` or `systemctl restart systemd-timesyncd`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1571")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1571.go
+++ b/pkg/katas/zc1571.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1571",
+		Title:    "Style: `ntpdate` is deprecated — use `chronyc makestep` / `systemd-timesyncd`",
+		Severity: SeverityStyle,
+		Description: "`ntpdate` was retired by the ntp.org project around 4.2.6. Distros " +
+			"increasingly ship without it, and packaging it breaks the invariant that only " +
+			"one program writes the clock at a time (if `chrony` or `timesyncd` is also " +
+			"running the two fight). Use `chronyc makestep` (if chrony is active) or " +
+			"`systemctl restart systemd-timesyncd` (if timesyncd is active) for a one-shot " +
+			"step, and leave the daemon to keep it synchronised.",
+		Check: checkZC1571,
+	})
+}
+
+func checkZC1571(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ntpdate" && ident.Value != "sntp" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1571",
+		Message: "`" + ident.Value + "` is deprecated and races any running chrony/timesyncd. " +
+			"Use `chronyc makestep` or `systemctl restart systemd-timesyncd`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 567 Katas = 0.5.67
-const Version = "0.5.67"
+// 568 Katas = 0.5.68
+const Version = "0.5.68"


### PR DESCRIPTION
## Summary
- Flags `ntpdate` and `sntp`
- Deprecated and races chrony/timesyncd
- Suggest `chronyc makestep` or `systemctl restart systemd-timesyncd`
- Severity: Style

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.68 (568 katas)