### PR TITLE
feat: ZC1709 — flag htpasswd -b basic-auth password in process list

### DIFF
--- a/pkg/katas/katatests/zc1709_test.go
+++ b/pkg/katas/katatests/zc1709_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1709(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — htpasswd -i (read stdin)",
+			input:    `htpasswd -i /etc/nginx/.htpasswd user`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — htpasswd interactive (prompts)",
+			input:    `htpasswd /etc/nginx/.htpasswd user`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — htpasswd -b user secret",
+			input: `htpasswd -b /etc/nginx/.htpasswd user secret`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1709",
+					Message: "`htpasswd -b USER PASSWORD` puts the password in argv — visible via `ps` / `/proc/PID/cmdline`. Use `htpasswd -i FILE USER` with the password piped on stdin instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — htpasswd -bB combined flags",
+			input: `htpasswd -bB /etc/nginx/.htpasswd user secret`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1709",
+					Message: "`htpasswd -b USER PASSWORD` puts the password in argv — visible via `ps` / `/proc/PID/cmdline`. Use `htpasswd -i FILE USER` with the password piped on stdin instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1709")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1709.go
+++ b/pkg/katas/zc1709.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1709",
+		Title:    "Error on `htpasswd -b USER PASSWORD` — basic-auth password in process list",
+		Severity: SeverityError,
+		Description: "`htpasswd -b FILE USER PASSWORD` (batch mode) takes the password as an " +
+			"argv slot. The cleartext sits in `/proc/PID/cmdline`, shell history, audit " +
+			"records, and any `ps` output. Use `htpasswd -i FILE USER` and pipe the " +
+			"secret on stdin (`printf %s \"$pw\" | htpasswd -i FILE USER`), or omit `-b` " +
+			"and `-i` so htpasswd prompts on the controlling TTY.",
+		Check: checkZC1709,
+	})
+}
+
+func checkZC1709(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "htpasswd" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if !strings.HasPrefix(v, "-") || strings.HasPrefix(v, "--") {
+			continue
+		}
+		body := strings.TrimPrefix(v, "-")
+		if strings.ContainsRune(body, 'b') {
+			return []Violation{{
+				KataID: "ZC1709",
+				Message: "`htpasswd -b USER PASSWORD` puts the password in argv — visible " +
+					"via `ps` / `/proc/PID/cmdline`. Use `htpasswd -i FILE USER` with the " +
+					"password piped on stdin instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 705 Katas = 0.7.5
-const Version = "0.7.5"
+// 706 Katas = 0.7.6
+const Version = "0.7.6"


### PR DESCRIPTION
ZC1709 — Error on `htpasswd -b USER PASSWORD` — basic-auth password in process list

What: `htpasswd -b FILE USER PASSWORD` (batch mode) takes the password as an argv slot.
Why: The cleartext sits in `/proc/PID/cmdline`, shell history, audit records, and `ps`.
Fix suggestion: `htpasswd -i FILE USER` and pipe the password on stdin (`printf %s "$pw" | htpasswd -i FILE USER`); or omit `-b`/`-i` so htpasswd prompts on the controlling TTY.
Severity: Error

## Test plan
- valid `htpasswd -i /etc/nginx/.htpasswd user` → no violation
- valid `htpasswd /etc/nginx/.htpasswd user` (interactive) → no violation
- invalid `htpasswd -b /etc/nginx/.htpasswd user secret` → ZC1709
- invalid `htpasswd -bB /etc/nginx/.htpasswd user secret` → ZC1709