### PR TITLE
feat: ZC1576 — warn on terraform apply -target (bypasses dependency order)

### DIFF
--- a/pkg/katas/katatests/zc1576_test.go
+++ b/pkg/katas/katatests/zc1576_test.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1576(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — terraform apply",
+			input:    `terraform apply`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — terraform apply -target=module.foo",
+			input: `terraform apply -target=module.foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1576",
+					Message: "`terraform -target=module.foo` bypasses dependency order — documented as incident response tool only. Re-run without -target or split root modules.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — terraform apply -target module.foo",
+			input: `terraform apply -target module.foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1576",
+					Message: "`terraform -target module.foo` bypasses dependency order — documented as incident response tool only. Re-run without -target or split root modules.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — tofu destroy -target=aws_instance.web",
+			input: `tofu destroy -target=aws_instance.web`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1576",
+					Message: "`terraform -target=aws_instance.web` bypasses dependency order — documented as incident response tool only. Re-run without -target or split root modules.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1576")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1576.go
+++ b/pkg/katas/zc1576.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1576",
+		Title:    "Warn on `terraform apply -target=...` — cherry-pick apply bypasses dependencies",
+		Severity: SeverityWarning,
+		Description: "`-target` restricts `terraform apply` to a specific resource / module and " +
+			"everything it depends on. In theory that is a surgical fix; in practice it " +
+			"routinely skips changes the targeted resource actually depends on, leading to " +
+			"drift between state and configuration. HashiCorp documents `-target` as a tool " +
+			"for incident response, not routine operations. Re-run without `-target` or " +
+			"split the configuration into separate root modules.",
+		Check: checkZC1576,
+	})
+}
+
+func checkZC1576(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "terraform" && ident.Value != "terragrunt" && ident.Value != "tofu" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	if sub != "apply" && sub != "destroy" && sub != "plan" {
+		return nil
+	}
+
+	var prevTarget bool
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if prevTarget {
+			return zc1576Violation(cmd, "-target "+v)
+		}
+		if v == "-target" {
+			prevTarget = true
+			continue
+		}
+		if strings.HasPrefix(v, "-target=") {
+			return zc1576Violation(cmd, v)
+		}
+	}
+	return nil
+}
+
+func zc1576Violation(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1576",
+		Message: "`terraform " + what + "` bypasses dependency order — documented as incident " +
+			"response tool only. Re-run without -target or split root modules.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 572 Katas = 0.5.72
-const Version = "0.5.72"
+// 573 Katas = 0.5.73
+const Version = "0.5.73"


### PR DESCRIPTION
## Summary
- Flags `terraform|terragrunt|tofu apply|destroy|plan -target=<addr>` / `-target <addr>`
- Cherry-pick apply drifts state vs config
- Suggest re-run without -target or split root modules
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.73 (573 katas)