### PR TITLE
feat: ZC1704 — flag aws ec2 authorize-security-group-ingress 0.0.0.0/0

### DIFF
--- a/pkg/katas/katatests/zc1704_test.go
+++ b/pkg/katas/katatests/zc1704_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1704(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — scoped CIDR",
+			input:    `aws ec2 authorize-security-group-ingress --group-id sg-123 --protocol tcp --port 22 --cidr 10.0.0.0/8`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — describe-security-groups (different subcommand)",
+			input:    `aws ec2 describe-security-groups`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — --cidr 0.0.0.0/0",
+			input: `aws ec2 authorize-security-group-ingress --group-id sg-123 --protocol tcp --port 22 --cidr 0.0.0.0/0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1704",
+					Message: "`aws ec2 authorize-security-group-ingress --cidr 0.0.0.0/0` opens the port to the entire internet — scope to a known source CIDR or `--source-group sg-…`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — --cidr-ipv6 ::/0",
+			input: `aws ec2 authorize-security-group-ingress --group-id sg-123 --ip-permissions proto --cidr-ipv6 ::/0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1704",
+					Message: "`aws ec2 authorize-security-group-ingress --cidr ::/0` opens the port to the entire internet — scope to a known source CIDR or `--source-group sg-…`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1704")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1704.go
+++ b/pkg/katas/zc1704.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1704",
+		Title:    "Error on `aws ec2 authorize-security-group-ingress --cidr 0.0.0.0/0` — port open to the internet",
+		Severity: SeverityError,
+		Description: "`aws ec2 authorize-security-group-ingress --cidr 0.0.0.0/0` (or `::/0` for " +
+			"IPv6) adds a rule that accepts the specified protocol/port from any source — " +
+			"the exact shape shodan, automated login-probers, and every exploit-as-a-" +
+			"service customer scans for. Restrict the source to the office CIDR, a VPN " +
+			"range, or a named security-group (`--source-group sg-…`). If the workload " +
+			"genuinely needs public access, front it with an ALB / API Gateway / CloudFront " +
+			"with WAF — not a raw SG rule from a shell script.",
+		Check: checkZC1704,
+	})
+}
+
+func checkZC1704(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "aws" {
+		return nil
+	}
+
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "ec2" {
+		return nil
+	}
+	if cmd.Arguments[1].String() != "authorize-security-group-ingress" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments[2:] {
+		v := arg.String()
+		if v != "--cidr" && v != "--cidr-ip" && v != "--cidr-ipv6" {
+			continue
+		}
+		idx := i + 3
+		if idx >= len(cmd.Arguments) {
+			continue
+		}
+		cidr := cmd.Arguments[idx].String()
+		if cidr == "0.0.0.0/0" || cidr == "::/0" {
+			return []Violation{{
+				KataID: "ZC1704",
+				Message: "`aws ec2 authorize-security-group-ingress --cidr " + cidr +
+					"` opens the port to the entire internet — scope to a known source CIDR " +
+					"or `--source-group sg-…`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 700 Katas = 0.7.0
-const Version = "0.7.0"
+// 701 Katas = 0.7.1
+const Version = "0.7.1"


### PR DESCRIPTION
ZC1704 — Error on `aws ec2 authorize-security-group-ingress --cidr 0.0.0.0/0` — port open to the internet

What: Adds an SG ingress rule that accepts the protocol/port from any source (`--cidr 0.0.0.0/0` or `--cidr-ipv6 ::/0`).
Why: Exact shape every probe / exploit-as-a-service customer scans for. SSH / RDP / DB ports facing the internet get hit within minutes.
Fix suggestion: Restrict to office CIDR, VPN range, or a named security group (`--source-group sg-…`). For genuine public access front it with ALB / API Gateway / CloudFront + WAF.
Severity: Error

## Test plan
- valid `aws ec2 authorize-security-group-ingress … --cidr 10.0.0.0/8` → no violation
- valid `aws ec2 describe-security-groups` → no violation
- invalid `aws ec2 authorize-security-group-ingress … --cidr 0.0.0.0/0` → ZC1704
- invalid `aws ec2 authorize-security-group-ingress … --cidr-ipv6 ::/0` → ZC1704