### PR TITLE
feat: ZC1669 — flag git gc --prune=now / reflog expire recovery wipe

### DIFF
--- a/pkg/katas/katatests/zc1669_test.go
+++ b/pkg/katas/katatests/zc1669_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1669(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — git gc default",
+			input:    `git gc`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — git gc --auto",
+			input:    `git gc --auto`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — git gc --prune=now",
+			input: `git gc --prune=now --aggressive`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1669",
+					Message: "`git gc --prune=now` bulldozes the reflog / prune recovery window — keep the default cadence unless you are actively purging leaked secrets, and mirror the dropped history off-box first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — git reflog expire --expire=now --all",
+			input: `git reflog expire --expire=now --all`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1669",
+					Message: "`git reflog expire --expire=now` bulldozes the reflog / prune recovery window — keep the default cadence unless you are actively purging leaked secrets, and mirror the dropped history off-box first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1669")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1669.go
+++ b/pkg/katas/zc1669.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1669",
+		Title:    "Warn on `git gc --prune=now` / `git reflog expire --expire=now` — deletes recovery window",
+		Severity: SeverityWarning,
+		Description: "Git keeps dropped commits and orphaned objects for `gc.reflogExpire` " +
+			"(default 90 days) and `gc.pruneExpire` (default two weeks) so a `git reflog` + " +
+			"`git reset` can still recover work you thought you threw away. `git gc " +
+			"--prune=now` and `git reflog expire --expire=now --all` bulldoze both windows " +
+			"in one go — a stray interactive rebase no longer has a safety net. Use the " +
+			"default cadence (`git gc`, no `--prune=now`) unless you are actively purging " +
+			"leaked secrets or proof-of-concept code; pair the destructive form with a " +
+			"stale mirror push so at least one copy of the dropped history remains.",
+		Check: checkZC1669,
+	})
+}
+
+func checkZC1669(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "git" {
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	switch cmd.Arguments[0].String() {
+	case "gc":
+		for _, arg := range cmd.Arguments[1:] {
+			if arg.String() == "--prune=now" || arg.String() == "--prune=0" {
+				return zc1669Hit(cmd, "git gc --prune=now")
+			}
+		}
+	case "reflog":
+		if len(cmd.Arguments) < 2 || cmd.Arguments[1].String() != "expire" {
+			return nil
+		}
+		for _, arg := range cmd.Arguments[2:] {
+			if arg.String() == "--expire=now" {
+				return zc1669Hit(cmd, "git reflog expire --expire=now")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1669Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1669",
+		Message: "`" + form + "` bulldozes the reflog / prune recovery window — keep the " +
+			"default cadence unless you are actively purging leaked secrets, and mirror " +
+			"the dropped history off-box first.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 665 Katas = 0.6.65
-const Version = "0.6.65"
+// 666 Katas = 0.6.66
+const Version = "0.6.66"


### PR DESCRIPTION
ZC1669 — Warn on `git gc --prune=now` / `git reflog expire --expire=now` — deletes recovery window

What: Both commands bulldoze the default `gc.reflogExpire` (90 d) and `gc.pruneExpire` (2 w) grace periods, so dropped commits become unrecoverable immediately.
Why: A stray interactive rebase, a bad `git reset`, or a dropped cherry-pick usually survives because `git reflog` still points at the old SHA. With `--prune=now` / `--expire=now`, no safety net.
Fix suggestion: Keep the default cadence. Only run the destructive form to purge leaked secrets, and mirror the dropped history off-box first.
Severity: Warning

## Test plan
- valid `git gc` → no violation
- valid `git gc --auto` → no violation
- invalid `git gc --prune=now --aggressive` → ZC1669
- invalid `git reflog expire --expire=now --all` → ZC1669