### PR TITLE
feat: ZC1590 — flag `sshpass -p SECRET` password in process list

### DIFF
--- a/pkg/katas/katatests/zc1590_test.go
+++ b/pkg/katas/katatests/zc1590_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1590(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sshpass -e (env var)",
+			input:    `sshpass -e ssh user@host cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — sshpass -f FILE",
+			input:    `sshpass -f /run/secrets/pw ssh user@host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — sshpass -p 'secret' ssh ...",
+			input: `sshpass -p 'secret' ssh user@host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1590",
+					Message: "`sshpass -p` places the password in argv — visible in `ps` / `/proc/<pid>/cmdline`. Switch to key-based auth, or at least use `sshpass -f FILE` / `sshpass -e`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — sshpass -psecret ssh ...",
+			input: `sshpass -psecret ssh user@host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1590",
+					Message: "`sshpass -p` places the password in argv — visible in `ps` / `/proc/<pid>/cmdline`. Switch to key-based auth, or at least use `sshpass -f FILE` / `sshpass -e`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1590")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1590.go
+++ b/pkg/katas/zc1590.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1590",
+		Title:    "Error on `sshpass -p SECRET` — password in process list and history",
+		Severity: SeverityError,
+		Description: "`sshpass -p SECRET` places the password in argv. It leaks into `ps`, " +
+			"`/proc/<pid>/cmdline`, shell history, and audit logs for every process on the box " +
+			"that can list processes. The `-f FILE` and `-e` (SSHPASS env) variants keep it off " +
+			"argv, but key-based auth is the real fix. Generate an SSH key, authorize it on the " +
+			"remote, and drop the password tool entirely.",
+		Check: checkZC1590,
+	})
+}
+
+func checkZC1590(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "sshpass" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-p" || (strings.HasPrefix(v, "-p") && len(v) > 2 && v[2] != '=') {
+			return []Violation{{
+				KataID: "ZC1590",
+				Message: "`sshpass -p` places the password in argv — visible in `ps` / " +
+					"`/proc/<pid>/cmdline`. Switch to key-based auth, or at least use " +
+					"`sshpass -f FILE` / `sshpass -e`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+		if strings.HasPrefix(v, "-p=") {
+			return []Violation{{
+				KataID: "ZC1590",
+				Message: "`sshpass -p` places the password in argv — visible in `ps` / " +
+					"`/proc/<pid>/cmdline`. Switch to key-based auth, or at least use " +
+					"`sshpass -f FILE` / `sshpass -e`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 586 Katas = 0.5.86
-const Version = "0.5.86"
+// 587 Katas = 0.5.87
+const Version = "0.5.87"


### PR DESCRIPTION
ZC1590 — Error on `sshpass -p SECRET` — password in argv

What: flags `sshpass -p 'pw' ...` / `sshpass -psecret ...` / `sshpass -p=pw ...`.
Why: `sshpass -p` places the password on the command line. It shows up in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs. Any process on the box that can list processes can grab it.
Fix suggestion: generate an SSH key, authorize it on the remote, and drop the password tool. If password auth is truly unavoidable, `sshpass -f FILE` or `sshpass -e` (SSHPASS env) keep it off argv.
Severity: Error