### PR TITLE
feat: ZC1596 — flag `emulate sh/bash/ksh` without `-L` global option flip

### DIFF
--- a/pkg/katas/katatests/zc1596_test.go
+++ b/pkg/katas/katatests/zc1596_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1596(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — emulate -L sh",
+			input:    `emulate -L sh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — emulate -LR bash",
+			input:    `emulate -LR bash`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — emulate zsh (reset to zsh)",
+			input:    `emulate zsh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — emulate sh",
+			input: `emulate sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1596",
+					Message: "`emulate sh` without `-L` flips the options for the whole shell. Use `emulate -L sh` inside a function, or rename the script to `.sh` if Zsh features are not needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — emulate -R bash",
+			input: `emulate -R bash`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1596",
+					Message: "`emulate bash` without `-L` flips the options for the whole shell. Use `emulate -L bash` inside a function, or rename the script to `.sh` if Zsh features are not needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1596")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1596.go
+++ b/pkg/katas/zc1596.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1596",
+		Title:    "Style: `emulate sh/bash/ksh` without `-L` — flips options for the whole shell",
+		Severity: SeverityStyle,
+		Description: "`emulate MODE` without the `-L` flag changes Zsh options globally. After " +
+			"that line runs the shell is no longer in Zsh mode — `${(F)arr}`, 1-indexed " +
+			"arrays, glob qualifiers, and other Zsh-only constructs either error or silently " +
+			"behave differently. Wrap emulation in a function and use `emulate -L MODE` to " +
+			"scope it to that function. A `.zsh` script that starts with `emulate sh` likely " +
+			"belongs in a `.sh` file instead.",
+		Check: checkZC1596,
+	})
+}
+
+func checkZC1596(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "emulate" {
+		return nil
+	}
+
+	var hasL bool
+	var mode string
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "-") {
+			if strings.Contains(v, "L") {
+				hasL = true
+			}
+			continue
+		}
+		if v == "sh" || v == "bash" || v == "ksh" || v == "csh" {
+			mode = v
+		}
+	}
+	if mode == "" || hasL {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1596",
+		Message: "`emulate " + mode + "` without `-L` flips the options for the whole " +
+			"shell. Use `emulate -L " + mode + "` inside a function, or rename the script " +
+			"to `.sh` if Zsh features are not needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 592 Katas = 0.5.92
-const Version = "0.5.92"
+// 593 Katas = 0.5.93
+const Version = "0.5.93"


### PR DESCRIPTION
ZC1596 — Style: `emulate sh/bash/ksh` without `-L` flips options for the whole shell

What: flags `emulate sh` / `emulate bash` / `emulate ksh` / `emulate csh` without the `-L` flag (scope-to-function).
Why: without `-L`, `emulate` rewrites option state for the entire shell. After that line, Zsh-specific constructs (`${(F)arr}`, 1-indexed arrays, glob qualifiers) error or silently behave differently.
Fix suggestion: wrap the call in a function and use `emulate -L MODE`, or rename the script to `.sh` if Zsh features are not needed.
Severity: Style