### PR TITLE
feat: ZC1643 — prefer `$(<file)` over `$(cat file)` (no fork)

### DIFF
--- a/pkg/katas/katatests/zc1643_test.go
+++ b/pkg/katas/katatests/zc1643_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1643(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — $(<file)",
+			input:    `echo "$(<file)"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — bare cat file (logging, not capture)",
+			input:    `cat /etc/os-release`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  `invalid — echo "$(cat /etc/hostname)"`,
+			input: `echo "$(cat /etc/hostname)"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1643",
+					Message: "`$(cat FILE)` forks cat just to read a file — use `$(<FILE)` (shell builtin, no fork).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — print -r -- "$(cat file)"`,
+			input: `print -r -- "$(cat file)"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1643",
+					Message: "`$(cat FILE)` forks cat just to read a file — use `$(<FILE)` (shell builtin, no fork).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1643")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1643.go
+++ b/pkg/katas/zc1643.go
@@ -1,0 +1,43 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1643",
+		Title:    "Style: `$(cat file)` — use `$(<file)` to skip the fork / exec",
+		Severity: SeverityStyle,
+		Description: "`$(cat FILE)` forks, execs `/usr/bin/cat`, reads FILE, writes the bytes " +
+			"to the pipe, waits for the child. `$(<FILE)` is a shell builtin — it reads FILE " +
+			"directly into the command-substitution buffer with no fork and no exec. In a hot " +
+			"path the speedup is dramatic, and even in cold paths it avoids one of the most " +
+			"common useless-use-of-cat patterns in review feedback.",
+		Check: checkZC1643,
+	})
+}
+
+func checkZC1643(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "$(cat ") {
+			return []Violation{{
+				KataID: "ZC1643",
+				Message: "`$(cat FILE)` forks cat just to read a file — use `$(<FILE)` " +
+					"(shell builtin, no fork).",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 639 Katas = 0.6.39
-const Version = "0.6.39"
+// 640 Katas = 0.6.40
+const Version = "0.6.40"


### PR DESCRIPTION
ZC1643 — Style: `$(cat file)` — use `$(<file)` to skip the fork / exec

What: flags any argument whose raw text contains the substring `$(cat ` (command substitution that forks `/usr/bin/cat`).
Why: `$(<FILE)` is a shell builtin — it reads FILE directly into the command-substitution buffer with no fork, no exec, no wait. In a hot path the speedup is dramatic; in cold paths it still avoids one of the most common useless-use-of-cat patterns in review feedback.
Fix suggestion: replace `$(cat FILE)` with `$(<FILE)`.
Severity: Style