### PR TITLE
feat: ZC1688 — flag aws s3 sync --delete destination-wipe risk

### DIFF
--- a/pkg/katas/katatests/zc1688_test.go
+++ b/pkg/katas/katatests/zc1688_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1688(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — aws s3 sync without --delete",
+			input:    `aws s3 sync ./build s3://my-bucket/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — aws s3 cp",
+			input:    `aws s3 cp file s3://bucket/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — aws s3 sync --delete",
+			input: `aws s3 sync ./build s3://my-bucket/ --delete`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1688",
+					Message: "`aws s3 sync --delete` wipes DST objects that are missing from SRC — a mistyped SRC bulk-deletes the bucket. Scope to the prefix, dry-run first, or enable versioning + MFA-delete.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — aws s3 sync between buckets with --delete",
+			input: `aws s3 sync s3://src/ s3://dst/ --delete`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1688",
+					Message: "`aws s3 sync --delete` wipes DST objects that are missing from SRC — a mistyped SRC bulk-deletes the bucket. Scope to the prefix, dry-run first, or enable versioning + MFA-delete.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1688")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1688.go
+++ b/pkg/katas/zc1688.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1688",
+		Title:    "Warn on `aws s3 sync --delete` — destination objects deleted when source diverges",
+		Severity: SeverityWarning,
+		Description: "`aws s3 sync SRC DST --delete` removes every object in DST that does not " +
+			"exist under SRC. A misspelled SRC, an empty build directory, or a stale " +
+			"`cd` turns the sync into a full-bucket wipe with no second confirmation and " +
+			"no recovery unless the bucket had versioning enabled. Restrict deletion to " +
+			"the prefix that really changed (`aws s3 sync ./build s3://bucket/app/ " +
+			"--delete`), add `--dryrun` behind a gate, or enable versioning and MFA-delete " +
+			"before running the command from a pipeline.",
+		Check: checkZC1688,
+	})
+}
+
+func checkZC1688(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "aws" {
+		return nil
+	}
+
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "s3" || cmd.Arguments[1].String() != "sync" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[2:] {
+		if arg.String() == "--delete" {
+			return []Violation{{
+				KataID: "ZC1688",
+				Message: "`aws s3 sync --delete` wipes DST objects that are missing from " +
+					"SRC — a mistyped SRC bulk-deletes the bucket. Scope to the prefix, " +
+					"dry-run first, or enable versioning + MFA-delete.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 684 Katas = 0.6.84
-const Version = "0.6.84"
+// 685 Katas = 0.6.85
+const Version = "0.6.85"


### PR DESCRIPTION
ZC1688 — Warn on `aws s3 sync --delete` — destination objects deleted when source diverges

What: `aws s3 sync SRC DST --delete` removes every object in DST that does not exist under SRC.
Why: A misspelled SRC, an empty build directory, or a stale `cd` turns the sync into a full-bucket wipe — no second confirmation, no recovery unless versioning is enabled.
Fix suggestion: Restrict deletion to the changed prefix (`aws s3 sync ./build s3://bucket/app/ --delete`), add `--dryrun` behind a gate, or enable versioning + MFA-delete before running from a pipeline.
Severity: Warning

## Test plan
- valid `aws s3 sync ./build s3://my-bucket/` → no violation
- valid `aws s3 cp file s3://bucket/` → no violation
- invalid `aws s3 sync ./build s3://my-bucket/ --delete` → ZC1688
- invalid `aws s3 sync s3://src/ s3://dst/ --delete` → ZC1688