### PR TITLE
feat: ZC1654 — flag `sysctl -p /tmp/...` TOCTOU config load

### DIFF
--- a/pkg/katas/katatests/zc1654_test.go
+++ b/pkg/katas/katatests/zc1654_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1654(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sysctl -p /etc/sysctl.conf",
+			input:    `sysctl -p /etc/sysctl.conf`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — sysctl -p (default)",
+			input:    `sysctl -p`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — sysctl -p /tmp/sysctl.conf",
+			input: `sysctl -p /tmp/sysctl.conf`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1654",
+					Message: "`sysctl -p /tmp/sysctl.conf` reads tunables from a world-traversable path — a concurrent local user can substitute the file. Keep configs under `/etc/sysctl.d/`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — sysctl -p /var/tmp/x",
+			input: `sysctl -p /var/tmp/x.conf`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1654",
+					Message: "`sysctl -p /var/tmp/x.conf` reads tunables from a world-traversable path — a concurrent local user can substitute the file. Keep configs under `/etc/sysctl.d/`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1654")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1654.go
+++ b/pkg/katas/zc1654.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1654",
+		Title:    "Warn on `sysctl -p /tmp/...` — loading kernel tunables from attacker-writable path",
+		Severity: SeverityWarning,
+		Description: "`sysctl -p PATH` reads `key=value` lines from PATH and applies them as " +
+			"kernel tunables. A PATH under `/tmp/` or `/var/tmp/` is world-traversable; a " +
+			"concurrent local user can substitute the file between write and read, " +
+			"injecting `kernel.core_pattern=|/tmp/evil`, `kernel.modprobe=/tmp/evil`, or " +
+			"disabling hardening knobs (`kernel.kptr_restrict=0`, `kernel.yama.ptrace_scope=" +
+			"0`). Keep sysctl configs under `/etc/sysctl.d/` with root ownership.",
+		Check: checkZC1654,
+	})
+}
+
+func checkZC1654(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "sysctl" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		if arg.String() != "-p" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			continue
+		}
+		next := cmd.Arguments[i+1].String()
+		if strings.HasPrefix(next, "/tmp/") || strings.HasPrefix(next, "/var/tmp/") {
+			return []Violation{{
+				KataID: "ZC1654",
+				Message: "`sysctl -p " + next + "` reads tunables from a world-traversable " +
+					"path — a concurrent local user can substitute the file. Keep configs " +
+					"under `/etc/sysctl.d/`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 650 Katas = 0.6.50
-const Version = "0.6.50"
+// 651 Katas = 0.6.51
+const Version = "0.6.51"


### PR DESCRIPTION
ZC1654 — Warn on `sysctl -p /tmp/...` — loading kernel tunables from attacker-writable path

What: flags `sysctl -p PATH` where PATH starts with `/tmp/` or `/var/tmp/`.
Why: `sysctl -p` reads `key=value` tunables from PATH and applies them. A `/tmp/` location is world-traversable — a concurrent local user can substitute the file between the script's write and sysctl's read, injecting `kernel.core_pattern=|/tmp/evil`, `kernel.modprobe=/tmp/evil`, or disabling hardening knobs.
Fix suggestion: keep sysctl configs under `/etc/sysctl.d/` with root ownership.
Severity: Warning