### PR TITLE
feat: ZC1651 — flag `docker run -p 0.0.0.0:PORT:PORT` all-interfaces publish

### DIFF
--- a/pkg/katas/katatests/zc1651_test.go
+++ b/pkg/katas/katatests/zc1651_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1651(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — localhost bind",
+			input:    `docker run -p 127.0.0.1:8080:80 nginx`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — implicit port (not explicit 0.0.0.0)",
+			input:    `docker run -p 8080:80 nginx`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — 0.0.0.0 explicit",
+			input: `docker run -p 0.0.0.0:8080:80 nginx`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1651",
+					Message: "`docker run -p 0.0.0.0:8080:80` publishes to every interface. Bind to `127.0.0.1:HOST:CONT` and put nginx / caddy in front for external access.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — [::] IPv6",
+			input: `podman run -p [::]:8080:80 nginx`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1651",
+					Message: "`podman run -p [::]:8080:80` publishes to every interface. Bind to `127.0.0.1:HOST:CONT` and put nginx / caddy in front for external access.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1651")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1651.go
+++ b/pkg/katas/zc1651.go
@@ -1,0 +1,68 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1651",
+		Title:    "Warn on `docker/podman run -p 0.0.0.0:PORT:PORT` — explicit all-interfaces publish",
+		Severity: SeverityWarning,
+		Description: "A port spec of `0.0.0.0:HOST:CONT`, `[::]:HOST:CONT`, or `*:HOST:CONT` " +
+			"publishes the container port to every interface the host has. On a multi-" +
+			"tenant LAN or a cloud host with a public IP the service is immediately reachable " +
+			"from anywhere. If the service needs only local reverse-proxy access, bind to " +
+			"`127.0.0.1:HOST:CONT` and let nginx / caddy handle external exposure.",
+		Check: checkZC1651,
+	})
+}
+
+func checkZC1651(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	if sub != "run" && sub != "create" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v != "-p" && v != "--publish" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			continue
+		}
+		spec := strings.Trim(cmd.Arguments[i+1].String(), "\"'")
+		if strings.HasPrefix(spec, "0.0.0.0:") ||
+			strings.HasPrefix(spec, "[::]:") ||
+			strings.HasPrefix(spec, "*:") {
+			return []Violation{{
+				KataID: "ZC1651",
+				Message: "`" + ident.Value + " " + sub + " -p " + spec + "` publishes to " +
+					"every interface. Bind to `127.0.0.1:HOST:CONT` and put nginx / caddy " +
+					"in front for external access.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 647 Katas = 0.6.47
-const Version = "0.6.47"
+// 648 Katas = 0.6.48
+const Version = "0.6.48"


### PR DESCRIPTION
ZC1651 — Warn on `docker/podman run -p 0.0.0.0:PORT:PORT` — explicit all-interfaces publish

What: flags `docker run` / `podman run` / `docker create` / `podman create` with `-p` / `--publish` where the bind spec starts with `0.0.0.0:`, `[::]:`, or `*:`.
Why: these bind the container port to every interface the host has. On a multi-tenant LAN or a cloud host with a public IP the service is immediately reachable from anywhere.
Fix suggestion: bind to `127.0.0.1:HOST:CONT` and put nginx / caddy in front for external access.
Severity: Warning