### PR TITLE
feat: ZC1701 — flag dpkg -i FILE.deb local install without signature check

### DIFF
--- a/pkg/katas/katatests/zc1701_test.go
+++ b/pkg/katas/katatests/zc1701_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1701(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — dpkg -l (list)",
+			input:    `dpkg -l`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — apt install from repo",
+			input:    `apt install mypkg`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — dpkg -i local.deb",
+			input: `dpkg -i local.deb`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1701",
+					Message: "`dpkg -i FILE.deb` runs the package without signature verification — `sha256sum -c` or `debsig-verify` the file first, or install via `apt install` from a signed repo.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — dpkg -i /tmp/download.deb",
+			input: `dpkg -i /tmp/download.deb`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1701",
+					Message: "`dpkg -i FILE.deb` runs the package without signature verification — `sha256sum -c` or `debsig-verify` the file first, or install via `apt install` from a signed repo.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1701")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1701.go
+++ b/pkg/katas/zc1701.go
@@ -1,0 +1,53 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1701",
+		Title:    "Info: `dpkg -i FILE.deb` installs without automatic signature verification",
+		Severity: SeverityInfo,
+		Description: "Unlike `apt install`, which verifies package signatures against the apt " +
+			"repository's `Release.gpg`, plain `dpkg -i FILE.deb` applies the package with " +
+			"no integrity check beyond Debian's own `.deb` format. In a provisioning " +
+			"pipeline that downloaded the file over HTTPS from a vendor, that is usually " +
+			"fine — the TLS chain vouches for the bytes. In scripts that pick the file up " +
+			"from `/tmp`, `/var/tmp`, `/dev/shm`, or a mutable cache, a local user could " +
+			"swap the file between download and install. Verify with `sha256sum -c`, " +
+			"`debsig-verify`, or `dpkg-sig --verify` before invoking `dpkg -i`.",
+		Check: checkZC1701,
+	})
+}
+
+func checkZC1701(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "dpkg" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-i" {
+			return []Violation{{
+				KataID: "ZC1701",
+				Message: "`dpkg -i FILE.deb` runs the package without signature verification — " +
+					"`sha256sum -c` or `debsig-verify` the file first, or install via `apt " +
+					"install` from a signed repo.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityInfo,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 697 Katas = 0.6.97
-const Version = "0.6.97"
+// 698 Katas = 0.6.98
+const Version = "0.6.98"


### PR DESCRIPTION
ZC1701 — Info: `dpkg -i FILE.deb` installs without automatic signature verification

What: Unlike `apt install` (verifies against the repo's `Release.gpg`), plain `dpkg -i FILE.deb` applies the package with no integrity check.
Why: In a pipeline that picks the `.deb` from `/tmp`, `/var/tmp`, `/dev/shm`, or a mutable cache, a local user can swap the file between download and install.
Fix suggestion: Verify with `sha256sum -c`, `debsig-verify`, or `dpkg-sig --verify` before `dpkg -i`. Or `apt install` from a signed repo when possible.
Severity: Info

## Test plan
- valid `dpkg -l` → no violation
- valid `apt install mypkg` → no violation
- invalid `dpkg -i local.deb` → ZC1701
- invalid `dpkg -i /tmp/download.deb` → ZC1701