### PR TITLE
feat: ZC1714 — flag gh repo/release delete --yes confirmation bypass

### DIFF
--- a/pkg/katas/katatests/zc1714_test.go
+++ b/pkg/katas/katatests/zc1714_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1714(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — gh repo delete without --yes (prompts)",
+			input:    `gh repo delete owner/repo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — gh repo create",
+			input:    `gh repo create owner/repo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — gh repo delete --yes",
+			input: `gh repo delete owner/repo --yes`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1714",
+					Message: "`gh repo delete --yes` bypasses GitHub's confirmation — a typo or stale variable destroys the target with no soft-delete. Drop `--yes` so a human confirms.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — gh release delete --yes",
+			input: `gh release delete v1.0 --yes`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1714",
+					Message: "`gh release delete --yes` bypasses GitHub's confirmation — a typo or stale variable destroys the target with no soft-delete. Drop `--yes` so a human confirms.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1714")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1714.go
+++ b/pkg/katas/zc1714.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1714",
+		Title:    "Error on `gh repo delete --yes` / `gh release delete --yes` — bypassed confirmation",
+		Severity: SeverityError,
+		Description: "`gh repo delete OWNER/REPO --yes` (and `gh release delete TAG --yes`) " +
+			"skip the interactive confirmation that protects against typos and broken " +
+			"variable expansion. A repository deletion is final — issues, PRs, releases, " +
+			"GitHub Actions history, and (for free accounts) any forks against it all " +
+			"disappear with no soft-delete window. From a script, run without `--yes` so a " +
+			"human reviews the target, or wrap deletion in a manually-triggered workflow " +
+			"with explicit input prompts.",
+		Check: checkZC1714,
+	})
+}
+
+func checkZC1714(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "gh" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	scope := cmd.Arguments[0].String()
+	if scope != "repo" && scope != "release" {
+		return nil
+	}
+	if cmd.Arguments[1].String() != "delete" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[2:] {
+		if arg.String() == "--yes" {
+			return []Violation{{
+				KataID: "ZC1714",
+				Message: "`gh " + scope + " delete --yes` bypasses GitHub's confirmation — " +
+					"a typo or stale variable destroys the target with no soft-delete. " +
+					"Drop `--yes` so a human confirms.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 710 Katas = 0.7.10
-const Version = "0.7.10"
+// 711 Katas = 0.7.11
+const Version = "0.7.11"


### PR DESCRIPTION
ZC1714 — Error on `gh repo delete --yes` / `gh release delete --yes` — bypassed confirmation

What: `gh repo delete OWNER/REPO --yes` and `gh release delete TAG --yes` skip GitHub's interactive confirmation.
Why: Repository deletion is final — issues, PRs, releases, Actions history, forks (free accounts) gone with no soft-delete window.
Fix suggestion: Run without `--yes` so a human reviews the target. Or wrap deletion in a manual workflow with explicit input prompts.
Severity: Error

## Test plan
- valid `gh repo delete owner/repo` (prompts) → no violation
- valid `gh repo create owner/repo` → no violation
- invalid `gh repo delete owner/repo --yes` → ZC1714
- invalid `gh release delete v1.0 --yes` → ZC1714