### PR TITLE
feat: ZC1612 — flag `sysctl -w` disabling kernel hardening knobs

### DIFF
--- a/pkg/katas/katatests/zc1612_test.go
+++ b/pkg/katas/katatests/zc1612_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1612(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sysctl tightening ptrace_scope",
+			input:    `sysctl -w kernel.yama.ptrace_scope=3`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — unrelated sysctl",
+			input:    `sysctl -w vm.swappiness=10`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — sysctl -w kernel.yama.ptrace_scope=0",
+			input: `sysctl -w kernel.yama.ptrace_scope=0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1612",
+					Message: "`sysctl ... kernel.yama.ptrace_scope=0` disables YAMA ptrace scope (lets any process attach) — defense-in-depth loss. Leave the default unless a measured need justifies it.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — sysctl -w kernel.kptr_restrict=0",
+			input: `sysctl -w kernel.kptr_restrict=0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1612",
+					Message: "`sysctl ... kernel.kptr_restrict=0` disables kernel pointer restriction (leaks kptrs to /proc) — defense-in-depth loss. Leave the default unless a measured need justifies it.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1612")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1612.go
+++ b/pkg/katas/zc1612.go
@@ -1,0 +1,62 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1612HardeningDisables = map[string]string{
+	"kernel.yama.ptrace_scope=0":         "YAMA ptrace scope (lets any process attach)",
+	"kernel.kptr_restrict=0":             "kernel pointer restriction (leaks kptrs to /proc)",
+	"kernel.dmesg_restrict=0":            "dmesg restriction (unprivileged users read ring buffer)",
+	"kernel.unprivileged_bpf_disabled=0": "unprivileged BPF gate (any user loads BPF)",
+	"net.core.bpf_jit_harden=0":          "BPF JIT hardening (JIT-spray mitigations off)",
+	"kernel.perf_event_paranoid=-1":      "perf_event paranoid (unprivileged perf access)",
+	"kernel.perf_event_paranoid=0":       "perf_event paranoid (unprivileged perf access)",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1612",
+		Title:    "Warn on `sysctl -w` disabling kernel hardening knobs",
+		Severity: SeverityWarning,
+		Description: "Several sysctl knobs exist specifically to constrain what unprivileged " +
+			"users can do — `kernel.yama.ptrace_scope`, `kernel.kptr_restrict`, " +
+			"`kernel.dmesg_restrict`, `kernel.unprivileged_bpf_disabled`, " +
+			"`net.core.bpf_jit_harden`, and `kernel.perf_event_paranoid`. Setting any of them " +
+			"to the lowest-restriction value removes a distinct defense-in-depth layer: " +
+			"unrelated processes can ptrace each other, kernel pointers leak to `/proc`, " +
+			"unprivileged users read kernel ring buffers, BPF JIT-spray mitigations disappear. " +
+			"Leave these defaults alone unless a measured performance or debugging need justifies it.",
+		Check: checkZC1612,
+	})
+}
+
+func checkZC1612(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "sysctl" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if note, ok := zc1612HardeningDisables[v]; ok {
+			return []Violation{{
+				KataID: "ZC1612",
+				Message: "`sysctl ... " + v + "` disables " + note + " — defense-in-depth " +
+					"loss. Leave the default unless a measured need justifies it.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 608 Katas = 0.6.8
-const Version = "0.6.8"
+// 609 Katas = 0.6.9
+const Version = "0.6.9"


### PR DESCRIPTION
ZC1612 — Warn on `sysctl -w` disabling kernel hardening knobs

What: flags `sysctl -w ... KEY=VAL` (or `sysctl KEY=VAL`) where the key/value pair loosens one of:
- `kernel.yama.ptrace_scope=0` — any process can ptrace any other.
- `kernel.kptr_restrict=0` — kernel pointers leak via `/proc/kallsyms`.
- `kernel.dmesg_restrict=0` — unprivileged dmesg access.
- `kernel.unprivileged_bpf_disabled=0` — unprivileged BPF loading.
- `net.core.bpf_jit_harden=0` — BPF JIT-spray mitigations off.
- `kernel.perf_event_paranoid=-1` / `=0` — unprivileged perf access.

Why: each is a defense-in-depth layer. Loosening them removes an isolation guarantee the kernel documents.
Fix suggestion: leave the default unless there is a measured performance or debugging need that outweighs the security trade-off.
Severity: Warning