### PR TITLE
feat: ZC1691 — flag rsync --remove-source-files optimistic delete

### DIFF
--- a/pkg/katas/katatests/zc1691_test.go
+++ b/pkg/katas/katatests/zc1691_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1691(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — rsync without --remove-source-files",
+			input:    `rsync -av src/ dst/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — rsync --delete (different flag)",
+			input:    `rsync -av --delete src/ dst/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — rsync --remove-source-files (local)",
+			input: `rsync -av --remove-source-files src/ dst/`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1691",
+					Message: "`rsync --remove-source-files` deletes SRC on optimistic per-file success — verify DST after the transfer and `rm` explicitly instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — rsync --remove-source-files (remote)",
+			input: `rsync -a --remove-source-files host:src dst`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1691",
+					Message: "`rsync --remove-source-files` deletes SRC on optimistic per-file success — verify DST after the transfer and `rm` explicitly instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1691")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1691.go
+++ b/pkg/katas/zc1691.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1691",
+		Title:    "Warn on `rsync --remove-source-files` — SRC deletion tied to optimistic success",
+		Severity: SeverityWarning,
+		Description: "`rsync --remove-source-files` deletes each source file once rsync has " +
+			"transferred it. The delete is gated on rsync's per-file success, which is " +
+			"generous: a remote out-of-disk error after the partial write, a `--chmod` " +
+			"rejection, or a flaky network that drops after the data bytes but before " +
+			"metadata can still look like success. Couple that with a wrong DST path and " +
+			"the source is gone with nothing to recover. Prefer a two-step flow: `rsync " +
+			"-a SRC DST` first, verify DST (checksums / file count), then `rm` the source " +
+			"explicitly, or use `mv` for local moves.",
+		Check: checkZC1691,
+	})
+}
+
+func checkZC1691(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "rsync" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "--remove-source-files" {
+			return []Violation{{
+				KataID: "ZC1691",
+				Message: "`rsync --remove-source-files` deletes SRC on optimistic per-file " +
+					"success — verify DST after the transfer and `rm` explicitly instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 687 Katas = 0.6.87
-const Version = "0.6.87"
+// 688 Katas = 0.6.88
+const Version = "0.6.88"


### PR DESCRIPTION
ZC1691 — Warn on `rsync --remove-source-files` — SRC deletion tied to optimistic success

What: `rsync --remove-source-files` deletes each source file after rsync reports per-file transfer success.
Why: The success check is generous: remote out-of-disk after the partial write, `--chmod` rejection, or a flaky network that drops after data bytes but before metadata can still look like success. Combined with a wrong DST, the source is gone.
Fix suggestion: Two-step flow — `rsync -a SRC DST`, verify DST (checksums / file count), then `rm` explicitly. For local moves, use `mv`.
Severity: Warning

## Test plan
- valid `rsync -av src/ dst/` → no violation
- valid `rsync -av --delete src/ dst/` → no violation
- invalid `rsync -av --remove-source-files src/ dst/` → ZC1691
- invalid `rsync -a --remove-source-files host:src dst` → ZC1691