### PR TITLE
feat: ZC1695 — flag terraform state rm / push outside plan/apply

### DIFF
--- a/pkg/katas/katatests/zc1695_test.go
+++ b/pkg/katas/katatests/zc1695_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1695(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — terraform plan",
+			input:    `terraform plan`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — terraform state mv (tracked rename)",
+			input:    `terraform state mv old new`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — terraform state rm",
+			input: `terraform state rm module.app.aws_instance.x`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1695",
+					Message: "`terraform state rm` mutates shared state outside plan/apply — use `terraform import` or `apply -replace=ADDR` instead, and review / back up first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — tofu state push",
+			input: `tofu state push local.tfstate`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1695",
+					Message: "`tofu state push` mutates shared state outside plan/apply — use `terraform import` or `apply -replace=ADDR` instead, and review / back up first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1695")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1695.go
+++ b/pkg/katas/zc1695.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1695",
+		Title:    "Warn on `terraform state rm` / `state push` — surgery on shared state outside plan/apply",
+		Severity: SeverityWarning,
+		Description: "`terraform state rm RESOURCE` drops the resource from Terraform's " +
+			"tracking without touching the real cloud object — the next `terraform apply` " +
+			"sees it as newly-created and tries to re-provision, often hitting name-" +
+			"collision errors. `terraform state push FILE` replaces the entire remote " +
+			"state with a local file, bypassing locking and overwriting any concurrent " +
+			"changes. Both commands skirt the usual plan/apply audit trail. Reach for " +
+			"`terraform import` / `terraform apply -replace=ADDR` instead, and only run " +
+			"`state rm|push` from a reviewed fix-up PR with state backup in hand.",
+		Check: checkZC1695,
+	})
+}
+
+func checkZC1695(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "terraform" && ident.Value != "tofu" && ident.Value != "terragrunt" {
+		return nil
+	}
+
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "state" {
+		return nil
+	}
+	sub := cmd.Arguments[1].String()
+	if sub != "rm" && sub != "push" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1695",
+		Message: "`" + ident.Value + " state " + sub + "` mutates shared state outside " +
+			"plan/apply — use `terraform import` or `apply -replace=ADDR` instead, and " +
+			"review / back up first.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 691 Katas = 0.6.91
-const Version = "0.6.91"
+// 692 Katas = 0.6.92
+const Version = "0.6.92"


### PR DESCRIPTION
ZC1695 — Warn on `terraform state rm` / `state push` — surgery on shared state outside plan/apply

What: `terraform state rm RESOURCE` drops the resource from state without touching the cloud object. `terraform state push FILE` replaces the entire remote state with a local file.
Why: `state rm` makes the next apply re-create the resource (name-collision errors, or silent duplication). `state push` bypasses locking and overwrites concurrent changes. Both skirt the plan/apply audit trail.
Fix suggestion: `terraform import` for re-adoption, `terraform apply -replace=ADDR` for surgical recreation. Run `state rm|push` only from a reviewed fix-up PR, with backups.
Severity: Warning

## Test plan
- valid `terraform plan` → no violation
- valid `terraform state mv old new` → no violation
- invalid `terraform state rm module.app.aws_instance.x` → ZC1695
- invalid `tofu state push local.tfstate` → ZC1695