### PR TITLE
feat: ZC1662 — flag pkexec env VAR=VAL root-env injection

### DIFF
--- a/pkg/katas/katatests/zc1662_test.go
+++ b/pkg/katas/katatests/zc1662_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1662(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — pkexec direct command",
+			input:    `pkexec /usr/bin/systemctl restart unit`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — pkexec apt install",
+			input:    `pkexec /usr/bin/apt install foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — pkexec env DISPLAY=... cmd",
+			input: `pkexec env DISPLAY=:0 /usr/bin/cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1662",
+					Message: "`pkexec env VAR=VAL CMD` hands the root session a caller-controlled environment — use a polkit rule or `systemd-run --user` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — pkexec env PATH=/tmp cmd",
+			input: `pkexec env PATH=/tmp /usr/bin/cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1662",
+					Message: "`pkexec env VAR=VAL CMD` hands the root session a caller-controlled environment — use a polkit rule or `systemd-run --user` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1662")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1662.go
+++ b/pkg/katas/zc1662.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1662",
+		Title:    "Error on `pkexec env VAR=VAL CMD` — controlled env crossed into the root session",
+		Severity: SeverityError,
+		Description: "`pkexec env VAR=VALUE CMD` invokes `/usr/bin/env` as the target user (root " +
+			"by default) with a caller-controlled environment. Polkit sanitizes a short " +
+			"allow-list on its own, but once `env` takes over the remaining variables " +
+			"(`LD_PRELOAD`, `GCONV_PATH`, `PYTHONPATH`, `XDG_RUNTIME_DIR`, `LANGUAGE`) ride " +
+			"straight into root. CVE-2021-4034 (pwnkit) demonstrated the same primitive by " +
+			"abusing argv[0]; the `env` wrapper makes the bypass trivial. If the child needs " +
+			"specific variables, set them in a polkit rule or via `systemd-run --user` " +
+			"instead, not through `env`.",
+		Check: checkZC1662,
+	})
+}
+
+func checkZC1662(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "pkexec" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "env" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1662",
+		Message: "`pkexec env VAR=VAL CMD` hands the root session a caller-controlled " +
+			"environment — use a polkit rule or `systemd-run --user` instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 658 Katas = 0.6.58
-const Version = "0.6.58"
+// 659 Katas = 0.6.59
+const Version = "0.6.59"


### PR DESCRIPTION
ZC1662 — Error on `pkexec env VAR=VAL CMD` — controlled env crossed into the root session

What: `pkexec env VAR=VALUE CMD` invokes `/usr/bin/env` as root with a caller-controlled environment.
Why: Polkit sanitizes a small allow-list, but once `env` takes over the remaining variables (`LD_PRELOAD`, `GCONV_PATH`, `PYTHONPATH`, `XDG_RUNTIME_DIR`, `LANGUAGE`) ride straight into root. CVE-2021-4034 used the same primitive via argv[0]; `env` makes it trivial.
Fix suggestion: Set required variables in a polkit rule or via `systemd-run --user` instead.
Severity: Error

## Test plan
- valid `pkexec /usr/bin/systemctl restart unit` → no violation
- valid `pkexec /usr/bin/apt install foo` → no violation
- invalid `pkexec env DISPLAY=:0 /usr/bin/cmd` → ZC1662
- invalid `pkexec env PATH=/tmp /usr/bin/cmd` → ZC1662