### PR TITLE
feat: ZC1618 — flag `git commit/push --no-verify` hook bypass

### DIFF
--- a/pkg/katas/katatests/zc1618_test.go
+++ b/pkg/katas/katatests/zc1618_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1618(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — git commit -m (no skip)",
+			input:    `git commit -m "msg"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — git push --dry-run",
+			input:    `git push --dry-run origin main`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  `invalid — git commit --no-verify`,
+			input: `git commit --no-verify -m "msg"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1618",
+					Message: "`git commit --no-verify` skips pre-commit / commit-msg hooks — lint, test, and secret-scan checks do not run. Reserve for emergencies; scripts should pass the hooks.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — git push --no-verify`,
+			input: `git push --no-verify origin main`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1618",
+					Message: "`git push --no-verify` skips pre-push / commit-msg hooks — lint, test, and secret-scan checks do not run. Reserve for emergencies; scripts should pass the hooks.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — git commit -n -m`,
+			input: `git commit -n -m "msg"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1618",
+					Message: "`git commit -n` skips pre-commit / commit-msg hooks — lint, test, and secret-scan checks do not run. Reserve for emergencies; scripts should pass the hooks.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1618")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1618.go
+++ b/pkg/katas/zc1618.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1618",
+		Title:    "Warn on `git commit --no-verify` / `git push --no-verify` — bypasses hooks",
+		Severity: SeverityWarning,
+		Description: "`--no-verify` skips pre-commit, commit-msg, and pre-push hooks. Those " +
+			"hooks are where projects run linting, type-checking, unit tests, and secret " +
+			"scanning before code lands. A commit or push with `--no-verify` ships code the " +
+			"project's own automation would have rejected. Reserve the flag for emergencies " +
+			"with a follow-up commit that passes the hooks; scripts should not use it " +
+			"routinely.",
+		Check: checkZC1618,
+	})
+}
+
+func checkZC1618(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "git" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	if sub != "commit" && sub != "push" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--no-verify" || (sub == "commit" && v == "-n") {
+			return []Violation{{
+				KataID: "ZC1618",
+				Message: "`git " + sub + " " + v + "` skips pre-" + sub + " / commit-msg " +
+					"hooks — lint, test, and secret-scan checks do not run. Reserve for " +
+					"emergencies; scripts should pass the hooks.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 614 Katas = 0.6.14
-const Version = "0.6.14"
+// 615 Katas = 0.6.15
+const Version = "0.6.15"


### PR DESCRIPTION
ZC1618 — Warn on `git commit --no-verify` / `git push --no-verify` — bypasses hooks

What: flags `git commit --no-verify`, `git push --no-verify`, and `git commit -n` (the alias).
Why: `--no-verify` skips pre-commit, commit-msg, and pre-push hooks. Those are where projects run linting, type-checking, unit tests, and secret scanning. Skipping them ships code the project's own automation would have rejected.
Fix suggestion: reserve the flag for emergencies and follow up with a commit that passes the hooks. Scripts should never need `--no-verify`.
Severity: Warning