### PR TITLE
feat: ZC1660 — prefer Zsh ${(l:N::0:)} over printf '%0Nd' zero-pad

### DIFF
--- a/pkg/katas/katatests/zc1660_test.go
+++ b/pkg/katas/katatests/zc1660_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1660(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — printf %d without width",
+			input:    `printf '%d' 5`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — printf %-20s left-aligned string (space fill)",
+			input:    `printf '%-20s' "$name"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — printf %05d",
+			input: `printf '%05d' $n`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1660",
+					Message: "`printf '%0Nd'` forks for zero-padding — prefer Zsh `${(l:N::0:)n}` parameter-expansion pad (same for `(r:N::0:)` on the right).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — printf %03d literal",
+			input: `printf '%03d' 7`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1660",
+					Message: "`printf '%0Nd'` forks for zero-padding — prefer Zsh `${(l:N::0:)n}` parameter-expansion pad (same for `(r:N::0:)` on the right).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1660")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1660.go
+++ b/pkg/katas/zc1660.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"regexp"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1660ZeroPad = regexp.MustCompile(`%0[1-9][0-9]*d`)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1660",
+		Title:    "Style: `printf '%0Nd' $n` — prefer Zsh `${(l:N::0:)n}` left-zero-pad",
+		Severity: SeverityStyle,
+		Description: "Zero-padding an integer through `printf '%0Nd'` forks a tiny sub-process " +
+			"and relies on printf's format-string parser — both things Zsh can avoid. " +
+			"`${(l:N::0:)n}` left-pads `$n` with `0` to width N using Zsh parameter " +
+			"expansion, no fork, and composes cleanly with other `(q)` / `(L)` / `(U)` " +
+			"flags. For right-pad use `${(r:N::0:)n}`; for space padding swap the fill " +
+			"character: `${(l:N:)n}` or `${(r:N:)n}`.",
+		Check: checkZC1660,
+	})
+}
+
+func checkZC1660(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "printf" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	fmtArg := cmd.Arguments[0].String()
+	if !zc1660ZeroPad.MatchString(fmtArg) {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1660",
+		Message: "`printf '%0Nd'` forks for zero-padding — prefer Zsh `${(l:N::0:)n}` " +
+			"parameter-expansion pad (same for `(r:N::0:)` on the right).",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 656 Katas = 0.6.56
-const Version = "0.6.56"
+// 657 Katas = 0.6.57
+const Version = "0.6.57"


### PR DESCRIPTION
ZC1660 — Style: `printf '%0Nd' $n` — prefer Zsh `${(l:N::0:)n}` left-zero-pad

What: `printf '%0Nd' $n` zero-pads an integer to width N by forking `/usr/bin/printf`.
Why: Zsh's parameter-expansion pad `${(l:N::0:)n}` does the same with no fork and composes with other flags (`(q)`, `(L)`, `(U)`). Skips the format-string parser entirely.
Fix suggestion: Use `${(l:N::0:)n}` for left zero-pad, `${(r:N::0:)n}` for right. For space fill, drop the third colon group: `${(l:N:)n}`.
Severity: Style

## Test plan
- valid `printf '%d' 5` → no violation
- valid `printf '%-20s' "$name"` → no violation
- invalid `printf '%05d' $n` → ZC1660
- invalid `printf '%03d' 7` → ZC1660