### PR TITLE
feat: ZC1601 — flag `ethtool -s $IF wol` enabling Wake-on-LAN

### DIFF
--- a/pkg/katas/katatests/zc1601_test.go
+++ b/pkg/katas/katatests/zc1601_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1601(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ethtool wol d (disable)",
+			input:    `ethtool -s eth0 wol d`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ethtool setting different knob",
+			input:    `ethtool -s eth0 autoneg on`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ethtool -s eth0 wol g",
+			input: `ethtool -s eth0 wol g`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1601",
+					Message: "`ethtool -s eth0 wol g` enables Wake-on-LAN — the NIC powers the host on before firewall rules load. Keep `wol d` unless a documented operational need requires g.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ethtool -s $IF wol ubg",
+			input: `ethtool -s $IF wol ubg`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1601",
+					Message: "`ethtool -s $IF wol ubg` enables Wake-on-LAN — the NIC powers the host on before firewall rules load. Keep `wol d` unless a documented operational need requires ubg.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1601")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1601.go
+++ b/pkg/katas/zc1601.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1601",
+		Title:    "Warn on `ethtool -s $IF wol <g|u|m|b|a>` — enables remote Wake-on-LAN",
+		Severity: SeverityWarning,
+		Description: "Wake-on-LAN powers the host on from a sleep / soft-off state when a " +
+			"matching packet reaches the NIC. The wake logic fires in a privileged firmware " +
+			"path long before the kernel boots and firewall rules are loaded — so any packet " +
+			"that reaches the interface (magic-packet, unicast, broadcast, ARP) triggers the " +
+			"power-on unfiltered. On a shared or public LAN attackers on the broadcast domain " +
+			"can wake hosts at will. Keep `wol d` (disable) unless a documented operational " +
+			"need requires one of the wake bits.",
+		Check: checkZC1601,
+	})
+}
+
+func checkZC1601(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ethtool" {
+		return nil
+	}
+	if len(cmd.Arguments) < 4 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "-s" {
+		return nil
+	}
+
+	for i := 2; i+1 < len(cmd.Arguments); i++ {
+		if cmd.Arguments[i].String() != "wol" {
+			continue
+		}
+		bits := cmd.Arguments[i+1].String()
+		if bits == "d" {
+			return nil
+		}
+		enables := false
+		for _, c := range bits {
+			switch c {
+			case 'g', 'u', 'm', 'b', 'a', 'p', 's', 'f':
+				enables = true
+			}
+		}
+		if !enables {
+			return nil
+		}
+		return []Violation{{
+			KataID: "ZC1601",
+			Message: "`ethtool -s " + cmd.Arguments[1].String() + " wol " + bits + "` " +
+				"enables Wake-on-LAN — the NIC powers the host on before firewall rules " +
+				"load. Keep `wol d` unless a documented operational need requires " +
+				strings.TrimSpace(bits) + ".",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 597 Katas = 0.5.97
-const Version = "0.5.97"
+// 598 Katas = 0.5.98
+const Version = "0.5.98"


### PR DESCRIPTION
ZC1601 — Warn on `ethtool -s $IF wol <g|u|m|b|a|p|s|f>` — enables remote Wake-on-LAN

What: flags `ethtool -s $IF wol X` where X is any enable bit (`g` magic, `u` unicast, `m` multicast, `b` broadcast, `a` ARP, `p` phy, `s` SecureOn, `f` filter). `wol d` (disable) is valid.
Why: WoL powers the host from sleep / soft-off when a matching packet reaches the NIC. The wake path is firmware-level and fires before the kernel boots or firewall rules load — nothing filters the wake packet.
Fix suggestion: keep `wol d` unless a documented operational need requires one of the wake bits.
Severity: Warning