### PR TITLE
feat: ZC1692 — flag kexec -e silent kernel transition without audit

### DIFF
--- a/pkg/katas/katatests/zc1692_test.go
+++ b/pkg/katas/katatests/zc1692_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1692(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — kexec -l load only",
+			input:    `kexec -l /boot/vmlinuz --initrd=/boot/initrd.img`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — kexec -u unload",
+			input:    `kexec -u`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — kexec -e",
+			input: `kexec -e`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1692",
+					Message: "`kexec -e` jumps to a preloaded kernel without firmware reboot — wtmp / auditd see nothing. Use `systemctl kexec` or a real `systemctl reboot` to keep the audit trail.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1692")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1692.go
+++ b/pkg/katas/zc1692.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1692",
+		Title:    "Error on `kexec -e` — jumps into a new kernel without reboot, no audit trail",
+		Severity: SeverityError,
+		Description: "`kexec -e` transfers control to whatever kernel image is currently " +
+			"loaded via `kexec -l` — there is no firmware reboot, no init re-run, no " +
+			"chance for PAM / auditd / systemd hooks to record the transition. Malware " +
+			"uses it to pivot into a rootkit kernel while the audit log shows no reboot. " +
+			"If the intent is a fast reboot, prefer `systemctl kexec` (writes a wtmp entry " +
+			"and flushes filesystems), or just `reboot` / `systemctl reboot` and take the " +
+			"firmware cost for the audit trail.",
+		Check: checkZC1692,
+	})
+}
+
+func checkZC1692(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kexec" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-e" {
+			return []Violation{{
+				KataID: "ZC1692",
+				Message: "`kexec -e` jumps to a preloaded kernel without firmware reboot " +
+					"— wtmp / auditd see nothing. Use `systemctl kexec` or a real " +
+					"`systemctl reboot` to keep the audit trail.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 688 Katas = 0.6.88
-const Version = "0.6.88"
+// 689 Katas = 0.6.89
+const Version = "0.6.89"


### PR DESCRIPTION
ZC1692 — Error on `kexec -e` — jumps into a new kernel without reboot, no audit trail

What: `kexec -e` transfers control to the kernel image preloaded via `kexec -l`.
Why: No firmware reboot, no init re-run, no PAM / auditd / systemd hooks record the transition. Wtmp / auditd see nothing. Malware uses it to pivot into a rootkit kernel silently.
Fix suggestion: `systemctl kexec` (writes wtmp, flushes filesystems) for fast reboot, or a plain `systemctl reboot` for a firmware-reset audit trail.
Severity: Error

## Test plan
- valid `kexec -l /boot/vmlinuz --initrd=/boot/initrd.img` → no violation
- valid `kexec -u` (unload) → no violation
- invalid `kexec -e` → ZC1692