### PR TITLE
feat: ZC1614 — flag `expect` script containing literal password/passphrase

### DIFF
--- a/pkg/katas/katatests/zc1614_test.go
+++ b/pkg/katas/katatests/zc1614_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1614(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — expect driving a non-auth dialog",
+			input:    `expect -c 'spawn lftp host; expect lftp; send "ls\r"; interact'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — no expect in use",
+			input:    `ssh -i key host cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — expect with password",
+			input: `expect -c 'spawn ssh user@host; expect password; send "s3cret\r"; interact'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1614",
+					Message: "`expect` script contains `password` / `passphrase` — the full argv lands in `ps` and audit logs. Switch to key-based auth, or read the credential from a protected file the expect script opens.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — expect with passphrase",
+			input: `expect -c 'spawn ssh-keygen -p -f key; expect passphrase; send "x\r"'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1614",
+					Message: "`expect` script contains `password` / `passphrase` — the full argv lands in `ps` and audit logs. Switch to key-based auth, or read the credential from a protected file the expect script opens.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1614")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1614.go
+++ b/pkg/katas/zc1614.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1614",
+		Title:    "Error on `expect` script containing `password` / `passphrase`",
+		Severity: SeverityError,
+		Description: "`expect -c '... password ... send \"...\"'` puts the entire scripted " +
+			"dialog on the command line. Anything there — including the password or passphrase " +
+			"— is visible in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs. Use " +
+			"key-based authentication (SSH keys, GSSAPI) where possible. If password feeding is " +
+			"truly unavoidable, read it from a protected file with `spawn -o`, or source it " +
+			"from an environment variable the script does not print.",
+		Check: checkZC1614,
+	})
+}
+
+func checkZC1614(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "expect" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		low := strings.ToLower(arg.String())
+		if strings.Contains(low, "password") || strings.Contains(low, "passphrase") {
+			return []Violation{{
+				KataID: "ZC1614",
+				Message: "`expect` script contains `password` / `passphrase` — the full " +
+					"argv lands in `ps` and audit logs. Switch to key-based auth, or " +
+					"read the credential from a protected file the expect script opens.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 610 Katas = 0.6.10
-const Version = "0.6.10"
+// 611 Katas = 0.6.11
+const Version = "0.6.11"


### PR DESCRIPTION
ZC1614 — Error on `expect` script containing `password` / `passphrase`

What: flags any `expect` invocation whose argument list contains the substring `password` or `passphrase`.
Why: `expect -c '...'` puts the full scripted dialog on the command line. The credential lands in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs — readable by any local user who can list processes.
Fix suggestion: use key-based authentication (SSH keys, GSSAPI) where possible. If credential feeding is genuinely unavoidable, keep the secret in a protected file the expect script reads, not in the argv.
Severity: Error