### PR TITLE
feat: ZC1588 — flag `nsenter -t 1` host-namespace container escape

### DIFF
--- a/pkg/katas/katatests/zc1588_test.go
+++ b/pkg/katas/katatests/zc1588_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1588(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — nsenter without target 1",
+			input:    `nsenter -t 4242 -m sh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — nsenter on arbitrary pid",
+			input:    `nsenter -t 8123 -m sh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — nsenter -t 1 -m -u -i -n -p sh",
+			input: `nsenter -t 1 -m -u -i -n -p sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1588",
+					Message: "`nsenter --target 1` joins the host init namespaces — classic container-escape primitive. Use `docker exec` / `kubectl exec` for legitimate debugging.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — nsenter -t1 -m sh",
+			input: `nsenter -t1 -m sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1588",
+					Message: "`nsenter --target 1` joins the host init namespaces — classic container-escape primitive. Use `docker exec` / `kubectl exec` for legitimate debugging.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1588")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1588.go
+++ b/pkg/katas/zc1588.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1588",
+		Title:    "Error on `nsenter --target 1` — joins host init namespaces (container escape)",
+		Severity: SeverityError,
+		Description: "`nsenter -t 1` attaches to the namespaces of pid 1. Inside a privileged " +
+			"container or one with `CAP_SYS_ADMIN`, pid 1 is the host init — joining its " +
+			"mount / pid / net / uts / ipc namespaces is the canonical escape primitive. " +
+			"From that new shell the caller sees and writes the host filesystem, kills host " +
+			"processes, and hijacks host network. Legit debugging runs from the host, not from " +
+			"inside the container. If you need to exec into a container, use `docker exec` / " +
+			"`kubectl exec`.",
+		Check: checkZC1588,
+	})
+}
+
+func checkZC1588(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "nsenter" {
+		return nil
+	}
+
+	var expectTarget, hit bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--target=1" || v == "-t1" {
+			hit = true
+			break
+		}
+		if expectTarget && v == "1" {
+			hit = true
+			break
+		}
+		expectTarget = v == "-t" || v == "--target"
+	}
+	if !hit {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1588",
+		Message: "`nsenter --target 1` joins the host init namespaces — classic container-" +
+			"escape primitive. Use `docker exec` / `kubectl exec` for legitimate debugging.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 584 Katas = 0.5.84
-const Version = "0.5.84"
+// 585 Katas = 0.5.85
+const Version = "0.5.85"


### PR DESCRIPTION
ZC1588 — Error on `nsenter --target 1` — joins host init namespaces (container escape)

What: flags `nsenter -t 1` / `nsenter -t1` / `nsenter --target=1` — attaching the caller to the namespaces of pid 1.
Why: inside a privileged container pid 1 is the host init. Joining its mount/pid/net/uts/ipc namespaces drops the caller onto the host with the container's capabilities intact — the canonical escape primitive.
Fix suggestion: use `docker exec` / `kubectl exec` for legitimate debugging, from the host side rather than pivoting out of a guest.
Severity: Error