### PR TITLE
feat: ZC1705 — flag awk -i inplace gawk-only portability footgun

### DIFF
--- a/pkg/katas/katatests/zc1705_test.go
+++ b/pkg/katas/katatests/zc1705_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1705(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — awk without -i",
+			input:    `awk '{print}' file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — awk -i with non-inplace path",
+			input:    `awk -i /usr/share/awk/lib.awk '{print}' file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — awk -i inplace",
+			input: `awk -i inplace '{print}' file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1705",
+					Message: "`awk -i inplace` is gawk-only — fails on mawk / BSD awk / busybox awk. For portability rewrite as `awk … input > tmp && mv tmp input`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — gawk -i inplace -v",
+			input: `gawk -i inplace -v x=1 '{print x}' file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1705",
+					Message: "`awk -i inplace` is gawk-only — fails on mawk / BSD awk / busybox awk. For portability rewrite as `awk … input > tmp && mv tmp input`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1705")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1705.go
+++ b/pkg/katas/zc1705.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1705",
+		Title:    "Info: `awk -i inplace` is gawk-only — script breaks on mawk / BSD awk",
+		Severity: SeverityInfo,
+		Description: "The `inplace` extension that powers `awk -i inplace` ships only with gawk. " +
+			"On Alpine (default `mawk`), Debian-busybox, macOS, FreeBSD, NetBSD, OpenBSD, " +
+			"or any container image without `gawk` installed the script aborts with " +
+			"`fatal: can't open extension 'inplace'`. If portability matters, write through " +
+			"a temporary file (`awk … input > tmp && mv tmp input`); if you really do need " +
+			"in-place edits in scripts that target gawk only, document the requirement and " +
+			"add `command -v gawk >/dev/null` at the top.",
+		Check: checkZC1705,
+	})
+}
+
+func checkZC1705(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "awk" && ident.Value != "gawk" && ident.Value != "mawk" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		if arg.String() != "-i" {
+			continue
+		}
+		if i+1 >= len(cmd.Arguments) {
+			continue
+		}
+		if cmd.Arguments[i+1].String() == "inplace" {
+			return []Violation{{
+				KataID: "ZC1705",
+				Message: "`awk -i inplace` is gawk-only — fails on mawk / BSD awk / busybox " +
+					"awk. For portability rewrite as `awk … input > tmp && mv tmp input`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityInfo,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 701 Katas = 0.7.1
-const Version = "0.7.1"
+// 702 Katas = 0.7.2
+const Version = "0.7.2"


### PR DESCRIPTION
ZC1705 — Info: `awk -i inplace` is gawk-only — script breaks on mawk / BSD awk

What: The `inplace` extension that powers `awk -i inplace` ships only with gawk.
Why: On Alpine (default mawk), Debian-busybox, macOS, BSDs, and any container without `gawk` installed, the script aborts with `fatal: can't open extension 'inplace'`.
Fix suggestion: For portability rewrite as `awk … input > tmp && mv tmp input`. If gawk is required, document it and add `command -v gawk >/dev/null` at script top.
Severity: Info

## Test plan
- valid `awk '{print}' file` → no violation
- valid `awk -i /usr/share/awk/lib.awk '{print}' file` → no violation
- invalid `awk -i inplace '{print}' file` → ZC1705
- invalid `gawk -i inplace -v x=1 '{print x}' file` → ZC1705