### PR TITLE
feat: ZC1630 — flag `php -S 0.0.0.0:PORT` dev server on all interfaces

### DIFF
--- a/pkg/katas/katatests/zc1630_test.go
+++ b/pkg/katas/katatests/zc1630_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1630(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — localhost bind",
+			input:    `php -S 127.0.0.1:8000 -t public`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — php script (not -S)",
+			input:    `php artisan migrate`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — php -S 0.0.0.0:8000",
+			input: `php -S 0.0.0.0:8000`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1630",
+					Message: "`php -S 0.0.0.0:8000` binds the dev server to every interface — unauthenticated access to the working directory. Use `127.0.0.1:PORT` locally, nginx / caddy for external exposure.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — php -S [::]:8080",
+			input: `php -S [::]:8080 -t public`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1630",
+					Message: "`php -S [::]:8080` binds the dev server to every interface — unauthenticated access to the working directory. Use `127.0.0.1:PORT` locally, nginx / caddy for external exposure.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1630")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1630.go
+++ b/pkg/katas/zc1630.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1630",
+		Title:    "Warn on `php -S 0.0.0.0:PORT` — PHP dev server exposes CWD to all interfaces",
+		Severity: SeverityWarning,
+		Description: "`php -S 0.0.0.0:PORT` starts PHP's built-in dev server listening on every " +
+			"interface the host has. It serves files from the working directory (or the " +
+			"docroot named after the bind) with no auth, no TLS, and minimal access logging. " +
+			"The PHP docs explicitly say not to use it in production. Bind to `127.0.0.1:PORT` " +
+			"for local testing and put nginx / caddy in front for anything externally exposed.",
+		Check: checkZC1630,
+	})
+}
+
+func checkZC1630(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "php" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		if arg.String() != "-S" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			return nil
+		}
+		bind := cmd.Arguments[i+1].String()
+		if strings.HasPrefix(bind, "0.0.0.0:") ||
+			strings.HasPrefix(bind, "*:") ||
+			strings.HasPrefix(bind, "[::]:") {
+			return []Violation{{
+				KataID: "ZC1630",
+				Message: "`php -S " + bind + "` binds the dev server to every interface — " +
+					"unauthenticated access to the working directory. Use `127.0.0.1:PORT` " +
+					"locally, nginx / caddy for external exposure.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 626 Katas = 0.6.26
-const Version = "0.6.26"
+// 627 Katas = 0.6.27
+const Version = "0.6.27"


### PR DESCRIPTION
ZC1630 — Warn on `php -S 0.0.0.0:PORT` — PHP dev server exposes CWD to all interfaces

What: flags `php -S HOST:PORT` where HOST is `0.0.0.0`, `*`, or `[::]` (all interfaces, IPv4 or IPv6).
Why: PHP's built-in dev server serves files from the working directory with no auth, no TLS, and minimal access logging. The PHP docs explicitly warn against production use. Public-interface binds expose the CWD to everyone on the network.
Fix suggestion: bind to `127.0.0.1:PORT` locally; put nginx / caddy in front for external exposure.
Severity: Warning