### PR TITLE
feat: ZC1698 — flag fail2ban-client unban --all / stop wipes ban list

### DIFF
--- a/pkg/katas/katatests/zc1698_test.go
+++ b/pkg/katas/katatests/zc1698_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1698(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — fail2ban-client status",
+			input:    `fail2ban-client status`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — fail2ban-client set sshd unbanip scoped",
+			input:    `fail2ban-client set sshd unbanip 1.2.3.4`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — fail2ban-client unban --all",
+			input: `fail2ban-client unban --all`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1698",
+					Message: "`fail2ban-client unban --all` wipes every active brute-force ban — attacker IPs regain access. Target individual IPs with `set <jail> unbanip <ip>` or reload a single jail.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — fail2ban-client stop",
+			input: `fail2ban-client stop`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1698",
+					Message: "`fail2ban-client stop` wipes every active brute-force ban — attacker IPs regain access. Target individual IPs with `set <jail> unbanip <ip>` or reload a single jail.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1698")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1698.go
+++ b/pkg/katas/zc1698.go
@@ -1,0 +1,62 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1698",
+		Title:    "Warn on `fail2ban-client unban --all` / `stop` — wipes the active brute-force ban list",
+		Severity: SeverityWarning,
+		Description: "`fail2ban-client unban --all` clears every active ban across every jail; " +
+			"`fail2ban-client stop` shuts the service down and flushes its rules. Either " +
+			"command restores network access for the exact attacker IPs `fail2ban` has " +
+			"already flagged as hostile — usually hundreds of known bots. Target a single " +
+			"IP with `fail2ban-client set <jail> unbanip <ip>` or reload a jail with " +
+			"`reload <jail>` when you only need to pick up new filter rules.",
+		Check: checkZC1698,
+	})
+}
+
+func checkZC1698(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "fail2ban-client" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	switch cmd.Arguments[0].String() {
+	case "stop":
+		return zc1698Hit(cmd, "fail2ban-client stop")
+	case "unban":
+		for _, arg := range cmd.Arguments[1:] {
+			if arg.String() == "--all" {
+				return zc1698Hit(cmd, "fail2ban-client unban --all")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1698Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1698",
+		Message: "`" + form + "` wipes every active brute-force ban — attacker IPs " +
+			"regain access. Target individual IPs with `set <jail> unbanip <ip>` or " +
+			"reload a single jail.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 694 Katas = 0.6.94
-const Version = "0.6.94"
+// 695 Katas = 0.6.95
+const Version = "0.6.95"


### PR DESCRIPTION
ZC1698 — Warn on `fail2ban-client unban --all` / `stop` — wipes the active brute-force ban list

What: `fail2ban-client unban --all` clears every active ban across every jail. `fail2ban-client stop` shuts the service down and flushes its rules.
Why: Either command restores network access for the exact attacker IPs fail2ban has already flagged as hostile — usually hundreds of known bots.
Fix suggestion: Target a single IP with `fail2ban-client set <jail> unbanip <ip>`, or reload a jail with `reload <jail>` when picking up new filter rules.
Severity: Warning

## Test plan
- valid `fail2ban-client status` → no violation
- valid `fail2ban-client set sshd unbanip 1.2.3.4` → no violation
- invalid `fail2ban-client unban --all` → ZC1698
- invalid `fail2ban-client stop` → ZC1698