### PR TITLE
feat: ZC1682 — flag npm install --unsafe-perm root lifecycle script

### DIFF
--- a/pkg/katas/katatests/zc1682_test.go
+++ b/pkg/katas/katatests/zc1682_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1682(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — npm ci (no unsafe-perm)",
+			input:    `npm ci`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — yarn install",
+			input:    `yarn install`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — npm install --unsafe-perm",
+			input: `npm install --unsafe-perm`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1682",
+					Message: "`npm --unsafe-perm` keeps root for every lifecycle script — a compromised dep executes as root. Build in a dedicated builder container or run as a non-root user.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — npm install --unsafe-perm=true",
+			input: `npm install --unsafe-perm=true`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1682",
+					Message: "`npm --unsafe-perm=true` keeps root for every lifecycle script — a compromised dep executes as root. Build in a dedicated builder container or run as a non-root user.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1682")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1682.go
+++ b/pkg/katas/zc1682.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1682",
+		Title:    "Error on `npm install --unsafe-perm` — npm lifecycle scripts keep root privileges",
+		Severity: SeverityError,
+		Description: "npm normally drops to the UID that owns `package.json` before running " +
+			"`preinstall` / `install` / `postinstall` lifecycle scripts. `--unsafe-perm` " +
+			"(or `--unsafe-perm=true`) tells npm to skip that drop and run every script as " +
+			"the current UID — typically root when the install happens from a provisioning " +
+			"script. Any compromised or malicious dependency then executes as root. If a " +
+			"native addon truly needs privileges, scope them: drop them into a dedicated " +
+			"builder container, or use `sudo -u builduser npm install` from a non-root " +
+			"account that already owns `node_modules/`.",
+		Check: checkZC1682,
+	})
+}
+
+func checkZC1682(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "npm" && ident.Value != "yarn" && ident.Value != "pnpm" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--unsafe-perm" || v == "--unsafe-perm=true" {
+			return []Violation{{
+				KataID: "ZC1682",
+				Message: "`" + ident.Value + " " + v + "` keeps root for every lifecycle " +
+					"script — a compromised dep executes as root. Build in a dedicated " +
+					"builder container or run as a non-root user.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 678 Katas = 0.6.78
-const Version = "0.6.78"
+// 679 Katas = 0.6.79
+const Version = "0.6.79"


### PR DESCRIPTION
ZC1682 — Error on `npm install --unsafe-perm` — npm lifecycle scripts keep root privileges

What: `--unsafe-perm` (or `--unsafe-perm=true`) tells npm to skip its UID-drop before running `preinstall`/`install`/`postinstall` lifecycle scripts.
Why: The UID drop exists because a compromised dependency executes arbitrary code via those hooks. With `--unsafe-perm`, that code runs as the current UID — typically root during provisioning.
Fix suggestion: Build in a dedicated builder container, or `sudo -u builduser npm install` from a non-root account that already owns `node_modules/`.
Severity: Error

## Test plan
- valid `npm ci` → no violation
- valid `yarn install` → no violation
- invalid `npm install --unsafe-perm` → ZC1682
- invalid `npm install --unsafe-perm=true` → ZC1682