### PR TITLE
feat: ZC1685 — flag sleep infinity SIGTERM-insensitive keep-alive

### DIFF
--- a/pkg/katas/katatests/zc1685_test.go
+++ b/pkg/katas/katatests/zc1685_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1685(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sleep 30",
+			input:    `sleep 30`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — sleep variable",
+			input:    `sleep $timeout`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — sleep infinity",
+			input: `sleep infinity`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1685",
+					Message: "`sleep infinity` does not trap SIGTERM — the orchestrator hangs until SIGKILL. Use `exec tail -f /dev/null` or front with `tini` / `dumb-init`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1685")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1685.go
+++ b/pkg/katas/zc1685.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1685",
+		Title:    "Info: `sleep infinity` — container keep-alive pattern that ignores SIGTERM",
+		Severity: SeverityInfo,
+		Description: "`sleep infinity` is most often used as a container or systemd-unit keep-" +
+			"alive. Problem: GNU `sleep` does not install a SIGTERM handler, so when " +
+			"`docker stop` / `systemctl stop` sends SIGTERM the process sits unresponsive " +
+			"until the grace period expires and SIGKILL lands. The orchestrator reports a " +
+			"hung stop, logs look wrong, and any cleanup registered on signal handlers in " +
+			"a wrapping shell never runs. Replace with `exec tail -f /dev/null` (signal-" +
+			"handles cleanly) or front with `tini` / `dumb-init` when PID 1 must stay.",
+		Check: checkZC1685,
+	})
+}
+
+func checkZC1685(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "sleep" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "infinity" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1685",
+		Message: "`sleep infinity` does not trap SIGTERM — the orchestrator hangs until " +
+			"SIGKILL. Use `exec tail -f /dev/null` or front with `tini` / `dumb-init`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityInfo,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 681 Katas = 0.6.81
-const Version = "0.6.81"
+// 682 Katas = 0.6.82
+const Version = "0.6.82"


### PR DESCRIPTION
ZC1685 — Info: `sleep infinity` — container keep-alive pattern that ignores SIGTERM

What: `sleep infinity` as a container or systemd-unit keep-alive.
Why: GNU `sleep` installs no SIGTERM handler. `docker stop` / `systemctl stop` sends SIGTERM and the process sits unresponsive until grace-period expiry, then SIGKILL. The orchestrator reports a hung stop; any cleanup in a wrapping shell's signal traps never runs.
Fix suggestion: `exec tail -f /dev/null` (signal-handles cleanly), or front the container with `tini` / `dumb-init` when PID 1 must stay.
Severity: Info

## Test plan
- valid `sleep 30` → no violation
- valid `sleep $timeout` → no violation
- invalid `sleep infinity` → ZC1685