### PR TITLE
feat: ZC1653 — flag `$BASHPID` Bash-only parameter

### DIFF
--- a/pkg/katas/katatests/zc1653_test.go
+++ b/pkg/katas/katatests/zc1653_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1653(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — $sysparams[pid]",
+			input:    `echo "$sysparams[pid]"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — plain PID reference",
+			input:    `echo "$PPID"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  `invalid — echo "$BASHPID"`,
+			input: `echo "$BASHPID"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1653",
+					Message: "`$BASHPID` is Bash-only. Use `$sysparams[pid]` after `zmodload zsh/system`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — print "sub=${BASHPID}"`,
+			input: `print -r -- "sub=${BASHPID}"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1653",
+					Message: "`$BASHPID` is Bash-only. Use `$sysparams[pid]` after `zmodload zsh/system`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1653")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1653.go
+++ b/pkg/katas/zc1653.go
@@ -1,0 +1,43 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1653",
+		Title:    "Avoid `$BASHPID` — Bash-only; Zsh uses `$sysparams[pid]` from `zsh/system`",
+		Severity: SeverityWarning,
+		Description: "`$BASHPID` returns the PID of the current subshell (while `$$` returns " +
+			"the parent shell's PID). In Zsh this parameter is not set — scripts that rely " +
+			"on `$BASHPID` silently get an empty string and misbehave. After `zmodload " +
+			"zsh/system`, Zsh exposes the current process PID as `$sysparams[pid]`, which " +
+			"updates inside subshells just like Bash's `$BASHPID`.",
+		Check: checkZC1653,
+	})
+}
+
+func checkZC1653(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "$BASHPID") || strings.Contains(v, "${BASHPID}") {
+			return []Violation{{
+				KataID: "ZC1653",
+				Message: "`$BASHPID` is Bash-only. Use `$sysparams[pid]` after " +
+					"`zmodload zsh/system`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 649 Katas = 0.6.49
-const Version = "0.6.49"
+// 650 Katas = 0.6.50
+const Version = "0.6.50"


### PR DESCRIPTION
ZC1653 — Avoid `$BASHPID` — Bash-only; Zsh uses `$sysparams[pid]` from `zsh/system`

What: flags arguments referencing `$BASHPID` / `${BASHPID}`.
Why: `$BASHPID` returns the current subshell's PID (while `$$` returns the parent shell's PID). Zsh does not set this parameter — scripts silently read empty and misbehave.
Fix suggestion: `zmodload zsh/system` once, then read `$sysparams[pid]` — updates inside subshells the same way.
Severity: Warning

Milestone: this PR takes the project to 650 katas.