### PR TITLE
feat: ZC1690 — flag pip install git+URL without commit/tag pin

### DIFF
--- a/pkg/katas/katatests/zc1690_test.go
+++ b/pkg/katas/katatests/zc1690_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1690(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — pip install normal package",
+			input:    `pip install requests`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — pip install git+URL@commit-hash",
+			input:    `pip install git+https://github.com/org/repo@abc1234`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — pip install git+URL@v1.2.3 tag",
+			input:    `pip install git+https://github.com/org/repo@v1.2.3`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — pip install git+URL without ref",
+			input: `pip install git+https://github.com/org/repo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1690",
+					Message: "`pip install git+https://github.com/org/repo` tracks a moving git ref — pin to a commit SHA (`@abc1234…`) or signed tag (`@v1.2.3`), or use the PyPI release.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — pip install git+URL@main (moving branch)",
+			input: `pip install git+https://github.com/org/repo@main`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1690",
+					Message: "`pip install git+https://github.com/org/repo@main` tracks a moving git ref — pin to a commit SHA (`@abc1234…`) or signed tag (`@v1.2.3`), or use the PyPI release.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1690")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1690.go
+++ b/pkg/katas/zc1690.go
@@ -1,0 +1,77 @@
+package katas
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var (
+	zc1690GitURL = regexp.MustCompile(`^git\+(https?|ssh|file|git)://`)
+	zc1690Hash   = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
+	zc1690Tag    = regexp.MustCompile(`^v?\d+\.\d+`)
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1690",
+		Title:    "Warn on `pip install git+<URL>` without a commit / tag pin",
+		Severity: SeverityWarning,
+		Description: "`pip install git+https://host/repo[@main]` checks out a moving ref (the " +
+			"repository's default branch when no `@` suffix is given, otherwise a branch " +
+			"name the attacker can rewrite). Every subsequent install pulls whatever HEAD " +
+			"the branch currently points at — no lockfile, no checksum, no reproducibility. " +
+			"Pin to a specific commit SHA (`@abc1234…`) or a signed tag (`@v1.2.3`). If a " +
+			"proper PyPI release is available, drop the `git+` form entirely and install " +
+			"the versioned package.",
+		Check: checkZC1690,
+	})
+}
+
+func checkZC1690(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "pip", "pip3", "pipx", "uv":
+	default:
+		return nil
+	}
+
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "install" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if !zc1690GitURL.MatchString(v) {
+			continue
+		}
+		at := strings.LastIndex(v, "@")
+		// Skip the `@` that's part of `git+ssh://git@host/...` — locate only
+		// the refspec `@` that follows the path.
+		if at > 0 && at > strings.LastIndex(v, "/") {
+			ref := v[at+1:]
+			if zc1690Hash.MatchString(ref) || zc1690Tag.MatchString(ref) {
+				continue
+			}
+		}
+		return []Violation{{
+			KataID: "ZC1690",
+			Message: "`" + ident.Value + " install " + v + "` tracks a moving git ref — " +
+				"pin to a commit SHA (`@abc1234…`) or signed tag (`@v1.2.3`), or use the " +
+				"PyPI release.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 686 Katas = 0.6.86
-const Version = "0.6.86"
+// 687 Katas = 0.6.87
+const Version = "0.6.87"


### PR DESCRIPTION
ZC1690 — Warn on `pip install git+<URL>` without a commit / tag pin

What: `pip install git+https://host/repo[@main]` checks out a moving ref — default branch when no `@` is given, otherwise a branch name.
Why: Every subsequent install pulls whatever HEAD the branch currently points at — no lockfile, no checksum, no reproducibility.
Fix suggestion: Pin to a commit SHA (`@abc1234…`) or signed tag (`@v1.2.3`). If a PyPI release exists, install the versioned package instead.
Severity: Warning

## Test plan
- valid `pip install requests` → no violation
- valid `pip install git+https://github.com/org/repo@abc1234` (commit SHA) → no violation
- valid `pip install git+https://github.com/org/repo@v1.2.3` (tag) → no violation
- invalid `pip install git+https://github.com/org/repo` (no ref) → ZC1690
- invalid `pip install git+https://github.com/org/repo@main` (branch) → ZC1690