### PR TITLE
feat: ZC1609 — flag `aa-disable` / `aa-complain` / `apparmor_parser -R` profile removal

### DIFF
--- a/pkg/katas/katatests/zc1609_test.go
+++ b/pkg/katas/katatests/zc1609_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1609(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — aa-enforce reapplies enforcement",
+			input:    `aa-enforce /etc/apparmor.d/usr.bin.firefox`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — apparmor_parser -r (reload, not remove)",
+			input:    `apparmor_parser -r /etc/apparmor.d/profile`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — aa-disable",
+			input: `aa-disable /etc/apparmor.d/usr.bin.firefox`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1609",
+					Message: "`aa-disable` disables or softens the AppArmor profile — the confined process loses MAC restrictions. Review the profile's intent before disabling in automation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — aa-complain",
+			input: `aa-complain /etc/apparmor.d/usr.bin.firefox`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1609",
+					Message: "`aa-complain` disables or softens the AppArmor profile — the confined process loses MAC restrictions. Review the profile's intent before disabling in automation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — apparmor_parser -R",
+			input: `apparmor_parser -R /etc/apparmor.d/profile`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1609",
+					Message: "`apparmor_parser -R` removes the AppArmor profile from the kernel — the confined process loses MAC restrictions. Review the profile's intent before removing in automation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1609")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1609.go
+++ b/pkg/katas/zc1609.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1609",
+		Title:    "Warn on `aa-disable` / `aa-complain` / `apparmor_parser -R` — disables AppArmor enforcement",
+		Severity: SeverityWarning,
+		Description: "`aa-disable` fully unloads the named AppArmor profile; `aa-complain` " +
+			"flips the profile from enforce to complain (violations are logged but allowed); " +
+			"`apparmor_parser -R` removes a profile from the running kernel. Each one lets the " +
+			"confined process run without its mandatory-access-control restrictions — if the " +
+			"profile existed for a reason, that reason is now unenforced. Interactive debugging " +
+			"is legitimate, but scripts that permanently disable profiles should be reviewed.",
+		Check: checkZC1609,
+	})
+}
+
+func checkZC1609(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "aa-disable", "aa-complain":
+		if len(cmd.Arguments) == 0 {
+			return nil
+		}
+		return []Violation{{
+			KataID: "ZC1609",
+			Message: "`" + ident.Value + "` disables or softens the AppArmor profile — the " +
+				"confined process loses MAC restrictions. Review the profile's intent " +
+				"before disabling in automation.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	case "apparmor_parser":
+		for _, arg := range cmd.Arguments {
+			if arg.String() == "-R" || arg.String() == "--remove" {
+				return []Violation{{
+					KataID: "ZC1609",
+					Message: "`apparmor_parser -R` removes the AppArmor profile from the " +
+						"kernel — the confined process loses MAC restrictions. Review " +
+						"the profile's intent before removing in automation.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 605 Katas = 0.6.5
-const Version = "0.6.5"
+// 606 Katas = 0.6.6
+const Version = "0.6.6"


### PR DESCRIPTION
ZC1609 — Warn on `aa-disable` / `aa-complain` / `apparmor_parser -R` — disables AppArmor enforcement

What: flags `aa-disable` (with target), `aa-complain` (with target), and `apparmor_parser -R` / `--remove`.
Why: `aa-disable` unloads the profile entirely. `aa-complain` flips it from enforce to complain — violations are logged but allowed. `apparmor_parser -R` removes the profile from the running kernel. In each case the confined process loses its MAC restrictions.
Fix suggestion: keep the profile enforcing. If a specific rule is wrong, edit the profile file and run `apparmor_parser -r /etc/apparmor.d/<profile>` to reload it.
Severity: Warning