### PR TITLE
feat: ZC1608 — flag `find -exec sh -c '... {} ...'` filename injection

### DIFF
--- a/pkg/katas/katatests/zc1608_test.go
+++ b/pkg/katas/katatests/zc1608_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1608(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — find -exec rm {}",
+			input:    `find . -type f -exec rm {} \;`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — find -exec sh -c 'positional'",
+			input:    `find . -exec sh -c 'grep pat "$1"' _ {} \;`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  `invalid — find -exec sh -c 'echo {}'`,
+			input: `find . -exec sh -c 'echo {}' \;`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1608",
+					Message: "`find -exec sh -c '... {} ...'` interpolates filenames into the shell script — metacharacters break out. Pass `{}` as a positional arg: `sh -c '... \"$1\"' _ {} \\;`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — find -exec bash -c "grep X {}"`,
+			input: `find . -exec bash -c "grep X {}" \;`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1608",
+					Message: "`find -exec sh -c '... {} ...'` interpolates filenames into the shell script — metacharacters break out. Pass `{}` as a positional arg: `sh -c '... \"$1\"' _ {} \\;`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1608")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1608.go
+++ b/pkg/katas/zc1608.go
@@ -1,0 +1,71 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1608",
+		Title:    "Warn on `find -exec sh -c '... {} ...'` — filename in quoted script is injectable",
+		Severity: SeverityWarning,
+		Description: "Substituting `{}` directly into the quoted command string of `find -exec " +
+			"sh -c` lets filenames with shell metacharacters break out. A file named `$(rm " +
+			"-rf ~)` invokes command substitution; a file named `foo; curl evil` chains a " +
+			"second command. Pass `{}` as a positional argument to `sh` so the filename " +
+			"arrives as a parameter, not as source: `find -exec sh -c 'grep pat \"$1\"' _ {} " +
+			"\\;`.",
+		Check: checkZC1608,
+	})
+}
+
+func checkZC1608(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "find" {
+		return nil
+	}
+
+	hasExec := false
+	hasShellC := false
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-exec" || v == "-execdir" {
+			hasExec = true
+			continue
+		}
+		if !hasExec {
+			continue
+		}
+		if (v == "sh" || v == "bash" || v == "zsh" || v == "/bin/sh" || v == "/bin/bash") &&
+			i+1 < len(cmd.Arguments) && cmd.Arguments[i+1].String() == "-c" {
+			hasShellC = true
+			continue
+		}
+		if !hasShellC {
+			continue
+		}
+		if (strings.HasPrefix(v, "'") || strings.HasPrefix(v, "\"")) &&
+			strings.Contains(v, "{}") {
+			return []Violation{{
+				KataID: "ZC1608",
+				Message: "`find -exec sh -c '... {} ...'` interpolates filenames into the " +
+					"shell script — metacharacters break out. Pass `{}` as a positional " +
+					"arg: `sh -c '... \"$1\"' _ {} \\;`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 604 Katas = 0.6.4
-const Version = "0.6.4"
+// 605 Katas = 0.6.5
+const Version = "0.6.5"


### PR DESCRIPTION
ZC1608 — Warn on `find -exec sh -c '... {} ...'` — filename in quoted script is injectable

What: flags `find -exec sh -c`, `find -exec bash -c`, `find -exec zsh -c`, `find -execdir sh -c`, etc. when the quoted script argument contains `{}`.
Why: substituting `{}` directly into the shell script lets filenames with metacharacters break out. A file named `$(rm -rf ~)` triggers command substitution; a file named `foo; curl evil` chains a second command.
Fix suggestion: pass `{}` as a positional argument: `find -exec sh -c 'grep pat "$1"' _ {} \;` so the filename becomes `$1`, not source.
Severity: Warning