### PR TITLE
feat: ZC1679 — flag gcloud add-iam-policy-binding primitive admin roles

### DIFF
--- a/pkg/katas/katatests/zc1679_test.go
+++ b/pkg/katas/katatests/zc1679_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1679(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — gcloud add-iam-policy-binding roles/viewer",
+			input:    `gcloud projects add-iam-policy-binding PROJ --member=user:a@ex.com --role=roles/viewer`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — gcloud iam service-accounts create",
+			input:    `gcloud iam service-accounts create foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — add-iam-policy-binding roles/owner",
+			input: `gcloud projects add-iam-policy-binding PROJ --member=user:a@ex.com --role=roles/owner`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1679",
+					Message: "`gcloud ... add-iam-policy-binding --role=roles/owner` grants primitive / IAM-admin — use a predefined role with the minimum scope or a custom role, and apply admin changes via Terraform.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — add-iam-policy-binding roles/iam.serviceAccountTokenCreator",
+			input: `gcloud projects add-iam-policy-binding PROJ --member=user:a@ex.com --role=roles/iam.serviceAccountTokenCreator`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1679",
+					Message: "`gcloud ... add-iam-policy-binding --role=roles/iam.serviceAccountTokenCreator` grants primitive / IAM-admin — use a predefined role with the minimum scope or a custom role, and apply admin changes via Terraform.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1679")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1679.go
+++ b/pkg/katas/zc1679.go
@@ -1,0 +1,79 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1679BroadRoles = map[string]struct{}{
+	"roles/owner":                             {},
+	"roles/editor":                            {},
+	"roles/iam.securityAdmin":                 {},
+	"roles/iam.serviceAccountTokenCreator":    {},
+	"roles/iam.serviceAccountKeyAdmin":        {},
+	"roles/iam.workloadIdentityUser":          {},
+	"roles/resourcemanager.organizationAdmin": {},
+	"roles/resourcemanager.projectIamAdmin":   {},
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1679",
+		Title:    "Error on `gcloud ... add-iam-policy-binding ... --role=roles/owner` — GCP primitive admin",
+		Severity: SeverityError,
+		Description: "`gcloud projects|folders|organizations add-iam-policy-binding` with the " +
+			"primitive roles `roles/owner` or `roles/editor`, or with the IAM-escalation " +
+			"roles (`roles/iam.securityAdmin`, `roles/iam.serviceAccountTokenCreator`, " +
+			"`roles/iam.serviceAccountKeyAdmin`, `roles/resourcemanager.organizationAdmin`), " +
+			"hands the principal the ability to grant themselves any other permission. " +
+			"Scripts rarely need that scope; the pattern signals someone papering over a " +
+			"permissions error. Grant a specific predefined role (e.g. `roles/compute." +
+			"viewer`) or build a custom role with only the `Action`s the workload needs, " +
+			"and apply admin changes via Terraform under change review.",
+		Check: checkZC1679,
+	})
+}
+
+func checkZC1679(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "gcloud" {
+		return nil
+	}
+
+	hasAdd := false
+	var hit string
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "add-iam-policy-binding" {
+			hasAdd = true
+			continue
+		}
+		if strings.HasPrefix(v, "--role=") {
+			if _, broad := zc1679BroadRoles[strings.TrimPrefix(v, "--role=")]; broad {
+				hit = v
+			}
+		}
+	}
+	if !hasAdd || hit == "" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1679",
+		Message: "`gcloud ... add-iam-policy-binding " + hit + "` grants primitive / IAM-" +
+			"admin — use a predefined role with the minimum scope or a custom role, and " +
+			"apply admin changes via Terraform.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 675 Katas = 0.6.75
-const Version = "0.6.75"
+// 676 Katas = 0.6.76
+const Version = "0.6.76"


### PR DESCRIPTION
ZC1679 — Error on `gcloud ... add-iam-policy-binding ... --role=roles/owner` — GCP primitive admin

What: `gcloud projects|folders|organizations add-iam-policy-binding` with primitive roles (`roles/owner`, `roles/editor`) or IAM-escalation roles (`roles/iam.securityAdmin`, `roles/iam.serviceAccountTokenCreator`, `roles/iam.serviceAccountKeyAdmin`, `roles/resourcemanager.organizationAdmin`, `roles/resourcemanager.projectIamAdmin`).
Why: These hand the principal the ability to grant themselves any other permission. Scripts rarely need that scope — usually the signal is someone papering over a permissions error.
Fix suggestion: Grant a specific predefined role (`roles/compute.viewer` etc.) or a custom role with only the `Action`s needed. Apply admin changes via Terraform under change review.
Severity: Error

## Test plan
- valid `gcloud projects add-iam-policy-binding PROJ … --role=roles/viewer` → no violation
- valid `gcloud iam service-accounts create foo` → no violation
- invalid `gcloud projects add-iam-policy-binding PROJ … --role=roles/owner` → ZC1679
- invalid `gcloud projects add-iam-policy-binding PROJ … --role=roles/iam.serviceAccountTokenCreator` → ZC1679