### PR TITLE
feat: ZC1678 — flag borg init --encryption=none unencrypted repo

### DIFF
--- a/pkg/katas/katatests/zc1678_test.go
+++ b/pkg/katas/katatests/zc1678_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1678(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — borg init --encryption=repokey",
+			input:    `borg init --encryption=repokey-blake2 /backup`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — borg list (different subcommand)",
+			input:    `borg list /backup`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — borg init --encryption=none joined",
+			input: `borg init --encryption=none /backup`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1678",
+					Message: "`borg init --encryption=none` leaves archives unauthenticated and readable — use `--encryption=repokey-blake2` (or `keyfile-blake2`) and store the passphrase in `BORG_PASSPHRASE_FILE`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — borg init -e none",
+			input: `borg init -e none /backup`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1678",
+					Message: "`borg init --encryption=none` leaves archives unauthenticated and readable — use `--encryption=repokey-blake2` (or `keyfile-blake2`) and store the passphrase in `BORG_PASSPHRASE_FILE`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1678")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1678.go
+++ b/pkg/katas/zc1678.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1678",
+		Title:    "Error on `borg init --encryption=none` — unencrypted backup repository",
+		Severity: SeverityError,
+		Description: "`borg init --encryption=none REPO` creates a backup repository without " +
+			"client-side encryption or authentication. Anyone with read access to the repo " +
+			"gets every file in every archive, and no one can detect silent tampering — " +
+			"borg will happily extract a modified chunk. Even for local-only repos the cost " +
+			"of authenticated-encryption is tiny; use `--encryption=repokey-blake2` (or " +
+			"`--encryption=keyfile-blake2` when you want the key off the server), and store " +
+			"the passphrase in `BORG_PASSPHRASE_FILE` pointing at a mode-0400 file.",
+		Check: checkZC1678,
+	})
+}
+
+func checkZC1678(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "borg" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "init" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--encryption=none" {
+			return zc1678Hit(cmd)
+		}
+		if (v == "--encryption" || v == "-e") && i+2 < len(cmd.Arguments) &&
+			cmd.Arguments[i+2].String() == "none" {
+			return zc1678Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1678Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1678",
+		Message: "`borg init --encryption=none` leaves archives unauthenticated and " +
+			"readable — use `--encryption=repokey-blake2` (or `keyfile-blake2`) and store " +
+			"the passphrase in `BORG_PASSPHRASE_FILE`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 674 Katas = 0.6.74
-const Version = "0.6.74"
+// 675 Katas = 0.6.75
+const Version = "0.6.75"


### PR DESCRIPTION
ZC1678 — Error on `borg init --encryption=none` — unencrypted backup repository

What: `borg init --encryption=none REPO` creates a backup repo with no client-side encryption or authentication.
Why: Anyone with read access to the repo gets every file in every archive; borg can't detect silent tampering. Even for local-only repos the cost of authenticated encryption is negligible.
Fix suggestion: Use `--encryption=repokey-blake2` (or `--encryption=keyfile-blake2` to keep the key off the server), and store the passphrase in a mode-0400 file referenced by `BORG_PASSPHRASE_FILE`.
Severity: Error

## Test plan
- valid `borg init --encryption=repokey-blake2 /backup` → no violation
- valid `borg list /backup` → no violation
- invalid `borg init --encryption=none /backup` → ZC1678
- invalid `borg init -e none /backup` → ZC1678