### PR TITLE
feat: ZC1684 — flag redis-cli -a password in process list

### DIFF
--- a/pkg/katas/katatests/zc1684_test.go
+++ b/pkg/katas/katatests/zc1684_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1684(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — redis-cli PING",
+			input:    `redis-cli PING`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — redis-cli -h host",
+			input:    `redis-cli -h cache.example.com PING`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — redis-cli -a SECRET PING",
+			input: `redis-cli -a SECRET PING`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1684",
+					Message: "`redis-cli -a PASSWORD` leaks the password into `ps` / `/proc/PID/cmdline` — use `REDISCLI_AUTH` env var or `-askpass` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — redis-cli -aSECRET joined",
+			input: `redis-cli -aSECRET PING`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1684",
+					Message: "`redis-cli -a PASSWORD` leaks the password into `ps` / `/proc/PID/cmdline` — use `REDISCLI_AUTH` env var or `-askpass` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1684")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1684.go
+++ b/pkg/katas/zc1684.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1684",
+		Title:    "Error on `redis-cli -a PASSWORD` — authentication password in process list",
+		Severity: SeverityError,
+		Description: "`redis-cli -a <password>` (and the joined form `-aPASSWORD`) puts the " +
+			"authentication password in the command line — visible to every user on the " +
+			"host through `ps`, `/proc/PID/cmdline`, audit logs, and shell history. redis-" +
+			"cli 6.0+ prints a warning to stderr but still connects. Use the " +
+			"`REDISCLI_AUTH` environment variable (read automatically by redis-cli), or " +
+			"`-askpass` to prompt from TTY; both keep the secret out of the argv tail.",
+		Check: checkZC1684,
+	})
+}
+
+func checkZC1684(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "redis-cli" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-a" && i+1 < len(cmd.Arguments) {
+			return zc1684Hit(cmd)
+		}
+		if strings.HasPrefix(v, "-a") && v != "-a" && !strings.HasPrefix(v, "--") {
+			return zc1684Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1684Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1684",
+		Message: "`redis-cli -a PASSWORD` leaks the password into `ps` / `/proc/PID/cmdline` — " +
+			"use `REDISCLI_AUTH` env var or `-askpass` instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 680 Katas = 0.6.80
-const Version = "0.6.80"
+// 681 Katas = 0.6.81
+const Version = "0.6.81"


### PR DESCRIPTION
ZC1684 — Error on `redis-cli -a PASSWORD` — authentication password in process list

What: `redis-cli -a <password>` (and the joined form `-aPASSWORD`) authenticates via argv.
Why: Every user on the host sees it through `ps`, `/proc/PID/cmdline`, audit logs, and shell history. redis-cli 6.0+ warns on stderr but still connects.
Fix suggestion: Use `REDISCLI_AUTH` environment variable (read automatically) or `-askpass` to prompt from TTY — both keep the secret out of argv.
Severity: Error

## Test plan
- valid `redis-cli PING` → no violation
- valid `redis-cli -h cache.example.com PING` → no violation
- invalid `redis-cli -a SECRET PING` → ZC1684
- invalid `redis-cli -aSECRET PING` → ZC1684