### PR TITLE
feat: ZC1687 — flag snap install --classic / --devmode sandbox weakening

### DIFF
--- a/pkg/katas/katatests/zc1687_test.go
+++ b/pkg/katas/katatests/zc1687_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1687(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — snap install strict",
+			input:    `snap install hello-world`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — snap list",
+			input:    `snap list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — snap install --classic",
+			input: `snap install code --classic`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1687",
+					Message: "`snap install --classic` drops AppArmor / cgroup / seccomp sandbox — find a strict snap or a distro-package alternative, or document why this specific snap needs it.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — snap install --devmode",
+			input: `snap install pkg --devmode`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1687",
+					Message: "`snap install --devmode` logs confinement violations instead of blocking — find a strict snap or a distro-package alternative, or document why this specific snap needs it.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1687")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1687.go
+++ b/pkg/katas/zc1687.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1687",
+		Title:    "Warn on `snap install --classic` / `--devmode` — weakens snap confinement",
+		Severity: SeverityWarning,
+		Description: "`snap install --classic` drops the AppArmor / cgroup / seccomp sandbox " +
+			"entirely — the snap behaves like a normal Debian package with full system " +
+			"access. `--devmode` keeps the sandbox wired up but logs violations instead of " +
+			"blocking them. Both modes are documented escape hatches for snaps that cannot " +
+			"yet fit the strict confinement (IDEs, compilers, some network tooling), but in " +
+			"provisioning scripts they usually mean \"I could not be bothered to pick a " +
+			"strict snap.\" Find a strict alternative, or install from the distro repository " +
+			"with proper AppArmor profiles; if `--classic` is truly required, document the " +
+			"specific snap and the interface that needed elevation.",
+		Check: checkZC1687,
+	})
+}
+
+func checkZC1687(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "snap" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "install" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--classic" {
+			return zc1687Hit(cmd, "--classic", "drops AppArmor / cgroup / seccomp sandbox")
+		}
+		if v == "--devmode" {
+			return zc1687Hit(cmd, "--devmode", "logs confinement violations instead of blocking")
+		}
+	}
+	return nil
+}
+
+func zc1687Hit(cmd *ast.SimpleCommand, flag, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1687",
+		Message: "`snap install " + flag + "` " + what + " — find a strict snap or a " +
+			"distro-package alternative, or document why this specific snap needs it.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 683 Katas = 0.6.83
-const Version = "0.6.83"
+// 684 Katas = 0.6.84
+const Version = "0.6.84"


### PR DESCRIPTION
ZC1687 — Warn on `snap install --classic` / `--devmode` — weakens snap confinement

What: `--classic` drops the AppArmor / cgroup / seccomp sandbox entirely; `--devmode` keeps it wired but logs violations instead of blocking.
Why: Documented escape hatches for snaps that cannot fit strict confinement, but in provisioning scripts they usually mean "I could not be bothered to pick a strict snap."
Fix suggestion: Find a strict snap, install from the distro repo with proper AppArmor, or document which specific snap requires the elevation.
Severity: Warning

## Test plan
- valid `snap install hello-world` → no violation
- valid `snap list` → no violation
- invalid `snap install code --classic` → ZC1687
- invalid `snap install pkg --devmode` → ZC1687