### PR TITLE
feat: ZC1648 — flag `cp /dev/null /var/log/` / `truncate -s 0 /var/log/` audit-log wipe

### DIFF
--- a/pkg/katas/katatests/zc1648_test.go
+++ b/pkg/katas/katatests/zc1648_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1648(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — logrotate",
+			input:    `logrotate -f /etc/logrotate.d/app`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — cp /dev/null to app tmp",
+			input:    `cp /dev/null /tmp/marker`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — cp /dev/null /var/log/auth.log",
+			input: `cp /dev/null /var/log/auth.log`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1648",
+					Message: "`cp /dev/null /var/log/auth.log` wipes an audit log — use `logrotate -f` or `journalctl --vacuum-time=...` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — truncate -s 0 /var/log/wtmp",
+			input: `truncate -s 0 /var/log/wtmp`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1648",
+					Message: "`truncate -s 0 /var/log/wtmp` wipes an audit log — use `logrotate -f` or `journalctl --vacuum-time=...` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1648")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1648.go
+++ b/pkg/katas/zc1648.go
@@ -1,0 +1,76 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1648",
+		Title:    "Error on `cp /dev/null /var/log/...` / `truncate -s 0 /var/log/...` — audit-log wipe",
+		Severity: SeverityError,
+		Description: "Replacing a file under `/var/log/` with `/dev/null` or truncating it to " +
+			"size zero erases audit evidence: failed login attempts from `auth.log`, sudo " +
+			"usage from `sudo.log`, kernel audit trail from `audit/audit.log`, console " +
+			"history from `wtmp` / `btmp`. Scripts that do this during \"cleanup\" are almost " +
+			"always misusing logrotate (which handles rotation safely via a `create` stage) " +
+			"or deliberately covering tracks. Use `logrotate -f /etc/logrotate.d/...` for " +
+			"rotation, `journalctl --vacuum-time=...` for journald.",
+		Check: checkZC1648,
+	})
+}
+
+func checkZC1648(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "cp":
+		if len(cmd.Arguments) < 2 {
+			return nil
+		}
+		if cmd.Arguments[0].String() != "/dev/null" {
+			return nil
+		}
+		dest := cmd.Arguments[1].String()
+		if strings.HasPrefix(dest, "/var/log/") {
+			return zc1648Hit(cmd, "cp /dev/null "+dest)
+		}
+	case "truncate":
+		var zeroSize bool
+		var target string
+		for i, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "-s" && i+1 < len(cmd.Arguments) && cmd.Arguments[i+1].String() == "0" {
+				zeroSize = true
+			}
+			if strings.HasPrefix(v, "/var/log/") {
+				target = v
+			}
+		}
+		if zeroSize && target != "" {
+			return zc1648Hit(cmd, "truncate -s 0 "+target)
+		}
+	}
+	return nil
+}
+
+func zc1648Hit(cmd *ast.SimpleCommand, desc string) []Violation {
+	return []Violation{{
+		KataID: "ZC1648",
+		Message: "`" + desc + "` wipes an audit log — use `logrotate -f` or " +
+			"`journalctl --vacuum-time=...` instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 644 Katas = 0.6.44
-const Version = "0.6.44"
+// 645 Katas = 0.6.45
+const Version = "0.6.45"


### PR DESCRIPTION
ZC1648 — Error on `cp /dev/null /var/log/...` / `truncate -s 0 /var/log/...` — audit-log wipe

What: flags `cp /dev/null DEST` and `truncate -s 0 DEST` where DEST starts with `/var/log/`.
Why: replacing or zeroing a log under `/var/log/` erases audit evidence: failed logins in `auth.log`, sudo use in `sudo.log`, kernel audit trail in `audit/audit.log`, tty history in `wtmp` / `btmp`. Scripts doing this during "cleanup" are either misusing logrotate or deliberately covering tracks.
Fix suggestion: use `logrotate -f /etc/logrotate.d/<unit>` for rotation, `journalctl --vacuum-time=...` for the systemd journal.
Severity: Error