### PR TITLE
feat: ZC1659 — flag fuser -k path-target broad kill

### DIFF
--- a/pkg/katas/katatests/zc1659_test.go
+++ b/pkg/katas/katatests/zc1659_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1659(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — fuser -k port target",
+			input:    `fuser -k 8080/tcp`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — fuser without -k",
+			input:    `fuser /var/log/syslog`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — fuser -k /mnt",
+			input: `fuser -k /mnt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1659",
+					Message: "`fuser -k /mnt` signals every process with a file open anywhere under the path — use PID / port targets or `systemctl stop` for services.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — fuser -kim /",
+			input: `fuser -kim /`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1659",
+					Message: "`fuser -k /` signals every process with a file open anywhere under the path — use PID / port targets or `systemctl stop` for services.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1659")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1659.go
+++ b/pkg/katas/zc1659.go
@@ -1,0 +1,71 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1659",
+		Title:    "Warn on `fuser -k <path>` — kills every process holding the subtree open",
+		Severity: SeverityWarning,
+		Description: "`fuser -k PATH` sends a signal (SIGKILL by default) to every process that " +
+			"has any file under PATH open — not just the one you expected. On `/`, `/var`, " +
+			"`/tmp`, or any mount-root this reaches sshd, cron, dbus, and the caller's own " +
+			"shell; on a bind-mount it kills workloads that share the host inode. Target " +
+			"specific PIDs (`kill $(pidof app)`) or ports (`fuser -k PORT/tcp`), or use " +
+			"`systemctl stop UNIT` for services. `fuser -k` against a filesystem path is " +
+			"blast-radius that the caller rarely owns.",
+		Check: checkZC1659,
+	})
+}
+
+func checkZC1659(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "fuser" {
+		return nil
+	}
+
+	hasKill := false
+	pathTarget := ""
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "-") && !strings.HasPrefix(v, "--") {
+			if strings.ContainsRune(strings.TrimPrefix(v, "-"), 'k') {
+				hasKill = true
+			}
+			continue
+		}
+		if strings.HasPrefix(v, "/") {
+			if strings.HasSuffix(v, "/tcp") || strings.HasSuffix(v, "/udp") ||
+				strings.HasSuffix(v, "/sctp") {
+				continue
+			}
+			pathTarget = v
+		}
+	}
+
+	if !hasKill || pathTarget == "" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1659",
+		Message: "`fuser -k " + pathTarget + "` signals every process with a file open " +
+			"anywhere under the path — use PID / port targets or `systemctl stop` for " +
+			"services.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 655 Katas = 0.6.55
-const Version = "0.6.55"
+// 656 Katas = 0.6.56
+const Version = "0.6.56"


### PR DESCRIPTION
ZC1659 — Warn on `fuser -k <path>` — kills every process holding the subtree open

What: `fuser -k PATH` signals (SIGKILL by default) every process with a file open anywhere under PATH.
Why: On `/`, `/var`, `/tmp`, or any mount-root this reaches sshd, cron, dbus, and the caller's own shell. On a bind-mount it hits workloads that share the host inode. Blast radius is wider than the caller usually owns.
Fix suggestion: Target specific PIDs (`kill $(pidof app)`) or ports (`fuser -k 8080/tcp`), or `systemctl stop UNIT` for services.
Severity: Warning

## Test plan
- valid `fuser -k 8080/tcp` → no violation
- valid `fuser /var/log/syslog` (no -k) → no violation
- invalid `fuser -k /mnt` → ZC1659
- invalid `fuser -kim /` → ZC1659