### PR TITLE
feat: ZC1613 — flag `cat/grep/head` reading SSH private-key files

### DIFF
--- a/pkg/katas/katatests/zc1613_test.go
+++ b/pkg/katas/katatests/zc1613_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1613(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ssh-keygen on host key",
+			input:    `ssh-keygen -l -f /etc/ssh/ssh_host_rsa_key`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — cat public host key",
+			input:    `cat /etc/ssh/ssh_host_rsa_key.pub`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — cat /etc/ssh/ssh_host_ed25519_key",
+			input: `cat /etc/ssh/ssh_host_ed25519_key`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1613",
+					Message: "Reading `/etc/ssh/ssh_host_ed25519_key` through a text tool copies private-key material into the process and often into logs / scrollback. Use `ssh-keygen -l -f` for metadata, or pass the path directly to the consumer.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — grep PRIVATE $HOME/.ssh/id_rsa",
+			input: `grep PRIVATE $HOME/.ssh/id_rsa`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1613",
+					Message: "Reading `$HOME/.ssh/id_rsa` through a text tool copies private-key material into the process and often into logs / scrollback. Use `ssh-keygen -l -f` for metadata, or pass the path directly to the consumer.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1613")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1613.go
+++ b/pkg/katas/zc1613.go
@@ -1,0 +1,73 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1613Readers = map[string]bool{
+	"cat": true, "less": true, "more": true,
+	"head": true, "tail": true, "wc": true,
+	"grep": true, "awk": true, "sed": true, "cut": true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1613",
+		Title:    "Warn on reading SSH private-key files with `cat` / `less` / `grep` / `head`",
+		Severity: SeverityWarning,
+		Description: "Piping an SSH private key through a generic text tool copies the raw " +
+			"key material into the process and — if stdout is redirected or piped — often " +
+			"into logs, backup files, or a terminal scrollback buffer. Host keys under " +
+			"`/etc/ssh/ssh_host_*_key` impersonate the server; user keys under `~/.ssh/id_*` " +
+			"impersonate the user. Use `ssh-keygen -l -f KEY` for fingerprint / metadata, or " +
+			"pass the key path to the consumer directly (`ssh -i`, `git -c core.sshCommand`) " +
+			"without staging it through a shell tool.",
+		Check: checkZC1613,
+	})
+}
+
+func checkZC1613(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if !zc1613Readers[ident.Value] {
+		return nil
+	}
+
+	userSuffixes := []string{
+		"/.ssh/id_rsa", "/.ssh/id_ed25519", "/.ssh/id_ecdsa", "/.ssh/id_dsa",
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "/etc/ssh/ssh_host_") && strings.HasSuffix(v, "_key") {
+			return zc1613Hit(cmd, v)
+		}
+		for _, s := range userSuffixes {
+			if strings.HasSuffix(v, s) {
+				return zc1613Hit(cmd, v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1613Hit(cmd *ast.SimpleCommand, path string) []Violation {
+	return []Violation{{
+		KataID: "ZC1613",
+		Message: "Reading `" + path + "` through a text tool copies private-key material " +
+			"into the process and often into logs / scrollback. Use `ssh-keygen -l -f` " +
+			"for metadata, or pass the path directly to the consumer.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 609 Katas = 0.6.9
-const Version = "0.6.9"
+// 610 Katas = 0.6.10
+const Version = "0.6.10"


### PR DESCRIPTION
ZC1613 — Warn on reading SSH private-key files with `cat` / `less` / `grep` / `head`

What: flags text-tool reads (`cat`, `less`, `more`, `head`, `tail`, `wc`, `grep`, `awk`, `sed`, `cut`) of SSH host keys under `/etc/ssh/ssh_host_*_key` and user keys under `*/.ssh/id_{rsa,ed25519,ecdsa,dsa}`.
Why: piping a private key through a text tool copies key material into the process and — if stdout is redirected or piped — into logs, backups, or terminal scrollback. Host keys impersonate the server; user keys impersonate the user.
Fix suggestion: use `ssh-keygen -l -f KEY` for fingerprint / metadata. Pass the key path directly to the consumer (`ssh -i`, `git -c core.sshCommand`) rather than staging it through a shell tool.
Severity: Warning