### PR TITLE
feat: ZC1631 — flag `openssl -passin pass:SECRET` password in argv

### DIFF
--- a/pkg/katas/katatests/zc1631_test.go
+++ b/pkg/katas/katatests/zc1631_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1631(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — passin env:VAR",
+			input:    `openssl pkcs12 -in f.p12 -passin env:PASS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — passin file:path",
+			input:    `openssl pkcs12 -in f.p12 -passin file:/run/secrets/p`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — passin stdin",
+			input:    `openssl req -passin stdin`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — passin pass:LITERAL",
+			input: `openssl pkcs12 -in f.p12 -passin pass:hunter2 -nocerts`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1631",
+					Message: "`openssl -passin pass:hunter2` puts the password in argv — visible via `ps`. Use `env:VARNAME`, `file:PATH`, `fd:N`, or `stdin`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — passout pass:X",
+			input: `openssl genrsa -passout pass:X 2048`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1631",
+					Message: "`openssl -passout pass:X` puts the password in argv — visible via `ps`. Use `env:VARNAME`, `file:PATH`, `fd:N`, or `stdin`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1631")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1631.go
+++ b/pkg/katas/zc1631.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1631",
+		Title:    "Error on `openssl ... -passin pass:SECRET` / `-passout pass:SECRET`",
+		Severity: SeverityError,
+		Description: "OpenSSL's `-passin` / `-passout` accept a password source selector. The " +
+			"`pass:LITERAL` form embeds the password as an argv element — visible in `ps`, " +
+			"`/proc/<pid>/cmdline`, shell history, and audit logs. Use one of the safer " +
+			"sources: `env:VARNAME` reads from an env var, `file:PATH` reads the first line " +
+			"of PATH, `fd:N` reads from an open descriptor, `stdin` reads a line from stdin.",
+		Check: checkZC1631,
+	})
+}
+
+func checkZC1631(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "openssl" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v != "-passin" && v != "-passout" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			continue
+		}
+		val := cmd.Arguments[i+1].String()
+		if !strings.HasPrefix(val, "pass:") {
+			continue
+		}
+		return []Violation{{
+			KataID: "ZC1631",
+			Message: "`openssl " + v + " " + val + "` puts the password in argv — visible " +
+				"via `ps`. Use `env:VARNAME`, `file:PATH`, `fd:N`, or `stdin`.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityError,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 627 Katas = 0.6.27
-const Version = "0.6.27"
+// 628 Katas = 0.6.28
+const Version = "0.6.28"


### PR DESCRIPTION
ZC1631 — Error on `openssl ... -passin pass:SECRET` / `-passout pass:SECRET`

What: flags `openssl` invocations where `-passin` or `-passout` is followed by a `pass:` source (literal password).
Why: `pass:LITERAL` embeds the password in the argv; it's visible in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs.
Fix suggestion: use `env:VARNAME` (env var), `file:PATH` (first line of file), `fd:N` (open descriptor), or `stdin` (read from stdin) — all OpenSSL-native safer sources.
Severity: Error