### PR TITLE
feat: ZC1674 — flag docker/podman run --oom-kill-disable / --oom-score-adj abuse

### DIFF
--- a/pkg/katas/katatests/zc1674_test.go
+++ b/pkg/katas/katatests/zc1674_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1674(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — docker run default",
+			input:    `docker run alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — docker run --oom-score-adj 0",
+			input:    `docker run --oom-score-adj 0 alpine`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — docker run --oom-kill-disable",
+			input: `docker run --oom-kill-disable alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1674",
+					Message: "`--oom-kill-disable` shifts OOM pressure onto the rest of the host — cap memory with `--memory=<limit>` instead of rigging the OOM score.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — podman run --oom-score-adj=-1000",
+			input: `podman run --oom-score-adj=-1000 alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1674",
+					Message: "`--oom-score-adj=-1000` shifts OOM pressure onto the rest of the host — cap memory with `--memory=<limit>` instead of rigging the OOM score.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1674")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1674.go
+++ b/pkg/katas/zc1674.go
@@ -1,0 +1,87 @@
+package katas
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1674",
+		Title:    "Warn on `docker/podman run --oom-kill-disable` or `--oom-score-adj <= -500`",
+		Severity: SeverityWarning,
+		Description: "`--oom-kill-disable` tells the kernel OOM killer to never touch the " +
+			"container's memory cgroup — a leak inside then drives the whole host into OOM " +
+			"reclaim until `sshd`, `systemd-journald`, or the init daemon itself gets " +
+			"killed. `--oom-score-adj <= -500` stops short of full immunity but still " +
+			"preferentially kills unrelated host processes under pressure. If the workload " +
+			"genuinely needs resilience, cap memory with `--memory=<limit>` and accept the " +
+			"container being killed on overrun; shift the heavy workload to a dedicated " +
+			"node instead of rigging OOM scores.",
+		Check: checkZC1674,
+	})
+}
+
+func checkZC1674(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "run" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--oom-kill-disable" {
+			return zc1674Hit(cmd, v)
+		}
+		if strings.HasPrefix(v, "--oom-score-adj=") {
+			adj := strings.TrimPrefix(v, "--oom-score-adj=")
+			if zc1674Harsh(adj) {
+				return zc1674Hit(cmd, v)
+			}
+			continue
+		}
+		if v == "--oom-score-adj" {
+			idx := i + 2
+			if idx >= len(cmd.Arguments) {
+				continue
+			}
+			adj := cmd.Arguments[idx].String()
+			if zc1674Harsh(adj) {
+				return zc1674Hit(cmd, v+" "+adj)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1674Harsh(adj string) bool {
+	n, err := strconv.Atoi(adj)
+	if err != nil {
+		return false
+	}
+	return n <= -500
+}
+
+func zc1674Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1674",
+		Message: "`" + form + "` shifts OOM pressure onto the rest of the host — cap " +
+			"memory with `--memory=<limit>` instead of rigging the OOM score.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 670 Katas = 0.6.70
-const Version = "0.6.70"
+// 671 Katas = 0.6.71
+const Version = "0.6.71"


### PR DESCRIPTION
ZC1674 — Warn on `docker/podman run --oom-kill-disable` or `--oom-score-adj <= -500`

What: `--oom-kill-disable` (kernel OOM killer never touches the container) or `--oom-score-adj <= -500` (preferentially kill others).
Why: A memory leak inside then drives the host into OOM reclaim until sshd / journald / init itself is killed. Even at -500 the container shifts pressure onto unrelated host processes.
Fix suggestion: Cap memory with `--memory=<limit>` so the container is killed on overrun; shift heavy workloads to a dedicated node instead of rigging OOM scores.
Severity: Warning

## Test plan
- valid `docker run alpine` → no violation
- valid `docker run --oom-score-adj 0 alpine` → no violation
- invalid `docker run --oom-kill-disable alpine` → ZC1674
- invalid `podman run --oom-score-adj=-1000 alpine` → ZC1674