### PR TITLE
feat: ZC1675 — flag Bash-only export -f / -n in Zsh scripts

### DIFF
--- a/pkg/katas/katatests/zc1675_test.go
+++ b/pkg/katas/katatests/zc1675_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1675(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — plain export VAR=value",
+			input:    `export VAR=value`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — export multiple plain names",
+			input:    `export PATH HOME`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — export -f function",
+			input: `export -f my_func`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1675",
+					Message: "`export -f` is Bash-only — use `typeset -fx` in Zsh.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — export -n VAR",
+			input: `export -n VAR`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1675",
+					Message: "`export -n` is Bash-only — use `typeset +x` in Zsh.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1675")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1675.go
+++ b/pkg/katas/zc1675.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1675",
+		Title:    "Avoid Bash-only `export -f` / `export -n` — use Zsh `typeset -fx` / `typeset +x`",
+		Severity: SeverityInfo,
+		Description: "`export -f FUNC` (export a function to child processes) and `export -n " +
+			"VAR` (strip the export flag while keeping the value) are Bash-only. Zsh's " +
+			"`export` ignores `-f` entirely and prints usage for `-n`, so scripts that " +
+			"depend on either silently break under Zsh. The Zsh equivalents are `typeset " +
+			"-fx FUNC` for function export (parameter-passing via `$FUNCTIONS` in a " +
+			"subshell) and `typeset +x VAR` to drop the export flag. Functions that must " +
+			"cross a subshell are usually better handled by `autoload -Uz` from an `fpath` " +
+			"directory than by serialisation.",
+		Check: checkZC1675,
+	})
+}
+
+func checkZC1675(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "export" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "-f":
+			return zc1675Hit(cmd, "export -f", "typeset -fx")
+		case "-n":
+			return zc1675Hit(cmd, "export -n", "typeset +x")
+		}
+	}
+	return nil
+}
+
+func zc1675Hit(cmd *ast.SimpleCommand, bad, good string) []Violation {
+	return []Violation{{
+		KataID:  "ZC1675",
+		Message: "`" + bad + "` is Bash-only — use `" + good + "` in Zsh.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityInfo,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 671 Katas = 0.6.71
-const Version = "0.6.71"
+// 672 Katas = 0.6.72
+const Version = "0.6.72"


### PR DESCRIPTION
ZC1675 — Avoid Bash-only `export -f` / `export -n` — use Zsh `typeset -fx` / `typeset +x`

What: `export -f FUNC` (function export) and `export -n VAR` (remove-export) are Bash-only.
Why: Zsh's `export` ignores `-f` and errors on `-n` — scripts that rely on either silently break under Zsh.
Fix suggestion: Use `typeset -fx FUNC` for function export (or `autoload -Uz` from an `fpath` directory, which is better), and `typeset +x VAR` to drop the export flag.
Severity: Info

## Test plan
- valid `export VAR=value` → no violation
- valid `export PATH HOME` → no violation
- invalid `export -f my_func` → ZC1675
- invalid `export -n VAR` → ZC1675