### PR TITLE
feat: ZC1627 — flag `crontab /tmp/FILE` TOCTOU cron injection

### DIFF
--- a/pkg/katas/katatests/zc1627_test.go
+++ b/pkg/katas/katatests/zc1627_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1627(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — crontab from /etc",
+			input:    `crontab /etc/cron.install.conf`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — crontab $HOME path",
+			input:    `crontab $HOME/.crontab`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — crontab /tmp/newcron",
+			input: `crontab /tmp/newcron`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1627",
+					Message: "`crontab /tmp/newcron` reads cron rules from a world-traversable path — a concurrent local user can substitute the file between write and read. Stage the file in `$XDG_RUNTIME_DIR/` or `mktemp -d`, or pipe via `crontab -`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — crontab -u bob /tmp/evil",
+			input: `crontab -u bob /tmp/evil`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1627",
+					Message: "`crontab /tmp/evil` reads cron rules from a world-traversable path — a concurrent local user can substitute the file between write and read. Stage the file in `$XDG_RUNTIME_DIR/` or `mktemp -d`, or pipe via `crontab -`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1627")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1627.go
+++ b/pkg/katas/zc1627.go
@@ -1,0 +1,66 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1627",
+		Title:    "Warn on `crontab /tmp/FILE` — attacker-writable path installed as a user's cron",
+		Severity: SeverityWarning,
+		Description: "`crontab PATH` replaces the user's cron with whatever PATH currently " +
+			"contains. A path under `/tmp/` or `/var/tmp/` is world-traversable; a concurrent " +
+			"local user can replace the file between the moment the script writes it and the " +
+			"moment `crontab` reads it, substituting their own cron rules. Keep the staging " +
+			"file in a 0700-scoped directory (e.g. `$XDG_RUNTIME_DIR/` or `mktemp -d`), or " +
+			"pipe the content via `crontab -` after generating it in-memory.",
+		Check: checkZC1627,
+	})
+}
+
+func checkZC1627(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "crontab" {
+		return nil
+	}
+
+	var skipNext bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if v == "-u" || v == "-s" {
+			skipNext = true
+			continue
+		}
+		if strings.HasPrefix(v, "-") {
+			continue
+		}
+		if strings.HasPrefix(v, "/tmp/") || strings.HasPrefix(v, "/var/tmp/") {
+			return []Violation{{
+				KataID: "ZC1627",
+				Message: "`crontab " + v + "` reads cron rules from a world-traversable " +
+					"path — a concurrent local user can substitute the file between write " +
+					"and read. Stage the file in `$XDG_RUNTIME_DIR/` or `mktemp -d`, or " +
+					"pipe via `crontab -`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 623 Katas = 0.6.23
-const Version = "0.6.23"
+// 624 Katas = 0.6.24
+const Version = "0.6.24"


### PR DESCRIPTION
ZC1627 — Warn on `crontab /tmp/FILE` — attacker-writable path installed as a user's cron

What: flags `crontab PATH` (including `crontab -u USER PATH`) where PATH starts with `/tmp/` or `/var/tmp/`.
Why: `crontab` reads whatever PATH contains at the moment it opens the file. A concurrent local user can substitute the file between the script's write and crontab's read, injecting their own cron rules.
Fix suggestion: stage the file in a 0700-scoped dir (`$XDG_RUNTIME_DIR/` or `mktemp -d`), or pipe the content via `crontab -` so it's never on disk.
Severity: Warning