### PR TITLE
feat: ZC1655 — flag `read -n N` Bash-only character-count semantics

### DIFF
--- a/pkg/katas/katatests/zc1655_test.go
+++ b/pkg/katas/katatests/zc1655_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1655(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — read -k 1 (Zsh)",
+			input:    `read -k 1 var`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — read -r line",
+			input:    `read -r line`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — read -n 1 char",
+			input: `read -n 1 char`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1655",
+					Message: "`read -n N` is Bash syntax for \"read N characters\". Zsh's `-n` means \"drop trailing newline\" with no count. Use `read -k N var` in Zsh.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — read -n5 var",
+			input: `read -n5 var`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1655",
+					Message: "`read -n N` is Bash syntax for \"read N characters\". Zsh's `-n` means \"drop trailing newline\" with no count. Use `read -k N var` in Zsh.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1655")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1655.go
+++ b/pkg/katas/zc1655.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1655",
+		Title:    "Warn on `read -n N` — Bash reads N chars; Zsh's `-n` means \"drop newline\"",
+		Severity: SeverityWarning,
+		Description: "In Bash, `read -n N var` reads exactly N characters (handy for single-" +
+			"keypress prompts). In Zsh, `-n` is the \"don't append newline to the reply " +
+			"string\" flag and doesn't take a count — `read -n 1 var` sets `var` to the " +
+			"whole line, not a single character. Use `read -k N var` in Zsh for N-character " +
+			"reads.",
+		Check: checkZC1655,
+	})
+}
+
+func checkZC1655(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "read" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-n" && i+1 < len(cmd.Arguments) {
+			if _, err := strconv.Atoi(cmd.Arguments[i+1].String()); err == nil {
+				return zc1655Hit(cmd)
+			}
+		}
+		if strings.HasPrefix(v, "-n") && len(v) > 2 {
+			if _, err := strconv.Atoi(v[2:]); err == nil {
+				return zc1655Hit(cmd)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1655Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1655",
+		Message: "`read -n N` is Bash syntax for \"read N characters\". Zsh's `-n` means " +
+			"\"drop trailing newline\" with no count. Use `read -k N var` in Zsh.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 651 Katas = 0.6.51
-const Version = "0.6.51"
+// 652 Katas = 0.6.52
+const Version = "0.6.52"


### PR DESCRIPTION
ZC1655 — Warn on `read -n N` — Bash reads N chars; Zsh's `-n` means "drop newline"

What: flags `read -n N var` and `read -nN var` where N is an integer.
Why: Bash's `read -n N` reads exactly N characters. Zsh's `-n` is the "don't append trailing newline to the reply" flag and takes no count — `read -n 1 var` sets `var` to the whole input line instead of one character.
Fix suggestion: use `read -k N var` in Zsh for N-character reads.
Severity: Warning