### PR TITLE
feat: ZC1694 — flag ssh -A auth-socket forwarding to remote host

### DIFF
--- a/pkg/katas/katatests/zc1694_test.go
+++ b/pkg/katas/katatests/zc1694_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1694(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ssh without forwarding",
+			input:    `ssh user@host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ssh -J jump (ProxyJump)",
+			input:    `ssh -J bastion user@target`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ssh -A",
+			input: `ssh -A user@host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1694",
+					Message: "`ssh -A` forwards the caller's `SSH_AUTH_SOCK` into the remote — any root on that host can reuse the keys. Use `ssh -J jumphost` instead, or a scoped key for the remote task.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ssh -o ForwardAgent=yes",
+			input: `ssh -o ForwardAgent=yes user@host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1694",
+					Message: "`ssh -o ForwardAgent=yes` forwards the caller's `SSH_AUTH_SOCK` into the remote — any root on that host can reuse the keys. Use `ssh -J jumphost` instead, or a scoped key for the remote task.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1694")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1694.go
+++ b/pkg/katas/zc1694.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1694",
+		Title:    "Warn on `ssh -A` / `-o ForwardAgent=yes` — remote host can reuse local keys",
+		Severity: SeverityWarning,
+		Description: "`ssh -A` (and `-o ForwardAgent=yes`) forwards the caller's `SSH_AUTH_SOCK` " +
+			"into the remote session. Anyone with root on the remote (and any process " +
+			"that shares its uid) can read the socket and impersonate the caller against " +
+			"every host the caller's keys unlock. Prefer `ssh -J JUMP HOST` (ProxyJump) " +
+			"for multi-hop access — it keeps the keys on the local side — or configure a " +
+			"scoped key for the remote task and copy it in with `ssh-copy-id`. Save key-" +
+			"forwarding for interactive use on trusted hosts.",
+		Check: checkZC1694,
+	})
+}
+
+func checkZC1694(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ssh" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-A" {
+			return zc1694Hit(cmd, "-A")
+		}
+		if v == "-oForwardAgent=yes" {
+			return zc1694Hit(cmd, "-o ForwardAgent=yes")
+		}
+		if v == "-o" && i+1 < len(cmd.Arguments) &&
+			cmd.Arguments[i+1].String() == "ForwardAgent=yes" {
+			return zc1694Hit(cmd, "-o ForwardAgent=yes")
+		}
+	}
+	return nil
+}
+
+func zc1694Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1694",
+		Message: "`ssh " + form + "` forwards the caller's `SSH_AUTH_SOCK` into the " +
+			"remote — any root on that host can reuse the keys. Use `ssh -J jumphost` " +
+			"instead, or a scoped key for the remote task.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 690 Katas = 0.6.90
-const Version = "0.6.90"
+// 691 Katas = 0.6.91
+const Version = "0.6.91"


### PR DESCRIPTION
ZC1694 — Warn on `ssh -A` / `-o ForwardAgent=yes` — remote host can reuse local keys

What: `ssh -A` (and `-o ForwardAgent=yes`) forwards the caller's `SSH_AUTH_SOCK` into the remote session.
Why: Anyone with root on the remote — and any process that shares its uid — can read the socket and impersonate the caller against every host the local keys unlock.
Fix suggestion: Use `ssh -J jumphost target` (ProxyJump) for multi-hop access; keys stay local. Or scope a dedicated key for the remote task with `ssh-copy-id`. Keep key forwarding for interactive use on trusted hosts.
Severity: Warning

## Test plan
- valid `ssh user@host` → no violation
- valid `ssh -J bastion user@target` → no violation
- invalid `ssh -A user@host` → ZC1694
- invalid `ssh -o ForwardAgent=yes user@host` → ZC1694