### PR TITLE
feat: ZC1616 — flag `fsfreeze -f` without guaranteed unfreeze

### DIFF
--- a/pkg/katas/katatests/zc1616_test.go
+++ b/pkg/katas/katatests/zc1616_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1616(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — fsfreeze -u (unfreeze)",
+			input:    `fsfreeze -u /mnt/backup`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — different command",
+			input:    `mount /mnt/backup`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — fsfreeze -f /mnt/backup",
+			input: `fsfreeze -f /mnt/backup`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1616",
+					Message: "`fsfreeze -f` freezes the mountpoint — every write hangs until `fsfreeze -u` runs. Wrap the call in `trap 'fsfreeze -u PATH' EXIT` so the thaw fires even on failure.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — fsfreeze -f $ROOTFS",
+			input: `fsfreeze -f $ROOTFS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1616",
+					Message: "`fsfreeze -f` freezes the mountpoint — every write hangs until `fsfreeze -u` runs. Wrap the call in `trap 'fsfreeze -u PATH' EXIT` so the thaw fires even on failure.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1616")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1616.go
+++ b/pkg/katas/zc1616.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1616",
+		Title:    "Warn on `fsfreeze -f MOUNTPOINT` — filesystem stays frozen until `-u` runs",
+		Severity: SeverityWarning,
+		Description: "`fsfreeze -f` blocks every write on the mountpoint until `fsfreeze -u` " +
+			"thaws it. The intended use is a short window around a hypervisor or LVM snapshot. " +
+			"If the script errors between the freeze and the unfreeze (or is killed), the " +
+			"filesystem stays frozen — every subsequent write hangs forever until the admin " +
+			"manually thaws it, and a reboot may be the only way out on the root fs. Pair " +
+			"every freeze with `trap 'fsfreeze -u MOUNTPOINT' EXIT` and keep the window under " +
+			"a few seconds.",
+		Check: checkZC1616,
+	})
+}
+
+func checkZC1616(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "fsfreeze" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-f" {
+			return []Violation{{
+				KataID: "ZC1616",
+				Message: "`fsfreeze -f` freezes the mountpoint — every write hangs until " +
+					"`fsfreeze -u` runs. Wrap the call in `trap 'fsfreeze -u PATH' EXIT` " +
+					"so the thaw fires even on failure.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 612 Katas = 0.6.12
-const Version = "0.6.12"
+// 613 Katas = 0.6.13
+const Version = "0.6.13"


### PR DESCRIPTION
ZC1616 — Warn on `fsfreeze -f MOUNTPOINT` — filesystem stays frozen until `-u` runs

What: flags every `fsfreeze -f` invocation.
Why: `-f` blocks every write on the mountpoint until `fsfreeze -u` thaws it. The intended use is a short window around a hypervisor or LVM snapshot, but if the script errors between the freeze and the unfreeze the filesystem stays frozen forever. On the root fs, a reboot is often the only way out.
Fix suggestion: pair every freeze with `trap 'fsfreeze -u MOUNTPOINT' EXIT` so the thaw fires even on failure, and keep the frozen window under a few seconds.
Severity: Warning