### PR TITLE
feat: ZC1647 — flag `kubectl apply -f URL` remote manifest without digest check

### DIFF
--- a/pkg/katas/katatests/zc1647_test.go
+++ b/pkg/katas/katatests/zc1647_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1647(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — local file",
+			input:    `kubectl apply -f ./manifest.yaml`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — stdin",
+			input:    `kubectl apply -f -`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — kubectl apply -f https://example.com/m.yaml",
+			input: `kubectl apply -f https://example.com/manifest.yaml`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1647",
+					Message: "`kubectl apply -f https://example.com/manifest.yaml` applies a remote manifest — verify digest first. Download, check SHA256, then apply the local file.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — kubectl create -f http://insecure/m.yaml",
+			input: `kubectl create -f http://insecure/m.yaml`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1647",
+					Message: "`kubectl create -f http://insecure/m.yaml` applies a remote manifest — verify digest first. Download, check SHA256, then apply the local file.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1647")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1647.go
+++ b/pkg/katas/zc1647.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1647",
+		Title:    "Warn on `kubectl apply -f URL` — remote manifest applied without digest verification",
+		Severity: SeverityWarning,
+		Description: "`kubectl apply -f https://...` fetches the manifest over the network and " +
+			"applies it to the cluster. TLS (when present) verifies transport but not " +
+			"authorship — if the URL is compromised or the content changes between reviews, " +
+			"the cluster picks up the new definition. Pin the content: download to disk, " +
+			"verify a known SHA256, then `kubectl apply -f local.yaml`. For plain HTTP the " +
+			"attacker controls the response directly — never acceptable.",
+		Check: checkZC1647,
+	})
+}
+
+func checkZC1647(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kubectl" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	if sub != "apply" && sub != "create" && sub != "replace" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments[1:] {
+		if arg.String() != "-f" {
+			continue
+		}
+		idx := i + 2
+		if idx >= len(cmd.Arguments) {
+			continue
+		}
+		target := cmd.Arguments[idx].String()
+		if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
+			return []Violation{{
+				KataID: "ZC1647",
+				Message: "`kubectl " + sub + " -f " + target + "` applies a remote " +
+					"manifest — verify digest first. Download, check SHA256, then apply " +
+					"the local file.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 643 Katas = 0.6.43
-const Version = "0.6.43"
+// 644 Katas = 0.6.44
+const Version = "0.6.44"


### PR DESCRIPTION
ZC1647 — Warn on `kubectl apply -f URL` — remote manifest applied without digest verification

What: flags `kubectl {apply,create,replace} -f https://...yaml` / `http://...yaml`.
Why: the manifest is fetched from the network and applied to the cluster. TLS (when present) verifies transport but not authorship — if the URL is compromised or the file is rewritten, the cluster picks up whatever was substituted. Plain HTTP gives the attacker direct control of the response body.
Fix suggestion: download the manifest to disk, verify a known SHA256, then `kubectl apply -f local.yaml`.
Severity: Warning