### PR TITLE
feat: ZC1676 — flag helm rollback --force in-flight resource kick

### DIFF
--- a/pkg/katas/katatests/zc1676_test.go
+++ b/pkg/katas/katatests/zc1676_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1676(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — helm rollback without --force",
+			input:    `helm rollback myapp 2`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — helm history",
+			input:    `helm history myapp`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — helm rollback --force",
+			input: `helm rollback myapp 2 --force`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1676",
+					Message: "`helm rollback --force` deletes and recreates unpatched resources — loses in-flight traffic and bypasses PodDisruptionBudget. Drop `--force` and gate the rollback via change review.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1676")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1676.go
+++ b/pkg/katas/zc1676.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1676",
+		Title:    "Warn on `helm rollback --force` — recreates in-flight resources, corrupts rolling updates",
+		Severity: SeverityWarning,
+		Description: "`helm rollback RELEASE N --force` asks Helm to delete and recreate any " +
+			"resource that it cannot patch cleanly. If a deployment is mid-rollout, the " +
+			"`--force` flag takes out both the old and new ReplicaSets, kicks the pods, " +
+			"and forces a cold start — losing in-flight requests and any `PodDisruptionBudget` " +
+			"protections. Worse, rolling back to revision N brings back whatever CVEs or " +
+			"config regressions the later revisions had already fixed. Pin the target " +
+			"revision explicitly, omit `--force`, and gate the rollback behind a change-" +
+			"review ticket rather than a shell one-liner.",
+		Check: checkZC1676,
+	})
+}
+
+func checkZC1676(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "helm" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "rollback" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		if arg.String() == "--force" {
+			return []Violation{{
+				KataID: "ZC1676",
+				Message: "`helm rollback --force` deletes and recreates unpatched resources — " +
+					"loses in-flight traffic and bypasses PodDisruptionBudget. Drop `--force` " +
+					"and gate the rollback via change review.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 672 Katas = 0.6.72
-const Version = "0.6.72"
+// 673 Katas = 0.6.73
+const Version = "0.6.73"


### PR DESCRIPTION
ZC1676 — Warn on `helm rollback --force` — recreates in-flight resources, corrupts rolling updates

What: `helm rollback RELEASE N --force` asks Helm to delete and recreate any resource it cannot patch cleanly.
Why: During a mid-rollout, `--force` takes out both old and new ReplicaSets, kicks pods, bypasses `PodDisruptionBudget`, and loses in-flight requests. Rolling back to an older revision also reintroduces any CVEs the later revisions fixed.
Fix suggestion: Pin the target revision explicitly, drop `--force`, and gate the rollback behind a change-review ticket.
Severity: Warning

## Test plan
- valid `helm rollback myapp 2` → no violation
- valid `helm history myapp` → no violation
- invalid `helm rollback myapp 2 --force` → ZC1676