### PR TITLE
feat: ZC1624 — flag `az login -p` / `--password` credential in process list

### DIFF
--- a/pkg/katas/katatests/zc1624_test.go
+++ b/pkg/katas/katatests/zc1624_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1624(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — az login (interactive)",
+			input:    `az login`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — az login --service-principal with federated token",
+			input:    `az login --service-principal -u appid -t tenantid`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — az login -p $SECRET",
+			input: `az login --service-principal -u appid -p $SECRET`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1624",
+					Message: "`az login -p` puts the SP password in argv — visible in `ps` / `/proc/<pid>/cmdline`. Use federated-token OIDC, managed identity, or `AZURE_PASSWORD` via a protected env var.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — az login --password literal",
+			input: `az login --password hunter2 -u user`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1624",
+					Message: "`az login --password` puts the SP password in argv — visible in `ps` / `/proc/<pid>/cmdline`. Use federated-token OIDC, managed identity, or `AZURE_PASSWORD` via a protected env var.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1624")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1624.go
+++ b/pkg/katas/zc1624.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1624",
+		Title:    "Error on `az login -p` / `--password` — service-principal secret in process list",
+		Severity: SeverityError,
+		Description: "`az login -p SECRET` passes the service-principal password as an argv " +
+			"element. The expanded value shows up in `ps`, `/proc/<pid>/cmdline`, shell " +
+			"history, and audit logs — readable by any local user who can list processes. " +
+			"Prefer federated-token OIDC (`--federated-token`), managed identity on the host, " +
+			"or interactive device-code flow. If a password is unavoidable, export it as " +
+			"`AZURE_PASSWORD` via a protected env var and call plain `az login --service-" +
+			"principal` (which reads from env).",
+		Check: checkZC1624,
+	})
+}
+
+func checkZC1624(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "az" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "login" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "-p" || v == "--password" {
+			return []Violation{{
+				KataID: "ZC1624",
+				Message: "`az login " + v + "` puts the SP password in argv — visible in " +
+					"`ps` / `/proc/<pid>/cmdline`. Use federated-token OIDC, managed " +
+					"identity, or `AZURE_PASSWORD` via a protected env var.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 620 Katas = 0.6.20
-const Version = "0.6.20"
+// 621 Katas = 0.6.21
+const Version = "0.6.21"


### PR DESCRIPTION
ZC1624 — Error on `az login -p` / `--password` — service-principal secret in process list

What: flags `az login -p SECRET` and `az login --password SECRET`.
Why: the password passes as an argv element. The expanded value lands in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs — readable by any local user who can list processes.
Fix suggestion: use federated-token OIDC (`--federated-token`), managed identity on the host, or interactive device-code flow. If a password must be used, set `AZURE_PASSWORD` via a protected env var and call plain `az login --service-principal`.
Severity: Error