### PR TITLE
feat: ZC1702 — flag dpkg-reconfigure without noninteractive frontend

### DIFF
--- a/pkg/katas/katatests/zc1702_test.go
+++ b/pkg/katas/katatests/zc1702_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1702(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — dpkg-reconfigure -f noninteractive",
+			input:    `dpkg-reconfigure -f noninteractive tzdata`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — different command",
+			input:    `dpkg -l`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — dpkg-reconfigure tzdata (no frontend)",
+			input: `dpkg-reconfigure tzdata`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1702",
+					Message: "`dpkg-reconfigure` without `-f noninteractive` opens debconf dialogs — non-interactive pipelines hang. Pass `-f noninteractive` or export `DEBIAN_FRONTEND=noninteractive`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — dpkg-reconfigure --priority high (still interactive)",
+			input: `dpkg-reconfigure -p high tzdata`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1702",
+					Message: "`dpkg-reconfigure` without `-f noninteractive` opens debconf dialogs — non-interactive pipelines hang. Pass `-f noninteractive` or export `DEBIAN_FRONTEND=noninteractive`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1702")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1702.go
+++ b/pkg/katas/zc1702.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1702",
+		Title:    "Warn on `dpkg-reconfigure` without a noninteractive frontend — hangs in CI",
+		Severity: SeverityWarning,
+		Description: "`dpkg-reconfigure PACKAGE` opens the package's debconf questions in " +
+			"whatever frontend the caller's `DEBIAN_FRONTEND` resolves to — typically a " +
+			"terminal dialog that blocks until someone presses a key. Inside a non-" +
+			"interactive pipeline (Dockerfile, Ansible task, cloud-init) the call hangs " +
+			"until the build times out. Pass `-f noninteractive` (or export " +
+			"`DEBIAN_FRONTEND=noninteractive` at the top of the script) and accept the " +
+			"debconf defaults; pre-seed any non-default answer with `debconf-set-selections`.",
+		Check: checkZC1702,
+	})
+}
+
+func checkZC1702(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "dpkg-reconfigure" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "--frontend=") &&
+			strings.Contains(v, "noninteractive") {
+			return nil
+		}
+		if (v == "-f" || v == "--frontend") && i+1 < len(cmd.Arguments) &&
+			cmd.Arguments[i+1].String() == "noninteractive" {
+			return nil
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1702",
+		Message: "`dpkg-reconfigure` without `-f noninteractive` opens debconf dialogs — " +
+			"non-interactive pipelines hang. Pass `-f noninteractive` or export " +
+			"`DEBIAN_FRONTEND=noninteractive`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 698 Katas = 0.6.98
-const Version = "0.6.98"
+// 699 Katas = 0.6.99
+const Version = "0.6.99"


### PR DESCRIPTION
ZC1702 — Warn on `dpkg-reconfigure` without a noninteractive frontend — hangs in CI

What: `dpkg-reconfigure PACKAGE` opens the package's debconf questions in whatever frontend `DEBIAN_FRONTEND` resolves to — typically a terminal dialog that blocks until keypress.
Why: Inside a non-interactive pipeline (Dockerfile, Ansible task, cloud-init) the call hangs until build timeout.
Fix suggestion: Pass `-f noninteractive` (or export `DEBIAN_FRONTEND=noninteractive`). Pre-seed non-default answers with `debconf-set-selections`.
Severity: Warning

## Test plan
- valid `dpkg-reconfigure -f noninteractive tzdata` → no violation
- valid `dpkg -l` (different command) → no violation
- invalid `dpkg-reconfigure tzdata` → ZC1702
- invalid `dpkg-reconfigure -p high tzdata` → ZC1702