### PR TITLE
feat: ZC1663 — flag tune2fs -c 0 / -i 0 periodic-fsck disable

### DIFF
--- a/pkg/katas/katatests/zc1663_test.go
+++ b/pkg/katas/katatests/zc1663_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1663(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — tune2fs -c 30 (reduced cadence)",
+			input:    `tune2fs -c 30 $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — tune2fs -l (listing)",
+			input:    `tune2fs -l $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — tune2fs -c 0",
+			input: `tune2fs -c 0 $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1663",
+					Message: "`tune2fs -c 0` disables periodic fsck on the filesystem — lower the cadence (e.g. `-c 30` / `-i 3m`) instead of turning it off.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — tune2fs -i 0",
+			input: `tune2fs -i 0 $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1663",
+					Message: "`tune2fs -i 0` disables periodic fsck on the filesystem — lower the cadence (e.g. `-c 30` / `-i 3m`) instead of turning it off.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1663")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1663.go
+++ b/pkg/katas/zc1663.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1663",
+		Title:    "Warn on `tune2fs -c 0` / `-i 0` — disables periodic filesystem checks",
+		Severity: SeverityWarning,
+		Description: "`tune2fs -c 0` (mount count) and `tune2fs -i 0` (time interval) disable " +
+			"the ext2/3/4 periodic-fsck machinery so the filesystem only gets checked after a " +
+			"dirty unmount or a manual `fsck -f`. For desktops the nag is annoying; for " +
+			"long-lived servers it is the last line of defence against silent metadata " +
+			"corruption. Lower the cadence if the default is too aggressive (`tune2fs -c 30`, " +
+			"`-i 3m`) rather than turning it off, and schedule an offline `fsck` on a cadence " +
+			"you can defend.",
+		Check: checkZC1663,
+	})
+}
+
+func checkZC1663(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "tune2fs" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v != "-c" && v != "-i" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			continue
+		}
+		next := cmd.Arguments[i+1].String()
+		if next != "0" {
+			continue
+		}
+		return []Violation{{
+			KataID: "ZC1663",
+			Message: "`tune2fs " + v + " 0` disables periodic fsck on the filesystem — " +
+				"lower the cadence (e.g. `-c 30` / `-i 3m`) instead of turning it off.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 659 Katas = 0.6.59
-const Version = "0.6.59"
+// 660 Katas = 0.6.60
+const Version = "0.6.60"


### PR DESCRIPTION
ZC1663 — Warn on `tune2fs -c 0` / `-i 0` — disables periodic filesystem checks

What: `tune2fs -c 0` (mount count) and `tune2fs -i 0` (time interval) disable the ext2/3/4 periodic-fsck machinery.
Why: Filesystem is then only checked after a dirty unmount or manual `fsck -f`. For long-lived servers this removes the last line of defence against silent metadata corruption.
Fix suggestion: Lower the cadence (`tune2fs -c 30`, `-i 3m`) instead of turning it off, and schedule offline `fsck` on a defensible cadence.
Severity: Warning

## Test plan
- valid `tune2fs -c 30 $DISK` → no violation
- valid `tune2fs -l $DISK` → no violation
- invalid `tune2fs -c 0 $DISK` → ZC1663
- invalid `tune2fs -i 0 $DISK` → ZC1663