### PR TITLE
feat: ZC1586 — style: chkconfig / update-rc.d / insserv (SysV relics)

### DIFF
--- a/pkg/katas/katatests/zc1586_test.go
+++ b/pkg/katas/katatests/zc1586_test.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1586(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — systemctl enable sshd",
+			input:    `systemctl enable sshd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — chkconfig sshd on",
+			input: `chkconfig sshd on`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1586",
+					Message: "`chkconfig` is a SysV-init relic. Use `systemctl enable|disable <unit>` directly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — update-rc.d sshd defaults",
+			input: `update-rc.d sshd defaults`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1586",
+					Message: "`update-rc.d` is a SysV-init relic. Use `systemctl enable|disable <unit>` directly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — insserv sshd",
+			input: `insserv sshd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1586",
+					Message: "`insserv` is a SysV-init relic. Use `systemctl enable|disable <unit>` directly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1586")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1586.go
+++ b/pkg/katas/zc1586.go
@@ -1,0 +1,45 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1586",
+		Title:    "Style: `chkconfig` / `update-rc.d` / `insserv` — SysV init relics, use `systemctl`",
+		Severity: SeverityStyle,
+		Description: "`chkconfig` (Red Hat), `update-rc.d` (Debian), and `insserv` (SUSE) are " +
+			"SysV-init compatibility wrappers for enabling/disabling services at boot. On any " +
+			"distro that has used systemd for the last decade they are translated to " +
+			"`systemctl enable|disable`, but silently lose unit-template arguments, " +
+			"`[Install]` alias handling, and socket-activated services. Call `systemctl " +
+			"enable <unit>` directly.",
+		Check: checkZC1586,
+	})
+}
+
+func checkZC1586(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "chkconfig" && ident.Value != "update-rc.d" &&
+		ident.Value != "insserv" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1586",
+		Message: "`" + ident.Value + "` is a SysV-init relic. Use `systemctl enable|disable " +
+			"<unit>` directly.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 582 Katas = 0.5.82
-const Version = "0.5.82"
+// 583 Katas = 0.5.83
+const Version = "0.5.83"


### PR DESCRIPTION
## Summary
- Flags `chkconfig`, `update-rc.d`, `insserv`
- SysV-init wrappers lose template/alias/socket-activation semantics
- Suggest `systemctl enable|disable <unit>`
- Severity: Style

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.83 (583 katas)