### PR TITLE
feat: ZC1625 — flag `rm --no-preserve-root` safeguard bypass

### DIFF
--- a/pkg/katas/katatests/zc1625_test.go
+++ b/pkg/katas/katatests/zc1625_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1625(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — rm -rf scoped path",
+			input:    `rm -rf /tmp/staging`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — rm with --preserve-root=all",
+			input:    `rm -rf --preserve-root=all $TARGET`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — rm -rf --no-preserve-root /",
+			input: `rm -rf --no-preserve-root /`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1625",
+					Message: "`rm --no-preserve-root` disables the GNU safeguard against `rm -rf /`. Remove the flag; if a specific path needs deletion, list it explicitly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — rm -rf --no-preserve-root $TARGET",
+			input: `rm -rf --no-preserve-root $TARGET`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1625",
+					Message: "`rm --no-preserve-root` disables the GNU safeguard against `rm -rf /`. Remove the flag; if a specific path needs deletion, list it explicitly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1625")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1625.go
+++ b/pkg/katas/zc1625.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1625",
+		Title:    "Error on `rm --no-preserve-root` — disables GNU rm safeguard against `rm -rf /`",
+		Severity: SeverityError,
+		Description: "GNU `rm` refuses to remove `/` by default — the `--preserve-root` " +
+			"safeguard added in coreutils 8.4. `--no-preserve-root` explicitly disables that " +
+			"check so `rm -rf /` actually recurses and wipes the filesystem. Scripts that pass " +
+			"the flag are asking `rm` to go ahead if the argument happens to evaluate to `/`. " +
+			"Remove the flag; if a specific path genuinely needs deletion, list it explicitly " +
+			"and leave the safeguard in place.",
+		Check: checkZC1625,
+	})
+}
+
+func checkZC1625(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "rm" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "--no-preserve-root" {
+			return []Violation{{
+				KataID: "ZC1625",
+				Message: "`rm --no-preserve-root` disables the GNU safeguard against `rm -rf " +
+					"/`. Remove the flag; if a specific path needs deletion, list it " +
+					"explicitly.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 621 Katas = 0.6.21
-const Version = "0.6.21"
+// 622 Katas = 0.6.22
+const Version = "0.6.22"


### PR DESCRIPTION
ZC1625 — Error on `rm --no-preserve-root` — disables GNU rm safeguard against `rm -rf /`

What: flags `rm ... --no-preserve-root ...`.
Why: GNU `rm` refuses to remove `/` by default (the `--preserve-root` safeguard since coreutils 8.4). `--no-preserve-root` explicitly disables that check, so `rm -rf /` actually recurses and wipes the filesystem.
Fix suggestion: drop the flag. If a specific path needs deletion, list it explicitly and leave the safeguard in place.
Severity: Error