### PR TITLE
feat: ZC1711 — flag etcdctl del --prefix "" wipes whole keyspace

### DIFF
--- a/pkg/katas/katatests/zc1711_test.go
+++ b/pkg/katas/katatests/zc1711_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1711(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — etcdctl del --prefix /app/",
+			input:    `etcdctl del --prefix /app/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — etcdctl get --prefix \"\" (read-only)",
+			input:    `etcdctl get --prefix ""`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  `invalid — etcdctl del --prefix ""`,
+			input: `etcdctl del --prefix ""`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1711",
+					Message: "`etcdctl del --prefix \"\"` deletes the entire etcd keyspace (including kube-apiserver state) — scope to a specific namespace prefix and review with `get --prefix --keys-only` first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  `invalid — etcdctl del --from-key ""`,
+			input: `etcdctl del --from-key ""`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1711",
+					Message: "`etcdctl del --from-key \"\"` deletes the entire etcd keyspace (including kube-apiserver state) — scope to a specific namespace prefix and review with `get --prefix --keys-only` first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1711")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1711.go
+++ b/pkg/katas/zc1711.go
@@ -1,0 +1,62 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1711",
+		Title:    "Error on `etcdctl del --prefix \"\"` / `--from-key \"\"` — wipes the entire keyspace",
+		Severity: SeverityError,
+		Description: "`etcdctl del --prefix KEY` deletes every key under KEY's range. With KEY " +
+			"empty (`\"\"` or `\"\\0\"`) the range is `[\"\", \"\\xFF\")` — the whole etcd " +
+			"cluster, including kube-apiserver state if etcd is the Kubernetes datastore. " +
+			"`--from-key \"\"` has the same effect for the lower-bound form. Restrict the " +
+			"prefix to the namespace you actually own (`/app/staging/`), or wrap the call " +
+			"with an explicit `etcdctl get --prefix --keys-only` review step.",
+		Check: checkZC1711,
+	})
+}
+
+func checkZC1711(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "etcdctl" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "del" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v != "--prefix" && v != "--from-key" {
+			continue
+		}
+		idx := i + 2
+		if idx >= len(cmd.Arguments) {
+			continue
+		}
+		next := cmd.Arguments[idx].String()
+		if next == `""` || next == "''" {
+			return []Violation{{
+				KataID: "ZC1711",
+				Message: "`etcdctl del " + v + " \"\"` deletes the entire etcd keyspace " +
+					"(including kube-apiserver state) — scope to a specific namespace " +
+					"prefix and review with `get --prefix --keys-only` first.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 707 Katas = 0.7.7
-const Version = "0.7.7"
+// 708 Katas = 0.7.8
+const Version = "0.7.8"


### PR DESCRIPTION
ZC1711 — Error on `etcdctl del --prefix ""` / `--from-key ""` — wipes the entire keyspace

What: `etcdctl del --prefix KEY` deletes every key under KEY's range. Empty KEY means the whole etcd keyspace.
Why: For Kubernetes datastores, that's the entire cluster state — kube-apiserver loses all objects in one shot.
Fix suggestion: Restrict the prefix to the namespace you own (e.g. `/app/staging/`); review with `etcdctl get --prefix --keys-only` first.
Severity: Error

## Test plan
- valid `etcdctl del --prefix /app/` → no violation
- valid `etcdctl get --prefix ""` (read-only) → no violation
- invalid `etcdctl del --prefix ""` → ZC1711
- invalid `etcdctl del --from-key ""` → ZC1711