### PR TITLE
feat: ZC1645 — prefer `/etc/os-release` over `lsb_release`

### DIFF
--- a/pkg/katas/katatests/zc1645_test.go
+++ b/pkg/katas/katatests/zc1645_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1645(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — source os-release",
+			input:    `source /etc/os-release`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — lsb_release -rs",
+			input: `lsb_release -rs`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1645",
+					Message: "`lsb_release` needs an optional package. Use `source /etc/os-release` and read `$ID` / `$VERSION_ID` / `$PRETTY_NAME` instead — always present, no fork.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — lsb_release -a",
+			input: `lsb_release -a`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1645",
+					Message: "`lsb_release` needs an optional package. Use `source /etc/os-release` and read `$ID` / `$VERSION_ID` / `$PRETTY_NAME` instead — always present, no fork.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1645")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1645.go
+++ b/pkg/katas/zc1645.go
@@ -1,0 +1,44 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1645",
+		Title:    "Style: `lsb_release` — prefer sourcing `/etc/os-release` (no dependency, no fork)",
+		Severity: SeverityStyle,
+		Description: "`lsb_release` is provided by the `lsb-release` / `redhat-lsb-core` " +
+			"package, which is missing on most minimal / container images (Alpine does not " +
+			"ship it at all). Scripts that depend on `lsb_release` fail the moment they hit " +
+			"a stripped image. `/etc/os-release` is standardized by systemd and always " +
+			"present on modern Linux — `source /etc/os-release; print -r -- $ID $VERSION_ID` " +
+			"gives the same distribution info without the extra package, and without forking.",
+		Check: checkZC1645,
+	})
+}
+
+func checkZC1645(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "lsb_release" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1645",
+		Message: "`lsb_release` needs an optional package. Use `source /etc/os-release` and " +
+			"read `$ID` / `$VERSION_ID` / `$PRETTY_NAME` instead — always present, no fork.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 641 Katas = 0.6.41
-const Version = "0.6.41"
+// 642 Katas = 0.6.42
+const Version = "0.6.42"


### PR DESCRIPTION
ZC1645 — Style: `lsb_release` — prefer sourcing `/etc/os-release` (no dependency, no fork)

What: flags every `lsb_release` invocation.
Why: `lsb_release` is provided by the `lsb-release` / `redhat-lsb-core` package, missing on most minimal / container images (Alpine doesn't ship it at all). Scripts that depend on it fail on stripped images. `/etc/os-release` is always present on modern systemd-based Linux.
Fix suggestion: `source /etc/os-release; print -r -- $ID $VERSION_ID` — same info, no package dependency, no fork.
Severity: Style