### PR TITLE
feat: ZC1672 — flag chcon ephemeral SELinux label

### DIFF
--- a/pkg/katas/katatests/zc1672_test.go
+++ b/pkg/katas/katatests/zc1672_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1672(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — different command",
+			input:    `semanage fcontext -a -t httpd_sys_content_t /var/www/app`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — chcon with no args",
+			input:    `chcon`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — chcon -t unconfined_t path",
+			input: `chcon -t unconfined_t /usr/local/bin/script`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1672",
+					Message: "`chcon` writes an ephemeral SELinux label — `restorecon` / policy rebuild reverts it. Persist via `semanage fcontext -a -t TYPE 'REGEX'` + `restorecon`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — chcon -R -t bin_t dir",
+			input: `chcon -R -t bin_t /srv/app`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1672",
+					Message: "`chcon` writes an ephemeral SELinux label — `restorecon` / policy rebuild reverts it. Persist via `semanage fcontext -a -t TYPE 'REGEX'` + `restorecon`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1672")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1672.go
+++ b/pkg/katas/zc1672.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1672",
+		Title:    "Info: `chcon` writes an ephemeral SELinux label — next `restorecon` wipes it",
+		Severity: SeverityInfo,
+		Description: "`chcon -t TYPE PATH` sets the file context out-of-band; it does not update " +
+			"the `file_contexts` policy database. As soon as `restorecon`, `semodule -n`, or " +
+			"a policy rebuild runs, the label snaps back to whatever the compiled policy " +
+			"says — often `default_t`, which can break a deployed workload or silently " +
+			"re-introduce a denial the script tried to fix. For anything long-lived use " +
+			"`semanage fcontext -a -t TYPE '<regex>'` then `restorecon -F <path>` so the " +
+			"mapping lives in policy.",
+		Check: checkZC1672,
+	})
+}
+
+func checkZC1672(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "chcon" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1672",
+		Message: "`chcon` writes an ephemeral SELinux label — `restorecon` / policy rebuild " +
+			"reverts it. Persist via `semanage fcontext -a -t TYPE 'REGEX'` + `restorecon`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityInfo,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 668 Katas = 0.6.68
-const Version = "0.6.68"
+// 669 Katas = 0.6.69
+const Version = "0.6.69"


### PR DESCRIPTION
ZC1672 — Info: `chcon` writes an ephemeral SELinux label — next `restorecon` wipes it

What: `chcon -t TYPE PATH` sets a file context out-of-band without updating the `file_contexts` policy database.
Why: `restorecon`, `semodule -n`, or any policy rebuild reverts the label to whatever the compiled policy says — often `default_t`. Breaks a deployed workload or re-introduces a denial the script tried to fix.
Fix suggestion: `semanage fcontext -a -t TYPE '<regex>'` then `restorecon -F <path>` so the mapping lives in policy.
Severity: Info

## Test plan
- valid `semanage fcontext -a -t httpd_sys_content_t /var/www/app` → no violation
- valid `chcon` (no args) → no violation
- invalid `chcon -t unconfined_t /usr/local/bin/script` → ZC1672
- invalid `chcon -R -t bin_t /srv/app` → ZC1672