### PR TITLE
feat: ZC1607 — flag `git config safe.directory '*'` CVE-2022-24765 bypass

### DIFF
--- a/pkg/katas/katatests/zc1607_test.go
+++ b/pkg/katas/katatests/zc1607_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1607(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — safe.directory scoped to a path",
+			input:    `git config --global safe.directory /workspace/repo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — unrelated git config",
+			input:    `git config user.email "me@example.com"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — git config safe.directory '*'",
+			input: `git config --global safe.directory '*'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1607",
+					Message: "`git config safe.directory '*'` trusts every directory — defeats CVE-2022-24765 protection. List specific paths, or fix the ownership mismatch.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — git -c safe.directory=* status",
+			input: `git -c safe.directory=* status`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1607",
+					Message: "`git config safe.directory '*'` trusts every directory — defeats CVE-2022-24765 protection. List specific paths, or fix the ownership mismatch.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1607")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1607.go
+++ b/pkg/katas/zc1607.go
@@ -1,0 +1,62 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1607",
+		Title:    "Warn on `git config safe.directory '*'` — disables CVE-2022-24765 protection",
+		Severity: SeverityWarning,
+		Description: "`safe.directory` is git's mitigation for CVE-2022-24765 (fake git dirs " +
+			"planted by another uid). Setting it to `'*'` trusts every directory on the host " +
+			"— an attacker who creates `/tmp/evil/.git` with a malicious `core.fsmonitor` hook " +
+			"gets arbitrary code execution the first time any user runs `git status` near that " +
+			"path. List the specific paths that need cross-owner git access instead, or fix " +
+			"the underlying ownership mismatch.",
+		Check: checkZC1607,
+	})
+}
+
+func checkZC1607(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "git" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "safe.directory=*" || strings.HasPrefix(v, "safe.directory=*") {
+			return violationZC1607(cmd)
+		}
+		if v == "safe.directory" && i+1 < len(cmd.Arguments) {
+			next := strings.Trim(cmd.Arguments[i+1].String(), "'\"")
+			if next == "*" {
+				return violationZC1607(cmd)
+			}
+		}
+	}
+	return nil
+}
+
+func violationZC1607(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1607",
+		Message: "`git config safe.directory '*'` trusts every directory — defeats CVE-" +
+			"2022-24765 protection. List specific paths, or fix the ownership mismatch.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 603 Katas = 0.6.3
-const Version = "0.6.3"
+// 604 Katas = 0.6.4
+const Version = "0.6.4"


### PR DESCRIPTION
ZC1607 — Warn on `git config safe.directory '*'` — disables CVE-2022-24765 protection

What: flags `git config ... safe.directory '*'` and the equivalent `git -c safe.directory=*` single-shot form.
Why: `safe.directory` is git's guard against fake repos planted by another uid. Setting it to `*` trusts every directory on the host — a planted `/tmp/evil/.git` with a malicious `core.fsmonitor` hook executes arbitrary code the next time any user runs `git status` near that path.
Fix suggestion: list the specific paths that need cross-owner git access, or fix the underlying ownership mismatch.
Severity: Warning