### PR TITLE
feat: ZC1706 — flag lvresize/lvreduce shrink without -r filesystem corruption

### DIFF
--- a/pkg/katas/katatests/zc1706_test.go
+++ b/pkg/katas/katatests/zc1706_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1706(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — lvresize grow without -r",
+			input:    `lvresize -L +2G vg/lv`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — lvresize shrink with -r",
+			input:    `lvresize -L -2G -r vg/lv`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — lvextend (always grows)",
+			input:    `lvextend -L +2G vg/lv`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — lvresize shrink without -r",
+			input: `lvresize -L -2G vg/lv`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1706",
+					Message: "`lvresize` shrinks the LV without `-r` / `--resizefs` — the filesystem on top is not shrunk first and writes past the new boundary corrupt metadata. Add `-r` (or shrink the FS manually first).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — lvreduce without -r",
+			input: `lvreduce -L 1G vg/lv`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1706",
+					Message: "`lvreduce` shrinks the LV without `-r` / `--resizefs` — the filesystem on top is not shrunk first and writes past the new boundary corrupt metadata. Add `-r` (or shrink the FS manually first).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1706")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1706.go
+++ b/pkg/katas/zc1706.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1706",
+		Title:    "Error on `lvresize -L -SIZE` without `-r` — shrink without filesystem resize corrupts data",
+		Severity: SeverityError,
+		Description: "`lvresize -L -SIZE` (or `--size -SIZE`) shrinks the logical volume by " +
+			"SIZE bytes/extents. The filesystem on top still thinks it owns the original " +
+			"range; reads beyond the new LV end now return zeros, and the next write " +
+			"corrupts metadata. The `-r` (`--resizefs`) flag tells lvresize to call " +
+			"`fsadm` (which calls `resize2fs` / `xfs_growfs` / etc.) so the filesystem " +
+			"shrinks first. For ext4, always shrink the FS before the LV; for XFS, online " +
+			"shrink is impossible — back up, recreate, restore.",
+		Check: checkZC1706,
+	})
+}
+
+func checkZC1706(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "lvresize" && ident.Value != "lvreduce" {
+		return nil
+	}
+
+	hasResizefs := false
+	shrinking := ident.Value == "lvreduce" // lvreduce always shrinks
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-r" || v == "--resizefs" {
+			hasResizefs = true
+		}
+		if (v == "-L" || v == "--size") && i+1 < len(cmd.Arguments) {
+			next := cmd.Arguments[i+1].String()
+			if strings.HasPrefix(next, "-") {
+				shrinking = true
+			}
+		}
+	}
+
+	if !shrinking || hasResizefs {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1706",
+		Message: "`" + ident.Value + "` shrinks the LV without `-r` / `--resizefs` — the " +
+			"filesystem on top is not shrunk first and writes past the new boundary " +
+			"corrupt metadata. Add `-r` (or shrink the FS manually first).",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 702 Katas = 0.7.2
-const Version = "0.7.2"
+// 703 Katas = 0.7.3
+const Version = "0.7.3"


### PR DESCRIPTION
ZC1706 — Error on `lvresize -L -SIZE` without `-r` — shrink without filesystem resize corrupts data

What: `lvresize -L -SIZE` (or `lvreduce`) shrinks the LV. The filesystem on top still thinks it owns the original range.
Why: Reads beyond the new LV end return zeros; the next write corrupts metadata. `-r` (`--resizefs`) tells lvresize to call `fsadm` so the filesystem shrinks first.
Fix suggestion: Add `-r` (or shrink the FS manually first). XFS cannot online-shrink — backup, recreate, restore.
Severity: Error

## Test plan
- valid `lvresize -L +2G vg/lv` (grow, FS resize-after handles itself) → no violation
- valid `lvresize -L -2G -r vg/lv` (shrink with -r) → no violation
- valid `lvextend -L +2G vg/lv` (always grows) → no violation
- invalid `lvresize -L -2G vg/lv` → ZC1706
- invalid `lvreduce -L 1G vg/lv` → ZC1706