### PR TITLE
feat: ZC1583 — warn on find -delete without -maxdepth/-xdev/-prune

### DIFF
--- a/pkg/katas/katatests/zc1583_test.go
+++ b/pkg/katas/katatests/zc1583_test.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1583(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — find without -delete",
+			input:    `find /tmp -name '*.log'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — find -maxdepth 2 -delete",
+			input:    `find /tmp -maxdepth 2 -name '*.log' -delete`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — find -xdev -delete",
+			input:    `find /var -xdev -name '*.log' -delete`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — find /tmp -name '*.log' -delete",
+			input: `find /tmp -name '*.log' -delete`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1583",
+					Message: "`find -delete` without `-maxdepth` / `-xdev` / `-prune` walks the whole tree. Scope the depth (e.g. `-maxdepth 2`) and dry-run first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1583")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1583.go
+++ b/pkg/katas/zc1583.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1583",
+		Title:    "Warn on `find ... -delete` without `-maxdepth` — unbounded recursive delete",
+		Severity: SeverityWarning,
+		Description: "`find PATH -delete` walks the tree recursively and removes every match. " +
+			"Without `-maxdepth N` the walk crosses into every subtree, including symlinks " +
+			"that point outside the intended scope and mount points that expand the blast " +
+			"radius. Scope the depth (`-maxdepth 2`) and prefer a dry-run first " +
+			"(`find ... -print | head`).",
+		Check: checkZC1583,
+	})
+}
+
+func checkZC1583(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "find" {
+		return nil
+	}
+
+	var hasDelete, hasMaxdepth, hasPrune, hasXdev bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "-delete":
+			hasDelete = true
+		case "-maxdepth":
+			hasMaxdepth = true
+		case "-prune":
+			hasPrune = true
+		case "-xdev", "-mount":
+			hasXdev = true
+		}
+	}
+	if !hasDelete || hasMaxdepth || hasPrune || hasXdev {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1583",
+		Message: "`find -delete` without `-maxdepth` / `-xdev` / `-prune` walks the whole " +
+			"tree. Scope the depth (e.g. `-maxdepth 2`) and dry-run first.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 579 Katas = 0.5.79
-const Version = "0.5.79"
+// 580 Katas = 0.5.80
+const Version = "0.5.80"


### PR DESCRIPTION
## Summary
- Flags `find … -delete` when there's no `-maxdepth`, `-xdev`/`-mount`, or `-prune`
- Unbounded recursive delete — crosses symlinks and mount points
- Suggest `-maxdepth N` and dry-run with `-print | head` first
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.80 (580 katas)