### PR TITLE
feat: ZC1642 — flag `tshark -w` / `dumpcap -w` without `-Z USER`

### DIFF
--- a/pkg/katas/katatests/zc1642_test.go
+++ b/pkg/katas/katatests/zc1642_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1642(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — tshark -w with -Z user",
+			input:    `tshark -i eth0 -w /tmp/cap.pcap -Z analyst`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — tshark without -w (display only)",
+			input:    `tshark -i any`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — tshark -w without -Z",
+			input: `tshark -i any -w /tmp/cap.pcap`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1642",
+					Message: "`tshark -w FILE` without `-Z USER` leaves the pcap root-owned. Add `-Z USER` to drop privileges for the capture.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — dumpcap -w without -Z",
+			input: `dumpcap -i eth0 -w /tmp/cap.pcap`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1642",
+					Message: "`dumpcap -w FILE` without `-Z USER` leaves the pcap root-owned. Add `-Z USER` to drop privileges for the capture.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1642")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1642.go
+++ b/pkg/katas/zc1642.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1642",
+		Title:    "Warn on `tshark -w FILE` / `dumpcap -w FILE` without `-Z user` — capture file owned by root",
+		Severity: SeverityWarning,
+		Description: "Packet captures routinely need `CAP_NET_RAW`, so the capture process " +
+			"typically runs as root. Without `-Z USER` the resulting pcap is root-owned — a " +
+			"subsequent analyst who opens it with Wireshark (which can run helper scripts from " +
+			"the file) operates on a root-owned file and may unintentionally invoke things as " +
+			"root. `-Z USER` tells `tshark` / `dumpcap` to drop privileges for the actual " +
+			"capture and write the file as `USER`.",
+		Check: checkZC1642,
+	})
+}
+
+func checkZC1642(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "tshark" && ident.Value != "dumpcap" {
+		return nil
+	}
+
+	var hasWrite, hasDrop bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-w" {
+			hasWrite = true
+		}
+		if v == "-Z" {
+			hasDrop = true
+		}
+	}
+	if !hasWrite || hasDrop {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1642",
+		Message: "`" + ident.Value + " -w FILE` without `-Z USER` leaves the pcap root-" +
+			"owned. Add `-Z USER` to drop privileges for the capture.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 638 Katas = 0.6.38
-const Version = "0.6.38"
+// 639 Katas = 0.6.39
+const Version = "0.6.39"


### PR DESCRIPTION
ZC1642 — Warn on `tshark -w FILE` / `dumpcap -w FILE` without `-Z USER` — capture file owned by root

What: flags `tshark -w FILE` / `dumpcap -w FILE` where `-Z USER` is absent.
Why: packet captures need `CAP_NET_RAW`, so the capture process typically runs as root. Without `-Z USER` the resulting pcap is root-owned. An analyst opening the file in Wireshark — which runs helper scripts from the capture — operates on a root-owned file and may unintentionally invoke things as root.
Fix suggestion: pass `-Z USER` so tshark/dumpcap drops privileges before writing the pcap.
Severity: Warning