### PR TITLE
feat: ZC1636 — flag `virsh destroy DOMAIN` force VM power-off

### DIFF
--- a/pkg/katas/katatests/zc1636_test.go
+++ b/pkg/katas/katatests/zc1636_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1636(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — virsh shutdown",
+			input:    `virsh shutdown my-vm`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — virsh destroy --graceful",
+			input:    `virsh destroy --graceful my-vm`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — virsh destroy my-vm",
+			input: `virsh destroy my-vm`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1636",
+					Message: "`virsh destroy` yanks power from the VM — filesystem corruption risk. Use `virsh shutdown` for graceful stop, or `virsh destroy --graceful` as a timed fallback.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — virsh destroy $DOM",
+			input: `virsh destroy $DOM`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1636",
+					Message: "`virsh destroy` yanks power from the VM — filesystem corruption risk. Use `virsh shutdown` for graceful stop, or `virsh destroy --graceful` as a timed fallback.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1636")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1636.go
+++ b/pkg/katas/zc1636.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1636",
+		Title:    "Warn on `virsh destroy DOMAIN` — force-stops VM (no graceful shutdown)",
+		Severity: SeverityWarning,
+		Description: "`virsh destroy DOM` is the libvirt equivalent of pulling the plug on a " +
+			"running VM. The guest OS gets no chance to flush filesystems, close network " +
+			"connections, or run its own shutdown services — data corruption risk on any " +
+			"open file in the guest. For graceful shutdown use `virsh shutdown DOM` (ACPI " +
+			"event), wait for completion, and only fall back to `destroy` for a genuinely " +
+			"unresponsive guest. `virsh destroy --graceful DOM` attempts a timed graceful " +
+			"first, then forces — that variant is not flagged.",
+		Check: checkZC1636,
+	})
+}
+
+func checkZC1636(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "virsh" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "destroy" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		if arg.String() == "--graceful" {
+			return nil
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1636",
+		Message: "`virsh destroy` yanks power from the VM — filesystem corruption risk. Use " +
+			"`virsh shutdown` for graceful stop, or `virsh destroy --graceful` as a timed " +
+			"fallback.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 632 Katas = 0.6.32
-const Version = "0.6.32"
+// 633 Katas = 0.6.33
+const Version = "0.6.33"


### PR DESCRIPTION
ZC1636 — Warn on `virsh destroy DOMAIN` — force-stops VM (no graceful shutdown)

What: flags `virsh destroy DOM` where `--graceful` is absent.
Why: `destroy` is the libvirt equivalent of pulling the plug. The guest OS gets no chance to flush filesystems, close network connections, or run shutdown services — filesystem corruption on any open guest file.
Fix suggestion: use `virsh shutdown DOM` (ACPI event) and wait for completion. `virsh destroy --graceful DOM` tries graceful first then forces and is not flagged.
Severity: Warning