### PR TITLE
feat: ZC1602 — flag `setopt KSH_ARRAYS / SH_WORD_SPLIT` global semantics flip

### DIFF
--- a/pkg/katas/katatests/zc1602_test.go
+++ b/pkg/katas/katatests/zc1602_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1602(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — setopt NO_NOMATCH",
+			input:    `setopt NO_NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — setopt EXTENDED_GLOB",
+			input:    `setopt EXTENDED_GLOB`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — setopt KSH_ARRAYS",
+			input: `setopt KSH_ARRAYS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1602",
+					Message: "`setopt KSH_ARRAYS` flips Zsh core semantics for the whole shell — pre-existing code silently misbehaves. Scope with `emulate -L ksh` / `emulate -L sh` inside the function that needs the mode.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — setopt shwordsplit (lowercase, no underscore)",
+			input: `setopt shwordsplit`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1602",
+					Message: "`setopt shwordsplit` flips Zsh core semantics for the whole shell — pre-existing code silently misbehaves. Scope with `emulate -L ksh` / `emulate -L sh` inside the function that needs the mode.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1602")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1602.go
+++ b/pkg/katas/zc1602.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1602",
+		Title:    "Warn on `setopt KSH_ARRAYS` / `SH_WORD_SPLIT` — flips Zsh core semantics shell-wide",
+		Severity: SeverityWarning,
+		Description: "`KSH_ARRAYS` makes arrays 0-indexed (the Bash / ksh convention), breaking " +
+			"every Zsh access that uses `[1]` for the first element. `SH_WORD_SPLIT` makes " +
+			"unquoted `$var` word-split on `IFS`, breaking the core Zsh promise that `echo " +
+			"$x` passes exactly one argument. Setting either globally is a bug-magnet — pre-" +
+			"existing code silently misbehaves from that line on. If you need the semantics " +
+			"only inside a function, scope it with `emulate -L ksh` or `emulate -L sh`.",
+		Check: checkZC1602,
+	})
+}
+
+func checkZC1602(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "setopt" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		raw := arg.String()
+		norm := strings.ToLower(strings.ReplaceAll(raw, "_", ""))
+		if norm == "ksharrays" || norm == "shwordsplit" {
+			return []Violation{{
+				KataID: "ZC1602",
+				Message: "`setopt " + raw + "` flips Zsh core semantics for the whole shell " +
+					"— pre-existing code silently misbehaves. Scope with `emulate -L ksh` / " +
+					"`emulate -L sh` inside the function that needs the mode.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 598 Katas = 0.5.98
-const Version = "0.5.98"
+// 599 Katas = 0.5.99
+const Version = "0.5.99"


### PR DESCRIPTION
ZC1602 — Warn on `setopt KSH_ARRAYS` / `SH_WORD_SPLIT` — flips Zsh core semantics shell-wide

What: flags `setopt` with the args `KSH_ARRAYS`, `SH_WORD_SPLIT`, or their lowercase / no-underscore variants (Zsh accepts `ksharrays`, `shwordsplit`, etc.).
Why: `KSH_ARRAYS` makes arrays 0-indexed, breaking every Zsh access that uses `[1]` for the first element. `SH_WORD_SPLIT` makes unquoted `$var` word-split on `IFS`, breaking Zsh's default "one token per reference" promise. Either setting applied globally silently breaks pre-existing code from that line on.
Fix suggestion: scope inside a function with `emulate -L ksh` or `emulate -L sh` so the calling shell keeps Zsh semantics.
Severity: Warning