### PR TITLE
feat: ZC1605 — flag `debugfs -w DEV` write-mode fs debugger bypass

### DIFF
--- a/pkg/katas/katatests/zc1605_test.go
+++ b/pkg/katas/katatests/zc1605_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1605(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — read-only debugfs",
+			input:    `debugfs $DEV`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — debugfs -R command (read-only)",
+			input:    `debugfs -R "stat foo.txt" $DEV`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — debugfs -w $DEV",
+			input: `debugfs -w $DEV`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1605",
+					Message: "`debugfs -w` writes to the filesystem outside the kernel's normal path — journal bypassed, locks ignored. Keep it as an interactive rescue tool, not a script path.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — debugfs -w /dev/loop0",
+			input: `debugfs -w /dev/loop0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1605",
+					Message: "`debugfs -w` writes to the filesystem outside the kernel's normal path — journal bypassed, locks ignored. Keep it as an interactive rescue tool, not a script path.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1605")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1605.go
+++ b/pkg/katas/zc1605.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1605",
+		Title:    "Error on `debugfs -w DEV` — write-mode filesystem debugger bypasses journal",
+		Severity: SeverityError,
+		Description: "`debugfs -w` opens the filesystem in write mode. It sidesteps the kernel's " +
+			"normal write path — the journal doesn't see the changes, filesystem locks are " +
+			"ignored, and inodes / blocks can be edited directly. On a mounted filesystem this " +
+			"corrupts state silently; even on an unmounted one, the operator can repoint a " +
+			"directory entry at an arbitrary inode. Scripts should never need this — keep " +
+			"`debugfs -w` as an interactive last-resort from a rescue environment.",
+		Check: checkZC1605,
+	})
+}
+
+func checkZC1605(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "debugfs" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-w" {
+			return []Violation{{
+				KataID: "ZC1605",
+				Message: "`debugfs -w` writes to the filesystem outside the kernel's normal " +
+					"path — journal bypassed, locks ignored. Keep it as an interactive " +
+					"rescue tool, not a script path.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 601 Katas = 0.6.1
-const Version = "0.6.1"
+// 602 Katas = 0.6.2
+const Version = "0.6.2"


### PR DESCRIPTION
ZC1605 — Error on `debugfs -w DEV` — write-mode filesystem debugger bypasses journal

What: flags `debugfs -w` invocations.
Why: `-w` opens the filesystem in write mode, sidestepping the kernel's normal write path. The journal does not see the changes, filesystem locks are ignored, and inodes / blocks can be edited directly. On a mounted filesystem this corrupts state silently.
Fix suggestion: keep `debugfs -w` out of scripts — use it interactively from a rescue environment only.
Severity: Error