### PR TITLE
feat: ZC1597 — flag `systemd-run -p User=root` transient-unit privilege escalation

### DIFF
--- a/pkg/katas/katatests/zc1597_test.go
+++ b/pkg/katas/katatests/zc1597_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1597(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — systemd-run as non-root user",
+			input:    `systemd-run -p User=www-data /usr/bin/cleanup`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — systemd-run without user property",
+			input:    `systemd-run /usr/bin/cleanup`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — systemd-run -p User=root",
+			input: `systemd-run -p User=root sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1597",
+					Message: "`systemd-run -p User=root` runs arbitrary commands as root via systemd — bypasses the `sudo` audit path. Prefer explicit `sudo` or a fixed systemd unit.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — systemd-run -p User=0",
+			input: `systemd-run -p User=0 sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1597",
+					Message: "`systemd-run -p User=0` runs arbitrary commands as root via systemd — bypasses the `sudo` audit path. Prefer explicit `sudo` or a fixed systemd unit.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1597")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1597.go
+++ b/pkg/katas/zc1597.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1597",
+		Title:    "Warn on `systemd-run -p User=root` — launches arbitrary command with root privileges",
+		Severity: SeverityWarning,
+		Description: "`systemd-run` submits a transient unit to systemd. With `-p User=root` " +
+			"(or `User=0`) the unit runs as root — bypassing the usual `sudo` audit path in " +
+			"`/var/log/auth.log`. On hosts where the caller's polkit / dbus rules allow the " +
+			"operation, this is effectively privilege escalation by a different name. Prefer " +
+			"explicit `sudo` so the invocation is logged, or pre-provision a dedicated systemd " +
+			"unit that names the exact command it can run.",
+		Check: checkZC1597,
+	})
+}
+
+func checkZC1597(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "systemd-run" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "User=root" || v == "User=0" {
+			return []Violation{{
+				KataID: "ZC1597",
+				Message: "`systemd-run -p " + v + "` runs arbitrary commands as root via " +
+					"systemd — bypasses the `sudo` audit path. Prefer explicit `sudo` or a " +
+					"fixed systemd unit.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 593 Katas = 0.5.93
-const Version = "0.5.93"
+// 594 Katas = 0.5.94
+const Version = "0.5.94"


### PR DESCRIPTION
ZC1597 — Warn on `systemd-run -p User=root` — launches arbitrary command with root privileges

What: flags `systemd-run -p User=root` / `systemd-run -p User=0`.
Why: systemd-run submits a transient unit. `User=root` runs it as root — bypassing the `sudo` audit path in `/var/log/auth.log`. On hosts where the caller's polkit / dbus rules permit the call, this is privilege escalation by another name.
Fix suggestion: use explicit `sudo` so the invocation is logged, or pre-provision a dedicated systemd unit that names the exact command it can run.
Severity: Warning