### PR TITLE
feat: ZC1626 — flag `helm --set` secret key exposing value in process list

### DIFF
--- a/pkg/katas/katatests/zc1626_test.go
+++ b/pkg/katas/katatests/zc1626_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1626(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — --set non-secret",
+			input:    `helm install myapp chart --set replicas=3`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — -f values.yaml",
+			input:    `helm install myapp chart -f /secure/values.yaml`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — --set-file points at path",
+			input:    `helm install myapp chart --set-file db.password=/run/secrets/db`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — helm install --set password=...",
+			input: `helm install myapp chart --set password=s3cret`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1626",
+					Message: "`helm install --set password=s3cret` places a secret value in argv — readable via `ps`. Use `-f values.yaml` or `--set-file password=PATH`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — helm upgrade --set-string token=$TOKEN",
+			input: `helm upgrade myapp chart --set-string token=$TOKEN`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1626",
+					Message: "`helm upgrade --set-string token=$TOKEN` places a secret value in argv — readable via `ps`. Use `-f values.yaml` or `--set-file token=PATH`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1626")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1626.go
+++ b/pkg/katas/zc1626.go
@@ -1,0 +1,82 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1626SecretKeys = []string{
+	"password", "passwd", "secret", "token",
+	"apikey", "api_key", "api-key",
+	"accesskey", "access_key", "access-key",
+	"privatekey", "private_key", "private-key",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1626",
+		Title:    "Error on `helm install/upgrade --set KEY=VALUE` with secret-shaped key",
+		Severity: SeverityError,
+		Description: "`--set` and `--set-string` put the full `KEY=VALUE` pair on the helm " +
+			"command line. When the key name looks like a secret (`password`, `secret`, " +
+			"`token`, `apikey`, `access_key`, `private_key`), the expanded VALUE appears in " +
+			"`ps`, `/proc/<pid>/cmdline`, shell history, and audit logs — readable by any " +
+			"local user who can list processes. Put secrets in a protected values file " +
+			"(`helm install -f /secure/values.yaml`), or use `--set-file KEY=PATH` so helm " +
+			"reads the content from PATH at apply time.",
+		Check: checkZC1626,
+	})
+}
+
+func checkZC1626(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "helm" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	if sub != "install" && sub != "upgrade" && sub != "template" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v != "--set" && v != "--set-string" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			continue
+		}
+		pair := cmd.Arguments[i+1].String()
+		eq := strings.Index(pair, "=")
+		if eq < 0 {
+			continue
+		}
+		key := strings.ToLower(pair[:eq])
+		for _, s := range zc1626SecretKeys {
+			if strings.Contains(key, s) {
+				return []Violation{{
+					KataID: "ZC1626",
+					Message: "`helm " + sub + " " + v + " " + pair + "` places a secret " +
+						"value in argv — readable via `ps`. Use `-f values.yaml` or " +
+						"`--set-file " + key + "=PATH`.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityError,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 622 Katas = 0.6.22
-const Version = "0.6.22"
+// 623 Katas = 0.6.23
+const Version = "0.6.23"


### PR DESCRIPTION
ZC1626 — Error on `helm install/upgrade --set KEY=VALUE` with secret-shaped key

What: flags `helm install|upgrade|template --set KEY=VALUE` or `--set-string KEY=VALUE` where KEY contains one of `password`, `passwd`, `secret`, `token`, `apikey`, `api_key`, `access_key`, `private_key` (dotted names like `db.password` also matched).
Why: `--set` puts the full `KEY=VALUE` pair on the command line. The expanded secret value ends up in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs.
Fix suggestion: pass secrets via a protected values file (`helm install -f /secure/values.yaml`) or `--set-file KEY=PATH` so helm reads the value from PATH at apply time.
Severity: Error