### PR TITLE
feat: ZC1580 — warn on go build -ldflags injecting secret via -X

### DIFF
--- a/pkg/katas/katatests/zc1580_test.go
+++ b/pkg/katas/katatests/zc1580_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1580(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — go build",
+			input:    `go build -o app ./cmd/app`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — go build -ldflags with version",
+			input:    `go build -ldflags "-X main.Version=1.2.3" ./cmd/app`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — go build -ldflags with PASSWORD",
+			input: `go build -ldflags "-X main.PASSWORD=hunter2" ./cmd/app`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1580",
+					Message: "`go build -ldflags` injecting a secret bakes it into the binary. Read from os.Getenv / mounted secret file at runtime.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — go build -ldflags with API_KEY",
+			input: `go build -ldflags "-X main.API_KEY=xyz" ./cmd/app`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1580",
+					Message: "`go build -ldflags` injecting a secret bakes it into the binary. Read from os.Getenv / mounted secret file at runtime.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1580")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1580.go
+++ b/pkg/katas/zc1580.go
@@ -1,0 +1,62 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1580",
+		Title:    "Warn on `go build -ldflags \"-X main.<SECRET>=...\"` — secret embedded in binary",
+		Severity: SeverityWarning,
+		Description: "`-ldflags=\"-X pkg.Var=value\"` sets a Go string variable at link time. " +
+			"Putting a secret here bakes it into the resulting binary (discoverable with " +
+			"`strings`, `objdump`, or simply opening the file). It also leaves the value on " +
+			"the build host's shell history and in any CI transcript. Read the value at " +
+			"runtime from `os.Getenv` / a mounted secret file / the cloud secret manager.",
+		Check: checkZC1580,
+	})
+}
+
+func checkZC1580(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "go" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "build" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := strings.Trim(arg.String(), "\"'")
+		// Look for -ldflags=... content or "-X ..." content
+		if !strings.Contains(v, "-X ") && !strings.Contains(v, "-ldflags") {
+			continue
+		}
+		up := strings.ToUpper(v)
+		if strings.Contains(up, "PASSWORD=") || strings.Contains(up, "SECRET=") ||
+			strings.Contains(up, "APIKEY=") || strings.Contains(up, "API_KEY=") ||
+			strings.Contains(up, "TOKEN=") || strings.Contains(up, "PRIVATE_KEY=") {
+			return []Violation{{
+				KataID: "ZC1580",
+				Message: "`go build -ldflags` injecting a secret bakes it into the binary. " +
+					"Read from os.Getenv / mounted secret file at runtime.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 576 Katas = 0.5.76
-const Version = "0.5.76"
+// 577 Katas = 0.5.77
+const Version = "0.5.77"


### PR DESCRIPTION
## Summary
- Flags `go build -ldflags ...` content containing `-X ...PASSWORD=` / `SECRET=` / `APIKEY=` / `API_KEY=` / `TOKEN=` / `PRIVATE_KEY=`
- Baked-in secret is trivially extractable with `strings` / `objdump`
- Suggest runtime os.Getenv / mounted secret file
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.77 (577 katas)