### PR TITLE
feat: ZC1606 — flag `mkdir -m` / `install -m` world-write without sticky

### DIFF
--- a/pkg/katas/katatests/zc1606_test.go
+++ b/pkg/katas/katatests/zc1606_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1606(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — mkdir -m 700",
+			input:    `mkdir -m 700 /root/data`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — mkdir -m 755",
+			input:    `mkdir -m 755 /opt/app`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — mkdir -m 1777 (sticky)",
+			input:    `mkdir -m 1777 /tmp/shared`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — mkdir -m 777",
+			input: `mkdir -m 777 /tmp/shared`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1606",
+					Message: "`mkdir -m 777` creates a world-writable path without the sticky bit — TOCTOU symlink-attack ground. Use `-m 700` / `-m 750`, or `-m 1777` if a shared sticky dir is actually needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — install -m 666",
+			input: `install -m 666 file /tmp/x`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1606",
+					Message: "`install -m 666` creates a world-writable path without the sticky bit — TOCTOU symlink-attack ground. Use `-m 700` / `-m 750`, or `-m 1777` if a shared sticky dir is actually needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1606")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1606.go
+++ b/pkg/katas/zc1606.go
@@ -1,0 +1,69 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1606",
+		Title:    "Warn on `mkdir -m NNN` / `install -m NNN` with world-write bit (no sticky)",
+		Severity: SeverityWarning,
+		Description: "`mkdir -m 777 /path` and `install -m 777 src /dest` create a path that " +
+			"every local user can write and rename inside. If the script later creates files " +
+			"there, classic TOCTOU symlink attacks become trivial — the attacker drops a " +
+			"symlink named like the expected output file, redirecting the write wherever they " +
+			"choose. A sticky-bit mode (`1777`) mitigates this for shared temp dirs. Prefer " +
+			"`mkdir -m 700` (or 750), and scope access by group or ACL rather than everyone.",
+		Check: checkZC1606,
+	})
+}
+
+func checkZC1606(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "mkdir" && ident.Value != "install" {
+		return nil
+	}
+
+	for i := 0; i+1 < len(cmd.Arguments); i++ {
+		if cmd.Arguments[i].String() != "-m" {
+			continue
+		}
+		mode := cmd.Arguments[i+1].String()
+		if len(mode) != 3 {
+			continue
+		}
+		allOctal := true
+		for _, c := range mode {
+			if c < '0' || c > '7' {
+				allOctal = false
+				break
+			}
+		}
+		if !allOctal {
+			continue
+		}
+		last := mode[2]
+		if last != '2' && last != '3' && last != '6' && last != '7' {
+			continue
+		}
+		return []Violation{{
+			KataID: "ZC1606",
+			Message: "`" + ident.Value + " -m " + mode + "` creates a world-writable path " +
+				"without the sticky bit — TOCTOU symlink-attack ground. Use `-m 700` / " +
+				"`-m 750`, or `-m 1777` if a shared sticky dir is actually needed.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 602 Katas = 0.6.2
-const Version = "0.6.2"
+// 603 Katas = 0.6.3
+const Version = "0.6.3"


### PR DESCRIPTION
ZC1606 — Warn on `mkdir -m NNN` / `install -m NNN` with world-write bit (no sticky)

What: flags `mkdir -m NNN` / `install -m NNN` with a 3-digit octal mode whose last digit is `2`, `3`, `6`, or `7`. `1777` and other sticky-prefixed modes are exempt.
Why: world-writable directories / files without the sticky bit are TOCTOU symlink-attack ground. An attacker can drop a symlink with the expected output name before the script writes, redirecting the write wherever they choose.
Fix suggestion: use `-m 700` / `-m 750` and scope access by group or ACL. Use `-m 1777` only for genuine shared-sticky temp dirs.
Severity: Warning