### PR TITLE
feat: ZC1611 — prefer Zsh `${(U)var}` / `${(L)var}` over Bash `${var^^}` / `${var,,}`

### DIFF
--- a/pkg/katas/katatests/zc1611_test.go
+++ b/pkg/katas/katatests/zc1611_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1611(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — Zsh ${(U)var}",
+			input:    `echo "${(U)var}"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — plain expansion",
+			input:    `echo "${var}"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  `invalid — echo "${var^^}"`,
+			input: `echo "${var^^}"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1611",
+					Message: "`${var^^}` / `${var,,}` — prefer Zsh `${(U)var}` / `${(L)var}` for case conversion.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — print -r "${name,,}"`,
+			input: `print -r -- "${name,,}"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1611",
+					Message: "`${var^^}` / `${var,,}` — prefer Zsh `${(U)var}` / `${(L)var}` for case conversion.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1611")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1611.go
+++ b/pkg/katas/zc1611.go
@@ -1,0 +1,47 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1611",
+		Title:    "Style: `${var^^}` / `${var,,}` — prefer Zsh `${(U)var}` / `${(L)var}` for case change",
+		Severity: SeverityStyle,
+		Description: "`${var^^}` (uppercase) and `${var,,}` (lowercase) came from Bash 4. Zsh " +
+			"accepts them for compatibility but the idiomatic form is the parameter-expansion " +
+			"flag: `${(U)var}` / `${(L)var}`. The flag is also available per-element in " +
+			"arrays (`${(U)array}`) and composes with other flags (`${(UL)array}` doesn't " +
+			"make sense, but `${(U)${(f)str}}` does). Prefer the Zsh-native form in a `.zsh` " +
+			"script; it keeps the codebase consistent with other `(X)var` patterns.",
+		Check: checkZC1611,
+	})
+}
+
+func checkZC1611(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if !strings.Contains(v, "${") {
+			continue
+		}
+		if strings.Contains(v, "^^}") || strings.Contains(v, ",,}") {
+			return []Violation{{
+				KataID: "ZC1611",
+				Message: "`${var^^}` / `${var,,}` — prefer Zsh `${(U)var}` / `${(L)var}` " +
+					"for case conversion.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 607 Katas = 0.6.7
-const Version = "0.6.7"
+// 608 Katas = 0.6.8
+const Version = "0.6.8"


### PR DESCRIPTION
ZC1611 — Style: `${var^^}` / `${var,,}` — prefer Zsh `${(U)var}` / `${(L)var}`

What: flags arguments containing the Bash 4+ case-change syntax `${var^^}` / `${var,,}` — detected when the substring `^^}` or `,,}` appears inside a `${...}` expansion.
Why: Zsh accepts the `^^ / ,,` forms for compatibility, but the native flag form `${(U)var}` / `${(L)var}` is what Zsh documents and composes with other `(X)var` flags. Consistent Zsh style reads better.
Fix suggestion: replace with `${(U)var}` for uppercase and `${(L)var}` for lowercase.
Severity: Style