### PR TITLE
feat: ZC1621 — flag `tmux -S /tmp/SOCKET` shared socket hijack risk

### DIFF
--- a/pkg/katas/katatests/zc1621_test.go
+++ b/pkg/katas/katatests/zc1621_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1621(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — default tmux",
+			input:    `tmux new-session -d`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — tmux -S in XDG_RUNTIME_DIR",
+			input:    `tmux -S $XDG_RUNTIME_DIR/tmux-main new-session`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — tmux -S /tmp/shared",
+			input: `tmux -S /tmp/shared new-session`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1621",
+					Message: "`tmux -S /tmp/shared` places the socket in a world-traversable directory — any local user who can read the socket can attach the session. Use `$XDG_RUNTIME_DIR` or a 0700-scoped parent dir.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — tmux -S /var/tmp/pair",
+			input: `tmux -S /var/tmp/pair attach`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1621",
+					Message: "`tmux -S /var/tmp/pair` places the socket in a world-traversable directory — any local user who can read the socket can attach the session. Use `$XDG_RUNTIME_DIR` or a 0700-scoped parent dir.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1621")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1621.go
+++ b/pkg/katas/zc1621.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1621",
+		Title:    "Warn on `tmux -S /tmp/SOCKET` — shared-path socket invites session hijack",
+		Severity: SeverityWarning,
+		Description: "`tmux -S PATH` overrides the default socket location (normally under " +
+			"`$XDG_RUNTIME_DIR/tmux-$UID/`, a 0700-mode directory). Paths under `/tmp/` or " +
+			"`/var/tmp/` are world-traversable; if the socket is created with loose " +
+			"permissions, any local user who can read it can `tmux -S /tmp/PATH attach` and " +
+			"see / drive the session — keystrokes, output, arbitrary commands in the attached " +
+			"pane. Keep the socket in `$XDG_RUNTIME_DIR` or another 0700-scoped directory.",
+		Check: checkZC1621,
+	})
+}
+
+func checkZC1621(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "tmux" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		if arg.String() != "-S" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			continue
+		}
+		path := cmd.Arguments[i+1].String()
+		if strings.HasPrefix(path, "/tmp/") || strings.HasPrefix(path, "/var/tmp/") {
+			return []Violation{{
+				KataID: "ZC1621",
+				Message: "`tmux -S " + path + "` places the socket in a world-traversable " +
+					"directory — any local user who can read the socket can attach the " +
+					"session. Use `$XDG_RUNTIME_DIR` or a 0700-scoped parent dir.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 617 Katas = 0.6.17
-const Version = "0.6.17"
+// 618 Katas = 0.6.18
+const Version = "0.6.18"


### PR DESCRIPTION
ZC1621 — Warn on `tmux -S /tmp/SOCKET` — shared-path socket invites session hijack

What: flags `tmux -S PATH` where `PATH` starts with `/tmp/` or `/var/tmp/`.
Why: `-S PATH` overrides the default 0700 `$XDG_RUNTIME_DIR/tmux-$UID/` location. `/tmp/` and `/var/tmp/` are world-traversable; if the socket is created with loose perms any local user who can read it can `tmux -S PATH attach` and see or drive the session — keystrokes, output, arbitrary commands in the attached pane.
Fix suggestion: keep the socket in `$XDG_RUNTIME_DIR` or another 0700-scoped parent dir.
Severity: Warning