### PR TITLE
feat: ZC1589 — flag `trap 'set -x' ERR/RETURN/EXIT` xtrace-from-trap leak

### DIFF
--- a/pkg/katas/katatests/zc1589_test.go
+++ b/pkg/katas/katatests/zc1589_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1589(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — trap cleanup EXIT",
+			input:    `trap cleanup EXIT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — trap with safe dump",
+			input:    `trap 'echo failed' ERR`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — trap 'set -x' ERR",
+			input: `trap 'set -x' ERR`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1589",
+					Message: "`trap 'set -x' ERR` enables shell trace from a trap — expansions leak env vars (tokens, passwords) to stderr / CI logs. Use a scoped `set -x ... set +x`, not a trap.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — trap 'set -o xtrace' EXIT",
+			input: `trap 'set -o xtrace' EXIT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1589",
+					Message: "`trap 'set -x' EXIT` enables shell trace from a trap — expansions leak env vars (tokens, passwords) to stderr / CI logs. Use a scoped `set -x ... set +x`, not a trap.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — trap 'set -x' RETURN",
+			input: `trap 'set -x' RETURN`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1589",
+					Message: "`trap 'set -x' RETURN` enables shell trace from a trap — expansions leak env vars (tokens, passwords) to stderr / CI logs. Use a scoped `set -x ... set +x`, not a trap.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1589")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1589.go
+++ b/pkg/katas/zc1589.go
@@ -1,0 +1,66 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1589",
+		Title:    "Warn on `trap 'set -x' ERR/RETURN/EXIT/ZERR` — trace hook leaks env to stderr",
+		Severity: SeverityWarning,
+		Description: "Installing a trap that enables `set -x` (or `set -o xtrace` / `set -v`) " +
+			"causes every subsequent expanded command to hit stderr. Expansions embed " +
+			"environment variables — API tokens, passwords, signed URLs — directly into " +
+			"the trace. In CI, that stderr lands in build logs and gets shipped to long-term " +
+			"log retention. Scope `set -x` to a `set -x ... set +x` block around the suspect " +
+			"code, or replace the trap with `trap 'safe_dump' ERR` that prints only non-" +
+			"sensitive state.",
+		Check: checkZC1589,
+	})
+}
+
+func checkZC1589(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "trap" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+
+	action := strings.Trim(cmd.Arguments[0].String(), "'\"")
+	if !strings.Contains(action, "set -x") &&
+		!strings.Contains(action, "set -o xtrace") &&
+		!strings.Contains(action, "set -v") &&
+		!strings.Contains(action, "set -o verbose") {
+		return nil
+	}
+
+	sig := cmd.Arguments[1].String()
+	switch sig {
+	case "ERR", "RETURN", "EXIT", "ZERR":
+	default:
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1589",
+		Message: "`trap 'set -x' " + sig + "` enables shell trace from a trap — expansions " +
+			"leak env vars (tokens, passwords) to stderr / CI logs. Use a scoped `set -x " +
+			"... set +x`, not a trap.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 585 Katas = 0.5.85
-const Version = "0.5.85"
+// 586 Katas = 0.5.86
+const Version = "0.5.86"


### PR DESCRIPTION
ZC1589 — Warn on `trap 'set -x' ERR/RETURN/EXIT/ZERR` — trace hook leaks env to stderr

What: flags traps that install `set -x` / `set -o xtrace` / `set -v` on ERR, RETURN, EXIT, or ZERR.
Why: once the trap fires, every subsequent expansion hits stderr with environment vars substituted — API tokens, passwords, signed URLs. In CI that stderr ends up in build logs.
Fix suggestion: scope `set -x` to a `set -x ... set +x` block, or replace with `trap 'safe_dump' ERR` that only prints non-sensitive state.
Severity: Warning