### PR TITLE
feat: ZC1708 — flag find -L with -delete / -exec symlink follow into unintended tree

### DIFF
--- a/pkg/katas/katatests/zc1708_test.go
+++ b/pkg/katas/katatests/zc1708_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1708(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — find without -L",
+			input:    `find /var/log -mtime +30 -delete`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — find -L without destructive action",
+			input:    `find -L /opt -name '*.bak'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — find -L … -delete",
+			input: `find -L /var/log -mtime +30 -delete`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1708",
+					Message: "`find -L … -delete/-exec` follows symlinks into unintended trees — drop `-L`, add `-xdev`, or scope the walk explicitly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — find -L … -exec rm",
+			input: `find -L /var/log -mtime +30 -exec rm -f`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1708",
+					Message: "`find -L … -delete/-exec` follows symlinks into unintended trees — drop `-L`, add `-xdev`, or scope the walk explicitly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1708")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1708.go
+++ b/pkg/katas/zc1708.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1708",
+		Title:    "Error on `find -L ... -delete` / `-exec rm` — symlink follow into unintended trees",
+		Severity: SeverityError,
+		Description: "`find -L` follows symlinks during traversal. Combined with `-delete` (or " +
+			"`-exec rm`), a symlink under the start path that points outside the intended " +
+			"root steers `find` into / `unlink`s files in `/etc`, `/var/lib`, or any other " +
+			"directory the symlink target reaches. Drop `-L` (the default `-P` keeps " +
+			"symlinks as objects), or restrict the walk with `-xdev`, `-mount`, and an " +
+			"explicit `-type f` test. For log-rotation pipes, `logrotate` is safer than a " +
+			"`find` one-liner.",
+		Check: checkZC1708,
+	})
+}
+
+func checkZC1708(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "find" {
+		return nil
+	}
+
+	hasFollow := false
+	hasDestructive := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "-L", "--follow":
+			hasFollow = true
+		case "-delete", "-exec":
+			hasDestructive = true
+		}
+	}
+
+	if !hasFollow || !hasDestructive {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1708",
+		Message: "`find -L … -delete/-exec` follows symlinks into unintended trees — drop " +
+			"`-L`, add `-xdev`, or scope the walk explicitly.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 704 Katas = 0.7.4
-const Version = "0.7.4"
+// 705 Katas = 0.7.5
+const Version = "0.7.5"


### PR DESCRIPTION
ZC1708 — Error on `find -L ... -delete` / `-exec rm` — symlink follow into unintended trees

What: `find -L` follows symlinks. Combined with `-delete` (or `-exec rm`), a symlink in the start path that points outside steers find / unlinks files in `/etc`, `/var/lib`, etc.
Why: Trivial path-escape via planted symlinks. Common in log-rotation one-liners.
Fix suggestion: Drop `-L` (default `-P` keeps symlinks as objects), add `-xdev`/`-mount`, scope with `-type f`. For log rotation prefer `logrotate`.
Severity: Error

## Test plan
- valid `find /var/log -mtime +30 -delete` → no violation
- valid `find -L /opt -name '*.bak'` → no violation
- invalid `find -L /var/log -mtime +30 -delete` → ZC1708
- invalid `find -L /var/log -mtime +30 -exec rm -f` → ZC1708