### PR TITLE
feat: ZC1585 — warn on ufw allow from any (opens to entire internet)

### DIFF
--- a/pkg/katas/katatests/zc1585_test.go
+++ b/pkg/katas/katatests/zc1585_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1585(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ufw allow from 10.0.0.0/8 to any port 22",
+			input:    `ufw allow from 10.0.0.0/8 to any port 22`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ufw status",
+			input:    `ufw status`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ufw allow from any to any port 22",
+			input: `ufw allow from any to any port 22`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1585",
+					Message: "`ufw allow from any …` opens the port to the whole internet. Scope to a specific source CIDR.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1585")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1585.go
+++ b/pkg/katas/zc1585.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1585",
+		Title:    "Warn on `ufw allow from any` / `firewall-cmd --add-source=0.0.0.0/0`",
+		Severity: SeverityWarning,
+		Description: "`ufw allow from any to any port …` (and its firewall-cmd sibling " +
+			"`--add-source=0.0.0.0/0`) opens the port to the whole internet. That is " +
+			"sometimes the point (public HTTP / HTTPS), but on management ports (22, 3306, " +
+			"5432, 6379, 9200, 27017) it is a routine foot-gun when the script author " +
+			"assumed the host would only ever be reached via VPN. Scope the rule to a " +
+			"specific source CIDR.",
+		Check: checkZC1585,
+	})
+}
+
+func checkZC1585(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ufw" {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, a := range cmd.Arguments {
+		args = append(args, a.String())
+	}
+
+	if len(args) < 3 || args[0] != "allow" {
+		return nil
+	}
+	// ufw allow from any ...
+	for i := 1; i+1 < len(args); i++ {
+		if args[i] == "from" && args[i+1] == "any" {
+			return []Violation{{
+				KataID: "ZC1585",
+				Message: "`ufw allow from any …` opens the port to the whole internet. " +
+					"Scope to a specific source CIDR.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 581 Katas = 0.5.81
-const Version = "0.5.81"
+// 582 Katas = 0.5.82
+const Version = "0.5.82"


### PR DESCRIPTION
## Summary
- Flags `ufw allow from any …`
- Public internet exposure on management ports
- Suggest scoping to source CIDR
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.82 (582 katas)