### PR TITLE
feat: ZC1591 — prefer `print -l` / `${(F)array}` over `printf '%s\n' "${a[@]}"`

### DIFF
--- a/pkg/katas/katatests/zc1591_test.go
+++ b/pkg/katas/katatests/zc1591_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1591(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — printf with specific format",
+			input:    `printf '%-20s %d\n' "${pairs[@]}"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — printf on scalar",
+			input:    `printf '%s\n' "$msg"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  `invalid — printf '%s\n' "${array[@]}"`,
+			input: `printf '%s\n' "${array[@]}"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1591",
+					Message: "`printf '%s\\n' \"${array[@]}\"` — use Zsh `print -l -r -- \"${array[@]}\"` or `${(F)array}` for newline-joined output.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — printf '%s' "${a[*]}"`,
+			input: `printf '%s' "${a[*]}"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1591",
+					Message: "`printf '%s\\n' \"${array[@]}\"` — use Zsh `print -l -r -- \"${array[@]}\"` or `${(F)array}` for newline-joined output.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1591")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1591.go
+++ b/pkg/katas/zc1591.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1591",
+		Title:    "Style: use Zsh `print -l` / `${(F)array}` instead of `printf '%s\\n' \"${array[@]}\"`",
+		Severity: SeverityStyle,
+		Description: "`printf '%s\\n' \"${array[@]}\"` is the Bash-idiomatic way to print one " +
+			"element per line. Zsh has `print -l -r -- \"${array[@]}\"` (one element per line, " +
+			"raw, sentinel-safe) and the parameter-expansion flag `${(F)array}` (newline-join, " +
+			"fine for `$(...)`). Both are shorter than the printf incantation and avoid format-" +
+			"string surprises if the array ever contains a literal `%`.",
+		Check: checkZC1591,
+	})
+}
+
+func checkZC1591(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "printf" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+
+	format := strings.Trim(cmd.Arguments[0].String(), "'\"")
+	if format != `%s\n` && format != "%s" {
+		return nil
+	}
+
+	second := cmd.Arguments[1].String()
+	if !strings.Contains(second, "[@]") && !strings.Contains(second, "[*]") {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1591",
+		Message: "`printf '%s\\n' \"${array[@]}\"` — use Zsh `print -l -r -- \"${array[@]}\"` " +
+			"or `${(F)array}` for newline-joined output.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 587 Katas = 0.5.87
-const Version = "0.5.87"
+// 588 Katas = 0.5.88
+const Version = "0.5.88"


### PR DESCRIPTION
ZC1591 — Style: use Zsh `print -l` / `${(F)array}` for one-per-line array printing

What: flags `printf '%s\n' "${array[@]}"` and `printf '%s' "${a[*]}"` — the Bash idiom for one-element-per-line.
Why: Zsh has shorter, safer options. `print -l -r -- "${array[@]}"` prints one raw element per line. `${(F)array}` joins with newlines inline. Both avoid format-string surprises if an element ever contains `%`.
Fix suggestion: swap `printf '%s\n' "${array[@]}"` for `print -l -r -- "${array[@]}"`; use `${(F)array}` in command substitutions.
Severity: Style