### PR TITLE
feat: ZC1615 — prefer Zsh `$EPOCHREALTIME` over `date "+%s.%N"`

### DIFF
--- a/pkg/katas/katatests/zc1615_test.go
+++ b/pkg/katas/katatests/zc1615_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1615(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — plain date",
+			input:    `date "+%Y-%m-%d"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — date +%s only (ZC1119 handles)",
+			input:    `date "+%s"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  `invalid — date "+%s.%N"`,
+			input: `date "+%s.%N"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1615",
+					Message: "`date \"+%s.%N\"` forks for sub-second time. Use Zsh `$EPOCHREALTIME` / `$epochtime` from `zmodload zsh/datetime`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — date "+%s%N"`,
+			input: `date "+%s%N"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1615",
+					Message: "`date \"+%s%N\"` forks for sub-second time. Use Zsh `$EPOCHREALTIME` / `$epochtime` from `zmodload zsh/datetime`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1615")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1615.go
+++ b/pkg/katas/zc1615.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1615",
+		Title:    "Style: use Zsh `$EPOCHREALTIME` / `$epochtime` instead of `date \"+%s.%N\"`",
+		Severity: SeverityStyle,
+		Description: "Zsh's `zsh/datetime` module exposes `$EPOCHREALTIME` (scalar with " +
+			"fractional seconds) and `$epochtime` (two-element array of seconds and " +
+			"nanoseconds). Both read straight from `clock_gettime(CLOCK_REALTIME)` without " +
+			"forking `date`. On a hot path the builtin is dramatically faster and avoids " +
+			"subshell process-startup overhead. Autoload the module once with `zmodload " +
+			"zsh/datetime`.",
+		Check: checkZC1615,
+	})
+}
+
+func checkZC1615(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "date" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if !strings.Contains(v, "%s") {
+			continue
+		}
+		if strings.Contains(v, "%N") {
+			return []Violation{{
+				KataID: "ZC1615",
+				Message: "`date " + v + "` forks for sub-second time. Use Zsh " +
+					"`$EPOCHREALTIME` / `$epochtime` from `zmodload zsh/datetime`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 611 Katas = 0.6.11
-const Version = "0.6.11"
+// 612 Katas = 0.6.12
+const Version = "0.6.12"


### PR DESCRIPTION
ZC1615 — Style: use Zsh `$EPOCHREALTIME` / `$epochtime` instead of `date "+%s.%N"`

What: flags `date ...` invocations whose format string contains both `%s` (epoch seconds) and `%N` (nanoseconds).
Why: Zsh's `zsh/datetime` module exposes `$EPOCHREALTIME` (scalar with fractional seconds) and `$epochtime` (two-element array). Both come from `clock_gettime(CLOCK_REALTIME)` without forking `date` — on a hot path, dramatically faster.
Fix suggestion: `zmodload zsh/datetime` once, then use `$EPOCHREALTIME` for the fractional epoch or `$epochtime[1]`/`$epochtime[2]` for seconds and nanoseconds.
Severity: Style