### PR TITLE
feat: ZC1623 — flag `kill -STOP PID` without guaranteed `-CONT`

### DIFF
--- a/pkg/katas/katatests/zc1623_test.go
+++ b/pkg/katas/katatests/zc1623_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1623(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — kill -TERM",
+			input:    `kill -TERM $PID`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — kill -CONT (resume)",
+			input:    `kill -CONT $PID`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — kill -STOP $PID",
+			input: `kill -STOP $PID`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1623",
+					Message: "`kill -STOP` halts the target until SIGCONT arrives. Pair every STOP with `trap \"kill -CONT PID\" EXIT` so the resume fires even on failure.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — kill -s STOP $PID",
+			input: `kill -s STOP $PID`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1623",
+					Message: "`kill -STOP` halts the target until SIGCONT arrives. Pair every STOP with `trap \"kill -CONT PID\" EXIT` so the resume fires even on failure.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — pkill -19",
+			input: `pkill -19 slowproc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1623",
+					Message: "`kill -STOP` halts the target until SIGCONT arrives. Pair every STOP with `trap \"kill -CONT PID\" EXIT` so the resume fires even on failure.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1623")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1623.go
+++ b/pkg/katas/zc1623.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1623",
+		Title:    "Warn on `kill -STOP PID` / `pkill -STOP` — target halts until `kill -CONT` runs",
+		Severity: SeverityWarning,
+		Description: "Sending SIGSTOP halts the target process until SIGCONT arrives. If the " +
+			"script fails, is killed, or exits before the resume, the target stays paused " +
+			"indefinitely — consuming memory, holding locks, blocking its dependents. Wrap " +
+			"every `kill -STOP $PID` with `trap \"kill -CONT $PID\" EXIT` (or an explicit " +
+			"cleanup path) so the resume fires even on failure. Prefer `kill -TSTP` if the " +
+			"target can handle it (the user-space tstop that the process can ignore).",
+		Check: checkZC1623,
+	})
+}
+
+func checkZC1623(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kill" && ident.Value != "pkill" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-STOP" || v == "-SIGSTOP" || v == "-19" {
+			return zc1623Hit(cmd)
+		}
+		if v == "-s" && i+1 < len(cmd.Arguments) {
+			sig := cmd.Arguments[i+1].String()
+			if sig == "STOP" || sig == "SIGSTOP" || sig == "19" {
+				return zc1623Hit(cmd)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1623Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1623",
+		Message: "`kill -STOP` halts the target until SIGCONT arrives. Pair every STOP " +
+			"with `trap \"kill -CONT PID\" EXIT` so the resume fires even on failure.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 619 Katas = 0.6.19
-const Version = "0.6.19"
+// 620 Katas = 0.6.20
+const Version = "0.6.20"


### PR DESCRIPTION
ZC1623 — Warn on `kill -STOP PID` / `pkill -STOP` — target halts until `kill -CONT` runs

What: flags `kill -STOP`, `kill -SIGSTOP`, `kill -19`, `kill -s STOP`, and the same forms on `pkill`.
Why: SIGSTOP halts the target process until SIGCONT arrives. If the script fails, is killed, or exits before the resume, the target stays paused indefinitely — consuming memory, holding locks, blocking its dependents.
Fix suggestion: pair every STOP with `trap "kill -CONT $PID" EXIT` so the resume fires even on failure. Consider `kill -TSTP` when the target handles tstop signals.
Severity: Warning