### PR TITLE
feat: ZC1677 — flag trap 'set -x' DEBUG global xtrace secret leak

### DIFF
--- a/pkg/katas/katatests/zc1677_test.go
+++ b/pkg/katas/katatests/zc1677_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1677(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — trap cleanup EXIT",
+			input:    `trap 'cleanup' EXIT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — trap set -x on ERR (different signal)",
+			input:    `trap 'set -x' ERR`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — trap 'set -x' DEBUG",
+			input: `trap 'set -x' DEBUG`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1677",
+					Message: "`trap 'set -x' DEBUG` keeps xtrace on after the first command — every subsequent argv (passwords, bearer tokens) lands in the log. Trace a narrow block with `set -x … set +x` or use `typeset -ft FUNC` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — trap "set -o xtrace" DEBUG`,
+			input: `trap "set -o xtrace" DEBUG`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1677",
+					Message: "`trap 'set -x' DEBUG` keeps xtrace on after the first command — every subsequent argv (passwords, bearer tokens) lands in the log. Trace a narrow block with `set -x … set +x` or use `typeset -ft FUNC` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1677")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1677.go
+++ b/pkg/katas/zc1677.go
@@ -1,0 +1,62 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1677",
+		Title:    "Warn on `trap 'set -x' DEBUG` — xtrace on every command leaks secrets",
+		Severity: SeverityWarning,
+		Description: "`trap 'set -x' DEBUG` runs the trap handler before every simple command, " +
+			"turning on xtrace for the remainder of the shell. Every subsequent `curl " +
+			"-H 'Authorization: Bearer …'`, `mysql -p<password>`, or `aws configure set " +
+			"…` then prints its full argv to stderr — commonly into a log file or CI " +
+			"artifact. The same antipattern shows up as `set -o xtrace` inside a DEBUG " +
+			"trap. Instrument selectively with `typeset -ft FUNC` (Zsh function-level " +
+			"xtrace), or add `exec 2>>\"$log\"; set -x` only around the part of the " +
+			"script you want traced.",
+		Check: checkZC1677,
+	})
+}
+
+func checkZC1677(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "trap" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+
+	last := cmd.Arguments[len(cmd.Arguments)-1].String()
+	if last != "DEBUG" {
+		return nil
+	}
+
+	handler := strings.Trim(cmd.Arguments[0].String(), "'\"")
+	if !strings.Contains(handler, "set -x") && !strings.Contains(handler, "set -o xtrace") {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1677",
+		Message: "`trap 'set -x' DEBUG` keeps xtrace on after the first command — " +
+			"every subsequent argv (passwords, bearer tokens) lands in the log. Trace a " +
+			"narrow block with `set -x … set +x` or use `typeset -ft FUNC` instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 673 Katas = 0.6.73
-const Version = "0.6.73"
+// 674 Katas = 0.6.74
+const Version = "0.6.74"


### PR DESCRIPTION
ZC1677 — Warn on `trap 'set -x' DEBUG` — xtrace on every command leaks secrets

What: `trap 'set -x' DEBUG` runs the trap handler before every simple command, turning on xtrace for the rest of the shell.
Why: Every subsequent `curl -H 'Authorization: Bearer …'`, `mysql -p<password>`, or `aws configure set …` prints its full argv to stderr, typically into a log file or CI artifact. Same antipattern with `set -o xtrace` inside a DEBUG trap.
Fix suggestion: Trace a narrow block with `set -x … set +x` around the section you want, or use Zsh `typeset -ft FUNC` for function-level xtrace without argv-spray.
Severity: Warning

## Test plan
- valid `trap 'cleanup' EXIT` → no violation
- valid `trap 'set -x' ERR` → no violation
- invalid `trap 'set -x' DEBUG` → ZC1677
- invalid `trap "set -o xtrace" DEBUG` → ZC1677