### PR TITLE
feat: ZC1619 — flag `mount -t nfs/cifs/smb/sshfs` missing `nosuid,nodev`

### DIFF
--- a/pkg/katas/katatests/zc1619_test.go
+++ b/pkg/katas/katatests/zc1619_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1619(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — nfs with nosuid,nodev",
+			input:    `mount -t nfs -o rw,nosuid,nodev host:/export /mnt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — local ext4",
+			input:    `mount -t ext4 /dev/nvme0n1p1 /data`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — nfs without nosuid/nodev",
+			input: `mount -t nfs -o rw host:/export /mnt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1619",
+					Message: "`mount -t nfs` without nosuid,nodev — a hostile server can plant setuid binaries or device nodes that the client kernel honors. Add `nosuid,nodev` to the `-o` options.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — cifs with only nosuid",
+			input: `mount -t cifs -o username=foo,nosuid //host/share /mnt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1619",
+					Message: "`mount -t cifs` without nodev — a hostile server can plant setuid binaries or device nodes that the client kernel honors. Add `nosuid,nodev` to the `-o` options.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1619")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1619.go
+++ b/pkg/katas/zc1619.go
@@ -1,0 +1,79 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1619NetworkFS = map[string]bool{
+	"nfs": true, "nfs4": true,
+	"cifs": true, "smbfs": true, "smb3": true,
+	"sshfs": true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1619",
+		Title:    "Warn on `mount -t nfs/cifs/smb/sshfs` missing `nosuid` or `nodev`",
+		Severity: SeverityWarning,
+		Description: "Network filesystems present files whose mode bits are controlled by a " +
+			"remote server. Without `nosuid` in the mount options, a compromised or hostile " +
+			"server can plant a setuid-root binary on the share; the client kernel honors the " +
+			"suid bit and the binary runs as root on the mounting host. Without `nodev`, the " +
+			"server can plant device nodes the kernel treats as real. Always mount network " +
+			"shares with `nosuid,nodev`; add `noexec` unless the export is intended to hold " +
+			"executables.",
+		Check: checkZC1619,
+	})
+}
+
+func checkZC1619(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "mount" {
+		return nil
+	}
+
+	var fsType, opts string
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-t" && i+1 < len(cmd.Arguments) {
+			fsType = cmd.Arguments[i+1].String()
+		}
+		if v == "-o" && i+1 < len(cmd.Arguments) {
+			opts = cmd.Arguments[i+1].String()
+		}
+	}
+
+	if !zc1619NetworkFS[fsType] {
+		return nil
+	}
+	if strings.Contains(opts, "nosuid") && strings.Contains(opts, "nodev") {
+		return nil
+	}
+
+	missing := []string{}
+	if !strings.Contains(opts, "nosuid") {
+		missing = append(missing, "nosuid")
+	}
+	if !strings.Contains(opts, "nodev") {
+		missing = append(missing, "nodev")
+	}
+	return []Violation{{
+		KataID: "ZC1619",
+		Message: "`mount -t " + fsType + "` without " + strings.Join(missing, ",") +
+			" — a hostile server can plant setuid binaries or device nodes that the " +
+			"client kernel honors. Add `nosuid,nodev` to the `-o` options.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 615 Katas = 0.6.15
-const Version = "0.6.15"
+// 616 Katas = 0.6.16
+const Version = "0.6.16"


### PR DESCRIPTION
ZC1619 — Warn on `mount -t nfs/cifs/smb/sshfs` missing `nosuid` or `nodev`

What: flags `mount -t {nfs,nfs4,cifs,smbfs,smb3,sshfs}` where the `-o` options don't include both `nosuid` and `nodev`.
Why: network filesystems present files whose mode bits come from a remote server. Without `nosuid`, a hostile server plants a setuid-root binary that the client honors. Without `nodev`, the server plants device nodes the kernel trusts.
Fix suggestion: always mount network shares with `nosuid,nodev` in `-o`. Add `noexec` unless the export is meant to hold executables.
Severity: Warning