### PR TITLE
feat: ZC1657 — flag semanage permissive -a SELinux domain disable

### DIFF
--- a/pkg/katas/katatests/zc1657_test.go
+++ b/pkg/katas/katatests/zc1657_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1657(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — semanage permissive -d removes domain",
+			input:    `semanage permissive -d httpd_t`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — semanage boolean -l listing",
+			input:    `semanage boolean -l`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — semanage permissive -a httpd_t",
+			input: `semanage permissive -a httpd_t`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1657",
+					Message: "`semanage permissive -a` puts an SELinux domain in permissive mode — policy violations log but no longer block. Write a scoped allow rule with `audit2allow` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — semanage permissive --add sshd_t",
+			input: `semanage permissive --add sshd_t`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1657",
+					Message: "`semanage permissive -a` puts an SELinux domain in permissive mode — policy violations log but no longer block. Write a scoped allow rule with `audit2allow` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1657")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1657.go
+++ b/pkg/katas/zc1657.go
@@ -1,0 +1,62 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1657",
+		Title:    "Warn on `semanage permissive -a <type>` — puts SELinux domain in permissive mode",
+		Severity: SeverityWarning,
+		Description: "`semanage permissive -a DOMAIN` (or `--add`) marks an SELinux domain as " +
+			"permissive: policy violations are logged but not blocked. It is narrower than " +
+			"`setenforce 0` but still disables enforcement for whatever DOMAIN covers — often " +
+			"`httpd_t`, `container_t`, or `sshd_t` — and the override persists across reboots " +
+			"because it is written to policy. Fix the denial with an explicit allow rule built " +
+			"from `audit2allow` or ship a custom policy module, and remove the permissive mark " +
+			"with `semanage permissive -d DOMAIN` once the rule lands.",
+		Check: checkZC1657,
+	})
+}
+
+func checkZC1657(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "semanage" {
+		return nil
+	}
+
+	hasPermissive := false
+	hasAdd := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "permissive":
+			hasPermissive = true
+		case "-a", "--add":
+			hasAdd = true
+		}
+	}
+
+	if !hasPermissive || !hasAdd {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1657",
+		Message: "`semanage permissive -a` puts an SELinux domain in permissive mode — " +
+			"policy violations log but no longer block. Write a scoped allow rule with " +
+			"`audit2allow` instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 653 Katas = 0.6.53
-const Version = "0.6.53"
+// 654 Katas = 0.6.54
+const Version = "0.6.54"


### PR DESCRIPTION
ZC1657 — Warn on `semanage permissive -a <type>` — puts SELinux domain in permissive mode

What: `semanage permissive -a DOMAIN` / `--add` adds an SELinux type to the permissive-domain list.
Why: Narrower than `setenforce 0` but still disables enforcement for the named domain (often `httpd_t`, `container_t`, `sshd_t`) and persists across reboots because it is baked into policy.
Fix suggestion: Build an explicit allow rule with `audit2allow` (or a hand-written policy module), then remove the permissive mark with `semanage permissive -d DOMAIN`.
Severity: Warning

## Test plan
- valid `semanage permissive -d httpd_t` → no violation
- valid `semanage boolean -l` → no violation
- invalid `semanage permissive -a httpd_t` → ZC1657
- invalid `semanage permissive --add sshd_t` → ZC1657