### PR TITLE
feat: ZC1637 — prefer Zsh `typeset -r` over POSIX `readonly`

### DIFF
--- a/pkg/katas/katatests/zc1637_test.go
+++ b/pkg/katas/katatests/zc1637_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1637(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — unrelated command",
+			input:    `export FOO=bar`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — readonly FOO=bar",
+			input: `readonly FOO=bar`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1637",
+					Message: "`readonly` works but `typeset -r NAME=value` is the Zsh-native form and composes with other typeset flags.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — readonly MAX_RETRIES=5",
+			input: `readonly MAX_RETRIES=5`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1637",
+					Message: "`readonly` works but `typeset -r NAME=value` is the Zsh-native form and composes with other typeset flags.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1637")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1637.go
+++ b/pkg/katas/zc1637.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1637",
+		Title:    "Style: prefer Zsh `typeset -r NAME=value` over POSIX `readonly NAME=value`",
+		Severity: SeverityStyle,
+		Description: "Both `readonly NAME` and `typeset -r NAME` create a read-only parameter. " +
+			"In Zsh the idiomatic form is `typeset -r` — it composes with other typeset flags " +
+			"(`-ir` for readonly integer, `-xr` for readonly export, `-gr` to pin a readonly " +
+			"global from inside a function). `readonly` works but reads as a Bash / POSIX-ism " +
+			"in a Zsh codebase.",
+		Check: checkZC1637,
+	})
+}
+
+func checkZC1637(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "readonly" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1637",
+		Message: "`readonly` works but `typeset -r NAME=value` is the Zsh-native form and " +
+			"composes with other typeset flags.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 633 Katas = 0.6.33
-const Version = "0.6.33"
+// 634 Katas = 0.6.34
+const Version = "0.6.34"


### PR DESCRIPTION
ZC1637 — Style: prefer Zsh `typeset -r NAME=value` over POSIX `readonly NAME=value`

What: flags `readonly NAME` / `readonly NAME=value` invocations.
Why: Zsh has a single, composable declaration verb: `typeset`. `typeset -r` creates a read-only parameter and composes with other flags — `-ir` for readonly integer, `-xr` for readonly-export, `-gr` for readonly global. `readonly` works but reads as POSIX / Bash in a Zsh codebase.
Fix suggestion: use `typeset -r NAME=value` (or `local -r NAME=value` inside a function).
Severity: Style