### PR TITLE
feat: ZC1595 — flag `setfacl -m u:nobody:... / o::rwx` ACL bypass

### DIFF
--- a/pkg/katas/katatests/zc1595_test.go
+++ b/pkg/katas/katatests/zc1595_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1595(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — setfacl -m u:alice:r file",
+			input:    `setfacl -m u:alice:r /tmp/report`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — setfacl -x",
+			input:    `setfacl -x u:alice /tmp/report`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — setfacl -m u:nobody:rwx file",
+			input: `setfacl -m u:nobody:rwx /etc/app.conf`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1595",
+					Message: "`setfacl -m u:nobody:rwx` grants perms via ACL, bypassing `chmod` / `stat -c %a` checks. Prefer chmod for world perms, and for specific users name the real account with minimum perms.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — setfacl -m o::rwx file",
+			input: `setfacl -m o::rwx /etc/app.conf`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1595",
+					Message: "`setfacl -m o::rwx` grants perms via ACL, bypassing `chmod` / `stat -c %a` checks. Prefer chmod for world perms, and for specific users name the real account with minimum perms.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1595")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1595.go
+++ b/pkg/katas/zc1595.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1595",
+		Title:    "Warn on `setfacl -m u:nobody:... / o::rwx` — ACL grants that bypass `chmod` scrutiny",
+		Severity: SeverityWarning,
+		Description: "Filesystem ACLs live outside the mode bits that `chmod` / `ls -l` / " +
+			"`stat -c %a` surface. Granting `u:nobody:rwx` gives the daemon-fallback account " +
+			"write access to a file; `o::rwx` / `o::rw` world-writes via ACL even when the mode " +
+			"bits still look safe. Review scripts that check `stat -c %a` miss both. Prefer " +
+			"`chmod` for world perms, and for specific users name the real account with the " +
+			"minimum perm set.",
+		Check: checkZC1595,
+	})
+}
+
+func checkZC1595(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "setfacl" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "u:nobody:") ||
+			strings.HasPrefix(v, "g:nobody:") ||
+			strings.HasPrefix(v, "u:nogroup:") ||
+			strings.HasPrefix(v, "g:nogroup:") ||
+			v == "o::rwx" || v == "o::rw" || v == "o::rwX" {
+			return []Violation{{
+				KataID: "ZC1595",
+				Message: "`setfacl -m " + v + "` grants perms via ACL, bypassing `chmod` / " +
+					"`stat -c %a` checks. Prefer chmod for world perms, and for specific " +
+					"users name the real account with minimum perms.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 591 Katas = 0.5.91
-const Version = "0.5.91"
+// 592 Katas = 0.5.92
+const Version = "0.5.92"


### PR DESCRIPTION
ZC1595 — Warn on `setfacl -m u:nobody:... / o::rwx` — ACL grants that bypass `chmod` scrutiny

What: flags `setfacl -m` arguments granting to `u:nobody:`, `g:nobody:`, `u:nogroup:`, `g:nogroup:`, or world (`o::rwx` / `o::rw`).
Why: ACL entries live outside the mode bits that `chmod` / `ls -l` / `stat -c %a` surface. Review scripts checking `stat -c %a` miss them entirely, and granting to the `nobody` daemon-fallback account is almost always a misconfiguration.
Fix suggestion: use `chmod` for world perms. For named users, name the real account — not `nobody` — and give only the minimum required perm.
Severity: Warning