### PR TITLE
feat: ZC1700 — flag ldapsearch/ldapmodify -w LDAP bind password leak

### DIFF
--- a/pkg/katas/katatests/zc1700_test.go
+++ b/pkg/katas/katatests/zc1700_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1700(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — ldapsearch -W (prompt)",
+			input:    `ldapsearch -x -D cn=admin -W -b dc=example`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — ldapsearch -y FILE",
+			input:    `ldapsearch -x -D cn=admin -y /etc/ldap.password`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — ldapsearch -w SECRET",
+			input: `ldapsearch -x -D cn=admin -w SECRET -b dc=example`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1700",
+					Message: "`ldapsearch -w PASSWORD` leaks the LDAP bind password into `ps` / `/proc/PID/cmdline` — use `-W` to prompt, `-y FILE` for a mode-0400 secret file, or SASL (`-Y GSSAPI`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — ldapmodify -w SECRET",
+			input: `ldapmodify -w SECRET -f change.ldif`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1700",
+					Message: "`ldapmodify -w PASSWORD` leaks the LDAP bind password into `ps` / `/proc/PID/cmdline` — use `-W` to prompt, `-y FILE` for a mode-0400 secret file, or SASL (`-Y GSSAPI`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1700")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1700.go
+++ b/pkg/katas/zc1700.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1700",
+		Title:    "Error on `ldapsearch -w PASSWORD` / `ldapmodify -w PASSWORD` — bind DN password in process list",
+		Severity: SeverityError,
+		Description: "OpenLDAP client tools (`ldapsearch`, `ldapmodify`, `ldapadd`, `ldapdelete`, " +
+			"`ldapmodrdn`, `ldappasswd`, `ldapcompare`) accept the bind password via `-w " +
+			"STRING`. Once invoked, the password sits in `/proc/PID/cmdline`, shell " +
+			"history, audit records, and any `ps` output — typically granting cn=admin / " +
+			"service-account bind over the whole directory. Use `-W` (prompt), `-y " +
+			"FILEPATH` (read from a mode-0400 file), or `SASL` auth (`-Y GSSAPI` with " +
+			"Kerberos) to keep the secret out of argv.",
+		Check: checkZC1700,
+	})
+}
+
+var zc1700LDAPTools = map[string]struct{}{
+	"ldapsearch":  {},
+	"ldapmodify":  {},
+	"ldapadd":     {},
+	"ldapdelete":  {},
+	"ldapmodrdn":  {},
+	"ldappasswd":  {},
+	"ldapcompare": {},
+}
+
+func checkZC1700(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if _, ok := zc1700LDAPTools[ident.Value]; !ok {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		if arg.String() != "-w" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			continue
+		}
+		return []Violation{{
+			KataID: "ZC1700",
+			Message: "`" + ident.Value + " -w PASSWORD` leaks the LDAP bind password into " +
+				"`ps` / `/proc/PID/cmdline` — use `-W` to prompt, `-y FILE` for a mode-0400 " +
+				"secret file, or SASL (`-Y GSSAPI`).",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityError,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 696 Katas = 0.6.96
-const Version = "0.6.96"
+// 697 Katas = 0.6.97
+const Version = "0.6.97"


### PR DESCRIPTION
ZC1700 — Error on `ldapsearch -w PASSWORD` / `ldapmodify -w PASSWORD` — bind DN password in process list

What: OpenLDAP client tools (`ldapsearch`, `ldapmodify`, `ldapadd`, `ldapdelete`, `ldapmodrdn`, `ldappasswd`, `ldapcompare`) accept the bind password via `-w STRING`.
Why: The password ends up in `/proc/PID/cmdline`, shell history, audit records, and `ps` — typically granting admin/service-account bind over the whole directory.
Fix suggestion: Use `-W` (prompt), `-y FILEPATH` (read from a mode-0400 file), or SASL (`-Y GSSAPI`) to keep the secret out of argv.
Severity: Error

## Test plan
- valid `ldapsearch -x -D cn=admin -W -b dc=example` → no violation
- valid `ldapsearch -x -D cn=admin -y /etc/ldap.password` → no violation
- invalid `ldapsearch -x -D cn=admin -w SECRET -b dc=example` → ZC1700
- invalid `ldapmodify -w SECRET -f change.ldif` → ZC1700