### PR TITLE
feat: ZC1673 — prefer Zsh read -s over stty -echo bracketing

### DIFF
--- a/pkg/katas/katatests/zc1673_test.go
+++ b/pkg/katas/katatests/zc1673_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1673(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — stty echo (restore)",
+			input:    `stty echo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — stty raw",
+			input:    `stty raw`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — stty -echo",
+			input: `stty -echo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1673",
+					Message: "`stty -echo` to mask password entry is fragile — a crash leaves the terminal echo-off. Use `read -s VAR` (Zsh / Bash 4+) instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1673")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1673.go
+++ b/pkg/katas/zc1673.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1673",
+		Title:    "Style: `stty -echo` around `read` — prefer Zsh `read -s`",
+		Severity: SeverityStyle,
+		Description: "The classic `stty -echo; IFS= read -r password; stty echo` pattern has a " +
+			"serious failure mode: a crash or SIGINT between the two `stty` calls leaves " +
+			"the user's terminal stuck in echo-off, which is silent and confusing. Zsh's " +
+			"`read -s VAR` (also Bash 4+) disables echo only for that one `read`, restores " +
+			"it on return even if the read is interrupted, and avoids two external forks. " +
+			"Switch the prompt to `read -s` (or `read -ks` for single-key password) and " +
+			"drop the `stty` bracketing.",
+		Check: checkZC1673,
+	})
+}
+
+func checkZC1673(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "stty" {
+		return nil
+	}
+
+	if len(cmd.Arguments) != 1 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "-echo" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1673",
+		Message: "`stty -echo` to mask password entry is fragile — a crash leaves the " +
+			"terminal echo-off. Use `read -s VAR` (Zsh / Bash 4+) instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 669 Katas = 0.6.69
-const Version = "0.6.69"
+// 670 Katas = 0.6.70
+const Version = "0.6.70"


### PR DESCRIPTION
ZC1673 — Style: `stty -echo` around `read` — prefer Zsh `read -s`

What: `stty -echo; IFS= read -r password; stty echo` to mask password entry.
Why: A crash or SIGINT between the two `stty` calls leaves the user's terminal stuck in echo-off — silent and confusing. `read -s` (Zsh / Bash 4+) disables echo only for that one read and restores it even on interrupt, with no external forks.
Fix suggestion: `read -s password` (or `read -ks` for single-key prompt) — drop the `stty` bracketing.
Severity: Style

## Test plan
- valid `stty echo` → no violation
- valid `stty raw` → no violation
- invalid `stty -echo` → ZC1673