### PR TITLE
feat: ZC1629 — flag `rsync --rsync-path='sudo rsync'` hidden privilege escalation

### DIFF
--- a/pkg/katas/katatests/zc1629_test.go
+++ b/pkg/katas/katatests/zc1629_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1629(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — rsync with explicit path",
+			input:    `rsync -a --rsync-path=/usr/bin/rsync src host:dst`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — rsync with no path override",
+			input:    `rsync -a src host:dst`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  `invalid — rsync --rsync-path="sudo rsync"`,
+			input: `rsync -a --rsync-path="sudo rsync" src host:dst`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1629",
+					Message: "`rsync --rsync-path='sudo rsync'` runs remote rsync under privilege escalation. Use a scoped sudoers rule on the remote host and keep the path explicit (`/usr/bin/rsync`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — rsync --rsync-path="doas rsync"`,
+			input: `rsync -a --rsync-path="doas rsync" src host:dst`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1629",
+					Message: "`rsync --rsync-path='doas rsync'` runs remote rsync under privilege escalation. Use a scoped sudoers rule on the remote host and keep the path explicit (`/usr/bin/rsync`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1629")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1629.go
+++ b/pkg/katas/zc1629.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1629",
+		Title:    "Warn on `rsync --rsync-path='sudo rsync'` — hidden remote privilege escalation",
+		Severity: SeverityWarning,
+		Description: "`--rsync-path` normally overrides the path to the remote rsync binary. " +
+			"Setting it to `sudo rsync` (or `doas rsync` / `pkexec rsync`) instead makes the " +
+			"remote side run rsync as root. That is sometimes legitimate — copying into " +
+			"`/etc/` from a CI job — but the flag is easy to miss in review because it looks " +
+			"like a path override. Provision a scoped sudoers rule that names exactly which " +
+			"rsync invocation the remote user may run, and keep the path explicit (`--rsync-" +
+			"path=/usr/bin/rsync`).",
+		Check: checkZC1629,
+	})
+}
+
+func checkZC1629(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "rsync" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if !strings.HasPrefix(v, "--rsync-path=") {
+			continue
+		}
+		val := strings.TrimPrefix(v, "--rsync-path=")
+		val = strings.Trim(val, "\"'")
+		if strings.Contains(val, "sudo") ||
+			strings.Contains(val, "doas") ||
+			strings.Contains(val, "pkexec") {
+			return []Violation{{
+				KataID: "ZC1629",
+				Message: "`rsync --rsync-path='" + val + "'` runs remote rsync under " +
+					"privilege escalation. Use a scoped sudoers rule on the remote host " +
+					"and keep the path explicit (`/usr/bin/rsync`).",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 625 Katas = 0.6.25
-const Version = "0.6.25"
+// 626 Katas = 0.6.26
+const Version = "0.6.26"


### PR DESCRIPTION
ZC1629 — Warn on `rsync --rsync-path='sudo rsync'` — remote privilege escalation

What: flags `rsync --rsync-path=VALUE` where VALUE contains `sudo`, `doas`, or `pkexec`.
Why: `--rsync-path` is normally used to pick a non-default remote rsync binary. Setting it to `sudo rsync` makes the remote side run rsync as root — a privilege-escalation hidden inside what looks like a path override.
Fix suggestion: provision a scoped sudoers rule on the remote host that names the specific rsync invocation, and keep the path explicit (`--rsync-path=/usr/bin/rsync`).
Severity: Warning