### PR TITLE
feat: ZC1696 — flag pnpm/yarn --no-frozen-lockfile / --no-immutable drift

### DIFF
--- a/pkg/katas/katatests/zc1696_test.go
+++ b/pkg/katas/katatests/zc1696_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1696(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — pnpm install --frozen-lockfile",
+			input:    `pnpm install --frozen-lockfile`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — npm ci",
+			input:    `npm ci`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — pnpm install --no-frozen-lockfile",
+			input: `pnpm install --no-frozen-lockfile`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1696",
+					Message: "`--no-frozen-lockfile` allows the lockfile to drift — the CI artifact no longer matches the reviewed dependency graph. Use `--frozen-lockfile` / `--immutable` in CI.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — yarn install --no-immutable",
+			input: `yarn install --no-immutable`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1696",
+					Message: "`--no-immutable` allows the lockfile to drift — the CI artifact no longer matches the reviewed dependency graph. Use `--frozen-lockfile` / `--immutable` in CI.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1696")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1696.go
+++ b/pkg/katas/zc1696.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1696",
+		Title:    "Warn on `pnpm install --no-frozen-lockfile` / `yarn install --no-immutable` — CI lockfile drift",
+		Severity: SeverityWarning,
+		Description: "`pnpm install --no-frozen-lockfile` (pnpm) and `yarn install " +
+			"--no-immutable` (yarn 4+) tell the package manager that the lockfile is " +
+			"merely a suggestion — any dep resolution change since the lockfile was " +
+			"written gets picked up silently. Run that from CI and the artifact no longer " +
+			"matches the pinned dependency graph reviewers signed off on. Use `pnpm " +
+			"install --frozen-lockfile` (the CI default) or `yarn install --immutable`, " +
+			"and let lockfile regen happen only from a dev workstation PR.",
+		Check: checkZC1696,
+	})
+}
+
+func checkZC1696(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "pnpm" && ident.Value != "yarn" && ident.Value != "npm" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "--no-frozen-lockfile":
+			return zc1696Hit(cmd, v)
+		case "--no-immutable":
+			return zc1696Hit(cmd, v)
+		}
+	}
+	return nil
+}
+
+func zc1696Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1696",
+		Message: "`" + form + "` allows the lockfile to drift — the CI artifact no " +
+			"longer matches the reviewed dependency graph. Use `--frozen-lockfile` / " +
+			"`--immutable` in CI.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 692 Katas = 0.6.92
-const Version = "0.6.92"
+// 693 Katas = 0.6.93
+const Version = "0.6.93"


### PR DESCRIPTION
ZC1696 — Warn on `pnpm install --no-frozen-lockfile` / `yarn install --no-immutable` — CI lockfile drift

What: Both flags tell the package manager that the lockfile is merely a suggestion — any resolution change since the lockfile was written gets picked up silently.
Why: Run from CI and the artifact no longer matches the dependency graph reviewers signed off on.
Fix suggestion: `pnpm install --frozen-lockfile` (CI default) or `yarn install --immutable`. Let lockfile regeneration happen only from a dev workstation PR.
Severity: Warning

## Test plan
- valid `pnpm install --frozen-lockfile` → no violation
- valid `npm ci` → no violation
- invalid `pnpm install --no-frozen-lockfile` → ZC1696
- invalid `yarn install --no-immutable` → ZC1696