### PR TITLE
feat: ZC1584 — warn on sudo -E (preserves caller env)

### DIFF
--- a/pkg/katas/katatests/zc1584_test.go
+++ b/pkg/katas/katatests/zc1584_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1584(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sudo -u root cmd",
+			input:    `sudo -u root cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — sudo env VAR=1 cmd",
+			input:    `sudo env VAR=1 cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — sudo -E cmd",
+			input: `sudo -E cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1584",
+					Message: "`sudo -E` carries the caller's PATH / LD_PRELOAD / … into the privileged process. Use `env_keep` in sudoers or explicit `sudo env VAR=… cmd`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — sudo -E -u svc cmd",
+			input: `sudo -E -u svc cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1584",
+					Message: "`sudo -E` carries the caller's PATH / LD_PRELOAD / … into the privileged process. Use `env_keep` in sudoers or explicit `sudo env VAR=… cmd`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1584")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1584.go
+++ b/pkg/katas/zc1584.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1584",
+		Title:    "Warn on `sudo -E` / `--preserve-env` — carries caller env into root shell",
+		Severity: SeverityWarning,
+		Description: "`sudo -E` preserves the invoking user's environment — `PATH`, " +
+			"`LD_PRELOAD`, `PYTHONPATH`, etc. On a workstation where the user has a personal " +
+			"`~/bin` early in `$PATH`, any wrapper named like a system binary gets executed " +
+			"by the privileged process. That is exactly the sudoers `secure_path` mechanic " +
+			"fails to protect against. Whitelist specific variables with `env_keep` in " +
+			"sudoers, or call `sudo env VAR=value cmd` with the minimum.",
+		Check: checkZC1584,
+	})
+}
+
+func checkZC1584(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "sudo" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-E" || v == "--preserve-env" {
+			return []Violation{{
+				KataID: "ZC1584",
+				Message: "`sudo " + v + "` carries the caller's PATH / LD_PRELOAD / … into " +
+					"the privileged process. Use `env_keep` in sudoers or explicit `sudo " +
+					"env VAR=… cmd`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 580 Katas = 0.5.80
-const Version = "0.5.80"
+// 581 Katas = 0.5.81
+const Version = "0.5.81"


### PR DESCRIPTION
## Summary
- Flags `sudo -E`
- Preserves caller's PATH / LD_PRELOAD / … into privileged process
- Suggest sudoers `env_keep` whitelist or `sudo env VAR=…`
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.81 (581 katas)