### PR TITLE
feat: ZC1573 — warn on chattr -i / -a (removes immutable/append-only attr)

### DIFF
--- a/pkg/katas/katatests/zc1573_test.go
+++ b/pkg/katas/katatests/zc1573_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1573(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — chattr =i (set exclusive)",
+			input:    `chattr =i /etc/shadow`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — chattr -i /etc/shadow",
+			input: `chattr -i /etc/shadow`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1573",
+					Message: "`chattr -i` removes the tamper-evident attribute. If this is a one-shot upgrade, re-set the attribute at the end of the block.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — chattr -a /var/log/auth.log",
+			input: `chattr -a /var/log/auth.log`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1573",
+					Message: "`chattr -a` removes the tamper-evident attribute. If this is a one-shot upgrade, re-set the attribute at the end of the block.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1573")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1573.go
+++ b/pkg/katas/zc1573.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1573",
+		Title:    "Warn on `chattr -i` / `chattr -a` — removes immutable / append-only attribute",
+		Severity: SeverityWarning,
+		Description: "Removing the immutable (`-i`) or append-only (`-a`) attribute lets the " +
+			"file be overwritten or truncated again. When the target is a log file, shadow " +
+			"file, or hardened system binary, that flag was explicitly set to make tampering " +
+			"noisy. Removing it mid-script is either a one-shot upgrade (follow with the " +
+			"`chattr +i` restore) or an anti-forensics step. If it is the former, wrap the " +
+			"change in a function and re-set the attribute at the end.",
+		Check: checkZC1573,
+	})
+}
+
+func checkZC1573(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "chattr" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-i" || v == "-a" || v == "-ia" || v == "-ai" {
+			return []Violation{{
+				KataID: "ZC1573",
+				Message: "`chattr " + v + "` removes the tamper-evident attribute. If this " +
+					"is a one-shot upgrade, re-set the attribute at the end of the block.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 569 Katas = 0.5.69
-const Version = "0.5.69"
+// 570 Katas = 0.5.70
+const Version = "0.5.70"


### PR DESCRIPTION
## Summary
- Flags `chattr -i|-a|-ia|-ai <file>`
- Tamper-evidence gone; wrap in function that re-sets at end
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.70 (570 katas)