### PR TITLE
feat: ZC1671 — flag install -m 777 / mkdir -m 777 world-writable

### DIFF
--- a/pkg/katas/katatests/zc1671_test.go
+++ b/pkg/katas/katatests/zc1671_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1671(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — install -m 755",
+			input:    `install -m 755 src /usr/local/bin/dst`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — mkdir -m 0755",
+			input:    `mkdir -m 0755 /opt/dir`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — install -m 777",
+			input: `install -m 777 src /usr/local/bin/dst`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1671",
+					Message: "`install -m 777` creates a world-writable target — drop the world-write bit (e.g. `0755` / `0644`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — mkdir -m 0666 (parser normalizes to 438)",
+			input: `mkdir -m 0666 /shared`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1671",
+					Message: "`mkdir -m 438` creates a world-writable target — drop the world-write bit (e.g. `0755` / `0644`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1671")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1671.go
+++ b/pkg/katas/zc1671.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"strconv"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1671",
+		Title:    "Error on `install -m 777` / `mkdir -m 777` — creates world-writable target",
+		Severity: SeverityError,
+		Description: "`install -m MODE` / `mkdir -m MODE` applies MODE atomically at file or " +
+			"directory creation, so the world-writable window from a later `chmod 777` is " +
+			"not even needed — the path is wide-open from the moment it exists. Any local " +
+			"user can swap binaries under `/usr/local/bin`, write shell-completion hooks " +
+			"into `/etc/bash_completion.d`, or turn a shared directory into an LPE staging " +
+			"ground. Drop the world-write bit: `0755` for binaries, `0644` for files, `2770` " +
+			"with `chgrp` for shared directories.",
+		Check: checkZC1671,
+	})
+}
+
+func checkZC1671(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "install" && ident.Value != "mkdir" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		if arg.String() != "-m" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			continue
+		}
+		mode := cmd.Arguments[i+1].String()
+		if !zc1671WorldWritable(mode) {
+			continue
+		}
+		return []Violation{{
+			KataID: "ZC1671",
+			Message: "`" + ident.Value + " -m " + mode + "` creates a world-writable " +
+				"target — drop the world-write bit (e.g. `0755` / `0644`).",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityError,
+		}}
+	}
+	return nil
+}
+
+// zc1671WorldWritable returns true if MODE has the world-write (o+w) bit set.
+// Users spell modes in octal. If the literal parses as octal, trust that
+// reading. Otherwise (a digit 8/9 appears — that only happens because the
+// parser normalized a leading-zero octal like `0666` to decimal `438`), parse
+// as decimal and still check the o+w bit.
+func zc1671WorldWritable(mode string) bool {
+	if n, err := strconv.ParseInt(mode, 8, 32); err == nil {
+		return n > 0 && n&0o002 != 0
+	}
+	if n, err := strconv.ParseInt(mode, 10, 32); err == nil && n > 0 && n&0o002 != 0 {
+		return true
+	}
+	return false
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 667 Katas = 0.6.67
-const Version = "0.6.67"
+// 668 Katas = 0.6.68
+const Version = "0.6.68"


### PR DESCRIPTION
ZC1671 — Error on `install -m 777` / `mkdir -m 777` — creates world-writable target

What: `install -m MODE` / `mkdir -m MODE` applies MODE atomically at creation time.
Why: The target is world-writable from the moment it exists — no `chmod 777` race needed. Local users can swap binaries under `/usr/local/bin`, plant hooks in `/etc/bash_completion.d`, or stage LPE in shared dirs.
Fix suggestion: Drop the world-write bit — `0755` for binaries, `0644` for files, `2770` + `chgrp` for shared directories.
Severity: Error

## Test plan
- valid `install -m 755 src dst` → no violation
- valid `mkdir -m 0755 /opt/dir` → no violation
- invalid `install -m 777 src dst` → ZC1671
- invalid `mkdir -m 0666 /shared` (parser normalizes to 438) → ZC1671