### PR TITLE
feat: ZC1680 — flag ansible-playbook vault-password-file in world-traversable path

### DIFF
--- a/pkg/katas/katatests/zc1680_test.go
+++ b/pkg/katas/katatests/zc1680_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1680(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — vault file under /etc/ansible",
+			input:    `ansible-playbook site.yml --vault-password-file=/etc/ansible/vault.pass`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — no vault file",
+			input:    `ansible-playbook site.yml`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — vault file under /tmp joined",
+			input: `ansible-playbook site.yml --vault-password-file=/tmp/vault.pass`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1680",
+					Message: "`ansible-playbook --vault-password-file` under `/tmp/` / `/var/tmp/` / `/dev/shm/` — world-traversable, any local user can race-read it. Store the key mode-0400 under `/etc/ansible/` or supply via a `vault-password-client` helper.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — vault file under /dev/shm split",
+			input: `ansible-playbook site.yml --vault-password-file /dev/shm/vault`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1680",
+					Message: "`ansible-playbook --vault-password-file` under `/tmp/` / `/var/tmp/` / `/dev/shm/` — world-traversable, any local user can race-read it. Store the key mode-0400 under `/etc/ansible/` or supply via a `vault-password-client` helper.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1680")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1680.go
+++ b/pkg/katas/zc1680.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1680",
+		Title:    "Error on `ansible-playbook --vault-password-file=/tmp/...` — world-traversable vault key",
+		Severity: SeverityError,
+		Description: "The Ansible Vault decryption key lives in the `--vault-password-file` " +
+			"path. `/tmp`, `/var/tmp`, and `/dev/shm` are world-traversable: a concurrent " +
+			"local user who guesses (or `inotifywait`s for) the filename opens it during " +
+			"the playbook run and dumps every secret the vault protects. Keep vault keys " +
+			"in a root-owned mode-0400 file under `/etc/ansible/` or `$HOME/.ansible/`, or " +
+			"supply the passphrase via a no-echo helper script (`vault-password-client`) " +
+			"that fetches from `pass` / `vault kv get`.",
+		Check: checkZC1680,
+	})
+}
+
+func checkZC1680(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ansible-playbook" && ident.Value != "ansible" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "--vault-password-file=") {
+			if zc1680Unsafe(strings.TrimPrefix(v, "--vault-password-file=")) {
+				return zc1680Hit(cmd)
+			}
+			continue
+		}
+		if v == "--vault-password-file" && i+1 < len(cmd.Arguments) {
+			if zc1680Unsafe(cmd.Arguments[i+1].String()) {
+				return zc1680Hit(cmd)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1680Unsafe(path string) bool {
+	return strings.HasPrefix(path, "/tmp/") ||
+		strings.HasPrefix(path, "/var/tmp/") ||
+		strings.HasPrefix(path, "/dev/shm/")
+}
+
+func zc1680Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1680",
+		Message: "`ansible-playbook --vault-password-file` under `/tmp/` / `/var/tmp/` / " +
+			"`/dev/shm/` — world-traversable, any local user can race-read it. Store the " +
+			"key mode-0400 under `/etc/ansible/` or supply via a `vault-password-client` helper.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 676 Katas = 0.6.76
-const Version = "0.6.76"
+// 677 Katas = 0.6.77
+const Version = "0.6.77"


### PR DESCRIPTION
ZC1680 — Error on `ansible-playbook --vault-password-file=/tmp/...` — world-traversable vault key

What: `--vault-password-file` pointing under `/tmp/`, `/var/tmp/`, or `/dev/shm/`.
Why: Those paths are world-traversable. A concurrent local user who guesses (or `inotifywait`s for) the filename opens it during the playbook run and dumps every secret the vault protects.
Fix suggestion: Keep vault keys root-owned, mode 0400, under `/etc/ansible/` or `$HOME/.ansible/`. Or supply via a `vault-password-client` helper that fetches from `pass` / `vault kv get`.
Severity: Error

## Test plan
- valid `ansible-playbook site.yml --vault-password-file=/etc/ansible/vault.pass` → no violation
- valid `ansible-playbook site.yml` → no violation
- invalid `ansible-playbook site.yml --vault-password-file=/tmp/vault.pass` → ZC1680
- invalid `ansible-playbook site.yml --vault-password-file /dev/shm/vault` → ZC1680