### PR TITLE
feat: ZC1707 — flag gpg --keyserver hkp:// plaintext key fetch

### DIFF
--- a/pkg/katas/katatests/zc1707_test.go
+++ b/pkg/katas/katatests/zc1707_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1707(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — gpg --keyserver hkps:// trailing",
+			input:    `gpg ABCD --keyserver hkps://keys.openpgp.org --recv-keys`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — gpg --recv-keys (default keyserver)",
+			input:    `gpg --recv-keys ABCD`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — gpg --keyserver hkp:// trailing",
+			input: `gpg ABCD --keyserver hkp://keys.example.com --recv-keys`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1707",
+					Message: "`gpg --keyserver hkp://…` is plaintext — a MITM swaps the key bytes. Use `hkps://keys.openpgp.org` or fetch over HTTPS and verify the fingerprint.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1707")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1707.go
+++ b/pkg/katas/zc1707.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1707",
+		Title:    "Warn on `gpg --keyserver hkp://…` — plaintext keyserver fetch",
+		Severity: SeverityWarning,
+		Description: "`hkp://` is the unencrypted HKP keyserver protocol. A MITM on the path " +
+			"(corporate proxy, hotel Wi-Fi, hostile router) can swap key bytes during the " +
+			"fetch and `gpg --recv-keys` happily imports the substitute. Use `hkps://" +
+			"keys.openpgp.org` (TLS) or fetch the armored key over HTTPS and verify the " +
+			"fingerprint out-of-band before `gpg --import`.",
+		Check: checkZC1707,
+	})
+}
+
+func checkZC1707(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value == "keyserver" {
+		// Parser-mangled form: `gpg --keyserver hkp://…` lost `gpg`.
+		if len(cmd.Arguments) > 0 && strings.HasPrefix(cmd.Arguments[0].String(), "hkp://") {
+			return zc1707Hit(cmd)
+		}
+		return nil
+	}
+	if ident.Value != "gpg" && ident.Value != "gpg2" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "--keyserver=hkp://") {
+			return zc1707Hit(cmd)
+		}
+		if v == "--keyserver" && i+1 < len(cmd.Arguments) &&
+			strings.HasPrefix(cmd.Arguments[i+1].String(), "hkp://") {
+			return zc1707Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1707Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1707",
+		Message: "`gpg --keyserver hkp://…` is plaintext — a MITM swaps the key bytes. Use " +
+			"`hkps://keys.openpgp.org` or fetch over HTTPS and verify the fingerprint.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 703 Katas = 0.7.3
-const Version = "0.7.3"
+// 704 Katas = 0.7.4
+const Version = "0.7.4"


### PR DESCRIPTION
ZC1707 — Warn on `gpg --keyserver hkp://…` — plaintext keyserver fetch

What: `hkp://` is the unencrypted HKP keyserver protocol.
Why: A MITM on the path (corporate proxy, hotel Wi-Fi, hostile router) can swap key bytes during the fetch and `gpg --recv-keys` happily imports the substitute.
Fix suggestion: Use `hkps://keys.openpgp.org` (TLS) or fetch the armored key over HTTPS and verify the fingerprint out-of-band before `gpg --import`.
Severity: Warning

## Test plan
- valid `gpg ABCD --keyserver hkps://keys.openpgp.org --recv-keys` → no violation
- valid `gpg --recv-keys ABCD` (default keyserver) → no violation
- invalid `gpg ABCD --keyserver hkp://keys.example.com --recv-keys` → ZC1707