### PR TITLE
feat: ZC1656 — flag rsync -e ssh host-key verify bypass

### DIFF
--- a/pkg/katas/katatests/zc1656_test.go
+++ b/pkg/katas/katatests/zc1656_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1656(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — rsync with plain ssh",
+			input:    `rsync -e ssh src host:dst`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — rsync without -e",
+			input:    `rsync -a src dst`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  `invalid — rsync -e "ssh -o StrictHostKeyChecking=no"`,
+			input: `rsync -e "ssh -o StrictHostKeyChecking=no" src host:dst`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1656",
+					Message: "`rsync -e 'ssh -o StrictHostKeyChecking=no'` disables host-key verification — MITM risk. Pre-provision `known_hosts` and keep `StrictHostKeyChecking=yes`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — rsync with UserKnownHostsFile=/dev/null`,
+			input: `rsync -e "ssh -o UserKnownHostsFile=/dev/null" src host:dst`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1656",
+					Message: "`rsync -e 'ssh -o StrictHostKeyChecking=no'` disables host-key verification — MITM risk. Pre-provision `known_hosts` and keep `StrictHostKeyChecking=yes`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1656")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1656.go
+++ b/pkg/katas/zc1656.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1656",
+		Title:    "Error on `rsync -e 'ssh -o StrictHostKeyChecking=no'` — host-key verify disabled",
+		Severity: SeverityError,
+		Description: "Disabling host-key verification through rsync's `-e` transport is the " +
+			"same attack surface as ZC1479 but easier to miss in review because the ssh flags " +
+			"sit inside a quoted string. A MITM on the network path can impersonate the " +
+			"remote host and the rsync stream goes straight through. Use `ssh-keyscan` or " +
+			"pre-provisioned `~/.ssh/known_hosts` to trust hosts deliberately, and keep " +
+			"`StrictHostKeyChecking=yes`.",
+		Check: checkZC1656,
+	})
+}
+
+func checkZC1656(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "rsync" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.Contains(v, "StrictHostKeyChecking=no") ||
+			strings.Contains(v, "UserKnownHostsFile=/dev/null") {
+			return []Violation{{
+				KataID: "ZC1656",
+				Message: "`rsync -e 'ssh -o StrictHostKeyChecking=no'` disables host-key " +
+					"verification — MITM risk. Pre-provision `known_hosts` and keep " +
+					"`StrictHostKeyChecking=yes`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 652 Katas = 0.6.52
-const Version = "0.6.52"
+// 653 Katas = 0.6.53
+const Version = "0.6.53"


### PR DESCRIPTION
ZC1656 — Error on `rsync -e 'ssh -o StrictHostKeyChecking=no'` — host-key verify disabled

What: `rsync -e "ssh -o StrictHostKeyChecking=no"` (or `UserKnownHostsFile=/dev/null`) ships the file stream over an ssh transport with host-key verification disabled.
Why: Same class as ZC1479 but easier to miss in review — the flags hide inside a quoted `-e` string. A MITM on the path impersonates the remote and the rsync stream goes straight through.
Fix suggestion: Pre-provision `~/.ssh/known_hosts` (or `ssh-keyscan` under review), keep `StrictHostKeyChecking=yes`.
Severity: Error