### PR TITLE
feat: ZC1634 — flag `umask` leaving world-write bit (mask inversion footgun)

### DIFF
--- a/pkg/katas/katatests/zc1634_test.go
+++ b/pkg/katas/katatests/zc1634_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1634(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — umask 022",
+			input:    `umask 022`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — umask 077",
+			input:    `umask 077`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — umask 002 (group-write collab)",
+			input:    `umask 002`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — umask 111",
+			input: `umask 111`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1634",
+					Message: "`umask 111` leaves world-write on new files — the \"other\" digit must be `2`/`3`/`6`/`7` to mask the write bit. Use `022` for public, `077` for secrets.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — umask 115 (last digit 5 leaves world-write)",
+			input: `umask 115`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1634",
+					Message: "`umask 115` leaves world-write on new files — the \"other\" digit must be `2`/`3`/`6`/`7` to mask the write bit. Use `022` for public, `077` for secrets.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1634")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1634.go
+++ b/pkg/katas/zc1634.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1634",
+		Title:    "Warn on `umask NNN` that fails to mask world-write — mask-inversion footgun",
+		Severity: SeverityWarning,
+		Description: "`umask` is a mask: bits that are set are removed from the default " +
+			"permission. The classic pitfall is reading it as \"permissions I want\" — " +
+			"`umask 111` feels tight (\"no execute for anyone\") but it does not mask the write " +
+			"bit, so every new file is `666` (rw-rw-rw-). The \"other\" digit must be one of " +
+			"`2/3/6/7` to strip world-write. Use `022` for publicly readable files, `077` for " +
+			"secrets-handling.",
+		Check: checkZC1634,
+	})
+}
+
+func checkZC1634(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "umask" {
+		return nil
+	}
+	if len(cmd.Arguments) != 1 {
+		return nil
+	}
+
+	v := cmd.Arguments[0].String()
+	// Exclude forms already flagged by ZC1195 / ZC1516.
+	if v == "0" || v == "00" || v == "000" || v == "0000" {
+		return nil
+	}
+	if len(v) < 3 || len(v) > 4 {
+		return nil
+	}
+	for _, c := range v {
+		if c < '0' || c > '7' {
+			return nil
+		}
+	}
+	last := v[len(v)-1]
+	if last != '0' && last != '1' && last != '4' && last != '5' {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1634",
+		Message: "`umask " + v + "` leaves world-write on new files — the \"other\" digit " +
+			"must be `2`/`3`/`6`/`7` to mask the write bit. Use `022` for public, `077` " +
+			"for secrets.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 630 Katas = 0.6.30
-const Version = "0.6.30"
+// 631 Katas = 0.6.31
+const Version = "0.6.31"


### PR DESCRIPTION
ZC1634 — Warn on `umask NNN` that fails to mask world-write — mask-inversion footgun

What: flags `umask NNN` (3- or 4-digit octal) whose "other" digit is `0`, `1`, `4`, or `5` — i.e., values that do not set the write-bit mask. Already-covered `000` / `0` cases (ZC1195, ZC1516) are excluded.
Why: `umask` is a mask; set bits are REMOVED from the default permission. `umask 111` feels restrictive ("no execute for anyone") but it doesn't mask the write bit, so new files default to `666` (rw-rw-rw-). Every new file becomes world-writable.
Fix suggestion: use `022` for publicly readable files (file mode 644), or `077` for secrets-handling (file mode 600). The "other" digit must be `2`/`3`/`6`/`7` to strip world-write.
Severity: Warning