### PR TITLE
feat: ZC1710 — flag journalctl --vacuum-size=1 / --vacuum-time=1s journal wipe

### DIFF
--- a/pkg/katas/katatests/zc1710_test.go
+++ b/pkg/katas/katatests/zc1710_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1710(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — journalctl --vacuum-time=2weeks (real retention)",
+			input:    `journalctl -q --vacuum-time=2weeks`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — journalctl --vacuum-size=500M",
+			input:    `journalctl -q --vacuum-size=500M`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — journalctl --vacuum-size=1 (wipe)",
+			input: `journalctl -q --vacuum-size=1`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1710",
+					Message: "`journalctl --vacuum-size=1` flushes the systemd journal — classic audit-clear shape. Set retention in `/etc/systemd/journald.conf` (`SystemMaxUse=`, `MaxRetentionSec=`) instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — journalctl --vacuum-time=1s",
+			input: `journalctl -m --vacuum-time=1s`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1710",
+					Message: "`journalctl --vacuum-time=1s` flushes the systemd journal — classic audit-clear shape. Set retention in `/etc/systemd/journald.conf` (`SystemMaxUse=`, `MaxRetentionSec=`) instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1710")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1710.go
+++ b/pkg/katas/zc1710.go
@@ -1,0 +1,82 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1710",
+		Title:    "Error on `journalctl --vacuum-size=1` / `--vacuum-time=1s` — journal-wipe pattern",
+		Severity: SeverityError,
+		Description: "`journalctl --vacuum-size=1` (down to 1 byte / 1K), `--vacuum-time=1s` " +
+			"(retain only the last second), or `--vacuum-files=1` (keep one journal file) " +
+			"effectively flushes the entire systemd journal. The classic shape after a " +
+			"compromise — clear the audit trail before re-enabling logging. Real retention " +
+			"belongs in `/etc/systemd/journald.conf` (`SystemMaxUse=`, `MaxRetentionSec=`), " +
+			"not in an ad-hoc one-shot. If you genuinely need to bound disk use, set the " +
+			"limit to a meaningful value (`--vacuum-time=2weeks`, `--vacuum-size=200M`).",
+		Check: checkZC1710,
+	})
+}
+
+var zc1710VacuumPrefixes = []string{
+	"--vacuum-size=",
+	"--vacuum-time=",
+	"--vacuum-files=",
+}
+
+func checkZC1710(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "journalctl" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		for _, prefix := range zc1710VacuumPrefixes {
+			if !strings.HasPrefix(v, prefix) {
+				continue
+			}
+			val := strings.TrimPrefix(v, prefix)
+			if !zc1710Aggressive(val) {
+				continue
+			}
+			return []Violation{{
+				KataID: "ZC1710",
+				Message: "`journalctl " + v + "` flushes the systemd journal — classic " +
+					"audit-clear shape. Set retention in `/etc/systemd/journald.conf` " +
+					"(`SystemMaxUse=`, `MaxRetentionSec=`) instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}
+
+// zc1710Aggressive returns true for vacuum values that effectively wipe the
+// journal: `1`, `1B`, `1K`, `1KB`, `1s`, `1m`, `0`, etc.
+func zc1710Aggressive(val string) bool {
+	switch val {
+	case "0", "1":
+		return true
+	}
+	low := strings.ToLower(val)
+	switch low {
+	case "1b", "1k", "1kb", "1kib", "1s", "1m", "1ms", "1µs", "0s", "0m":
+		return true
+	}
+	return false
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 706 Katas = 0.7.6
-const Version = "0.7.6"
+// 707 Katas = 0.7.7
+const Version = "0.7.7"


### PR DESCRIPTION
ZC1710 — Error on `journalctl --vacuum-size=1` / `--vacuum-time=1s` — journal-wipe pattern

What: `journalctl --vacuum-size=1` (down to 1 byte/1K), `--vacuum-time=1s`, or `--vacuum-files=1` effectively flushes the systemd journal.
Why: Classic shape after a compromise — clear the audit trail before re-enabling logging.
Fix suggestion: Configure retention in `/etc/systemd/journald.conf` (`SystemMaxUse=`, `MaxRetentionSec=`). For ad-hoc bounding use meaningful values (`--vacuum-time=2weeks`, `--vacuum-size=200M`).
Severity: Error

## Test plan
- valid `journalctl -q --vacuum-time=2weeks` → no violation
- valid `journalctl -q --vacuum-size=500M` → no violation
- invalid `journalctl -q --vacuum-size=1` → ZC1710
- invalid `journalctl -m --vacuum-time=1s` → ZC1710