### PR TITLE
feat: ZC1603 — flag `gdb -p PID` / `ltrace -p PID` live-attach secret exposure

### DIFF
--- a/pkg/katas/katatests/zc1603_test.go
+++ b/pkg/katas/katatests/zc1603_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1603(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — gdb on core file",
+			input:    `gdb /usr/bin/app /var/lib/cores/app.core`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — coredumpctl",
+			input:    `coredumpctl debug myapp`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — gdb -p 1234",
+			input: `gdb -p 1234`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1603",
+					Message: "`gdb -p PID` attaches via ptrace — memory, registers, env, and stack of the target are readable. Use `coredumpctl` on a captured core, not a live attach from a script.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ltrace -p $PID",
+			input: `ltrace -p $PID`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1603",
+					Message: "`ltrace -p PID` attaches via ptrace — memory, registers, env, and stack of the target are readable. Use `coredumpctl` on a captured core, not a live attach from a script.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1603")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1603.go
+++ b/pkg/katas/zc1603.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1603",
+		Title:    "Warn on `gdb -p PID` / `ltrace -p PID` — live attach reads target memory",
+		Severity: SeverityWarning,
+		Description: "`gdb -p PID` and `ltrace -p PID` attach via ptrace and hand the caller " +
+			"full read / write access to the target process: registers, heap, stack, open file " +
+			"descriptors, and every environment variable. Credentials in `$AWS_SECRET_ACCESS_" +
+			"KEY`, session tokens on the stack, TLS keys in memory — all readable. A root-run " +
+			"script that attaches to another user's process extracts everything that user has. " +
+			"Keep production scripts out of the debugger; if post-mortem diagnostics are " +
+			"needed, use `coredumpctl` against a captured core file instead.",
+		Check: checkZC1603,
+	})
+}
+
+func checkZC1603(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "gdb" && ident.Value != "ltrace" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-p" {
+			return []Violation{{
+				KataID: "ZC1603",
+				Message: "`" + ident.Value + " -p PID` attaches via ptrace — memory, " +
+					"registers, env, and stack of the target are readable. Use " +
+					"`coredumpctl` on a captured core, not a live attach from a script.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 599 Katas = 0.5.99
-const Version = "0.5.99"
+// 600 Katas = 0.6.0
+const Version = "0.6.0"


### PR DESCRIPTION
ZC1603 — Warn on `gdb -p PID` / `ltrace -p PID` — live attach reads target memory

What: flags `gdb -p` / `ltrace -p` invocations in scripts.
Why: both tools attach via ptrace and hand the caller full read/write access to registers, heap, stack, open fds, and every environment variable of the target. Credentials, session tokens, and TLS keys are all readable. From a root-run script this extracts everything a user's process holds.
Fix suggestion: keep production scripts out of the debugger. If post-mortem diagnostics are needed, run `coredumpctl` against a captured core file instead.
Severity: Warning

Milestone: this PR takes the project to 600 katas (v0.6.0).