### PR TITLE
feat: ZC1581 — warn on ssh forcing password auth over key auth

### DIFF
--- a/pkg/katas/katatests/zc1581_test.go
+++ b/pkg/katas/katatests/zc1581_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1581(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ssh user@host",
+			input:    `ssh user@host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ssh -o PubkeyAuthentication=yes",
+			input:    `ssh -o PubkeyAuthentication=yes user@host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ssh -o PubkeyAuthentication=no",
+			input: `ssh -o PubkeyAuthentication=no user@host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1581",
+					Message: "`ssh -o PubkeyAuthentication=no` forces password auth — weaker than key auth. Let the default preference pick.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ssh -o PasswordAuthentication=yes",
+			input: `ssh -o PasswordAuthentication=yes user@host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1581",
+					Message: "`ssh -o PasswordAuthentication=yes` forces password auth — weaker than key auth. Let the default preference pick.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ssh -o PreferredAuthentications=password",
+			input: `ssh -o PreferredAuthentications=password user@host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1581",
+					Message: "`ssh -o PreferredAuthentications=password` forces password auth — weaker than key auth. Let the default preference pick.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1581")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1581.go
+++ b/pkg/katas/zc1581.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1581",
+		Title:    "Warn on `ssh -o PubkeyAuthentication=no` / `-o PasswordAuthentication=yes`",
+		Severity: SeverityWarning,
+		Description: "Forcing password authentication on a connection that has a working key " +
+			"turns a strong (challenge-response, no password leaves the client) into a weak " +
+			"(password-in-the-clear-on-disk-or-prompt) authentication path. Similarly " +
+			"disabling pubkey skips the good path entirely. Leave the defaults, let the " +
+			"server's `PubkeyAuthentication yes` pick the key, and document any exception.",
+		Check: checkZC1581,
+	})
+}
+
+func checkZC1581(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ssh" && ident.Value != "scp" && ident.Value != "sftp" {
+		return nil
+	}
+
+	var prevO bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevO {
+			prevO = false
+			s := strings.TrimSpace(strings.ToLower(v))
+			if s == "pubkeyauthentication=no" || s == "passwordauthentication=yes" ||
+				s == "preferredauthentications=password" {
+				return []Violation{{
+					KataID: "ZC1581",
+					Message: "`" + ident.Value + " -o " + v + "` forces password auth — " +
+						"weaker than key auth. Let the default preference pick.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+		if v == "-o" {
+			prevO = true
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 577 Katas = 0.5.77
-const Version = "0.5.77"
+// 578 Katas = 0.5.78
+const Version = "0.5.78"


### PR DESCRIPTION
## Summary
- Flags `ssh|scp|sftp -o PubkeyAuthentication=no`, `PasswordAuthentication=yes`, `PreferredAuthentications=password`
- Weaker than default key-auth path
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.78 (578 katas)