### PR TITLE
feat: ZC1587 — warn on modprobe -r / rmmod (unload kernel module)

### DIFF
--- a/pkg/katas/katatests/zc1587_test.go
+++ b/pkg/katas/katatests/zc1587_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1587(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — modprobe nvme",
+			input:    `modprobe nvme`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — lsmod",
+			input:    `lsmod`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — modprobe -r nvme",
+			input: `modprobe -r nvme`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1587",
+					Message: "`modprobe -r` unloads an in-use module — the backing subsystem goes offline. Use `systemctl stop` if you meant to stop a service.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — rmmod nvidia",
+			input: `rmmod nvidia`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1587",
+					Message: "`rmmod` unloads a kernel module — the backing subsystem goes offline. Use `systemctl stop` if you meant to stop a service.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1587")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1587.go
+++ b/pkg/katas/zc1587.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1587",
+		Title:    "Warn on `modprobe -r` / `rmmod` from scripts — unloading active kernel modules",
+		Severity: SeverityWarning,
+		Description: "Unloading a kernel module that is in use — `nvme` (storage), `nvidia` " +
+			"(GPU), `e1000`/`ixgbe` (network), `kvm` (virt) — instantly takes the backing " +
+			"subsystem offline. On a remote host the script loses its storage or network " +
+			"mid-run. Reserve `modprobe -r` / `rmmod` for console maintenance, and consider " +
+			"`systemctl stop <unit>` if you are trying to stop a service.",
+		Check: checkZC1587,
+	})
+}
+
+func checkZC1587(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value == "modprobe" {
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "-r" || v == "--remove" {
+				return []Violation{{
+					KataID: "ZC1587",
+					Message: "`modprobe -r` unloads an in-use module — the backing subsystem " +
+						"goes offline. Use `systemctl stop` if you meant to stop a service.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+	if ident.Value == "rmmod" && len(cmd.Arguments) > 0 {
+		return []Violation{{
+			KataID: "ZC1587",
+			Message: "`rmmod` unloads a kernel module — the backing subsystem goes offline. " +
+				"Use `systemctl stop` if you meant to stop a service.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 583 Katas = 0.5.83
-const Version = "0.5.83"
+// 584 Katas = 0.5.84
+const Version = "0.5.84"


### PR DESCRIPTION
## Summary
- Flags `modprobe -r <mod>` and `rmmod <mod>`
- In-use module unload takes subsystem offline (storage/network/GPU loss)
- Suggest `systemctl stop <unit>` for service stops
- Severity: Warning

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] Version bumped to 0.5.84 (584 katas)