### PR TITLE
feat: ZC1632 — flag `shred` unreliable on journaled / CoW filesystems

### DIFF
--- a/pkg/katas/katatests/zc1632_test.go
+++ b/pkg/katas/katatests/zc1632_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1632(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — unrelated command",
+			input:    `rm /tmp/staging.log`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — shred -u FILE",
+			input: `shred -u /tmp/secret.key`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1632",
+					Message: "`shred` may not overwrite original blocks on ext4/btrfs/zfs. For guaranteed erasure, use full-disk encryption with key destruction, or `blkdiscard` when retiring an SSD.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — shred -n 3 file",
+			input: `shred -n 3 /var/log/secret.log`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1632",
+					Message: "`shred` may not overwrite original blocks on ext4/btrfs/zfs. For guaranteed erasure, use full-disk encryption with key destruction, or `blkdiscard` when retiring an SSD.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1632")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1632.go
+++ b/pkg/katas/zc1632.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1632",
+		Title:    "Warn on `shred` — unreliable on journaled / CoW filesystems (ext4, btrfs, zfs)",
+		Severity: SeverityWarning,
+		Description: "`shred` assumes in-place overwrites, which is how ext2 worked. On a " +
+			"journaled ext4 the overwrite passes go through the journal and may not hit the " +
+			"original data blocks. On CoW filesystems (btrfs, zfs, xfs with reflink) the " +
+			"overwrite lands in fresh blocks and leaves the old content intact until garbage " +
+			"collection decides otherwise. `shred`'s own man page warns about this. For modern " +
+			"secure deletion, use full-disk encryption with key destruction, or retire the " +
+			"device with `blkdiscard` on an SSD.",
+		Check: checkZC1632,
+	})
+}
+
+func checkZC1632(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "shred" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1632",
+		Message: "`shred` may not overwrite original blocks on ext4/btrfs/zfs. For " +
+			"guaranteed erasure, use full-disk encryption with key destruction, or " +
+			"`blkdiscard` when retiring an SSD.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 628 Katas = 0.6.28
-const Version = "0.6.28"
+// 629 Katas = 0.6.29
+const Version = "0.6.29"


### PR DESCRIPTION
ZC1632 — Warn on `shred` — unreliable on journaled / CoW filesystems (ext4, btrfs, zfs)

What: flags every `shred` invocation.
Why: `shred` assumes in-place overwrites (ext2 behavior). On ext4 with journaling, overwrite passes go through the journal and may not hit the original blocks. On CoW filesystems (btrfs, zfs, xfs with reflink) the overwrite lands in fresh blocks and leaves old content intact. `shred`'s own man page warns about this.
Fix suggestion: use full-disk encryption with key destruction for file-level erasure, or retire the drive with `blkdiscard` on an SSD.
Severity: Warning