### PR TITLE
feat: ZC1592 — flag `faillock --reset` / `pam_tally2 -r` lockout clearing

### DIFF
--- a/pkg/katas/katatests/zc1592_test.go
+++ b/pkg/katas/katatests/zc1592_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1592(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — faillock status",
+			input:    `faillock -u bob`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — pam_tally2 status",
+			input:    `pam_tally2 -u bob`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — faillock -u bob --reset",
+			input: `faillock -u bob --reset`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1592",
+					Message: "`faillock --reset` clears the PAM failed-auth counter — masks ongoing brute force. Log the prior count and alert before resetting.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — pam_tally2 -r -u bob",
+			input: `pam_tally2 -r -u bob`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1592",
+					Message: "`pam_tally2 -r` clears the PAM failed-auth counter — masks ongoing brute force. Log the prior count and alert before resetting.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1592")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1592.go
+++ b/pkg/katas/zc1592.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1592",
+		Title:    "Warn on `faillock --reset` / `pam_tally2 -r` — clears failed-auth counter",
+		Severity: SeverityWarning,
+		Description: "Both tools zero the PAM counter that triggers account lockout after too " +
+			"many failed logins. A script that resets lockouts — even legitimately, to recover " +
+			"locked users — also erases evidence of an ongoing brute-force attempt. Intrusion " +
+			"detection relies on those counters for alerting. Do not automate resets; if you " +
+			"must, log the prior count and page security on every invocation.",
+		Check: checkZC1592,
+	})
+}
+
+func checkZC1592(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "faillock" && ident.Value != "pam_tally2" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--reset" || v == "-r" {
+			return []Violation{{
+				KataID: "ZC1592",
+				Message: "`" + ident.Value + " " + v + "` clears the PAM failed-auth counter — " +
+					"masks ongoing brute force. Log the prior count and alert before resetting.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 588 Katas = 0.5.88
-const Version = "0.5.88"
+// 589 Katas = 0.5.89
+const Version = "0.5.89"


### PR DESCRIPTION
ZC1592 — Warn on `faillock --reset` / `pam_tally2 -r` — clears PAM failed-auth counter

What: flags `faillock ... --reset` and `pam_tally2 -r` / `pam_tally2 --reset`.
Why: both tools zero the PAM counter that locks an account after too many failed logins. Automated resets also erase evidence of an ongoing brute-force attempt — intrusion detection relies on those counters for alerting.
Fix suggestion: do not automate resets. If you must, snapshot the prior count first and page security on every invocation.
Severity: Warning