### PR TITLE
feat: ZC1686 — flag compinit -C / -u fpath integrity bypass

### DIFF
--- a/pkg/katas/katatests/zc1686_test.go
+++ b/pkg/katas/katatests/zc1686_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1686(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — bare compinit",
+			input:    `compinit -d $XDG_CACHE_HOME/zcompdump`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — different command",
+			input:    `compaudit`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — compinit -C",
+			input: `compinit -C`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1686",
+					Message: "`compinit -C` (skip-security-check) loads `$fpath` files that are writable by others — any user on the host can inject shell code. Run `compaudit`, fix permissions, then `compinit` without the flag.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — compinit -u",
+			input: `compinit -u`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1686",
+					Message: "`compinit -u` (load-insecure-files) loads `$fpath` files that are writable by others — any user on the host can inject shell code. Run `compaudit`, fix permissions, then `compinit` without the flag.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1686")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1686.go
+++ b/pkg/katas/zc1686.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1686",
+		Title:    "Warn on `compinit -C` / `compinit -u` — skips / ignores `$fpath` integrity checks",
+		Severity: SeverityWarning,
+		Description: "Zsh's completion system loads every file from `$fpath` as shell code. " +
+			"`compinit` normally warns when an `$fpath` directory (or a file in one) is " +
+			"writable by someone other than the current user or root, and skips loading. " +
+			"`compinit -C` skips the security check entirely for speed; `compinit -u` " +
+			"acknowledges the warning and loads the insecure files anyway. Either way, a " +
+			"world-writable entry in `$fpath` becomes an execution primitive for any user " +
+			"on the host. Audit `$fpath` with `compaudit`, fix ownership / permissions, " +
+			"then run plain `compinit`.",
+		Check: checkZC1686,
+	})
+}
+
+func checkZC1686(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "compinit" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-C" {
+			return zc1686Hit(cmd, "-C", "skip-security-check")
+		}
+		if v == "-u" {
+			return zc1686Hit(cmd, "-u", "load-insecure-files")
+		}
+	}
+	return nil
+}
+
+func zc1686Hit(cmd *ast.SimpleCommand, flag, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1686",
+		Message: "`compinit " + flag + "` (" + what + ") loads `$fpath` files that are " +
+			"writable by others — any user on the host can inject shell code. Run " +
+			"`compaudit`, fix permissions, then `compinit` without the flag.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 682 Katas = 0.6.82
-const Version = "0.6.82"
+// 683 Katas = 0.6.83
+const Version = "0.6.83"


### PR DESCRIPTION
ZC1686 — Warn on `compinit -C` / `compinit -u` — skips / ignores `$fpath` integrity checks

What: Zsh's completion system loads every file from `$fpath` as shell code. `compinit` normally refuses when an `$fpath` entry is writable by someone other than the current user or root.
Why: `-C` skips the security check entirely (for speed); `-u` loads the insecure files anyway. Either way, a world-writable `$fpath` dir becomes an execution primitive for any local user.
Fix suggestion: Audit `$fpath` with `compaudit`, fix ownership/permissions, then run plain `compinit` (or `compinit -d <cache>` for cache-path control).
Severity: Warning

## Test plan
- valid `compinit -d $XDG_CACHE_HOME/zcompdump` → no violation
- valid `compaudit` → no violation (different command)
- invalid `compinit -C` → ZC1686
- invalid `compinit -u` → ZC1686