### PR TITLE
feat: ZC1646 — flag `btrfs check --repair` / `xfs_repair -L` last-resort fs repair

### DIFF
--- a/pkg/katas/katatests/zc1646_test.go
+++ b/pkg/katas/katatests/zc1646_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1646(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — btrfs scrub",
+			input:    `btrfs scrub start /mnt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — btrfs check (read-only)",
+			input:    `btrfs check $DEV`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — xfs_repair without -L",
+			input:    `xfs_repair $DEV`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — btrfs check --repair",
+			input: `btrfs check --repair $DEV`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1646",
+					Message: "`btrfs check --repair` may worsen damage — try `btrfs scrub` and read-only `btrfs check` first, and snapshot the block device before running.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — xfs_repair -L",
+			input: `xfs_repair -L $DEV`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1646",
+					Message: "`xfs_repair -L` zeroes the log — uncommitted transactions are lost. Snapshot the block device first; mount read-only and read the log if possible.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1646")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1646.go
+++ b/pkg/katas/zc1646.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1646",
+		Title:    "Warn on `btrfs check --repair` / `xfs_repair -L` — last-resort recovery, may worsen damage",
+		Severity: SeverityWarning,
+		Description: "Both commands are destructive last-resort recovery. `btrfs check " +
+			"--repair` explicitly warns in its man page that it \"may cause additional " +
+			"filesystem damage\" and the btrfs developers ask users to try `btrfs scrub` and " +
+			"read-only `btrfs check` first. `xfs_repair -L` zeroes the log, dropping any " +
+			"uncommitted transactions and the data they held. In both cases snapshot the " +
+			"underlying block device before running, so the attempt is reversible.",
+		Check: checkZC1646,
+	})
+}
+
+func checkZC1646(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value == "btrfs" {
+		if len(cmd.Arguments) < 2 || cmd.Arguments[0].String() != "check" {
+			return nil
+		}
+		for _, arg := range cmd.Arguments[1:] {
+			if arg.String() == "--repair" {
+				return []Violation{{
+					KataID: "ZC1646",
+					Message: "`btrfs check --repair` may worsen damage — try `btrfs scrub` " +
+						"and read-only `btrfs check` first, and snapshot the block device " +
+						"before running.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+		return nil
+	}
+	if ident.Value == "xfs_repair" {
+		for _, arg := range cmd.Arguments {
+			if arg.String() == "-L" {
+				return []Violation{{
+					KataID: "ZC1646",
+					Message: "`xfs_repair -L` zeroes the log — uncommitted transactions are " +
+						"lost. Snapshot the block device first; mount read-only and read " +
+						"the log if possible.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 642 Katas = 0.6.42
-const Version = "0.6.42"
+// 643 Katas = 0.6.43
+const Version = "0.6.43"


### PR DESCRIPTION
ZC1646 — Warn on `btrfs check --repair` / `xfs_repair -L` — last-resort recovery, may worsen damage

What: flags `btrfs check --repair ...` and `xfs_repair -L ...`.
Why: both are destructive last-resort fs recovery. `btrfs check --repair` explicitly warns it may cause additional filesystem damage — the btrfs devs ask users to try `btrfs scrub` and read-only `btrfs check` first. `xfs_repair -L` zeroes the log, dropping any uncommitted transactions.
Fix suggestion: snapshot the underlying block device before either command, and exhaust non-destructive checks first.
Severity: Warning