### PR TITLE
feat: ZC1577 — warn on dig/drill ANY (RFC 8482 deprecated)

### DIFF
--- a/pkg/katas/katatests/zc1577_test.go
+++ b/pkg/katas/katatests/zc1577_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1577(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — dig A example.com",
+			input:    `dig A example.com`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — dig MX example.com",
+			input:    `dig MX example.com`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — dig ANY example.com",
+			input: `dig ANY example.com`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1577",
+					Message: "`dig ... ANY` is RFC 8482-deprecated — filtered by recursors. Query specific types (A / MX / NS / …) and combine.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — dig example.com ANY",
+			input: `dig example.com ANY`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1577",
+					Message: "`dig ... ANY` is RFC 8482-deprecated — filtered by recursors. Query specific types (A / MX / NS / …) and combine.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1577")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1577.go
+++ b/pkg/katas/zc1577.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1577",
+		Title:    "Warn on `dig <name> ANY` — deprecated query type (RFC 8482)",
+		Severity: SeverityWarning,
+		Description: "ANY queries return whatever the authoritative server feels like sending " +
+			"back — or just the HINFO placeholder mandated by RFC 8482. Modern recursors " +
+			"filter ANY to avoid reflection-amplification abuse, so scripts that rely on ANY " +
+			"for enumeration get inconsistent or empty results. Query the specific record " +
+			"types you want (`dig A name`, `dig MX name`, `dig NS name`) and combine them.",
+		Check: checkZC1577,
+	})
+}
+
+func checkZC1577(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "dig" && ident.Value != "drill" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "ANY" || v == "any" {
+			return []Violation{{
+				KataID: "ZC1577",
+				Message: "`" + ident.Value + " ... ANY` is RFC 8482-deprecated — filtered by " +
+					"recursors. Query specific types (A / MX / NS / …) and combine.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 573 Katas = 0.5.73
-const Version = "0.5.73"
+// 574 Katas = 0.5.74
+const Version = "0.5.74"


### PR DESCRIPTION
## Summary
- Flags `dig|drill ... ANY` (or `any`)
- RFC 8482 deprecates ANY — recursors filter
- Suggest specific types (A / MX / NS / …)
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.74 (574 katas)