### PR TITLE
feat: ZC1703 — flag sysctl disabling network-hardening knobs

### DIFF
--- a/pkg/katas/katatests/zc1703_test.go
+++ b/pkg/katas/katatests/zc1703_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1703(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — sysctl net.ipv4.conf.all.rp_filter=1 (strict)",
+			input:    `sysctl -w net.ipv4.conf.all.rp_filter=1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — sysctl unrelated knob",
+			input:    `sysctl -w net.ipv4.tcp_syncookies=1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — sysctl rp_filter=0",
+			input: `sysctl -w net.ipv4.conf.all.rp_filter=0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1703",
+					Message: "`sysctl net.ipv4.conf.all.rp_filter=0` disables reverse-path filtering (anti-spoofing) — classic layer-3 attacks (spoofing / smurf / redirect tamper) reopen. Keep the protective default.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — sysctl accept_source_route=1",
+			input: `sysctl -w net.ipv4.conf.all.accept_source_route=1`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1703",
+					Message: "`sysctl net.ipv4.conf.all.accept_source_route=1` disables source-routed packet acceptance — classic layer-3 attacks (spoofing / smurf / redirect tamper) reopen. Keep the protective default.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1703")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1703.go
+++ b/pkg/katas/zc1703.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1703NetHardening = map[string]string{
+	"rp_filter=0":                         "reverse-path filtering (anti-spoofing)",
+	"accept_source_route=1":               "source-routed packet acceptance",
+	"accept_redirects=1":                  "ICMP redirect acceptance (routing tampering)",
+	"send_redirects=1":                    "ICMP redirect emission",
+	"icmp_echo_ignore_broadcasts=0":       "ICMP broadcast ignore (enables smurf amplification)",
+	"icmp_ignore_bogus_error_responses=0": "bogus ICMP error ignore",
+	"log_martians=0":                      "martian-packet logging",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1703",
+		Title:    "Warn on `sysctl -w` disabling network-hardening knobs",
+		Severity: SeverityWarning,
+		Description: "Several `net.ipv4.*` / `net.ipv6.*` sysctl knobs exist specifically to " +
+			"harden the host against on-link spoofing, ICMP redirect tampering, smurf " +
+			"amplification, and source-routed packets — `rp_filter=1`, " +
+			"`accept_source_route=0`, `accept_redirects=0`, `send_redirects=0`, " +
+			"`icmp_echo_ignore_broadcasts=1`, `log_martians=1`. Flipping any of them to " +
+			"the lax value (rp_filter=0, accept_source_route=1, …) re-opens classic " +
+			"layer-3 attacks. Leave the protective defaults in place; if a niche workload " +
+			"really needs relaxed filtering, scope the change per-interface with a comment " +
+			"explaining why.",
+		Check: checkZC1703,
+	})
+}
+
+func checkZC1703(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "sysctl" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		for suffix, note := range zc1703NetHardening {
+			if !strings.HasSuffix(v, suffix) {
+				continue
+			}
+			if !strings.HasPrefix(v, "net.") {
+				continue
+			}
+			return []Violation{{
+				KataID: "ZC1703",
+				Message: "`sysctl " + v + "` disables " + note + " — classic layer-3 " +
+					"attacks (spoofing / smurf / redirect tamper) reopen. Keep the " +
+					"protective default.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 699 Katas = 0.6.99
-const Version = "0.6.99"
+// 700 Katas = 0.7.0
+const Version = "0.7.0"


### PR DESCRIPTION
ZC1703 — Warn on `sysctl -w` disabling network-hardening knobs

What: `net.ipv4.*` / `net.ipv6.*` knobs exist to harden against spoofing, ICMP redirect tampering, smurf amplification, source-routed packets — `rp_filter=1`, `accept_source_route=0`, `accept_redirects=0`, `send_redirects=0`, `icmp_echo_ignore_broadcasts=1`, `log_martians=1`.
Why: Flipping any to the lax value re-opens classic layer-3 attacks.
Fix suggestion: Keep the protective defaults. If a niche workload really needs relaxed filtering, scope the change per-interface with a comment explaining why.
Severity: Warning

## Test plan
- valid `sysctl -w net.ipv4.conf.all.rp_filter=1` → no violation
- valid `sysctl -w net.ipv4.tcp_syncookies=1` → no violation
- invalid `sysctl -w net.ipv4.conf.all.rp_filter=0` → ZC1703
- invalid `sysctl -w net.ipv4.conf.all.accept_source_route=1` → ZC1703