### PR TITLE
feat: ZC1661 — flag curl --cacert /dev/null empty trust store

### DIFF
--- a/pkg/katas/katatests/zc1661_test.go
+++ b/pkg/katas/katatests/zc1661_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1661(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — curl with real CA bundle",
+			input:    `curl https://example.com --cacert /etc/ssl/certs/ca-certificates.crt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — curl without cacert",
+			input:    `curl https://example.com -o out`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — curl URL --cacert /dev/null",
+			input: `curl https://example.com --cacert /dev/null`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1661",
+					Message: "`curl --cacert /dev/null` feeds curl an empty trust store — most TLS backends then accept any peer cert. Use a real bundle or `--pinnedpubkey`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — curl -s URL --capath /dev/null",
+			input: `curl -s https://example.com --capath /dev/null`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1661",
+					Message: "`curl --cacert /dev/null` feeds curl an empty trust store — most TLS backends then accept any peer cert. Use a real bundle or `--pinnedpubkey`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1661")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1661.go
+++ b/pkg/katas/zc1661.go
@@ -1,0 +1,69 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1661",
+		Title:    "Error on `curl --cacert /dev/null` — empty trust store, any cert passes",
+		Severity: SeverityError,
+		Description: "Pointing `--cacert` (or `--capath`) at `/dev/null` hands curl an empty " +
+			"trust anchor set. Counter-intuitively, curl treats the peer certificate as " +
+			"valid when no issuers are configured for the selected TLS backend (OpenSSL, " +
+			"wolfSSL, Schannel all accept any cert chain against an empty CA bundle). This is " +
+			"the TLS equivalent of `--insecure` with one more keystroke of plausible " +
+			"deniability. Use a real bundle (`/etc/ssl/certs/ca-certificates.crt`) or " +
+			"`--pinnedpubkey sha256//…` for known endpoints.",
+		Check: checkZC1661,
+	})
+}
+
+func checkZC1661(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "cacert", "capath":
+		if len(cmd.Arguments) > 0 && cmd.Arguments[0].String() == "/dev/null" {
+			return zc1661Hit(cmd)
+		}
+		return nil
+	case "curl":
+	default:
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v != "--cacert" && v != "--capath" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			continue
+		}
+		if cmd.Arguments[i+1].String() == "/dev/null" {
+			return zc1661Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1661Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1661",
+		Message: "`curl --cacert /dev/null` feeds curl an empty trust store — most TLS " +
+			"backends then accept any peer cert. Use a real bundle or `--pinnedpubkey`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 657 Katas = 0.6.57
-const Version = "0.6.57"
+// 658 Katas = 0.6.58
+const Version = "0.6.58"


### PR DESCRIPTION
ZC1661 — Error on `curl --cacert /dev/null` — empty trust store, any cert passes

What: Pointing `--cacert` or `--capath` at `/dev/null` hands curl an empty trust-anchor set.
Why: Most TLS backends (OpenSSL, wolfSSL, Schannel) treat the peer cert as valid when no issuers are configured. It is the TLS-equivalent of `--insecure` with one more keystroke of plausible deniability.
Fix suggestion: Use a real bundle (`/etc/ssl/certs/ca-certificates.crt`) or `--pinnedpubkey sha256//…` for known endpoints.
Severity: Error

## Test plan
- valid `curl URL --cacert /etc/ssl/certs/ca-certificates.crt` → no violation
- valid `curl URL -o out` → no violation
- invalid `curl URL --cacert /dev/null` → ZC1661
- invalid `curl -s URL --capath /dev/null` → ZC1661