### PR TITLE
feat: ZC1593 — flag `blkdiscard` full-device TRIM wipe

### DIFF
--- a/pkg/katas/katatests/zc1593_test.go
+++ b/pkg/katas/katatests/zc1593_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1593(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — different command",
+			input:    `lsblk $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — blkdiscard $DISK",
+			input: `blkdiscard $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1593",
+					Message: "`blkdiscard` issues TRIM/DISCARD across the full device — data is unrecoverable once the controller acknowledges. Require operator confirmation before running.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — blkdiscard -z $DISK",
+			input: `blkdiscard -z $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1593",
+					Message: "`blkdiscard` issues TRIM/DISCARD across the full device — data is unrecoverable once the controller acknowledges. Require operator confirmation before running.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1593")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1593.go
+++ b/pkg/katas/zc1593.go
@@ -1,0 +1,47 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1593",
+		Title:    "Error on `blkdiscard` — issues TRIM/DISCARD across the whole device (data loss)",
+		Severity: SeverityError,
+		Description: "`blkdiscard $DEV` tells the underlying SSD controller to invalidate every " +
+			"block in the range. On most modern drives the data is unrecoverable the moment the " +
+			"controller acknowledges — even forensic recovery cannot pull it back. Scripts that " +
+			"reach this command from any codepath an attacker or typo can trigger destroy the " +
+			"drive. Gate it behind interactive confirmation, not shell flow control.",
+		Check: checkZC1593,
+	})
+}
+
+func checkZC1593(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "blkdiscard" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1593",
+		Message: "`blkdiscard` issues TRIM/DISCARD across the full device — data is " +
+			"unrecoverable once the controller acknowledges. Require operator confirmation " +
+			"before running.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 589 Katas = 0.5.89
-const Version = "0.5.89"
+// 590 Katas = 0.5.90
+const Version = "0.5.90"


### PR DESCRIPTION
ZC1593 — Error on `blkdiscard` — TRIM/DISCARD across the whole device (data loss)

What: flags every `blkdiscard` invocation with a target argument.
Why: the command tells the SSD controller to invalidate every block in range. Modern drives make the data unrecoverable the moment the controller acknowledges — even forensic recovery cannot pull it back.
Fix suggestion: gate the command behind interactive operator confirmation, not shell flow control; never leave it on a codepath reachable from a typo or untrusted input.
Severity: Error