### PR TITLE
feat: ZC1598 — flag `chmod` world-write on sensitive `/dev/` nodes

### DIFF
--- a/pkg/katas/katatests/zc1598_test.go
+++ b/pkg/katas/katatests/zc1598_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1598(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — chmod 600 on /dev/kvm",
+			input:    `chmod 600 /dev/kvm`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — chmod 666 on /dev/null (safe)",
+			input:    `chmod 666 /dev/null`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — chmod 666 on regular file (not /dev/)",
+			input:    `chmod 666 /tmp/log`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — chmod 666 /dev/kvm",
+			input: `chmod 666 /dev/kvm`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1598",
+					Message: "`chmod 666 /dev/kvm` makes a sensitive device node world-writable — direct kernel access for every local user. Keep restrictive perms (600 / 660) and grant access via udev rules.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — chmod 777 /dev/mem",
+			input: `chmod 777 /dev/mem`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1598",
+					Message: "`chmod 777 /dev/mem` makes a sensitive device node world-writable — direct kernel access for every local user. Keep restrictive perms (600 / 660) and grant access via udev rules.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1598")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1598.go
+++ b/pkg/katas/zc1598.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1598",
+		Title:    "Error on `chmod` with world-write bit on a sensitive `/dev/` node",
+		Severity: SeverityError,
+		Description: "Device nodes under `/dev/` are kernel interfaces. Making one world-writable " +
+			"( last digit `2`, `3`, `6`, or `7` ) gives every local user a direct line into the " +
+			"kernel — `/dev/kvm` yields VM hypercalls, `/dev/mem` / `/dev/kmem` / `/dev/port` " +
+			"read and write physical memory, `/dev/sd*` and `/dev/nvme*` give raw block access, " +
+			"`/dev/input/*` sniffs keystrokes. Keep restrictive perms (600 / 660) and use udev " +
+			"rules (`GROUP=`, `MODE=`) to grant access declaratively.",
+		Check: checkZC1598,
+	})
+}
+
+func checkZC1598(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "chmod" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+
+	mode := cmd.Arguments[0].String()
+	if mode == "" {
+		return nil
+	}
+	last := mode[len(mode)-1]
+	if last != '2' && last != '3' && last != '6' && last != '7' {
+		return nil
+	}
+
+	safe := map[string]bool{
+		"/dev/null": true, "/dev/zero": true,
+		"/dev/random": true, "/dev/urandom": true, "/dev/full": true,
+		"/dev/stdin": true, "/dev/stdout": true, "/dev/stderr": true,
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if !strings.HasPrefix(v, "/dev/") {
+			continue
+		}
+		if safe[v] || strings.HasPrefix(v, "/dev/tty") || strings.HasPrefix(v, "/dev/pts/") {
+			continue
+		}
+		return []Violation{{
+			KataID: "ZC1598",
+			Message: "`chmod " + mode + " " + v + "` makes a sensitive device node world-" +
+				"writable — direct kernel access for every local user. Keep restrictive " +
+				"perms (600 / 660) and grant access via udev rules.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityError,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 594 Katas = 0.5.94
-const Version = "0.5.94"
+// 595 Katas = 0.5.95
+const Version = "0.5.95"


### PR DESCRIPTION
ZC1598 — Error on `chmod` with world-write bit on a sensitive `/dev/` node

What: flags `chmod NNN /dev/...` where the last mode digit is `2`, `3`, `6`, or `7` (world-writable) and the target is not in the safe list (`/dev/null`, `/dev/zero`, `/dev/random`, `/dev/urandom`, `/dev/full`, `/dev/stdin`, `/dev/stdout`, `/dev/stderr`, `/dev/tty*`, `/dev/pts/*`).
Why: device nodes are kernel interfaces. World-write on `/dev/kvm` opens VM hypercalls; `/dev/mem` / `/dev/kmem` / `/dev/port` expose physical memory; `/dev/sd*`, `/dev/nvme*` give raw block access; `/dev/input/*` sniffs keystrokes.
Fix suggestion: keep restrictive perms (600 / 660) and grant access declaratively via udev rules (`GROUP=`, `MODE=`).
Severity: Error