### PR TITLE
feat: ZC1635 — flag `mysql -pSECRET` / `--password=SECRET` credential in argv

### DIFF
--- a/pkg/katas/katatests/zc1635_test.go
+++ b/pkg/katas/katatests/zc1635_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1635(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — mysql -p (prompts)",
+			input:    `mysql -u root -p -h db.example.com`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — mysql --login-path",
+			input:    `mysql --login-path=prod mydb`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — mysql -psecret",
+			input: `mysql -u root -psecret -h db.example.com`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1635",
+					Message: "`mysql -psecret` puts the MySQL password in argv. Use `-p` with no arg (prompt), `--login-path`, or a 0600 `~/.my.cnf`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — mysqldump -p$PW",
+			input: `mysqldump -u root -p$PW mydb`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1635",
+					Message: "`mysqldump -p$PW` puts the MySQL password in argv. Use `-p` with no arg (prompt), `--login-path`, or a 0600 `~/.my.cnf`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1635")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1635.go
+++ b/pkg/katas/zc1635.go
@@ -1,0 +1,64 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1635",
+		Title:    "Error on `mysql -pSECRET` / `--password=SECRET` — password in process list",
+		Severity: SeverityError,
+		Description: "MySQL / MariaDB clients accept the password concatenated with the `-p` " +
+			"flag (`-pSECRET`) or via `--password=SECRET`. Both forms put the secret in argv " +
+			"— visible in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs for every " +
+			"local user who can list processes. Use `-p` with no argument for an interactive " +
+			"prompt, `--login-path` for the credentials helper file, or a `~/.my.cnf` with " +
+			"`0600` perms and `[client] password=...` so the client reads it at startup.",
+		Check: checkZC1635,
+	})
+}
+
+func checkZC1635(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "mysql", "mysqldump", "mysqladmin", "mariadb", "mariadb-dump", "mariadb-admin":
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "-p") && len(v) > 2 {
+			return []Violation{{
+				KataID: "ZC1635",
+				Message: "`" + ident.Value + " " + v + "` puts the MySQL password in argv. " +
+					"Use `-p` with no arg (prompt), `--login-path`, or a 0600 `~/.my.cnf`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+		if strings.HasPrefix(v, "--password=") {
+			return []Violation{{
+				KataID: "ZC1635",
+				Message: "`" + ident.Value + " " + v + "` puts the MySQL password in argv. " +
+					"Use `-p` with no arg (prompt), `--login-path`, or a 0600 `~/.my.cnf`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 631 Katas = 0.6.31
-const Version = "0.6.31"
+// 632 Katas = 0.6.32
+const Version = "0.6.32"


### PR DESCRIPTION
ZC1635 — Error on `mysql -pSECRET` / `--password=SECRET` — password in process list

What: flags `mysql` / `mysqldump` / `mysqladmin` / `mariadb` / `mariadb-dump` / `mariadb-admin` invocations where `-p` has a concatenated value (`-pSECRET`) or `--password=SECRET` is used.
Why: both forms place the password in argv. It shows up in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs for every local user who can list processes. Bare `-p` (no arg) prompts interactively and is safe.
Fix suggestion: use `-p` with no arg for interactive prompt, `--login-path=<group>` for the MySQL login-path credentials helper, or a `~/.my.cnf` with `0600` perms and `[client] password=...`.
Severity: Error