### PR TITLE
feat: ZC1670 — flag setsebool -P SELinux mem-protection weakening booleans

### DIFF
--- a/pkg/katas/katatests/zc1670_test.go
+++ b/pkg/katas/katatests/zc1670_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1670(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — setsebool -P httpd_can_network_connect on (not in dangerous list)",
+			input:    `setsebool -P httpd_can_network_connect on`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — setsebool without -P (session only)",
+			input:    `setsebool httpd_execmem 1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — setsebool -P httpd_execmem 1",
+			input: `setsebool -P httpd_execmem 1`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1670",
+					Message: "`setsebool -P httpd_execmem 1` persistently relaxes SELinux memory-protection policy — fix the binary instead (`execstack -c`, relabel with `chcon`, or change the domain).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — setsebool -P allow_execstack on",
+			input: `setsebool -P allow_execstack on`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1670",
+					Message: "`setsebool -P allow_execstack on` persistently relaxes SELinux memory-protection policy — fix the binary instead (`execstack -c`, relabel with `chcon`, or change the domain).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1670")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1670.go
+++ b/pkg/katas/zc1670.go
@@ -1,0 +1,85 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1670Dangerous = map[string]struct{}{
+	"allow_execstack":           {},
+	"allow_execmod":             {},
+	"allow_execmem":             {},
+	"httpd_execmem":             {},
+	"httpd_unified":             {},
+	"selinuxuser_execmod":       {},
+	"selinuxuser_execstack":     {},
+	"selinuxuser_execheap":      {},
+	"domain_kernel_load_modules": {},
+	"deny_ptrace":               {}, // flipping this OFF re-enables ptrace globally
+	"mmap_low_allowed":          {},
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1670",
+		Title:    "Warn on `setsebool -P` enabling memory-protection-relaxing SELinux boolean",
+		Severity: SeverityWarning,
+		Description: "Specific SELinux policy booleans (`allow_execstack`, `allow_execmem`, " +
+			"`httpd_execmem`, `selinuxuser_execstack`, `domain_kernel_load_modules`, " +
+			"`mmap_low_allowed`, etc.) relax per-domain memory protections that the policy " +
+			"puts in place precisely because those domains should not need writable-and-" +
+			"executable pages. Persisting the flip with `-P` carries the regression across " +
+			"reboots. Fix the underlying binary (`execstack -c`, `chcon`, stop generating " +
+			"runtime-JIT code in the wrong domain) instead of loosening policy.",
+		Check: checkZC1670,
+	})
+}
+
+func checkZC1670(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "setsebool" {
+		return nil
+	}
+
+	hasPersist := false
+	boolName := ""
+	boolValue := ""
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch {
+		case v == "-P":
+			hasPersist = true
+		case boolName == "":
+			boolName = v
+		case boolValue == "":
+			boolValue = v
+		}
+	}
+
+	if !hasPersist || boolName == "" || boolValue == "" {
+		return nil
+	}
+	if _, dangerous := zc1670Dangerous[boolName]; !dangerous {
+		return nil
+	}
+	if boolValue != "1" && boolValue != "on" && boolValue != "true" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1670",
+		Message: "`setsebool -P " + boolName + " " + boolValue + "` persistently relaxes " +
+			"SELinux memory-protection policy — fix the binary instead (`execstack -c`, " +
+			"relabel with `chcon`, or change the domain).",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/katas/zc1670.go
+++ b/pkg/katas/zc1670.go
@@ -5,17 +5,17 @@ import (
 )
 
 var zc1670Dangerous = map[string]struct{}{
-	"allow_execstack":           {},
-	"allow_execmod":             {},
-	"allow_execmem":             {},
-	"httpd_execmem":             {},
-	"httpd_unified":             {},
-	"selinuxuser_execmod":       {},
-	"selinuxuser_execstack":     {},
-	"selinuxuser_execheap":      {},
+	"allow_execstack":            {},
+	"allow_execmod":              {},
+	"allow_execmem":              {},
+	"httpd_execmem":              {},
+	"httpd_unified":              {},
+	"selinuxuser_execmod":        {},
+	"selinuxuser_execstack":      {},
+	"selinuxuser_execheap":       {},
 	"domain_kernel_load_modules": {},
-	"deny_ptrace":               {}, // flipping this OFF re-enables ptrace globally
-	"mmap_low_allowed":          {},
+	"deny_ptrace":                {},
+	"mmap_low_allowed":           {},
 }
 
 func init() {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 666 Katas = 0.6.66
-const Version = "0.6.66"
+// 667 Katas = 0.6.67
+const Version = "0.6.67"


### PR DESCRIPTION
ZC1670 — Warn on `setsebool -P` enabling memory-protection-relaxing SELinux boolean

What: `setsebool -P` persists a SELinux policy-boolean change. Specific booleans (`allow_execstack`, `allow_execmem`, `httpd_execmem`, `selinuxuser_execstack`, `domain_kernel_load_modules`, `mmap_low_allowed`, etc.) relax per-domain memory-protection rules.
Why: The policy blocks writable-and-executable pages for those domains precisely because they should not need them. Flipping the boolean (persistently) carries the regression across reboots.
Fix suggestion: Fix the binary (`execstack -c`), relabel with `chcon`, or move the workload into a domain where the behavior is legitimate — instead of loosening policy.
Severity: Warning

## Test plan
- valid `setsebool -P httpd_can_network_connect on` → no violation
- valid `setsebool httpd_execmem 1` (no -P) → no violation
- invalid `setsebool -P httpd_execmem 1` → ZC1670
- invalid `setsebool -P allow_execstack on` → ZC1670