### PR TITLE
feat: ZC1697 — flag cryptsetup --allow-discards sector-layout leak

### DIFF
--- a/pkg/katas/katatests/zc1697_test.go
+++ b/pkg/katas/katatests/zc1697_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1697(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — cryptsetup open without --allow-discards",
+			input:    `cryptsetup open $DISK data`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — cryptsetup luksClose",
+			input:    `cryptsetup luksClose data`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — cryptsetup open --allow-discards",
+			input: `cryptsetup open --allow-discards $DISK data`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1697",
+					Message: "`cryptsetup --allow-discards` leaks free-sector layout to anyone with raw-device access — drop it if offline-disk inspection is in scope, or document the trade-off.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — cryptsetup luksOpen --allow-discards",
+			input: `cryptsetup luksOpen --allow-discards $DISK data`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1697",
+					Message: "`cryptsetup --allow-discards` leaks free-sector layout to anyone with raw-device access — drop it if offline-disk inspection is in scope, or document the trade-off.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1697")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1697.go
+++ b/pkg/katas/zc1697.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1697",
+		Title:    "Info: `cryptsetup open --allow-discards` — TRIM pass-through leaks free-sector map",
+		Severity: SeverityInfo,
+		Description: "`--allow-discards` tells dm-crypt to forward TRIM/DISCARD commands from " +
+			"the filesystem to the underlying SSD. The performance and wear-levelling gains " +
+			"are real, but so is the side effect: an attacker with raw-device access can " +
+			"read the free-sector map and see which blocks are empty — enough to fingerprint " +
+			"partition layouts, distinguish encrypted-full-volume from encrypted-sparse-" +
+			"content cases, and defeat plausible-deniability scenarios. If the threat model " +
+			"includes offline-disk inspection, drop `--allow-discards` and accept the perf " +
+			"hit; otherwise keep the flag but state the trade-off in the runbook.",
+		Check: checkZC1697,
+	})
+}
+
+func checkZC1697(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "cryptsetup" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "--allow-discards" {
+			return []Violation{{
+				KataID: "ZC1697",
+				Message: "`cryptsetup --allow-discards` leaks free-sector layout to anyone " +
+					"with raw-device access — drop it if offline-disk inspection is in " +
+					"scope, or document the trade-off.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityInfo,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 693 Katas = 0.6.93
-const Version = "0.6.93"
+// 694 Katas = 0.6.94
+const Version = "0.6.94"


### PR DESCRIPTION
ZC1697 — Info: `cryptsetup open --allow-discards` — TRIM pass-through leaks free-sector map

What: `--allow-discards` forwards TRIM/DISCARD commands from the filesystem to the underlying SSD through dm-crypt.
Why: Real gains in performance and wear-levelling, real trade-off in deniability: an attacker with raw-device access sees which blocks are empty, fingerprinting partition layouts and defeating plausible-deniability scenarios.
Fix suggestion: Drop `--allow-discards` if offline-disk inspection is in scope; otherwise keep it but document the trade-off in the runbook.
Severity: Info

## Test plan
- valid `cryptsetup open $DISK data` → no violation
- valid `cryptsetup luksClose data` → no violation
- invalid `cryptsetup open --allow-discards $DISK data` → ZC1697
- invalid `cryptsetup luksOpen --allow-discards $DISK data` → ZC1697