### PR TITLE
feat: ZC1599 — flag `ldconfig -f PATH` with non-`/etc/` loader config

### DIFF
--- a/pkg/katas/katatests/zc1599_test.go
+++ b/pkg/katas/katatests/zc1599_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1599(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — plain ldconfig",
+			input:    `ldconfig`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ldconfig -f /etc/ld.so.conf.d/custom.conf",
+			input:    `ldconfig -f /etc/ld.so.conf.d/custom.conf`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ldconfig -f $LDCONF (variable)",
+			input:    `ldconfig -f $LDCONF`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ldconfig -f /tmp/fake.conf",
+			input: `ldconfig -f /tmp/fake.conf`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1599",
+					Message: "`ldconfig -f /tmp/fake.conf` uses a config outside `/etc/`. If the file is attacker-writable, every binary on the host loads the attacker's library. Keep config under `/etc/ld.so.conf.d/`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ldconfig -f /var/tmp/x.conf",
+			input: `ldconfig -f /var/tmp/x.conf`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1599",
+					Message: "`ldconfig -f /var/tmp/x.conf` uses a config outside `/etc/`. If the file is attacker-writable, every binary on the host loads the attacker's library. Keep config under `/etc/ld.so.conf.d/`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1599")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1599.go
+++ b/pkg/katas/zc1599.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1599",
+		Title:    "Warn on `ldconfig -f PATH` outside `/etc/` — attacker-writable loader cache",
+		Severity: SeverityWarning,
+		Description: "`ldconfig -f PATH` rebuilds `/etc/ld.so.cache` using PATH instead of the " +
+			"system `/etc/ld.so.conf`. If PATH sits in `/tmp`, `/var/tmp`, `$HOME`, or any " +
+			"directory an attacker can create, they can inject an `include` line that points " +
+			"at their directory of malicious shared objects. After the cache rebuild, every " +
+			"subsequent executable on the host loads their library first. Keep the config " +
+			"under `/etc/ld.so.conf.d/` with root ownership and run `ldconfig` with no `-f`.",
+		Check: checkZC1599,
+	})
+}
+
+func checkZC1599(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ldconfig" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		if arg.String() != "-f" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			continue
+		}
+		next := cmd.Arguments[i+1].String()
+		if strings.HasPrefix(next, "/etc/") || strings.HasPrefix(next, "$") {
+			continue
+		}
+		return []Violation{{
+			KataID: "ZC1599",
+			Message: "`ldconfig -f " + next + "` uses a config outside `/etc/`. If the " +
+				"file is attacker-writable, every binary on the host loads the attacker's " +
+				"library. Keep config under `/etc/ld.so.conf.d/`.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 595 Katas = 0.5.95
-const Version = "0.5.95"
+// 596 Katas = 0.5.96
+const Version = "0.5.96"


### PR DESCRIPTION
ZC1599 — Warn on `ldconfig -f PATH` with non-`/etc/` config — attacker-writable loader cache

What: flags `ldconfig -f <path>` where `<path>` does not start with `/etc/` (and is not a shell variable `$X`).
Why: `ldconfig -f` rebuilds `/etc/ld.so.cache` using the given config. If the file sits in `/tmp`, `/var/tmp`, `$HOME`, or any attacker-writable path, the attacker can add an `include` line pointing at their library directory and every subsequent executable on the host loads their `.so` first.
Fix suggestion: keep config under `/etc/ld.so.conf.d/` with root ownership, and run `ldconfig` with no `-f`.
Severity: Warning