### PR TITLE
feat: ZC1652 — flag `ssh -Y` trusted X11 forwarding

### DIFF
--- a/pkg/katas/katatests/zc1652_test.go
+++ b/pkg/katas/katatests/zc1652_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1652(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ssh without X11",
+			input:    `ssh user@host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ssh -X (untrusted)",
+			input:    `ssh -X user@host firefox`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ssh -Y user@host",
+			input: `ssh -Y user@host xclock`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1652",
+					Message: "`ssh -Y` enables trusted X11 forwarding — remote clients get full access to the local X server. Use `-X` (untrusted) or drop X11 forwarding entirely.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ssh -i key -Y user@host",
+			input: `ssh -i key -Y user@host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1652",
+					Message: "`ssh -Y` enables trusted X11 forwarding — remote clients get full access to the local X server. Use `-X` (untrusted) or drop X11 forwarding entirely.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1652")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1652.go
+++ b/pkg/katas/zc1652.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1652",
+		Title:    "Warn on `ssh -Y` — trusted X11 forwarding grants full X-server access to remote clients",
+		Severity: SeverityWarning,
+		Description: "`ssh -Y` enables trusted X11 forwarding. Remote X clients can read every " +
+			"keystroke on the local display, take screenshots, inject synthetic events, and " +
+			"otherwise drive the local session with no sandbox. `ssh -X` enables the " +
+			"untrusted variant, which routes X traffic through the X SECURITY extension so " +
+			"those capabilities are limited (some GUI features break, which is why people " +
+			"reach for `-Y` — usually at far higher risk than they realised). Prefer `-X` " +
+			"when X11 forwarding is genuinely needed; better yet drop it for Wayland tools " +
+			"or VNC-over-SSH with its own auth.",
+		Check: checkZC1652,
+	})
+}
+
+func checkZC1652(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ssh" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-Y" {
+			return []Violation{{
+				KataID: "ZC1652",
+				Message: "`ssh -Y` enables trusted X11 forwarding — remote clients get full " +
+					"access to the local X server. Use `-X` (untrusted) or drop X11 " +
+					"forwarding entirely.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 648 Katas = 0.6.48
-const Version = "0.6.48"
+// 649 Katas = 0.6.49
+const Version = "0.6.49"


### PR DESCRIPTION
ZC1652 — Warn on `ssh -Y` — trusted X11 forwarding grants full X-server access to remote clients

What: flags `ssh -Y` invocations.
Why: remote X clients get keystrokes, screenshots, synthetic event injection, and full control of the local X server with no sandbox. `-X` routes via the X SECURITY extension with those capabilities limited.
Fix suggestion: use `-X` when X11 forwarding is genuinely needed, or drop X11 forwarding for Wayland tools / VNC-over-SSH.
Severity: Warning