### PR TITLE
feat: ZC1579 — warn on curl --retry-all-errors without --max-time

### DIFF
--- a/pkg/katas/katatests/zc1579_test.go
+++ b/pkg/katas/katatests/zc1579_test.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1579(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — curl https://host",
+			input:    `curl https://host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — curl --retry-all-errors --max-time 30 URL",
+			input:    `curl https://host --retry-all-errors --max-time 30`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — curl --retry-all-errors -m 30 URL",
+			input:    `curl https://host --retry-all-errors -m 30`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — curl URL --retry-all-errors (no max-time)",
+			input: `curl https://host --retry-all-errors`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1579",
+					Message: "`curl --retry-all-errors` with no `--max-time` hammers the upstream on failure. Pair with `-m <seconds>` or use `--retry-connrefused`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1579")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1579.go
+++ b/pkg/katas/zc1579.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1579",
+		Title:    "Warn on `curl --retry-all-errors` without `--max-time` — hammers endpoint on failure",
+		Severity: SeverityWarning,
+		Description: "`--retry-all-errors` (curl 7.71+) treats every HTTP error as retryable. " +
+			"Without `--max-time` capping total wall clock, a server that responds `500` " +
+			"quickly gets hit back-to-back until `--retry` exhausts — a mini-DoS against your " +
+			"own upstream, especially if the script itself is scheduled on many nodes. Pair " +
+			"with `--max-time <seconds>` or prefer `--retry-connrefused` (only retries " +
+			"connection-level failures).",
+		Check: checkZC1579,
+	})
+}
+
+func checkZC1579(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "curl" {
+		return nil
+	}
+
+	var hasRetryAll, hasMaxTime bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--retry-all-errors" {
+			hasRetryAll = true
+		}
+		if v == "--max-time" || v == "-m" {
+			hasMaxTime = true
+		}
+	}
+	if !hasRetryAll || hasMaxTime {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1579",
+		Message: "`curl --retry-all-errors` with no `--max-time` hammers the upstream on " +
+			"failure. Pair with `-m <seconds>` or use `--retry-connrefused`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 575 Katas = 0.5.75
-const Version = "0.5.75"
+// 576 Katas = 0.5.76
+const Version = "0.5.76"


### PR DESCRIPTION
## Summary
- Flags `curl --retry-all-errors` when neither `--max-time` nor `-m` is set
- Suggest pairing with `-m <seconds>` or using `--retry-connrefused`
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.76 (576 katas)