### PR TITLE
feat: ZC1620 — flag `tee /etc/sudoers` bypassing `visudo -cf` validation

### DIFF
--- a/pkg/katas/katatests/zc1620_test.go
+++ b/pkg/katas/katatests/zc1620_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1620(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — tee on log file",
+			input:    `tee -a /var/log/app.log`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — tee to tmp staging",
+			input:    `tee /tmp/sudoers.new`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — tee /etc/sudoers",
+			input: `tee /etc/sudoers`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1620",
+					Message: "`tee /etc/sudoers` writes without syntax validation — a typo locks everyone out of sudo. Pipe through `visudo -cf /dev/stdin` or stage in a temp file and `visudo -cf` before `mv`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — tee -a /etc/sudoers.d/custom",
+			input: `tee -a /etc/sudoers.d/custom`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1620",
+					Message: "`tee /etc/sudoers.d/custom` writes without syntax validation — a typo locks everyone out of sudo. Pipe through `visudo -cf /dev/stdin` or stage in a temp file and `visudo -cf` before `mv`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1620")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1620.go
+++ b/pkg/katas/zc1620.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1620",
+		Title:    "Error on `tee /etc/sudoers` / `/etc/sudoers.d/*` — writes without `visudo -cf`",
+		Severity: SeverityError,
+		Description: "`tee` copies stdin to the file with no syntax check. A typo in a sudoers " +
+			"rule — a stray comma, a missing `ALL`, an unclosed alias — leaves the file " +
+			"unparseable. The next sudo call refuses to load it and on most systems nobody " +
+			"can become root until someone boots from rescue media. Pipe the content through " +
+			"`visudo -cf /dev/stdin` first, or write to a temp file, validate with " +
+			"`visudo -cf`, then atomically `mv` into `/etc/sudoers.d/`.",
+		Check: checkZC1620,
+	})
+}
+
+func checkZC1620(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "tee" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "/etc/sudoers" || strings.HasPrefix(v, "/etc/sudoers.d/") {
+			return []Violation{{
+				KataID: "ZC1620",
+				Message: "`tee " + v + "` writes without syntax validation — a typo locks " +
+					"everyone out of sudo. Pipe through `visudo -cf /dev/stdin` or stage " +
+					"in a temp file and `visudo -cf` before `mv`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 616 Katas = 0.6.16
-const Version = "0.6.16"
+// 617 Katas = 0.6.17
+const Version = "0.6.17"


### PR DESCRIPTION
ZC1620 — Error on `tee /etc/sudoers` / `/etc/sudoers.d/*` — writes without `visudo -cf`

What: flags `tee` invocations whose output path is `/etc/sudoers` or anything under `/etc/sudoers.d/`.
Why: `tee` writes stdin verbatim. A typo in a sudoers rule (stray comma, missing `ALL`, unclosed alias) leaves the file unparseable. The next sudo refuses to load it; on most systems that means nobody can become root until someone boots from rescue.
Fix suggestion: pipe through `visudo -cf /dev/stdin` first, or stage in a temp file, validate with `visudo -cf`, then atomically `mv` into `/etc/sudoers.d/`.
Severity: Error