### PR TITLE
feat: ZC1575 — error on aws configure set aws_secret_access_key

### DIFF
--- a/pkg/katas/katatests/zc1575_test.go
+++ b/pkg/katas/katatests/zc1575_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1575(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — aws configure set region us-east-1",
+			input:    `aws configure set region us-east-1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — aws configure set aws_secret_access_key VALUE",
+			input: `aws configure set aws_secret_access_key AKIAEXAMPLEKEYXYZ`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1575",
+					Message: "`aws configure set aws_secret_access_key …` puts the secret in ps / history. Use IAM-role auth or import from stdin / 0600 file.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — aws configure set aws_session_token",
+			input: `aws configure set aws_session_token FwoGZXIvYXdzEXAMPLE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1575",
+					Message: "`aws configure set aws_session_token …` puts the secret in ps / history. Use IAM-role auth or import from stdin / 0600 file.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1575")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1575.go
+++ b/pkg/katas/zc1575.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1575",
+		Title:    "Error on `aws configure set aws_secret_access_key <value>` — secret on cmdline",
+		Severity: SeverityError,
+		Description: "`aws configure set aws_secret_access_key …` writes the secret access key " +
+			"into `~/.aws/credentials` and leaves the raw value in `ps` / shell history until " +
+			"the process exits. On a shared CI runner or a multi-user host, that window is " +
+			"long enough for a co-tenant to snapshot the key. Use IAM-role-based auth (EC2 " +
+			"instance profile, IRSA on EKS, OIDC from GitHub / GitLab) or read the value from " +
+			"stdin / a 0600 file and let `aws configure` import it interactively.",
+		Check: checkZC1575,
+	})
+}
+
+func checkZC1575(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "aws" {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, a.String())
+	}
+
+	// aws configure set aws_secret_access_key VALUE
+	for i := 0; i+3 < len(args); i++ {
+		if args[i] == "configure" && args[i+1] == "set" {
+			key := strings.ToLower(args[i+2])
+			if key == "aws_secret_access_key" || key == "aws_session_token" ||
+				strings.Contains(key, "secret") {
+				return []Violation{{
+					KataID: "ZC1575",
+					Message: "`aws configure set " + args[i+2] + " …` puts the secret in " +
+						"ps / history. Use IAM-role auth or import from stdin / 0600 file.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityError,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 571 Katas = 0.5.71
-const Version = "0.5.71"
+// 572 Katas = 0.5.72
+const Version = "0.5.72"


### PR DESCRIPTION
## Summary
- Flags `aws configure set aws_secret_access_key|aws_session_token <value>` (and generic keys containing "secret")
- Secret in ps/proc/history on shared hosts
- Suggest IAM role auth or stdin / 0600 file import
- Severity: Error

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.72 (572 katas)