### PR TITLE
fix: allow openssl flag names in typos allowlist

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -5,6 +5,11 @@ dbe = "dbe"
 ede = "ede"
 # Hashi is the short form used in vendor name HashiCorp
 Hashi = "Hashi"
+# passin / passout are openssl password-source flag names
+passin = "passin"
+passout = "passout"
+# unparseable is standard English spelling (alongside "unparsable")
+unparseable = "unparseable"
 
 [default.extend-identifiers]
 # mke2fs is the canonical GNU ext2/3/4 filesystem creation tool


### PR DESCRIPTION
Add `passin`, `passout`, and `unparseable` to the typos extend-words list so Check Spelling stops failing on OpenSSL password-source flag docs and ZC1620 description text.