### PR TITLE
feat: ZC1667 — flag openssl enc without -pbkdf2 legacy KDF

### DIFF
--- a/pkg/katas/katatests/zc1667_test.go
+++ b/pkg/katas/katatests/zc1667_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1667(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — openssl enc with -pbkdf2",
+			input:    `openssl enc -aes-256-cbc -pbkdf2 -iter 100000 -in file -out file.enc`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — openssl req (different subcommand)",
+			input:    `openssl req -new -key key.pem -out csr.pem`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — openssl enc -aes-256-cbc without pbkdf2",
+			input: `openssl enc -aes-256-cbc -salt -in file -out file.enc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1667",
+					Message: "`openssl enc` without `-pbkdf2` uses single-round EVP_BytesToKey (MD5) — add `-pbkdf2 -iter 100000`, or prefer `age` / `gpg --symmetric`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — openssl enc -aes-256-gcm (no pbkdf2, no AEAD support)",
+			input: `openssl enc -aes-256-gcm -in file -out file.enc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1667",
+					Message: "`openssl enc` without `-pbkdf2` uses single-round EVP_BytesToKey (MD5) — add `-pbkdf2 -iter 100000`, or prefer `age` / `gpg --symmetric`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1667")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1667.go
+++ b/pkg/katas/zc1667.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1667",
+		Title:    "Warn on `openssl enc` without `-pbkdf2` — legacy MD5-based key derivation",
+		Severity: SeverityWarning,
+		Description: "Without `-pbkdf2`, `openssl enc` derives the symmetric key through " +
+			"EVP_BytesToKey, which is a single MD5 round over `password || salt`. A modern " +
+			"GPU cracks that at billions of guesses per second. Add `-pbkdf2 -iter 100000` " +
+			"(OpenSSL 1.1.1+) to switch to PBKDF2-HMAC-SHA256 with a real iteration count. " +
+			"Even better, stop using `openssl enc` for new code — it has no AEAD support and " +
+			"`-aes-256-gcm` silently drops the auth tag — and reach for `age`, " +
+			"`gpg --symmetric --cipher-algo AES256`, or `openssl smime` instead.",
+		Check: checkZC1667,
+	})
+}
+
+func checkZC1667(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "openssl" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "enc" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		if arg.String() == "-pbkdf2" {
+			return nil
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1667",
+		Message: "`openssl enc` without `-pbkdf2` uses single-round EVP_BytesToKey (MD5) — " +
+			"add `-pbkdf2 -iter 100000`, or prefer `age` / `gpg --symmetric`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 663 Katas = 0.6.63
-const Version = "0.6.63"
+// 664 Katas = 0.6.64
+const Version = "0.6.64"


### PR DESCRIPTION
ZC1667 — Warn on `openssl enc` without `-pbkdf2` — legacy MD5-based key derivation

What: Without `-pbkdf2`, `openssl enc` derives the symmetric key via EVP_BytesToKey (single-round MD5 over `password || salt`).
Why: A modern GPU cracks single-MD5 passphrases at billions of guesses per second. `-aes-256-gcm` with `openssl enc` also silently drops the auth tag — so there is no AEAD path through this command at all.
Fix suggestion: Add `-pbkdf2 -iter 100000` (OpenSSL 1.1.1+). For new code, prefer `age`, `gpg --symmetric --cipher-algo AES256`, or `openssl smime`.
Severity: Warning

## Test plan
- valid `openssl enc -aes-256-cbc -pbkdf2 -iter 100000 …` → no violation
- valid `openssl req -new …` → no violation
- invalid `openssl enc -aes-256-cbc -salt -in file -out file.enc` → ZC1667
- invalid `openssl enc -aes-256-gcm -in file -out file.enc` → ZC1667