### PR TITLE
feat: ZC1594 — flag `docker run --security-opt=systempaths=unconfined`

### DIFF
--- a/pkg/katas/katatests/zc1594_test.go
+++ b/pkg/katas/katatests/zc1594_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1594(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — plain docker run",
+			input:    `docker run --rm alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — podman run with different security-opt",
+			input:    `podman run --security-opt=no-new-privileges alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker run --security-opt=systempaths=unconfined",
+			input: `docker run --security-opt=systempaths=unconfined alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1594",
+					Message: "`docker run --security-opt=systempaths=unconfined` unhides `/proc/sys`, `/proc/sysrq-trigger`, and other kernel knobs. A compromise in the container can then panic or re-tune the host.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — podman create systempaths=unconfined",
+			input: `podman create --security-opt=systempaths=unconfined alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1594",
+					Message: "`podman run --security-opt=systempaths=unconfined` unhides `/proc/sys`, `/proc/sysrq-trigger`, and other kernel knobs. A compromise in the container can then panic or re-tune the host.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1594")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1594.go
+++ b/pkg/katas/zc1594.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1594",
+		Title:    "Warn on `docker/podman run --security-opt=systempaths=unconfined` — unhides host kernel knobs",
+		Severity: SeverityWarning,
+		Description: "`systempaths=unconfined` removes the container runtime's masking of " +
+			"`/proc/sys`, `/proc/sysrq-trigger`, `/sys/firmware`, and related kernel surfaces. " +
+			"Without the default shield a compromised process inside the container can write " +
+			"`/proc/sysrq-trigger` to panic the host, or edit `/proc/sys/kernel/*` to change " +
+			"kernel policy on the fly. Keep the default `systempaths=all` (masked) unless you " +
+			"have a specific kernel tunable you need, then mount only that path.",
+		Check: checkZC1594,
+	})
+}
+
+func checkZC1594(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+
+	runSeen := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if !runSeen {
+			if v == "run" || v == "create" {
+				runSeen = true
+			}
+			continue
+		}
+		if strings.Contains(v, "systempaths=unconfined") {
+			return []Violation{{
+				KataID: "ZC1594",
+				Message: "`" + ident.Value + " run --security-opt=systempaths=unconfined` " +
+					"unhides `/proc/sys`, `/proc/sysrq-trigger`, and other kernel knobs. A " +
+					"compromise in the container can then panic or re-tune the host.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 590 Katas = 0.5.90
-const Version = "0.5.90"
+// 591 Katas = 0.5.91
+const Version = "0.5.91"


### PR DESCRIPTION
ZC1594 — Warn on `docker/podman run --security-opt=systempaths=unconfined` — unhides host kernel knobs

What: flags `docker run` / `docker create` / `podman run` / `podman create` invocations that set `--security-opt=systempaths=unconfined`.
Why: the default `systempaths=all` masks `/proc/sys`, `/proc/sysrq-trigger`, `/sys/firmware`, etc. from the container. Unhiding them lets a compromise inside the container panic the host via `sysrq-trigger` or re-tune kernel policy via `/proc/sys/kernel/*`.
Fix suggestion: keep the default masking and, if a specific kernel tunable is genuinely needed, bind-mount only that single path into the container.
Severity: Warning