### PR TITLE
feat: ZC1649 — flag `openssl` cert with validity > 825 days

### DIFF
--- a/pkg/katas/katatests/zc1649_test.go
+++ b/pkg/katas/katatests/zc1649_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1649(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — -days 90 (Let's Encrypt style)",
+			input:    `openssl req -x509 -days 90 -nodes`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — -days 398 (1-year max)",
+			input:    `openssl req -x509 -days 398 -nodes`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — -days 3650 (10 years)",
+			input: `openssl req -x509 -days 3650 -nodes -newkey rsa:2048`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1649",
+					Message: "`openssl req -days 3650` issues a cert with a long validity. Keep leaf certs under 398 days and automate rotation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — openssl x509 -days 1095 (3 years)",
+			input: `openssl x509 -req -days 1095 -signkey key -in csr`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1649",
+					Message: "`openssl x509 -days 1095` issues a cert with a long validity. Keep leaf certs under 398 days and automate rotation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1649")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1649.go
+++ b/pkg/katas/zc1649.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"strconv"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1649",
+		Title:    "Warn on `openssl req -days N` with N > 825 — long-validity certificate",
+		Severity: SeverityWarning,
+		Description: "CA/Browser Forum capped public TLS cert validity at 825 days in 2018 and " +
+			"major browsers tightened it to 398 days in 2020. A cert issued for 3650 days " +
+			"(10 years) can not be revoked effectively — once the private key leaks, the " +
+			"attacker keeps access until the cert expires naturally. For an internal root CA " +
+			"the long validity is defensible; for leaf / server certs keep it under 398 " +
+			"days and automate rotation. `-days` over 825 almost always means \"I don't want " +
+			"to deal with renewal,\" which is a maintenance smell dressed up as security.",
+		Check: checkZC1649,
+	})
+}
+
+func checkZC1649(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "openssl" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	if sub != "req" && sub != "x509" && sub != "ca" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		if arg.String() != "-days" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			continue
+		}
+		days, err := strconv.Atoi(cmd.Arguments[i+1].String())
+		if err != nil {
+			continue
+		}
+		if days > 825 {
+			return []Violation{{
+				KataID: "ZC1649",
+				Message: "`openssl " + sub + " -days " + cmd.Arguments[i+1].String() +
+					"` issues a cert with a long validity. Keep leaf certs under 398 " +
+					"days and automate rotation.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 645 Katas = 0.6.45
-const Version = "0.6.45"
+// 646 Katas = 0.6.46
+const Version = "0.6.46"


### PR DESCRIPTION
ZC1649 — Warn on `openssl req -days N` with N > 825 — long-validity certificate

What: flags `openssl req`, `openssl x509`, and `openssl ca` invocations where `-days N` is greater than 825.
Why: CA/Browser Forum capped public TLS cert validity at 825 days in 2018; major browsers tightened it to 398 days in 2020. A 10-year cert can't be revoked effectively — once the key leaks, the attacker keeps access until natural expiry.
Fix suggestion: keep leaf / server certs under 398 days and automate rotation. Long validity is defensible for internal root CAs only.
Severity: Warning