### PR TITLE
feat: ZC1693 — flag ionice -c 1 real-time I/O starvation risk

### DIFF
--- a/pkg/katas/katatests/zc1693_test.go
+++ b/pkg/katas/katatests/zc1693_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1693(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ionice -c 2 (best-effort)",
+			input:    `ionice -c 2 -n 4 cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ionice -c 3 (idle)",
+			input:    `ionice -c 3 cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ionice -c 1 (real-time, split)",
+			input: `ionice -c 1 -n 0 cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1693",
+					Message: "`ionice -c 1` puts the child in the real-time I/O class — a long-running workload starves sshd / journald / the rest of the host. Stay on class 2.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ionice -c1 (real-time, joined)",
+			input: `ionice -c1 cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1693",
+					Message: "`ionice -c 1` puts the child in the real-time I/O class — a long-running workload starves sshd / journald / the rest of the host. Stay on class 2.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1693")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1693.go
+++ b/pkg/katas/zc1693.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1693",
+		Title:    "Warn on `ionice -c 1` — real-time I/O class starves every other disk consumer",
+		Severity: SeverityWarning,
+		Description: "`ionice -c 1` (real-time I/O scheduling class) promotes the child above " +
+			"every best-effort (class 2) and idle (class 3) task queued against the same " +
+			"device. A busy workload — `rsync`, `dd`, database backup — then blocks sshd " +
+			"reads, systemd journal writes, and every other process until it yields, which " +
+			"for sequential I/O is effectively never. If the intent is \"fast I/O\", stay on " +
+			"class 2 and let CFQ / BFQ handle it; reserve class 1 for latency-critical " +
+			"paths launched by a scheduler that knows how to cap duration.",
+		Check: checkZC1693,
+	})
+}
+
+func checkZC1693(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ionice" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-c1" {
+			return zc1693Hit(cmd)
+		}
+		if v == "-c" && i+1 < len(cmd.Arguments) && cmd.Arguments[i+1].String() == "1" {
+			return zc1693Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1693Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1693",
+		Message: "`ionice -c 1` puts the child in the real-time I/O class — a long-running " +
+			"workload starves sshd / journald / the rest of the host. Stay on class 2.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 689 Katas = 0.6.89
-const Version = "0.6.89"
+// 690 Katas = 0.6.90
+const Version = "0.6.90"


### PR DESCRIPTION
ZC1693 — Warn on `ionice -c 1` — real-time I/O class starves every other disk consumer

What: `ionice -c 1` (real-time I/O scheduling class) promotes the child above every best-effort (class 2) and idle (class 3) task queued for the same device.
Why: A busy `rsync` / `dd` / DB backup then blocks sshd reads, journald writes, and every other process until it yields — which for sequential I/O is effectively never.
Fix suggestion: Stay on class 2 (default). Reserve class 1 for latency-critical paths launched by a scheduler that caps duration.
Severity: Warning

## Test plan
- valid `ionice -c 2 -n 4 cmd` → no violation
- valid `ionice -c 3 cmd` → no violation
- invalid `ionice -c 1 -n 0 cmd` → ZC1693
- invalid `ionice -c1 cmd` → ZC1693