### PR TITLE
feat: ZC1572 — warn on docker run -e <SECRET>=<value>

### DIFF
--- a/pkg/katas/katatests/zc1572_test.go
+++ b/pkg/katas/katatests/zc1572_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1572(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker run -e LOG_LEVEL=info",
+			input:    `docker run -e LOG_LEVEL=info alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — docker run -e PASSWORD (no value, inherits)",
+			input:    `docker run -e PASSWORD alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — docker run --env-file secrets alpine",
+			input:    `docker run --env-file secrets alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker run -e PASSWORD=hunter2",
+			input: `docker run -e PASSWORD=hunter2 alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1572",
+					Message: "`-e PASSWORD=<value>` writes the secret into `docker inspect` and `/proc/1/environ`. Use `--env-file` 0600 or `--secret`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — podman run -e API_KEY=abc123",
+			input: `podman run -e API_KEY=abc123 alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1572",
+					Message: "`-e API_KEY=<value>` writes the secret into `docker inspect` and `/proc/1/environ`. Use `--env-file` 0600 or `--secret`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1572")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1572.go
+++ b/pkg/katas/zc1572.go
@@ -1,0 +1,104 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1572",
+		Title:    "Warn on `docker run -e PASSWORD=<value>` — secret in container env / inspect",
+		Severity: SeverityWarning,
+		Description: "Passing a secret through `docker run -e NAME=value` puts it in the output " +
+			"of `docker inspect`, the container's `/proc/1/environ` (readable by anything that " +
+			"shares the PID namespace), and the shell history of whoever launched the " +
+			"container. Use `--env-file` with 0600 perms, a secret-mount `--secret` via " +
+			"BuildKit / Swarm, or mount a tmpfs file the container reads at runtime.",
+		Check: checkZC1572,
+	})
+}
+
+var secretEnvPrefixes = []string{
+	"PASSWORD", "PASSWD", "PASS",
+	"SECRET", "SECRET_KEY", "API_KEY",
+	"TOKEN", "AUTH_TOKEN", "ACCESS_TOKEN",
+	"PRIVATE_KEY", "DB_PASSWORD", "DB_PASS",
+	"AWS_SECRET", "AWS_SECRET_ACCESS_KEY",
+	"GITHUB_TOKEN", "GH_TOKEN", "NPM_TOKEN",
+}
+
+func checkZC1572(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" && ident.Value != "nerdctl" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "run" {
+		return nil
+	}
+
+	var prevE bool
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if prevE {
+			prevE = false
+			name, value, ok := strings.Cut(v, "=")
+			if !ok || value == "" {
+				// `-e NAME` (value from caller env) is fine.
+				continue
+			}
+			if looksLikeSecret(name) {
+				return []Violation{{
+					KataID: "ZC1572",
+					Message: "`-e " + name + "=<value>` writes the secret into `docker " +
+						"inspect` and `/proc/1/environ`. Use `--env-file` 0600 or " +
+						"`--secret`.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+		if v == "-e" || v == "--env" {
+			prevE = true
+			continue
+		}
+		// Joined form: --env=NAME=value
+		if strings.HasPrefix(v, "--env=") {
+			inner := v[len("--env="):]
+			name, value, ok := strings.Cut(inner, "=")
+			if ok && value != "" && looksLikeSecret(name) {
+				return []Violation{{
+					KataID: "ZC1572",
+					Message: "`--env=" + name + "=<value>` writes the secret into `docker " +
+						"inspect` and `/proc/1/environ`. Use `--env-file` 0600 or " +
+						"`--secret`.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+	return nil
+}
+
+func looksLikeSecret(name string) bool {
+	up := strings.ToUpper(name)
+	for _, p := range secretEnvPrefixes {
+		if up == p || strings.Contains(up, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 568 Katas = 0.5.68
-const Version = "0.5.68"
+// 569 Katas = 0.5.69
+const Version = "0.5.69"


### PR DESCRIPTION
## Summary
- Flags `docker|podman|nerdctl run -e NAME=<value>` where NAME looks like a secret
- Detects PASSWORD/PASS, SECRET, API_KEY, TOKEN, PRIVATE_KEY, DB_PASSWORD, AWS_SECRET*, GH_TOKEN, NPM_TOKEN
- Leaks via `docker inspect` and `/proc/1/environ`
- Suggest `--env-file` 0600, `--secret`, or tmpfs file
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.69 (569 katas)