### PR TITLE
feat: ZC1681 — flag tar -P absolute-names extract over host paths

### DIFF
--- a/pkg/katas/katatests/zc1681_test.go
+++ b/pkg/katas/katatests/zc1681_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1681(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — tar -xf archive.tar",
+			input:    `tar -xf archive.tar`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — tar -xvzf archive.tgz (no P)",
+			input:    `tar -xvzf archive.tgz`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — tar -xPf archive.tar (short-flag cluster)",
+			input: `tar -xPf archive.tar`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1681",
+					Message: "`tar -xPf` keeps absolute paths during extraction — an untrusted archive can overwrite `/etc/cron.d`, `/usr/local/bin`, etc. Drop the flag and extract with `-C <scratch-dir>` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — tar xf archive.tar -P",
+			input: `tar xf archive.tar -P`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1681",
+					Message: "`tar -P` keeps absolute paths during extraction — an untrusted archive can overwrite `/etc/cron.d`, `/usr/local/bin`, etc. Drop the flag and extract with `-C <scratch-dir>` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1681")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1681.go
+++ b/pkg/katas/zc1681.go
@@ -1,0 +1,71 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1681",
+		Title:    "Error on `tar -P` / `--absolute-names` — archive absolute paths, can overwrite host files",
+		Severity: SeverityError,
+		Description: "By default GNU tar strips the leading `/` from archive member paths so " +
+			"that extraction stays under the current directory. `-P` (or the long form " +
+			"`--absolute-names`) disables that strip: `tar -xPf evil.tar` happily writes to " +
+			"`/etc/cron.d/evil`, `/usr/local/bin/sshd`, or any other absolute path the " +
+			"archive mentions. Archives from untrusted sources should never be unpacked " +
+			"with `-P`. Drop the flag, extract with `-C <scratch-dir>`, audit the tree, " +
+			"then copy files into place with `install` or `cp`.",
+		Check: checkZC1681,
+	})
+}
+
+func checkZC1681(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "tar", "bsdtar", "gtar":
+	case "absolute-names":
+		// `tar --absolute-names …` parses with `tar` consumed — the trailing
+		// name alone is unambiguous evidence of the flag.
+		return zc1681Hit(cmd, "--absolute-names")
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-P" || v == "--absolute-names" {
+			return zc1681Hit(cmd, v)
+		}
+		if !strings.HasPrefix(v, "-") || strings.HasPrefix(v, "--") {
+			continue
+		}
+		body := strings.TrimPrefix(v, "-")
+		if strings.ContainsRune(body, 'P') {
+			return zc1681Hit(cmd, v)
+		}
+	}
+	return nil
+}
+
+func zc1681Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1681",
+		Message: "`tar " + form + "` keeps absolute paths during extraction — an " +
+			"untrusted archive can overwrite `/etc/cron.d`, `/usr/local/bin`, etc. Drop " +
+			"the flag and extract with `-C <scratch-dir>` instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 677 Katas = 0.6.77
-const Version = "0.6.77"
+// 678 Katas = 0.6.78
+const Version = "0.6.78"


### PR DESCRIPTION
ZC1681 — Error on `tar -P` / `--absolute-names` — archive absolute paths, can overwrite host files

What: By default GNU tar strips the leading `/` from archive paths. `-P` / `--absolute-names` disables the strip.
Why: `tar -xPf evil.tar` writes to `/etc/cron.d/evil`, `/usr/local/bin/sshd`, or any absolute path the archive mentions — a trivial host-takeover on an untrusted tarball.
Fix suggestion: Drop the flag. Extract with `-C <scratch-dir>`, audit the tree, then copy into place with `install` or `cp`.
Severity: Error

## Test plan
- valid `tar -xf archive.tar` → no violation
- valid `tar -xvzf archive.tgz` → no violation
- invalid `tar -xPf archive.tar` → ZC1681
- invalid `tar xf archive.tar -P` → ZC1681