### PR TITLE
feat: ZC1683 — flag npm/yarn/pnpm config set registry plaintext HTTP

### DIFF
--- a/pkg/katas/katatests/zc1683_test.go
+++ b/pkg/katas/katatests/zc1683_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1683(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — https registry",
+			input:    `npm config set registry https://registry.npmjs.org/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — npm config set strict-ssl",
+			input:    `npm config set strict-ssl false`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — npm config set registry http://...",
+			input: `npm config set registry http://internal.example.com/`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1683",
+					Message: "`npm config set registry http://internal.example.com/` uses plaintext HTTP — any proxy / CDN can rewrite tarballs. Use `https://` and a custom CA via `NODE_EXTRA_CA_CERTS` if needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — yarn config set registry http://...",
+			input: `yarn config set registry http://internal/`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1683",
+					Message: "`yarn config set registry http://internal/` uses plaintext HTTP — any proxy / CDN can rewrite tarballs. Use `https://` and a custom CA via `NODE_EXTRA_CA_CERTS` if needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1683")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1683.go
+++ b/pkg/katas/zc1683.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1683",
+		Title:    "Error on `npm/yarn/pnpm config set registry http://...` — plaintext package index",
+		Severity: SeverityError,
+		Description: "Pointing a JavaScript package manager at an `http://` registry disables " +
+			"TLS during fetch. Any host on the path (corporate proxy, hotel Wi-Fi, " +
+			"compromised CDN) can rewrite tarballs mid-flight; lockfile hashes catch the " +
+			"rewrite only if the user locks every dependency before the swap. Even on " +
+			"internal networks, pin to `https://` — reach for your own CA via " +
+			"`NODE_EXTRA_CA_CERTS` or `registry.cafile` rather than falling back to HTTP.",
+		Check: checkZC1683,
+	})
+}
+
+func checkZC1683(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "npm" && ident.Value != "yarn" && ident.Value != "pnpm" {
+		return nil
+	}
+
+	if len(cmd.Arguments) < 4 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "config" || cmd.Arguments[1].String() != "set" {
+		return nil
+	}
+	if cmd.Arguments[2].String() != "registry" {
+		return nil
+	}
+	url := cmd.Arguments[3].String()
+	if !strings.HasPrefix(url, "http://") {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1683",
+		Message: "`" + ident.Value + " config set registry " + url + "` uses plaintext " +
+			"HTTP — any proxy / CDN can rewrite tarballs. Use `https://` and a custom " +
+			"CA via `NODE_EXTRA_CA_CERTS` if needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 679 Katas = 0.6.79
-const Version = "0.6.79"
+// 680 Katas = 0.6.80
+const Version = "0.6.80"


### PR DESCRIPTION
ZC1683 — Error on `npm/yarn/pnpm config set registry http://...` — plaintext package index

What: Pointing a JS package manager at an `http://` registry disables TLS during fetch.
Why: Any host on the path (corporate proxy, hotel Wi-Fi, compromised CDN) can rewrite tarballs mid-flight; lockfile hashes catch the rewrite only if every dep was locked pre-swap.
Fix suggestion: Pin to `https://`. If the internal registry uses a custom CA, point to it via `NODE_EXTRA_CA_CERTS` or `registry.cafile` instead of falling back to HTTP.
Severity: Error

## Test plan
- valid `npm config set registry https://registry.npmjs.org/` → no violation
- valid `npm config set strict-ssl false` (different setting) → no violation
- invalid `npm config set registry http://internal.example.com/` → ZC1683
- invalid `yarn config set registry http://internal/` → ZC1683