### PR TITLE
feat: ZC1665 — flag chrt -r / -f real-time scheduling in scripts

### DIFF
--- a/pkg/katas/katatests/zc1665_test.go
+++ b/pkg/katas/katatests/zc1665_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1665(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — chrt -o 0 (SCHED_OTHER)",
+			input:    `chrt -o 0 /usr/bin/cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — chrt listing priority",
+			input:    `chrt -p 1234`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — chrt -r 99 cmd",
+			input: `chrt -r 99 /usr/bin/cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1665",
+					Message: "`chrt -r` puts the child on a real-time scheduling class — a busy-loop or deadlock then starves kworker / sshd. Prefer `nice -n -5` or a systemd unit with `CPUWeight=`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — chrt -f 50 cmd",
+			input: `chrt -f 50 /usr/bin/cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1665",
+					Message: "`chrt -f` puts the child on a real-time scheduling class — a busy-loop or deadlock then starves kworker / sshd. Prefer `nice -n -5` or a systemd unit with `CPUWeight=`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1665")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1665.go
+++ b/pkg/katas/zc1665.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1665",
+		Title:    "Warn on `chrt -r` / `-f` — real-time scheduling class from a shell script",
+		Severity: SeverityWarning,
+		Description: "`chrt -r PRIO CMD` (SCHED_RR) and `chrt -f PRIO CMD` (SCHED_FIFO) launch " +
+			"the child under a POSIX real-time scheduling class. An RT thread preempts " +
+			"every normal-priority task until it voluntarily yields; a busy-loop or a " +
+			"deadlock leaves the kernel with kworker, ksoftirqd, and sshd starved, often " +
+			"forcing a hard reboot. Unless the binary is known-bounded (audio glitch-free " +
+			"path, protocol timing loop), keep scripts on SCHED_OTHER — use `nice -n -5` or " +
+			"a systemd unit with `CPUWeight=` / `IOWeight=` instead of `chrt -r`.",
+		Check: checkZC1665,
+	})
+}
+
+func checkZC1665(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "chrt" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-r" || v == "-f" || v == "--rr" || v == "--fifo" {
+			return []Violation{{
+				KataID: "ZC1665",
+				Message: "`chrt " + v + "` puts the child on a real-time scheduling class — a " +
+					"busy-loop or deadlock then starves kworker / sshd. Prefer `nice -n -5` " +
+					"or a systemd unit with `CPUWeight=`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 661 Katas = 0.6.61
-const Version = "0.6.61"
+// 662 Katas = 0.6.62
+const Version = "0.6.62"


### PR DESCRIPTION
ZC1665 — Warn on `chrt -r` / `-f` — real-time scheduling class from a shell script

What: `chrt -r PRIO CMD` (SCHED_RR) / `chrt -f PRIO CMD` (SCHED_FIFO) launches the child under a POSIX real-time scheduling class.
Why: An RT thread preempts every normal-priority task until it yields; a busy-loop or deadlock leaves kworker, ksoftirqd, and sshd starved — often a hard-reboot situation.
Fix suggestion: Keep scripts on SCHED_OTHER with `nice -n -5`, or a systemd unit using `CPUWeight=` / `IOWeight=` instead of `chrt -r`.
Severity: Warning

## Test plan
- valid `chrt -o 0 /usr/bin/cmd` → no violation
- valid `chrt -p 1234` → no violation
- invalid `chrt -r 99 /usr/bin/cmd` → ZC1665
- invalid `chrt -f 50 /usr/bin/cmd` → ZC1665