### PR TITLE
feat: ZC1644 — flag `unzip -P` / `zip -P` archive password in argv

### DIFF
--- a/pkg/katas/katatests/zc1644_test.go
+++ b/pkg/katas/katatests/zc1644_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1644(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — unzip without -P (prompts)",
+			input:    `unzip archive.zip`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — zip without password",
+			input:    `zip archive.zip files/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — unzip -P secret",
+			input: `unzip -P s3cret archive.zip`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1644",
+					Message: "`unzip -P` places the archive password in argv — visible via `ps`. Drop `-P` for interactive prompt, or switch to `7z -p` (reads from stdin) / `age` / `gpg` with keys in a protected file.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — zip -Psecret",
+			input: `zip -Ps3cret archive.zip files/`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1644",
+					Message: "`zip -P` places the archive password in argv — visible via `ps`. Drop `-P` for interactive prompt, or switch to `7z -p` (reads from stdin) / `age` / `gpg` with keys in a protected file.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1644")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1644.go
+++ b/pkg/katas/zc1644.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1644",
+		Title:    "Error on `unzip -P SECRET` / `zip -P SECRET` — archive password in process list",
+		Severity: SeverityError,
+		Description: "`unzip -P PASSWORD` / `zip -P PASSWORD` (or the concatenated `-PPASSWORD` " +
+			"form) places the archive password in argv. The expanded value shows up in `ps`, " +
+			"`/proc/<pid>/cmdline`, shell history, and audit logs for every local user who " +
+			"can list processes. Both tools prompt interactively if `-P` is absent — use that " +
+			"for human workflows. For automation prefer an archive format with a real key-" +
+			"derivation story (for example `7z -p` piped over stdin, or `age` / `gpg` " +
+			"envelope encryption that reads keys from a protected file).",
+		Check: checkZC1644,
+	})
+}
+
+func checkZC1644(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "unzip" && ident.Value != "zip" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-P" && i+1 < len(cmd.Arguments) {
+			return zc1644Hit(cmd, ident.Value)
+		}
+		if strings.HasPrefix(v, "-P") && len(v) > 2 {
+			return zc1644Hit(cmd, ident.Value)
+		}
+	}
+	return nil
+}
+
+func zc1644Hit(cmd *ast.SimpleCommand, name string) []Violation {
+	return []Violation{{
+		KataID: "ZC1644",
+		Message: "`" + name + " -P` places the archive password in argv — visible via " +
+			"`ps`. Drop `-P` for interactive prompt, or switch to `7z -p` (reads from " +
+			"stdin) / `age` / `gpg` with keys in a protected file.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 640 Katas = 0.6.40
-const Version = "0.6.40"
+// 641 Katas = 0.6.41
+const Version = "0.6.41"


### PR DESCRIPTION
ZC1644 — Error on `unzip -P SECRET` / `zip -P SECRET` — archive password in process list

What: flags `unzip` / `zip` invocations with `-P` followed by a password (or concatenated `-PSECRET`).
Why: `-P` puts the password in argv. The value shows up in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs.
Fix suggestion: drop `-P` for interactive prompt, or switch to `7z -p` (reads from stdin) / `age` / `gpg` with keys in a protected file for automation.
Severity: Error