### PR TITLE
feat: ZC1668 — flag aws iam attach-*-policy AdministratorAccess

### DIFF
--- a/pkg/katas/katatests/zc1668_test.go
+++ b/pkg/katas/katatests/zc1668_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1668(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — aws iam attach-user-policy ReadOnlyAccess",
+			input:    `aws iam attach-user-policy --user-name foo --policy-arn arn:aws:iam::aws:policy/ReadOnlyAccess`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — aws iam create-access-key",
+			input:    `aws iam create-access-key --user-name foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — attach-user-policy AdministratorAccess",
+			input: `aws iam attach-user-policy --user-name foo --policy-arn arn:aws:iam::aws:policy/AdministratorAccess`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1668",
+					Message: "`aws iam attach-user-policy ... arn:aws:iam::aws:policy/AdministratorAccess` grants sweeping admin — use a scoped inline policy (`put-user-policy`) or a customer-managed policy with the minimum `Action`/`Resource` set.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — attach-role-policy PowerUserAccess",
+			input: `aws iam attach-role-policy --role-name r --policy-arn arn:aws:iam::aws:policy/PowerUserAccess`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1668",
+					Message: "`aws iam attach-role-policy ... arn:aws:iam::aws:policy/PowerUserAccess` grants sweeping admin — use a scoped inline policy (`put-user-policy`) or a customer-managed policy with the minimum `Action`/`Resource` set.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1668")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1668.go
+++ b/pkg/katas/zc1668.go
@@ -1,0 +1,69 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1668",
+		Title:    "Error on `aws iam attach-*-policy ... AdministratorAccess` — grants full AWS admin",
+		Severity: SeverityError,
+		Description: "Attaching the AWS-managed `AdministratorAccess` (or `PowerUserAccess`) " +
+			"policy gives the target principal `*:*` — create/delete IAM users, mutate KMS " +
+			"keys, rotate root passwords, exfiltrate every S3 bucket. Scripts rarely need " +
+			"full admin; the pattern usually means someone hit a permissions error and " +
+			"replaced the scoped policy with the blanket one. Write a least-privilege inline " +
+			"policy (`iam put-user-policy --policy-document`), or reference a customer-" +
+			"managed policy with only the `Action`/`Resource` pairs the workload needs. Admin " +
+			"attachment should land via change-reviewed Terraform, not a shell loop.",
+		Check: checkZC1668,
+	})
+}
+
+func checkZC1668(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "aws" {
+		return nil
+	}
+
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "iam" {
+		return nil
+	}
+	sub := cmd.Arguments[1].String()
+	if sub != "attach-user-policy" && sub != "attach-role-policy" &&
+		sub != "attach-group-policy" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[2:] {
+		v := arg.String()
+		if strings.HasSuffix(v, "/AdministratorAccess") ||
+			strings.HasSuffix(v, "/PowerUserAccess") ||
+			strings.HasSuffix(v, "/IAMFullAccess") {
+			return []Violation{{
+				KataID: "ZC1668",
+				Message: "`aws iam " + sub + " ... " + v + "` grants sweeping admin — " +
+					"use a scoped inline policy (`put-user-policy`) or a customer-managed " +
+					"policy with the minimum `Action`/`Resource` set.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 664 Katas = 0.6.64
-const Version = "0.6.64"
+// 665 Katas = 0.6.65
+const Version = "0.6.65"


### PR DESCRIPTION
ZC1668 — Error on `aws iam attach-*-policy ... AdministratorAccess` — grants full AWS admin

What: Attaching the AWS-managed `AdministratorAccess` / `PowerUserAccess` / `IAMFullAccess` policy to a user/role/group.
Why: Grants `*:*` — IAM mutation, KMS key rotation, S3 exfiltration, root-password reset. Scripts almost never need it; usually the signal is someone replacing a scoped policy after hitting a permissions error.
Fix suggestion: Write a least-privilege inline policy (`iam put-user-policy --policy-document`) or reference a customer-managed policy with the minimum `Action`/`Resource` pairs. Admin attachment should land via change-reviewed Terraform, not a shell loop.
Severity: Error

## Test plan
- valid `aws iam attach-user-policy … ReadOnlyAccess` → no violation
- valid `aws iam create-access-key --user-name foo` → no violation
- invalid `aws iam attach-user-policy … AdministratorAccess` → ZC1668
- invalid `aws iam attach-role-policy … PowerUserAccess` → ZC1668