### PR TITLE
feat: ZC1640 — prefer Zsh `${(P)var}` over Bash `${!var}` indirect expansion

### DIFF
--- a/pkg/katas/katatests/zc1640_test.go
+++ b/pkg/katas/katatests/zc1640_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1640(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — Zsh (P) flag",
+			input:    `echo "${(P)var}"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — plain expansion",
+			input:    `echo "${var}"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  `invalid — echo "${!var}"`,
+			input: `echo "${!var}"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1640",
+					Message: "`${!var}` Bash indirect — prefer Zsh `${(P)var}` for the same semantics with flag composability.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — print "${!array[@]}"`,
+			input: `print -r -- "${!array[@]}"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1640",
+					Message: "`${!var}` Bash indirect — prefer Zsh `${(P)var}` for the same semantics with flag composability.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1640")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1640.go
+++ b/pkg/katas/zc1640.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1640",
+		Title:    "Style: `${!var}` Bash indirect expansion — prefer Zsh `${(P)var}`",
+		Severity: SeverityStyle,
+		Description: "`${!var}` is Bash indirect expansion — it reads the value of the " +
+			"parameter whose name is stored in `$var`. Zsh has the native flag form " +
+			"`${(P)var}` which does the same and composes with other parameter-expansion " +
+			"flags (`${(Pf)var}` to split the indirect value on newlines, for example). " +
+			"`${!prefix*}` / `${!array[@]}` have Zsh equivalents via the `$parameters` hash " +
+			"or `(k)` subscript flags. Prefer the native Zsh form in a Zsh codebase.",
+		Check: checkZC1640,
+	})
+}
+
+func checkZC1640(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "${!") {
+			return []Violation{{
+				KataID: "ZC1640",
+				Message: "`${!var}` Bash indirect — prefer Zsh `${(P)var}` for the same " +
+					"semantics with flag composability.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 636 Katas = 0.6.36
-const Version = "0.6.36"
+// 637 Katas = 0.6.37
+const Version = "0.6.37"


### PR DESCRIPTION
ZC1640 — Style: `${!var}` Bash indirect expansion — prefer Zsh `${(P)var}`

What: flags any argument containing the substring `${!` (Bash indirect parameter reference).
Why: Zsh has `${(P)var}` as the native equivalent. It composes with other parameter-expansion flags (`${(Pf)var}` to read the indirect value split on newlines, `${(PU)var}` to uppercase it, etc.) and reads consistently across Zsh docs.
Fix suggestion: replace `${!var}` with `${(P)var}`; `${!prefix*}` / `${!array[@]}` have Zsh equivalents via the `$parameters` hash or `(k)` subscript flags.
Severity: Style