### PR TITLE
feat: ZC1689 — flag borg delete --force bypassing confirmation

### DIFF
--- a/pkg/katas/katatests/zc1689_test.go
+++ b/pkg/katas/katatests/zc1689_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1689(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — borg delete without --force (prompts)",
+			input:    `borg delete /backup::archive1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — borg prune",
+			input:    `borg prune --keep-last 7 /backup`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — borg delete --force",
+			input: `borg delete --force /backup`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1689",
+					Message: "`borg delete --force` skips confirmation and can nuke the whole repository on a typo — use `borg prune --keep-*` with a retention policy, or gate outright deletion behind a manual review.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1689")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1689.go
+++ b/pkg/katas/zc1689.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1689",
+		Title:    "Error on `borg delete --force` — forced deletion of backup archives or repository",
+		Severity: SeverityError,
+		Description: "`borg delete --force REPO[::ARCHIVE]` bypasses the confirmation prompt " +
+			"and removes the archive (or the whole repository, if ARCHIVE is omitted) in " +
+			"one go. Unlike `borg prune`, which keeps a retention ladder and logs what it " +
+			"would drop, `--force` deletion leaves nothing to restore from if the target " +
+			"was typed wrong. Keep scripts to `borg prune --keep-daily` / `--keep-within` " +
+			"with an explicit retention policy and gate any outright `borg delete` behind " +
+			"a human `--checkpoint-interval` review.",
+		Check: checkZC1689,
+	})
+}
+
+func checkZC1689(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "borg" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "delete" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		if arg.String() == "--force" {
+			return []Violation{{
+				KataID: "ZC1689",
+				Message: "`borg delete --force` skips confirmation and can nuke the whole " +
+					"repository on a typo — use `borg prune --keep-*` with a retention " +
+					"policy, or gate outright deletion behind a manual review.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 685 Katas = 0.6.85
-const Version = "0.6.85"
+// 686 Katas = 0.6.86
+const Version = "0.6.86"


### PR DESCRIPTION
ZC1689 — Error on `borg delete --force` — forced deletion of backup archives or repository

What: `borg delete --force REPO[::ARCHIVE]` skips the confirmation prompt and removes the archive, or the whole repo if ARCHIVE is omitted.
Why: Unlike `borg prune`, which keeps a retention ladder, `--force` deletion leaves nothing to restore from if the target was typed wrong.
Fix suggestion: `borg prune --keep-daily` / `--keep-within` with an explicit retention policy; gate outright `borg delete` behind a manual review.
Severity: Error

## Test plan
- valid `borg delete /backup::archive1` (prompts) → no violation
- valid `borg prune --keep-last 7 /backup` → no violation
- invalid `borg delete --force /backup` → ZC1689