### PR TITLE
feat: ZC1600 — flag bare `chroot DIR CMD` keeping uid 0 inside the jail

### DIFF
--- a/pkg/katas/katatests/zc1600_test.go
+++ b/pkg/katas/katatests/zc1600_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1600(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — bwrap for sandboxed exec",
+			input:    `bwrap --ro-bind / / --unshare-user --uid 1000 /bin/sh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — no chroot call",
+			input:    `mount --bind /src /dst`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — chroot /var/sandbox /bin/sh",
+			input: `chroot /var/sandbox /bin/sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1600",
+					Message: "`chroot` without `--userspec=` runs the inner command as uid 0. Pass `--userspec=USER:GROUP` to drop privileges, or use `bwrap` / `firejail` for user-namespace isolation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — chroot $ROOT sh",
+			input: `chroot $ROOT sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1600",
+					Message: "`chroot` without `--userspec=` runs the inner command as uid 0. Pass `--userspec=USER:GROUP` to drop privileges, or use `bwrap` / `firejail` for user-namespace isolation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1600")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1600.go
+++ b/pkg/katas/zc1600.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1600",
+		Title:    "Warn on bare `chroot DIR CMD` — missing `--userspec=` keeps uid 0 inside the jail",
+		Severity: SeverityWarning,
+		Description: "`chroot` changes the filesystem root but does not drop privileges. The " +
+			"caller is almost always root (the syscall needs `CAP_SYS_CHROOT`), and without " +
+			"`--userspec=USER:GROUP` the command inside the chroot still runs as uid 0. It can " +
+			"write anywhere inside the tree, chmod binaries, and — if proc / sys / device nodes " +
+			"are bind-mounted in — escape. Pass `--userspec=` to run the command as a named " +
+			"unprivileged user, or drop to a dedicated helper (bubblewrap, firejail) that also " +
+			"unshares user namespaces.",
+		Check: checkZC1600,
+	})
+}
+
+func checkZC1600(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "chroot" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1600",
+		Message: "`chroot` without `--userspec=` runs the inner command as uid 0. Pass " +
+			"`--userspec=USER:GROUP` to drop privileges, or use `bwrap` / `firejail` for " +
+			"user-namespace isolation.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 596 Katas = 0.5.96
-const Version = "0.5.96"
+// 597 Katas = 0.5.97
+const Version = "0.5.97"


### PR DESCRIPTION
ZC1600 — Warn on bare `chroot DIR CMD` — missing `--userspec=` keeps uid 0 inside the jail

What: flags every `chroot DIR CMD` invocation. ( When `--userspec=` is used, the parser re-interprets the tokens and this kata never fires — only the bare form hits. )
Why: `chroot` changes the filesystem root but does not drop privileges. The caller is almost always root, so without `--userspec=USER:GROUP` the inner command still runs as uid 0. It can write anywhere in the tree and — given bind-mounted `/proc`, `/sys`, or device nodes — escape.
Fix suggestion: pass `--userspec=USER:GROUP`, or drop to `bwrap` / `firejail` for user-namespace isolation.
Severity: Warning