### PR TITLE
feat: ZC1622 — prefer Zsh `${(X)var}` flags over Bash `${var@U/L/Q}` operators

### DIFF
--- a/pkg/katas/katatests/zc1622_test.go
+++ b/pkg/katas/katatests/zc1622_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1622(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — Zsh flag form",
+			input:    `echo "${(U)var}"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — plain expansion",
+			input:    `print -r -- "${var}"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  `invalid — echo "${var@U}"`,
+			input: `echo "${var@U}"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1622",
+					Message: "`${var@U}` — prefer Zsh `${(X)var}` parameter-expansion flags (e.g. `${(U)var}` for uppercase).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — print "${path@Q}"`,
+			input: `print -r -- "${path@Q}"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1622",
+					Message: "`${var@Q}` — prefer Zsh `${(X)var}` parameter-expansion flags (e.g. `${(U)var}` for uppercase).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1622")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1622.go
+++ b/pkg/katas/zc1622.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1622BashOps = []string{"@U}", "@L}", "@Q}", "@E}", "@A}", "@K}", "@a}"}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1622",
+		Title:    "Style: `${var@U/L/Q/...}` — prefer Zsh `${(U)var}` / `${(L)var}` / `${(Q)var}` flags",
+		Severity: SeverityStyle,
+		Description: "The `@<op>` suffix came from Bash 5. Zsh 5.9+ compiles in compatibility " +
+			"for the common ones, but the idiomatic Zsh form is the `(X)var` parameter-" +
+			"expansion flag — `${(U)var}` uppercase, `${(L)var}` lowercase, `${(Q)var}` " +
+			"unquote, `${(k)var}` keys, `${(t)var}` type, `${(e)var}` re-evaluate. The flag " +
+			"form composes (`${(Uf)str}` works) and reads consistently across the Zsh " +
+			"documentation. Prefer the native flag over the Bash-compat form.",
+		Check: checkZC1622,
+	})
+}
+
+func checkZC1622(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if !strings.Contains(v, "${") {
+			continue
+		}
+		for _, op := range zc1622BashOps {
+			if strings.Contains(v, op) {
+				return []Violation{{
+					KataID: "ZC1622",
+					Message: "`${var" + strings.TrimSuffix(op, "}") + "}` — prefer Zsh " +
+						"`${(X)var}` parameter-expansion flags (e.g. `${(U)var}` for " +
+						"uppercase).",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityStyle,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 618 Katas = 0.6.18
-const Version = "0.6.18"
+// 619 Katas = 0.6.19
+const Version = "0.6.19"


### PR DESCRIPTION
ZC1622 — Style: `${var@U/L/Q/...}` — prefer Zsh `${(U)var}` / `${(L)var}` / `${(Q)var}` flags

What: flags arguments whose `${...}` contains the Bash 5 operator suffix `@U`, `@L`, `@Q`, `@E`, `@A`, `@K`, or `@a`.
Why: Zsh 5.9+ has compatibility for most of these, but the idiomatic Zsh form is the `(X)var` flag — `${(U)var}` uppercase, `${(L)var}` lowercase, `${(Q)var}` unquote, `${(k)var}` keys, `${(t)var}` type, `${(e)var}` re-evaluate. The flag form composes (`${(Uf)str}` works) and reads consistently across Zsh docs.
Fix suggestion: replace `${var@U}` with `${(U)var}` and so on.
Severity: Style