### PR TITLE
feat: ZC1578 — warn on ssh-keygen -t dsa / -b <2048 (weak SSH key)

### DIFF
--- a/pkg/katas/katatests/zc1578_test.go
+++ b/pkg/katas/katatests/zc1578_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1578(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ssh-keygen -t ed25519 -f key",
+			input:    `ssh-keygen -t ed25519 -f key`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ssh-keygen -t rsa -b 4096",
+			input:    `ssh-keygen -t rsa -b 4096`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ssh-keygen -t rsa -b 1024",
+			input: `ssh-keygen -t rsa -b 1024`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1578",
+					Message: "`ssh-keygen -b 1024` — RSA below 2048 bits is rejected by modern OpenSSH. Use `-t ed25519` or `-b 4096`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ssh-keygen -t dsa",
+			input: `ssh-keygen -t dsa -f key`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1578",
+					Message: "`ssh-keygen -t dsa` — DSA removed from OpenSSH 9.8. Use `-t ed25519`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1578")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1578.go
+++ b/pkg/katas/zc1578.go
@@ -1,0 +1,74 @@
+package katas
+
+import (
+	"strconv"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1578",
+		Title:    "Warn on `ssh-keygen -b <2048` for RSA / DSA — weak SSH key",
+		Severity: SeverityWarning,
+		Description: "Generating an SSH RSA or DSA key shorter than 2048 bits fails current " +
+			"OpenSSH baselines and is rejected by recent `ssh` versions when used for " +
+			"authentication. DSA was removed from OpenSSH 9.8 outright. Use `ssh-keygen -t " +
+			"ed25519` (compact, fast, modern defaults) or `ssh-keygen -t rsa -b 4096` if you " +
+			"need RSA for compatibility.",
+		Check: checkZC1578,
+	})
+}
+
+func checkZC1578(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ssh-keygen" {
+		return nil
+	}
+
+	var keyType string
+	var bits int
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-t" && i+1 < len(cmd.Arguments) {
+			keyType = cmd.Arguments[i+1].String()
+		}
+		if v == "-b" && i+1 < len(cmd.Arguments) {
+			n, err := strconv.Atoi(cmd.Arguments[i+1].String())
+			if err == nil {
+				bits = n
+			}
+		}
+	}
+
+	// DSA regardless of size is weak / removed.
+	if keyType == "dsa" {
+		return []Violation{{
+			KataID:  "ZC1578",
+			Message: "`ssh-keygen -t dsa` — DSA removed from OpenSSH 9.8. Use `-t ed25519`.",
+			Line:    cmd.Token.Line,
+			Column:  cmd.Token.Column,
+			Level:   SeverityWarning,
+		}}
+	}
+	// RSA below 2048 bits is weak.
+	if (keyType == "rsa" || keyType == "") && bits > 0 && bits < 2048 {
+		return []Violation{{
+			KataID: "ZC1578",
+			Message: "`ssh-keygen -b " + strconv.Itoa(bits) + "` — RSA below 2048 bits is " +
+				"rejected by modern OpenSSH. Use `-t ed25519` or `-b 4096`.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 574 Katas = 0.5.74
-const Version = "0.5.74"
+// 575 Katas = 0.5.75
+const Version = "0.5.75"


### PR DESCRIPTION
## Summary
- Flags `ssh-keygen -t dsa` (removed in OpenSSH 9.8) and `ssh-keygen -b <2048` for RSA
- Suggest `-t ed25519` or `-b 4096`
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.75 (575 katas)