### PR TITLE
feat: ZC1639 — flag `curl -H 'Authorization: ...'` credential header in argv

### DIFF
--- a/pkg/katas/katatests/zc1639_test.go
+++ b/pkg/katas/katatests/zc1639_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1639(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — non-credential header",
+			input:    `curl -H "Content-Type: application/json" https://api`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — -H @file (read from file)",
+			input:    `curl -H @/run/secrets/auth_header https://api`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — Authorization Bearer",
+			input: `curl -H "Authorization: Bearer $TOKEN" https://api`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1639",
+					Message: "`curl -H \"Authorization: Bearer $TOKEN\"` places the credential in argv — visible via `ps`. Use `-H @FILE` or `--config FILE` with 0600 perms.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — X-Api-Key",
+			input: `curl -H "X-Api-Key: $KEY" https://api`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1639",
+					Message: "`curl -H \"X-Api-Key: $KEY\"` places the credential in argv — visible via `ps`. Use `-H @FILE` or `--config FILE` with 0600 perms.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1639")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1639.go
+++ b/pkg/katas/zc1639.go
@@ -1,0 +1,73 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1639AuthHeaders = []string{
+	"authorization:",
+	"proxy-authorization:",
+	"x-api-key:",
+	"api-key:",
+	"apikey:",
+	"x-auth-token:",
+	"x-access-token:",
+	"cookie:",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1639",
+		Title:    "Error on `curl -H 'Authorization: ...'` — credential header in process list",
+		Severity: SeverityError,
+		Description: "`-H \"Authorization: Bearer $TOKEN\"` (and similar credential-bearing " +
+			"headers like `X-Api-Key`, `X-Auth-Token`, `Proxy-Authorization`, `Cookie`) put " +
+			"the expanded value in argv. It shows up in `ps`, `/proc/<pid>/cmdline`, shell " +
+			"history, and audit logs — every local user who can list processes reads the " +
+			"secret. Pass the header via a file with `-H @FILE` or use `--config FILE` so the " +
+			"value stays on disk (with 0600 perms), never on the command line.",
+		Check: checkZC1639,
+	})
+}
+
+func checkZC1639(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "curl" && ident.Value != "wget" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v != "-H" && v != "--header" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			continue
+		}
+		header := strings.ToLower(cmd.Arguments[i+1].String())
+		for _, h := range zc1639AuthHeaders {
+			if strings.Contains(header, h) {
+				return []Violation{{
+					KataID: "ZC1639",
+					Message: "`" + ident.Value + " -H " + cmd.Arguments[i+1].String() +
+						"` places the credential in argv — visible via `ps`. Use `-H @FILE`" +
+						" or `--config FILE` with 0600 perms.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityError,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 635 Katas = 0.6.35
-const Version = "0.6.35"
+// 636 Katas = 0.6.36
+const Version = "0.6.36"


### PR DESCRIPTION
ZC1639 — Error on `curl -H 'Authorization: ...'` — credential header in process list

What: flags `curl` / `wget` invocations where `-H` / `--header` carries a credential-bearing header (`Authorization`, `Proxy-Authorization`, `X-Api-Key`, `Api-Key`, `X-Auth-Token`, `X-Access-Token`, `Cookie`).
Why: the header value passes as an argv element. The expanded token shows up in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs.
Fix suggestion: use `curl -H @FILE` (reads header from a 0600-protected file) or `curl --config FILE` with `header = "..."` lines so the secret stays on disk, never on the command line.
Severity: Error