### PR TITLE
feat: ZC1641 — flag `kubectl create secret --from-literal` / `--docker-password`

### DIFF
--- a/pkg/katas/katatests/zc1641_test.go
+++ b/pkg/katas/katatests/zc1641_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1641(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — --from-file",
+			input:    `kubectl create secret generic mysec --from-file=password=/run/secrets/pw`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — --from-env-file",
+			input:    `kubectl create secret generic mysec --from-env-file=/run/secrets/env`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — --from-literal=password=X",
+			input: `kubectl create secret generic mysec --from-literal=password=hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1641",
+					Message: "`kubectl create secret --from-literal=password=hunter2` puts the secret in argv — visible via `ps`. Use `--from-file=KEY=PATH` / `--from-env-file=PATH`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — --docker-password=$PW",
+			input: `kubectl create secret docker-registry reg --docker-password=$PW --docker-username=u`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1641",
+					Message: "`kubectl create secret --docker-password=$PW` puts the secret in argv — visible via `ps`. Use `--from-file=KEY=PATH` / `--from-env-file=PATH`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1641")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1641.go
+++ b/pkg/katas/zc1641.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1641",
+		Title:    "Error on `kubectl create secret --from-literal=...` / `--docker-password=...`",
+		Severity: SeverityError,
+		Description: "`kubectl create secret generic --from-literal=KEY=VALUE` and " +
+			"`kubectl create secret docker-registry --docker-password=VALUE` put the secret " +
+			"content in argv. The expanded value shows up in `ps`, `/proc/<pid>/cmdline`, " +
+			"shell history, and audit logs — readable by any local user who can list " +
+			"processes. Use `--from-file=KEY=PATH` (reads from a 0600-protected file), " +
+			"`--from-env-file=PATH` (reads KEY=VALUE lines), or pipe a manifest into " +
+			"`kubectl apply -f -` with base64-encoded `data:` values staged on disk.",
+		Check: checkZC1641,
+	})
+}
+
+func checkZC1641(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kubectl" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "create" || cmd.Arguments[1].String() != "secret" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[2:] {
+		v := arg.String()
+		if strings.HasPrefix(v, "--from-literal=") || strings.HasPrefix(v, "--docker-password=") {
+			return []Violation{{
+				KataID: "ZC1641",
+				Message: "`kubectl create secret " + v + "` puts the secret in argv — " +
+					"visible via `ps`. Use `--from-file=KEY=PATH` / `--from-env-file=PATH`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 637 Katas = 0.6.37
-const Version = "0.6.37"
+// 638 Katas = 0.6.38
+const Version = "0.6.38"


### PR DESCRIPTION
ZC1641 — Error on `kubectl create secret --from-literal=...` / `--docker-password=...`

What: flags `kubectl create secret ...` invocations containing `--from-literal=KEY=VALUE` or `--docker-password=VALUE`.
Why: both forms put the secret content in argv. The expanded value ends up in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs.
Fix suggestion: use `--from-file=KEY=PATH` (reads from a 0600-protected file), `--from-env-file=PATH` (KEY=VALUE lines), or pipe a manifest into `kubectl apply -f -` with base64-encoded `data:` values staged on disk.
Severity: Error