### PR TITLE
feat: ZC1666 — flag kubectl patch --type=json raw RFC-6902 patch

### DIFF
--- a/pkg/katas/katatests/zc1666_test.go
+++ b/pkg/katas/katatests/zc1666_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1666(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — kubectl patch --type=strategic",
+			input:    `kubectl patch deployment nginx --type=strategic`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — kubectl patch --type=merge",
+			input:    `kubectl patch deployment nginx --type=merge`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — kubectl patch --type=json joined",
+			input: `kubectl patch deployment nginx --type=json -p '[...]'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1666",
+					Message: "`kubectl patch --type=json` applies a raw RFC-6902 patch that bypasses strategic-merge reconciliation — prefer `--type=strategic` and hold JSON patches behind code review.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — kubectl patch --type json split",
+			input: `kubectl patch deployment nginx --type json -p '[...]'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1666",
+					Message: "`kubectl patch --type=json` applies a raw RFC-6902 patch that bypasses strategic-merge reconciliation — prefer `--type=strategic` and hold JSON patches behind code review.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1666")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1666.go
+++ b/pkg/katas/zc1666.go
@@ -1,0 +1,66 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1666",
+		Title:    "Warn on `kubectl patch --type=json` — bypasses strategic-merge defaults",
+		Severity: SeverityWarning,
+		Description: "`kubectl patch --type=json` applies a raw RFC-6902 JSON patch: `remove`, " +
+			"`replace`, `add /spec/containers/0`, and `move` land verbatim on the resource. " +
+			"Unlike strategic-merge or merge-patch, Kubernetes does not reconcile the " +
+			"patch against field ownership or default values — so a mistyped `path` or an " +
+			"index that no longer exists fails silently or drops the wrong field. From a " +
+			"script this is a foot-gun for drift and supply-chain compromise: an attacker " +
+			"with write access to the patch file can slip `privileged: true` or `hostPath` " +
+			"mounts in. Prefer `--type=strategic` (the default) and hold JSON patches " +
+			"behind code review.",
+		Check: checkZC1666,
+	})
+}
+
+func checkZC1666(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kubectl" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "patch" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--type=json" {
+			return zc1666Hit(cmd)
+		}
+		if v == "--type" && i+1 < len(cmd.Arguments) &&
+			cmd.Arguments[i+1].String() == "json" {
+			return zc1666Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1666Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1666",
+		Message: "`kubectl patch --type=json` applies a raw RFC-6902 patch that bypasses " +
+			"strategic-merge reconciliation — prefer `--type=strategic` and hold JSON " +
+			"patches behind code review.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 662 Katas = 0.6.62
-const Version = "0.6.62"
+// 663 Katas = 0.6.63
+const Version = "0.6.63"


### PR DESCRIPTION
ZC1666 — Warn on `kubectl patch --type=json` — bypasses strategic-merge defaults

What: `kubectl patch --type=json` applies a raw RFC-6902 JSON patch (`remove`, `replace`, `add`, `move`).
Why: Unlike strategic-merge or merge-patch, Kubernetes does not reconcile the patch against field ownership or defaults — a mistyped `path` or a stale index fails silently or drops the wrong field. An attacker with patch-file access can slip `privileged: true` / `hostPath` mounts in.
Fix suggestion: Prefer `--type=strategic` (the default) and hold JSON patches behind code review.
Severity: Warning

## Test plan
- valid `kubectl patch deployment nginx --type=strategic` → no violation
- valid `kubectl patch deployment nginx --type=merge` → no violation
- invalid `kubectl patch deployment nginx --type=json -p '[...]'` → ZC1666
- invalid `kubectl patch deployment nginx --type json -p '[...]'` → ZC1666