### PR TITLE
feat: ZC1610 — flag `curl -o /etc/...` / `wget -O /etc/...` direct system-path download

### DIFF
--- a/pkg/katas/katatests/zc1610_test.go
+++ b/pkg/katas/katatests/zc1610_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1610(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — curl to temp path",
+			input:    `curl -fsSL -o /tmp/download.tar.gz https://example.com/x.tar.gz`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — wget to user home",
+			input:    `wget -O $HOME/.local/bin/tool https://example.com/tool`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — curl -o /etc/config",
+			input: `curl -fsSL -o /etc/myapp/config.yaml https://example.com/config`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1610",
+					Message: "`curl -o /etc/myapp/config.yaml` writes an HTTP response straight into a system path — a compromised URL replaces the target. Download to a temp file, verify, then `install` into place.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — wget -O /usr/local/bin/tool",
+			input: `wget -O /usr/local/bin/tool https://example.com/tool`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1610",
+					Message: "`wget -O /usr/local/bin/tool` writes an HTTP response straight into a system path — a compromised URL replaces the target. Download to a temp file, verify, then `install` into place.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — wget -O /lib/x.so",
+			input: `wget -O /lib/evil.so https://example.com/evil.so`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1610",
+					Message: "`wget -O /lib/evil.so` writes an HTTP response straight into a system path — a compromised URL replaces the target. Download to a temp file, verify, then `install` into place.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1610")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1610.go
+++ b/pkg/katas/zc1610.go
@@ -1,0 +1,82 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1610",
+		Title:    "Warn on `curl -o /etc/...` / `wget -O /etc/...` — direct download to a system path",
+		Severity: SeverityWarning,
+		Description: "Writing the body of an HTTP response straight into `/etc/`, `/usr/`, " +
+			"`/bin/`, `/sbin/`, or `/lib/` skips every integrity check the system usually " +
+			"applies. If the URL is compromised or MITM'd, the attacker's content replaces a " +
+			"system config or binary the next command over. Download to a temp file, verify " +
+			"signature / checksum, and `install -m 0644` the final file into place. Package " +
+			"managers exist for a reason — prefer them for system files.",
+		Check: checkZC1610,
+	})
+}
+
+func checkZC1610(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "curl" && ident.Value != "wget" {
+		return nil
+	}
+
+	systemPrefixes := []string{"/etc/", "/usr/", "/bin/", "/sbin/", "/lib/", "/lib64/", "/opt/"}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		isOutFlag := v == "-o" || v == "-O" || v == "--output" || v == "--output-document"
+		if isOutFlag && i+1 < len(cmd.Arguments) {
+			next := cmd.Arguments[i+1].String()
+			for _, p := range systemPrefixes {
+				if strings.HasPrefix(next, p) {
+					return []Violation{{
+						KataID: "ZC1610",
+						Message: "`" + ident.Value + " " + v + " " + next + "` writes " +
+							"an HTTP response straight into a system path — a compromised " +
+							"URL replaces the target. Download to a temp file, verify, " +
+							"then `install` into place.",
+						Line:   cmd.Token.Line,
+						Column: cmd.Token.Column,
+						Level:  SeverityWarning,
+					}}
+				}
+			}
+		}
+		// Handle --output=/path and --output-document=/path joined forms.
+		for _, prefix := range []string{"--output=", "--output-document="} {
+			if strings.HasPrefix(v, prefix) {
+				path := strings.TrimPrefix(v, prefix)
+				for _, p := range systemPrefixes {
+					if strings.HasPrefix(path, p) {
+						return []Violation{{
+							KataID: "ZC1610",
+							Message: "`" + ident.Value + " " + v + "` writes an HTTP " +
+								"response straight into a system path — a compromised " +
+								"URL replaces the target. Download to a temp file, " +
+								"verify, then `install` into place.",
+							Line:   cmd.Token.Line,
+							Column: cmd.Token.Column,
+							Level:  SeverityWarning,
+						}}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 606 Katas = 0.6.6
-const Version = "0.6.6"
+// 607 Katas = 0.6.7
+const Version = "0.6.7"


### PR DESCRIPTION
ZC1610 — Warn on `curl -o /etc/...` / `wget -O /etc/...` — direct download to a system path

What: flags `curl -o`, `curl --output`, `wget -O`, `wget --output-document` that target paths under `/etc/`, `/usr/`, `/bin/`, `/sbin/`, `/lib/`, `/lib64/`, `/opt/`.
Why: writing the HTTP response body straight into a system path skips every integrity check. A compromised URL or MITM replaces the file with attacker content; the next command over picks it up.
Fix suggestion: download to a temp file, verify signature / checksum, then `install -m 0644 tmpfile /etc/...` into place. For system packages, prefer the package manager.
Severity: Warning