### PR TITLE
feat: ZC1658 — flag curl -OJ server-named output filename

### DIFF
--- a/pkg/katas/katatests/zc1658_test.go
+++ b/pkg/katas/katatests/zc1658_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1658(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — curl -O without -J",
+			input:    `curl -O https://example.com/file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — curl -o with fixed name",
+			input:    `curl -o out.bin https://example.com/file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — curl -OJ combined",
+			input: `curl -OJ https://example.com/file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1658",
+					Message: "`curl -OJ` saves the response under the name the server picks in `Content-Disposition` — path traversal is blocked but arbitrary same-dir overwrites are not. Pass `-o NAME` with a filename you control.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — curl -O -J split",
+			input: `curl -O -J https://example.com/file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1658",
+					Message: "`curl -OJ` saves the response under the name the server picks in `Content-Disposition` — path traversal is blocked but arbitrary same-dir overwrites are not. Pass `-o NAME` with a filename you control.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1658")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1658.go
+++ b/pkg/katas/zc1658.go
@@ -1,0 +1,76 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1658",
+		Title:    "Warn on `curl -OJ` / `-J -O` — server-controlled output filename",
+		Severity: SeverityWarning,
+		Description: "`curl -J` (`--remote-header-name`) combined with `-O` (`--remote-name`) " +
+			"saves the response using the filename the server puts in the `Content-Disposition` " +
+			"header. The server — or anything on the path that can set headers, including a " +
+			"compromised CDN or an HTTP-serving reverse proxy — chooses the destination name. " +
+			"Paths like `../../etc/cron.d/evil` are rejected by curl's sanitizer, but benign-" +
+			"looking names still overwrite files in the current directory. Use `-o NAME` with " +
+			"a filename you control, and validate the payload before you act on it.",
+		Check: checkZC1658,
+	})
+}
+
+func checkZC1658(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "curl" {
+		return nil
+	}
+
+	hasJ := false
+	hasO := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--remote-header-name" {
+			hasJ = true
+			continue
+		}
+		if v == "--remote-name" {
+			hasO = true
+			continue
+		}
+		if !strings.HasPrefix(v, "-") || strings.HasPrefix(v, "--") {
+			continue
+		}
+		body := strings.TrimPrefix(v, "-")
+		if strings.ContainsRune(body, 'J') {
+			hasJ = true
+		}
+		if strings.ContainsRune(body, 'O') {
+			hasO = true
+		}
+	}
+
+	if !hasJ || !hasO {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1658",
+		Message: "`curl -OJ` saves the response under the name the server picks in " +
+			"`Content-Disposition` — path traversal is blocked but arbitrary same-dir " +
+			"overwrites are not. Pass `-o NAME` with a filename you control.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 654 Katas = 0.6.54
-const Version = "0.6.54"
+// 655 Katas = 0.6.55
+const Version = "0.6.55"


### PR DESCRIPTION
ZC1658 — Warn on `curl -OJ` / `-J -O` — server-controlled output filename

What: `curl -J` (`--remote-header-name`) + `-O` saves the response using whatever filename the server sends in `Content-Disposition`.
Why: Server (or anything on the path that can set headers — compromised CDN, reverse proxy, MITM) picks the destination name. Path traversal is sanitized, but same-directory overwrites (e.g., stomping `.zshrc` in the current dir) are not.
Fix suggestion: Use `-o NAME` with a filename the script controls, and validate the payload before acting on it.
Severity: Warning

## Test plan
- valid `curl -O https://example.com/file` → no violation
- valid `curl -o out.bin https://example.com/file` → no violation
- invalid `curl -OJ https://example.com/file` → ZC1658
- invalid `curl -O -J https://example.com/file` → ZC1658