### PR TITLE
feat: ZC1713 — flag consul kv delete -recurse / wipes whole KV store

### DIFF
--- a/pkg/katas/katatests/zc1713_test.go
+++ b/pkg/katas/katatests/zc1713_test.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1713(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — consul kv delete scoped",
+			input:    `consul kv delete -recurse /app/staging/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — consul kv delete single key",
+			input:    `consul kv delete /key`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — consul kv get (read-only)",
+			input:    `consul kv get -recurse /`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — consul kv delete -recurse /",
+			input: `consul kv delete -recurse /`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1713",
+					Message: "`consul kv delete -recurse /` removes the entire KV store — service discovery, ACL bootstrap, app config. Scope the prefix and snapshot (`consul snapshot save`) first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1713")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1713.go
+++ b/pkg/katas/zc1713.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1713",
+		Title:    "Error on `consul kv delete -recurse /` — wipes the entire Consul KV store",
+		Severity: SeverityError,
+		Description: "`consul kv delete -recurse PREFIX` removes every key under PREFIX. With " +
+			"PREFIX `/` (or an empty string) the command nukes the whole KV store, " +
+			"including service-discovery payloads, ACL bootstrap tokens, and any " +
+			"application-level config the cluster relies on. Scope the prefix to the app " +
+			"namespace (`consul kv delete -recurse /app/staging/`), confirm the keys you " +
+			"are about to lose with `consul kv get -recurse -keys`, and snapshot the " +
+			"datacenter (`consul snapshot save snap.bin`) before any large delete.",
+		Check: checkZC1713,
+	})
+}
+
+func checkZC1713(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "consul" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "kv" || cmd.Arguments[1].String() != "delete" {
+		return nil
+	}
+
+	hasRecurse := false
+	rootPrefix := false
+	for _, arg := range cmd.Arguments[2:] {
+		v := arg.String()
+		switch v {
+		case "-recurse", "--recurse":
+			hasRecurse = true
+		case "/", "", `""`, "''":
+			rootPrefix = true
+		}
+	}
+	if !hasRecurse || !rootPrefix {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1713",
+		Message: "`consul kv delete -recurse /` removes the entire KV store — service " +
+			"discovery, ACL bootstrap, app config. Scope the prefix and snapshot " +
+			"(`consul snapshot save`) first.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 709 Katas = 0.7.9
-const Version = "0.7.9"
+// 710 Katas = 0.7.10
+const Version = "0.7.10"


### PR DESCRIPTION
ZC1713 — Error on `consul kv delete -recurse /` — wipes the entire Consul KV store

What: `consul kv delete -recurse PREFIX` removes every key under PREFIX. Empty / `/` prefix nukes the whole KV store.
Why: Includes service-discovery payloads, ACL bootstrap tokens, and app config.
Fix suggestion: Scope to a namespace prefix (`/app/staging/`); list with `consul kv get -recurse -keys` first; snapshot the datacenter (`consul snapshot save snap.bin`) before any large delete.
Severity: Error

## Test plan
- valid `consul kv delete -recurse /app/staging/` → no violation
- valid `consul kv delete /key` → no violation
- valid `consul kv get -recurse /` (read-only) → no violation
- invalid `consul kv delete -recurse /` → ZC1713