### PR TITLE
feat: ZC1712 — flag vault kv put / write secret value in argv

### DIFF
--- a/pkg/katas/katatests/zc1712_test.go
+++ b/pkg/katas/katatests/zc1712_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1712(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — vault kv put with @file",
+			input:    `vault kv put secret/app @secret.json`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — vault kv put with stdin sentinel",
+			input:    `vault kv put secret/app password=-`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — vault kv put with non-secret key",
+			input:    `vault kv put secret/app environment=prod`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — vault kv put password=hunter2",
+			input: `vault kv put secret/app password=hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1712",
+					Message: "`vault kv password=hunter2` puts the secret value in argv — visible to every local user. Use `password=@FILE` or `password=-` to read from disk / stdin.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — vault write secret/app api_key=ABC",
+			input: `vault write secret/app api_key=ABC123`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1712",
+					Message: "`vault write api_key=ABC123` puts the secret value in argv — visible to every local user. Use `api_key=@FILE` or `api_key=-` to read from disk / stdin.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1712")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1712.go
+++ b/pkg/katas/zc1712.go
@@ -1,0 +1,92 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1712SecretKeys = []string{
+	"password", "passwd", "secret", "token",
+	"apikey", "api_key", "api-key",
+	"accesskey", "access_key", "access-key",
+	"privatekey", "private_key", "private-key",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1712",
+		Title:    "Error on `vault kv put PATH password=…` — secret value in process list",
+		Severity: SeverityError,
+		Description: "`vault kv put PATH key=value` (and the older `vault write PATH key=value`) " +
+			"put the value on the command line. When the key name screams secret " +
+			"(`password`, `secret`, `token`, `apikey`, `access_key`, `private_key`), the " +
+			"cleartext shows up in `ps`, `/proc/<pid>/cmdline`, shell history, and the " +
+			"audit log of the calling host — exactly the surface Vault is meant to remove. " +
+			"Use `key=@path/to/file` to read from disk, `key=-` to take the value on stdin, " +
+			"or `vault kv put -mount=secret PATH @secret.json` for a JSON payload.",
+		Check: checkZC1712,
+	})
+}
+
+func checkZC1712(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "vault" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+
+	var start int
+	switch cmd.Arguments[0].String() {
+	case "write":
+		start = 2
+	case "kv":
+		if len(cmd.Arguments) < 2 || cmd.Arguments[1].String() != "put" {
+			return nil
+		}
+		start = 3
+	default:
+		return nil
+	}
+	if start >= len(cmd.Arguments) {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[start:] {
+		v := arg.String()
+		eq := strings.IndexByte(v, '=')
+		if eq <= 0 {
+			continue
+		}
+		key := strings.ToLower(v[:eq])
+		val := v[eq+1:]
+		if val == "" || val == "-" || strings.HasPrefix(val, "@") {
+			continue
+		}
+		for _, secret := range zc1712SecretKeys {
+			if !strings.Contains(key, secret) {
+				continue
+			}
+			return []Violation{{
+				KataID: "ZC1712",
+				Message: "`vault " + cmd.Arguments[0].String() + " " + v + "` puts the " +
+					"secret value in argv — visible to every local user. Use " +
+					"`" + key + "=@FILE` or `" + key + "=-` to read from disk / stdin.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 708 Katas = 0.7.8
-const Version = "0.7.8"
+// 709 Katas = 0.7.9
+const Version = "0.7.9"


### PR DESCRIPTION
ZC1712 — Error on `vault kv put PATH password=…` — secret value in process list

What: `vault kv put PATH key=value` (and `vault write PATH key=value`) put the value on the command line.
Why: When the key looks like a secret (`password`, `secret`, `token`, `apikey`, `access_key`, `private_key`), the cleartext shows up in `ps`, `/proc/<pid>/cmdline`, shell history, and audit logs — the exact surface Vault is meant to remove.
Fix suggestion: `key=@path/to/file` to read from disk, `key=-` to read from stdin, or `vault kv put PATH @secret.json` for a JSON payload.
Severity: Error

## Test plan
- valid `vault kv put secret/app @secret.json` → no violation
- valid `vault kv put secret/app password=-` → no violation
- valid `vault kv put secret/app environment=prod` → no violation
- invalid `vault kv put secret/app password=hunter2` → ZC1712
- invalid `vault write secret/app api_key=ABC123` → ZC1712