### PR TITLE
feat: ZC1574 — warn on git config credential.helper store

### DIFF
--- a/pkg/katas/katatests/zc1574_test.go
+++ b/pkg/katas/katatests/zc1574_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1574(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — git config credential.helper libsecret",
+			input:    `git config credential.helper libsecret`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — git config credential.helper 'cache --timeout=3600'",
+			input:    `git config credential.helper 'cache --timeout=3600'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — git config credential.helper store",
+			input: `git config credential.helper store`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1574",
+					Message: "`git credential.helper store` saves credentials in plaintext — backups leak the token. Use platform helper (manager-core / libsecret) or `cache --timeout=<sec>`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — git config --global credential.helper store",
+			input: `git config --global credential.helper store`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1574",
+					Message: "`git credential.helper store` saves credentials in plaintext — backups leak the token. Use platform helper (manager-core / libsecret) or `cache --timeout=<sec>`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1574")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1574.go
+++ b/pkg/katas/zc1574.go
@@ -1,0 +1,71 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1574",
+		Title:    "Warn on `git config credential.helper store` — plaintext credentials on disk",
+		Severity: SeverityWarning,
+		Description: "`credential.helper store` writes the username and password to " +
+			"`~/.git-credentials` in plaintext. Anything that backs up that file (rsync, " +
+			"imaging, cloud sync) then carries the credential around. Use a platform helper " +
+			"instead: `manager` / `manager-core` on Windows / Mac, `libsecret` on Linux, or " +
+			"`cache --timeout=3600` for short-lived in-memory caching.",
+		Check: checkZC1574,
+	})
+}
+
+func checkZC1574(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "git" {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, a.String())
+	}
+
+	// git config [scope] credential.helper store
+	for i, a := range args {
+		if a != "config" {
+			continue
+		}
+		// Walk past optional scope flag.
+		j := i + 1
+		for j < len(args) && strings.HasPrefix(args[j], "--") && args[j] != "--" {
+			j++
+		}
+		if j+1 < len(args) && args[j] == "credential.helper" {
+			v := args[j+1]
+			// Accept bare `store` or quoted `store --file=...`.
+			if v == "store" || strings.HasPrefix(v, "store ") ||
+				strings.Contains(v, "store --file=") ||
+				strings.Contains(v, "'store") || strings.Contains(v, "\"store") {
+				return []Violation{{
+					KataID: "ZC1574",
+					Message: "`git credential.helper store` saves credentials in plaintext — " +
+						"backups leak the token. Use platform helper (manager-core / " +
+						"libsecret) or `cache --timeout=<sec>`.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 570 Katas = 0.5.70
-const Version = "0.5.70"
+// 571 Katas = 0.5.71
+const Version = "0.5.71"


### PR DESCRIPTION
## Summary
- Flags `git config [scope] credential.helper store` (and quoted variants with --file=)
- Plaintext `~/.git-credentials` — leaks via backup
- Suggest manager-core / libsecret / cache
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.71 (571 katas)