### PR TITLE
feat: ZC1650 — flag `setopt RM_STAR_SILENT` / `unsetopt RM_STAR_WAIT` prompt removal

### DIFF
--- a/pkg/katas/katatests/zc1650_test.go
+++ b/pkg/katas/katatests/zc1650_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1650(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — setopt NO_NOMATCH",
+			input:    `setopt NO_NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — unsetopt BEEP",
+			input:    `unsetopt BEEP`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — setopt RM_STAR_SILENT",
+			input: `setopt RM_STAR_SILENT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1650",
+					Message: "`setopt RM_STAR_SILENT` removes the `rm *` confirmation prompt — keep the default `RM_STAR_WAIT` so accidental deletions pause before they happen.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — unsetopt rmstarwait (lowercase, no underscore)",
+			input: `unsetopt rmstarwait`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1650",
+					Message: "`unsetopt rmstarwait` removes the `rm *` confirmation prompt — keep the default `RM_STAR_WAIT` so accidental deletions pause before they happen.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1650")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1650.go
+++ b/pkg/katas/zc1650.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1650",
+		Title:    "Warn on `setopt RM_STAR_SILENT` / `unsetopt RM_STAR_WAIT` — removes `rm *` prompt",
+		Severity: SeverityWarning,
+		Description: "Zsh's default behaviour on an interactive `rm *` (or `rm /path/*`) is to " +
+			"pause for 10 seconds and ask \"do you really want to delete N files?\" — the " +
+			"`RM_STAR_WAIT` option. `setopt RM_STAR_SILENT` or `unsetopt RM_STAR_WAIT` both " +
+			"disable the prompt. In a profile / dot file the option leaks to every future " +
+			"interactive shell and removes a safety net that has saved countless home " +
+			"directories.",
+		Check: checkZC1650,
+	})
+}
+
+func checkZC1650(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			norm := strings.ToLower(strings.ReplaceAll(arg.String(), "_", ""))
+			if norm == "rmstarsilent" {
+				return zc1650Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			norm := strings.ToLower(strings.ReplaceAll(arg.String(), "_", ""))
+			if norm == "rmstarwait" {
+				return zc1650Hit(cmd, "unsetopt "+arg.String())
+			}
+		}
+	}
+	return nil
+}
+
+func zc1650Hit(cmd *ast.SimpleCommand, desc string) []Violation {
+	return []Violation{{
+		KataID: "ZC1650",
+		Message: "`" + desc + "` removes the `rm *` confirmation prompt — keep the default " +
+			"`RM_STAR_WAIT` so accidental deletions pause before they happen.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 646 Katas = 0.6.46
-const Version = "0.6.46"
+// 647 Katas = 0.6.47
+const Version = "0.6.47"


### PR DESCRIPTION
ZC1650 — Warn on `setopt RM_STAR_SILENT` / `unsetopt RM_STAR_WAIT` — removes `rm *` prompt

What: flags `setopt RM_STAR_SILENT` / `unsetopt RM_STAR_WAIT` (and their case / underscore variants).
Why: Zsh's default is to pause for 10 seconds on an interactive `rm *` and confirm. Disabling the prompt removes a safety net that has saved countless home directories.
Fix suggestion: keep the default `RM_STAR_WAIT` on. For scripted deletions where the prompt is a nuisance, pass `rm` through a subshell that scopes the option: `( setopt RM_STAR_SILENT; rm -- "${files[@]}" )`.
Severity: Warning