### PR TITLE
feat: ZC1604 — flag `source <glob>` sourcing every matched file

### DIFF
--- a/pkg/katas/katatests/zc1604_test.go
+++ b/pkg/katas/katatests/zc1604_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1604(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — source explicit file",
+			input:    `source /etc/bashrc`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — source variable path (no glob)",
+			input:    `source $HOME/dotfiles/common.sh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — source /etc/profile.d/*.sh",
+			input: `source /etc/profile.d/*.sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1604",
+					Message: "`source /etc/profile.d/*.sh` loads every matched file. One attacker-writable match is arbitrary code execution. Use explicit filenames.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — . $HOME/dotfiles/*.sh",
+			input: `. $HOME/dotfiles/*.sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1604",
+					Message: "`. $HOME/dotfiles/*.sh` loads every matched file. One attacker-writable match is arbitrary code execution. Use explicit filenames.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1604")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1604.go
+++ b/pkg/katas/zc1604.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1604",
+		Title:    "Warn on `source <glob>` / `. <glob>` — loads every match; one bad file = code exec",
+		Severity: SeverityWarning,
+		Description: "`source /etc/profile.d/*.sh` and similar glob-sourcing patterns load every " +
+			"file that matches, in the order Zsh enumerates them. One attacker-writable file " +
+			"anywhere in the glob yields arbitrary code execution as whoever is running the " +
+			"script, with that caller's privileges. Prefer explicit filenames so review can " +
+			"enumerate exactly what gets loaded. If a directory of drop-ins is required, audit " +
+			"ownership and perms at install time and keep the directory root-owned.",
+		Check: checkZC1604,
+	})
+}
+
+func checkZC1604(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "source" && ident.Value != "." {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	target := cmd.Arguments[0].String()
+	if !strings.ContainsAny(target, "*?[") {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1604",
+		Message: "`" + ident.Value + " " + target + "` loads every matched file. One " +
+			"attacker-writable match is arbitrary code execution. Use explicit filenames.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 600 Katas = 0.6.0
-const Version = "0.6.0"
+// 601 Katas = 0.6.1
+const Version = "0.6.1"


### PR DESCRIPTION
ZC1604 — Warn on `source <glob>` / `. <glob>` — loads every match; one bad file = code exec

What: flags `source` and `.` commands whose first argument contains glob metacharacters (`*`, `?`, `[`).
Why: glob-sourcing (e.g. `source /etc/profile.d/*.sh`) loads every file that matches. One attacker-writable file anywhere in the glob yields arbitrary code execution as the caller, with the caller's privileges.
Fix suggestion: list the files explicitly so review can enumerate what gets loaded. If a directory of drop-ins is required, keep it root-owned and audit ownership at install time.
Severity: Warning