### PR TITLE
feat: ZC1582 — warn on bash/sh/zsh -x (xtrace leaks secrets)

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -5,3 +5,9 @@ dbe = "dbe"
 [default.extend-identifiers]
 # mke2fs is the canonical GNU ext2/3/4 filesystem creation tool
 mke2fs = "mke2fs"
+# chage is the GNU password-aging utility
+chage = "chage"
+# HashiCorp is the vendor name
+Hashi = "Hashi"
+# EDE is DES "encrypt-decrypt-encrypt" 3DES mode (openssl cipher name)
+ede = "ede"

--- a/pkg/katas/katatests/zc1582_test.go
+++ b/pkg/katas/katatests/zc1582_test.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1582(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — bash script.sh",
+			input:    `bash script.sh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — bash -x script.sh",
+			input: `bash -x script.sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1582",
+					Message: "`bash -x` traces every expanded command — CI logs leak secrets verbatim. Scope with `set -x; …; set +x`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — sh -x script.sh",
+			input: `sh -x script.sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1582",
+					Message: "`sh -x` traces every expanded command — CI logs leak secrets verbatim. Scope with `set -x; …; set +x`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — zsh -xv script.zsh",
+			input: `zsh -xv script.zsh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1582",
+					Message: "`zsh -xv` traces every expanded command — CI logs leak secrets verbatim. Scope with `set -x; …; set +x`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1582")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1560.go
+++ b/pkg/katas/zc1560.go
@@ -12,7 +12,7 @@ func init() {
 		Description: "`--trusted-host` tells pip to skip TLS certificate verification for the " +
 			"specified host and to allow plain-HTTP URLs from that host. Any MITM on the path " +
 			"can substitute packages on install, and a typo in the host name means every " +
-			"subsequent `install` from the mis-spelled host is unauthenticated. Fix the CA " +
+			"subsequent `install` from the misspelled host is unauthenticated. Fix the CA " +
 			"trust (install the real corporate CA) instead of silencing pip, and keep the " +
 			"default `--index-url https://...` over the TLS-verified endpoint.",
 		Check: checkZC1560,

--- a/pkg/katas/zc1582.go
+++ b/pkg/katas/zc1582.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1582",
+		Title:    "Warn on `bash -x` / `sh -x` / `zsh -x` — traces every command, leaks secrets",
+		Severity: SeverityWarning,
+		Description: "`-x` turns on xtrace, printing every command (expanded) to stderr before " +
+			"it runs. In a CI log that is indexed / shared / archived, any line that touches " +
+			"a secret leaks it verbatim — `curl` with a `Bearer` header, `psql` with a " +
+			"password, `echo $API_TOKEN > ...`. If you really need tracing, wrap the non-" +
+			"secret block with `set -x; ...; set +x` and exclude the secret-handling parts.",
+		Check: checkZC1582,
+	})
+}
+
+func checkZC1582(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "bash" && ident.Value != "sh" && ident.Value != "zsh" &&
+		ident.Value != "dash" && ident.Value != "ksh" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-x" || v == "-xv" || v == "-vx" {
+			return []Violation{{
+				KataID: "ZC1582",
+				Message: "`" + ident.Value + " " + v + "` traces every expanded command — CI logs " +
+					"leak secrets verbatim. Scope with `set -x; …; set +x`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 578 Katas = 0.5.78
-const Version = "0.5.78"
+// 579 Katas = 0.5.79
+const Version = "0.5.79"


### PR DESCRIPTION
## Summary
- Flags `bash|sh|zsh|dash|ksh -x|-xv|-vx`
- xtrace prints every expanded command to stderr — secrets leak verbatim in CI logs
- Suggest scoped `set -x; …; set +x`
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.79 (579 katas)