### PR TITLE
feat: ZC1699 — flag kubectl drain --delete-emptydir-data scratch wipe

### DIFF
--- a/pkg/katas/katatests/zc1699_test.go
+++ b/pkg/katas/katatests/zc1699_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1699(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — kubectl drain with --ignore-daemonsets only",
+			input:    `kubectl drain NODE --ignore-daemonsets`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — kubectl cordon (no drain)",
+			input:    `kubectl cordon NODE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — kubectl drain --delete-emptydir-data",
+			input: `kubectl drain NODE --delete-emptydir-data --ignore-daemonsets`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1699",
+					Message: "`kubectl drain --delete-emptydir-data` deletes `emptyDir` volumes along with the evicted pods — caches / WAL / scratch state are lost. Verify tolerance or migrate to a PersistentVolumeClaim first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — kubectl drain --delete-local-data (deprecated alias)",
+			input: `kubectl drain NODE --force --delete-local-data`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1699",
+					Message: "`kubectl drain --delete-local-data` deletes `emptyDir` volumes along with the evicted pods — caches / WAL / scratch state are lost. Verify tolerance or migrate to a PersistentVolumeClaim first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1699")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1699.go
+++ b/pkg/katas/zc1699.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1699",
+		Title:    "Warn on `kubectl drain --delete-emptydir-data` — pod-local scratch data lost",
+		Severity: SeverityWarning,
+		Description: "`kubectl drain NODE --delete-emptydir-data` (older alias `--delete-local-" +
+			"data`) lets drain evict pods that mount an `emptyDir` volume — the volume is " +
+			"deleted along with the pod, destroying any scratch data it held. Production " +
+			"clusters use `emptyDir` for caches, write-ahead logs, and scratch state that " +
+			"takes hours to rebuild. Confirm the pods on the node tolerate the loss (or " +
+			"migrate to a `persistentVolumeClaim`) before adding the flag; otherwise plan " +
+			"a controlled drain without it and accept the stuck-drain warning for the " +
+			"affected pods.",
+		Check: checkZC1699,
+	})
+}
+
+func checkZC1699(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kubectl" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "drain" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--delete-emptydir-data" || v == "--delete-local-data" {
+			return []Violation{{
+				KataID: "ZC1699",
+				Message: "`kubectl drain " + v + "` deletes `emptyDir` volumes along with the " +
+					"evicted pods — caches / WAL / scratch state are lost. Verify tolerance " +
+					"or migrate to a PersistentVolumeClaim first.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 695 Katas = 0.6.95
-const Version = "0.6.95"
+// 696 Katas = 0.6.96
+const Version = "0.6.96"


### PR DESCRIPTION
ZC1699 — Warn on `kubectl drain --delete-emptydir-data` — pod-local scratch data lost

What: `kubectl drain NODE --delete-emptydir-data` (older alias `--delete-local-data`) evicts pods that mount an `emptyDir`; the volume is deleted with the pod.
Why: Production clusters use `emptyDir` for caches, write-ahead logs, scratch state that takes hours to rebuild.
Fix suggestion: Verify pods on the node tolerate the loss (or migrate to a `persistentVolumeClaim`). Otherwise plan a controlled drain without the flag and accept the stuck-drain warning.
Severity: Warning

## Test plan
- valid `kubectl drain NODE --ignore-daemonsets` → no violation
- valid `kubectl cordon NODE` → no violation
- invalid `kubectl drain NODE --delete-emptydir-data --ignore-daemonsets` → ZC1699
- invalid `kubectl drain NODE --force --delete-local-data` → ZC1699