### PR TITLE
feat: ZC1633 — flag `gpg --passphrase SECRET` passphrase in argv

### DIFF
--- a/pkg/katas/katatests/zc1633_test.go
+++ b/pkg/katas/katatests/zc1633_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1633(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — passphrase-file",
+			input:    `gpg -d --passphrase-file /run/secrets/gpg file.gpg`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — passphrase-fd",
+			input:    `gpg -d --passphrase-fd 0 file.gpg`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — gpg -d --passphrase 'secret'",
+			input: `gpg -d --passphrase 'secret' file.gpg`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1633",
+					Message: "`gpg --passphrase` puts the passphrase in argv — visible via `ps`. Use `--passphrase-file`, `--passphrase-fd`, or `--pinentry-mode=loopback` with the value on stdin.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — gpg2 -d --passphrase $PW",
+			input: `gpg2 -d --passphrase $PW file.gpg`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1633",
+					Message: "`gpg --passphrase` puts the passphrase in argv — visible via `ps`. Use `--passphrase-file`, `--passphrase-fd`, or `--pinentry-mode=loopback` with the value on stdin.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1633")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1633.go
+++ b/pkg/katas/zc1633.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1633",
+		Title:    "Error on `gpg --passphrase SECRET` — passphrase on cmdline",
+		Severity: SeverityError,
+		Description: "`gpg --passphrase VALUE` passes the key passphrase as an argv element. " +
+			"Visible in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs for every " +
+			"local user who can list processes. Use `--passphrase-file PATH` (reads the first " +
+			"line of PATH), `--passphrase-fd N` (reads from file descriptor N), or " +
+			"`--pinentry-mode=loopback` with the passphrase piped on stdin. Pair with " +
+			"`--batch` for non-interactive runs.",
+		Check: checkZC1633,
+	})
+}
+
+func checkZC1633(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "gpg" && ident.Value != "gpg2" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "--passphrase" {
+			return []Violation{{
+				KataID: "ZC1633",
+				Message: "`gpg --passphrase` puts the passphrase in argv — visible via `ps`. " +
+					"Use `--passphrase-file`, `--passphrase-fd`, or `--pinentry-" +
+					"mode=loopback` with the value on stdin.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 629 Katas = 0.6.29
-const Version = "0.6.29"
+// 630 Katas = 0.6.30
+const Version = "0.6.30"


### PR DESCRIPTION
ZC1633 — Error on `gpg --passphrase SECRET` — passphrase on cmdline

What: flags `gpg` / `gpg2` invocations containing the bare `--passphrase` flag.
Why: `--passphrase VALUE` passes the key passphrase as an argv element. It ends up in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs — readable by any local user.
Fix suggestion: use `--passphrase-file PATH`, `--passphrase-fd N`, or `--pinentry-mode=loopback` with the passphrase piped on stdin. Pair with `--batch` for non-interactive runs.
Severity: Error