### PR TITLE
feat: ZC1638 — flag `docker build --build-arg SECRET=VALUE` layer leak

### DIFF
--- a/pkg/katas/katatests/zc1638_test.go
+++ b/pkg/katas/katatests/zc1638_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1638(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — non-secret build-arg",
+			input:    `docker build --build-arg VERSION=1.0 -t app .`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — BuildKit secret",
+			input:    `docker build --secret id=dbpass,src=/run/secrets/db -t app .`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker build --build-arg PASSWORD=s3cret",
+			input: `docker build --build-arg PASSWORD=s3cret -t app .`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1638",
+					Message: "`docker build --build-arg PASSWORD=s3cret` bakes the secret into the image layer metadata. Use `--secret id=NAME,src=PATH` (BuildKit) or a multi-stage build.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — podman build --build-arg API_KEY=$KEY",
+			input: `podman build --build-arg API_KEY=$KEY -t app .`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1638",
+					Message: "`podman build --build-arg API_KEY=$KEY` bakes the secret into the image layer metadata. Use `--secret id=NAME,src=PATH` (BuildKit) or a multi-stage build.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1638")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1638.go
+++ b/pkg/katas/zc1638.go
@@ -1,0 +1,80 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1638SecretArgs = []string{
+	"password", "passwd", "secret", "token",
+	"apikey", "api_key", "api-key",
+	"accesskey", "access_key", "access-key",
+	"privatekey", "private_key", "private-key",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1638",
+		Title:    "Error on `docker/podman build --build-arg SECRET=VALUE` — secret baked into image layer",
+		Severity: SeverityError,
+		Description: "`--build-arg KEY=VALUE` values land in the image metadata that `docker " +
+			"history` (and the analogous podman / buildah tooling) read back from the layer. " +
+			"Even if the Dockerfile only uses the arg to export as a build-time env var, the " +
+			"literal value is cached in the layer forever. A key-shaped name (`password`, " +
+			"`secret`, `token`, `apikey`, `access_key`, `private_key`) with a concrete value " +
+			"embeds that secret in every image pulled. Use BuildKit secrets " +
+			"(`--secret id=mysecret,src=path`) or a multi-stage build where the secret stays " +
+			"in a discarded stage.",
+		Check: checkZC1638,
+	})
+}
+
+func checkZC1638(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "docker", "podman", "buildah":
+	default:
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "build" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		if arg.String() != "--build-arg" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			continue
+		}
+		pair := cmd.Arguments[i+1].String()
+		eq := strings.Index(pair, "=")
+		if eq < 0 {
+			continue
+		}
+		key := strings.ToLower(pair[:eq])
+		for _, s := range zc1638SecretArgs {
+			if strings.Contains(key, s) {
+				return []Violation{{
+					KataID: "ZC1638",
+					Message: "`" + ident.Value + " build --build-arg " + pair + "` bakes " +
+						"the secret into the image layer metadata. Use `--secret " +
+						"id=NAME,src=PATH` (BuildKit) or a multi-stage build.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityError,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 634 Katas = 0.6.34
-const Version = "0.6.34"
+// 635 Katas = 0.6.35
+const Version = "0.6.35"


### PR DESCRIPTION
ZC1638 — Error on `docker/podman/buildah build --build-arg SECRET=VALUE` — secret baked into image layer

What: flags `docker build` / `podman build` / `buildah build` with `--build-arg KEY=VALUE` where KEY contains one of `password`, `passwd`, `secret`, `token`, `apikey`, `api_key`, `access_key`, `private_key`.
Why: `--build-arg` values land in image metadata visible via `docker history`. The value is cached in the layer forever, even if the Dockerfile only used it as a build-time env var. Everyone who pulls the image reads the secret back.
Fix suggestion: use BuildKit secrets (`--secret id=NAME,src=PATH`) or a multi-stage build where the secret stays in a discarded stage.
Severity: Error