### PR TITLE
feat: ZC1617 — flag `xargs -P 0` unbounded parallelism risk

### DIFF
--- a/pkg/katas/katatests/zc1617_test.go
+++ b/pkg/katas/katatests/zc1617_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1617(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — xargs -P 4",
+			input:    `xargs -P 4 -n 1 echo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — xargs without -P",
+			input:    `xargs -n 10 echo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — xargs -P 0",
+			input: `xargs -P 0 -n 1 echo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1617",
+					Message: "`xargs -P 0` spawns one child per input line — CPU / FD / memory exhaustion risk. Use `-P $(nproc)` or an explicit cap.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — xargs -P0 (joined)",
+			input: `xargs -P0 -n1 echo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1617",
+					Message: "`xargs -P 0` spawns one child per input line — CPU / FD / memory exhaustion risk. Use `-P $(nproc)` or an explicit cap.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1617")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1617.go
+++ b/pkg/katas/zc1617.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1617",
+		Title:    "Warn on `xargs -P 0` — unbounded parallelism risks CPU / fd / memory exhaustion",
+		Severity: SeverityWarning,
+		Description: "`xargs -P 0` tells xargs to spawn as many concurrent children as input " +
+			"lines. On any non-trivial input that number can blow past `RLIMIT_NPROC`, " +
+			"saturate the downstream tool's file-descriptor limit, or drive the host OOM. " +
+			"Pick an explicit cap — `xargs -P $(nproc)` for CPU-bound work, `-P 4..8` for " +
+			"I/O-bound — so the failure mode is bounded and predictable.",
+		Check: checkZC1617,
+	})
+}
+
+func checkZC1617(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "xargs" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-P0" {
+			return zc1617Hit(cmd)
+		}
+		if v == "-P" && i+1 < len(cmd.Arguments) && cmd.Arguments[i+1].String() == "0" {
+			return zc1617Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1617Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1617",
+		Message: "`xargs -P 0` spawns one child per input line — CPU / FD / memory " +
+			"exhaustion risk. Use `-P $(nproc)` or an explicit cap.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 613 Katas = 0.6.13
-const Version = "0.6.13"
+// 614 Katas = 0.6.14
+const Version = "0.6.14"


### PR DESCRIPTION
ZC1617 — Warn on `xargs -P 0` — unbounded parallelism risks CPU / fd / memory exhaustion

What: flags `xargs -P 0` and `xargs -P0`.
Why: `-P 0` tells xargs to spawn as many concurrent children as input lines. On any non-trivial input the count blows past `RLIMIT_NPROC`, saturates the downstream tool's fd limit, or drives the host OOM.
Fix suggestion: pick an explicit cap — `xargs -P $(nproc)` for CPU-bound work, `-P 4..8` for I/O-bound — so the failure mode is predictable.
Severity: Warning