### PR TITLE
feat: ZC1664 — flag systemctl set-default rescue/emergency persistent boot

### DIFF
--- a/pkg/katas/katatests/zc1664_test.go
+++ b/pkg/katas/katatests/zc1664_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1664(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — systemctl set-default multi-user.target",
+			input:    `systemctl set-default multi-user.target`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — systemctl set-default graphical.target",
+			input:    `systemctl set-default graphical.target`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — systemctl set-default rescue.target",
+			input: `systemctl set-default rescue.target`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1664",
+					Message: "`systemctl set-default rescue.target` makes every subsequent boot land in single-user mode — revert with `set-default multi-user.target` or `graphical.target`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — systemctl set-default emergency.target",
+			input: `systemctl set-default emergency.target`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1664",
+					Message: "`systemctl set-default emergency.target` makes every subsequent boot land in single-user mode — revert with `set-default multi-user.target` or `graphical.target`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1664")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1664.go
+++ b/pkg/katas/zc1664.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1664",
+		Title:    "Error on `systemctl set-default rescue.target|emergency.target` — persistent single-user boot",
+		Severity: SeverityError,
+		Description: "`systemctl set-default` rewrites `/etc/systemd/system/default.target` as a " +
+			"symlink to the named target. Pointing it at `rescue.target` or " +
+			"`emergency.target` means every subsequent boot drops to single-user mode " +
+			"before networking, sshd, or any normal unit starts — you lose remote access to " +
+			"the box unless you have serial console / out-of-band management. Unlike " +
+			"`systemctl isolate` (one-shot, caught by ZC1561) this persists across reboots. " +
+			"Revert with `systemctl set-default multi-user.target` (servers) or `graphical." +
+			"target` (desktops).",
+		Check: checkZC1664,
+	})
+}
+
+func checkZC1664(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "systemctl" {
+		return nil
+	}
+
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "set-default" {
+		return nil
+	}
+	target := cmd.Arguments[1].String()
+	if target != "rescue.target" && target != "emergency.target" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1664",
+		Message: "`systemctl set-default " + target + "` makes every subsequent boot land " +
+			"in single-user mode — revert with `set-default multi-user.target` or " +
+			"`graphical.target`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 660 Katas = 0.6.60
-const Version = "0.6.60"
+// 661 Katas = 0.6.61
+const Version = "0.6.61"


### PR DESCRIPTION
ZC1664 — Error on `systemctl set-default rescue.target|emergency.target` — persistent single-user boot

What: `systemctl set-default` rewrites `/etc/systemd/system/default.target` as a symlink to the named target.
Why: `rescue.target` / `emergency.target` means every boot drops to single-user mode before networking / sshd / normal units start — remote access is lost until reverted. Unlike `systemctl isolate` (one-shot, ZC1561), this persists across reboots.
Fix suggestion: Revert with `systemctl set-default multi-user.target` (servers) or `graphical.target` (desktops).
Severity: Error

## Test plan
- valid `systemctl set-default multi-user.target` → no violation
- valid `systemctl set-default graphical.target` → no violation
- invalid `systemctl set-default rescue.target` → ZC1664
- invalid `systemctl set-default emergency.target` → ZC1664