### PR TITLE
feat: ZC1628 — flag `insmod` / `modprobe -f` kernel-module bypass

### DIFF
--- a/pkg/katas/katatests/zc1628_test.go
+++ b/pkg/katas/katatests/zc1628_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1628(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — plain modprobe",
+			input:    `modprobe nvme`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — lsmod",
+			input:    `lsmod`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — insmod module.ko",
+			input: `insmod evilmod.ko`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1628",
+					Message: "`insmod` loads a kernel module bypassing depmod / blacklist — prefer `modprobe MODNAME` so system policy and signature checks apply.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — modprobe -f evilmod",
+			input: `modprobe -f evilmod`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1628",
+					Message: "`modprobe -f` ignores version-magic and kernel-mismatch checks — a mismatched module can crash or compromise the kernel. Drop the flag and fix the underlying version mismatch.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1628")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1628.go
+++ b/pkg/katas/zc1628.go
@@ -1,0 +1,62 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1628",
+		Title:    "Warn on `insmod` / `modprobe -f` — loads modules bypassing blacklist / signature checks",
+		Severity: SeverityWarning,
+		Description: "`insmod PATH.ko` loads a kernel module from a file, skipping the depmod-" +
+			"built dependency graph and the `/etc/modprobe.d/*.conf` blacklist. `modprobe " +
+			"-f` instructs modprobe to ignore version-magic and kernel-mismatch checks. " +
+			"Either path lets a module enter the kernel that the administrator explicitly " +
+			"disabled, or one compiled against a different kernel — crash, privesc, or full " +
+			"kernel compromise. Use plain `modprobe MODNAME` so the system's policy and " +
+			"signature verification run.",
+		Check: checkZC1628,
+	})
+}
+
+func checkZC1628(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value == "insmod" {
+		if len(cmd.Arguments) == 0 {
+			return nil
+		}
+		return []Violation{{
+			KataID: "ZC1628",
+			Message: "`insmod` loads a kernel module bypassing depmod / blacklist — prefer " +
+				"`modprobe MODNAME` so system policy and signature checks apply.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	if ident.Value == "modprobe" {
+		for _, arg := range cmd.Arguments {
+			if arg.String() == "-f" {
+				return []Violation{{
+					KataID: "ZC1628",
+					Message: "`modprobe -f` ignores version-magic and kernel-mismatch " +
+						"checks — a mismatched module can crash or compromise the kernel. " +
+						"Drop the flag and fix the underlying version mismatch.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 624 Katas = 0.6.24
-const Version = "0.6.24"
+// 625 Katas = 0.6.25
+const Version = "0.6.25"


### PR DESCRIPTION
ZC1628 — Warn on `insmod` / `modprobe -f` — loads modules bypassing blacklist / signature checks

What: flags `insmod PATH.ko` (any invocation with an arg) and `modprobe -f`.
Why: `insmod` loads a module directly, skipping depmod and `/etc/modprobe.d/*.conf` blacklists. `modprobe -f` tells modprobe to ignore version-magic and kernel-mismatch checks. Either path lets a disabled or mismatched module into the kernel — crash, privilege escalation, or full compromise.
Fix suggestion: use plain `modprobe MODNAME` so system policy and signature verification run; fix any underlying version mismatch rather than masking it.
Severity: Warning