### PR TITLE
feat: ZC1715 — flag `read -p` (Zsh coprocess clash, not a prompt)

### DIFF
--- a/pkg/katas/katatests/zc1715_test.go
+++ b/pkg/katas/katatests/zc1715_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1715(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — Zsh-idiomatic `read \"var?prompt\"`",
+			input:    `read "name?Enter your name: "`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `read -r line` (no -p)",
+			input:    `read -r line`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `read var` (bare)",
+			input:    `read var`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `read -p \"Prompt: \" name`",
+			input: `read -p "Prompt: " name`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1715",
+					Message: "`read -p` triggers Zsh's coprocess reader, not Bash's prompt — the variable stays empty. Use `read \"var?Prompt: \"` (the `?` after the variable name introduces the prompt).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `read -rp \"Prompt: \" name` (combined short flags)",
+			input: `read -rp "Prompt: " name`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1715",
+					Message: "`read -rp` triggers Zsh's coprocess reader, not Bash's prompt — the variable stays empty. Use `read \"var?Prompt: \"` (the `?` after the variable name introduces the prompt).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1715")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1715.go
+++ b/pkg/katas/zc1715.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1715",
+		Title:    "Error on `read -p \"prompt\"` — Zsh `-p` reads from coprocess, not a prompt",
+		Severity: SeverityError,
+		Description: "Bash's `read -p \"Prompt: \" var` prints the prompt before reading. " +
+			"Zsh's `read -p` means \"read from the coprocess set up with `coproc`\" — when " +
+			"no coprocess exists, `read` errors with `no coprocess` and leaves the variable " +
+			"empty, silently breaking the script. The Zsh idiom is `read \"var?Prompt: \"` " +
+			"— a `?` after the variable name introduces the prompt string, with the same " +
+			"behavior under `-r`, `-s`, etc.",
+		Check: checkZC1715,
+	})
+}
+
+func checkZC1715(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "read" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if len(v) < 2 || v[0] != '-' {
+			continue
+		}
+		// Skip long flags (none of read's short flags need to be considered as long).
+		if v[1] == '-' {
+			continue
+		}
+		if !strings.ContainsRune(v[1:], 'p') {
+			continue
+		}
+		return []Violation{{
+			KataID: "ZC1715",
+			Message: "`read " + v + "` triggers Zsh's coprocess reader, not Bash's prompt — " +
+				"the variable stays empty. Use `read \"var?Prompt: \"` (the `?` after the " +
+				"variable name introduces the prompt).",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityError,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 711 Katas = 0.7.11
-const Version = "0.7.11"
+// 712 Katas = 0.7.12
+const Version = "0.7.12"


### PR DESCRIPTION
ZC1715 — `read -p` collides with Zsh coprocess semantics

What: Detect `read -p` (and combined short flags like `-rp`, `-rsp`) — Bash uses `-p` for the prompt string, Zsh uses it for "read from coprocess".
Why: In Zsh, `read -p "Prompt: " var` errors with `no coprocess` and leaves the variable empty, silently breaking the script.
Fix suggestion: Use the Zsh idiom `read "var?Prompt: "` — the `?` after the variable name introduces the prompt.
Severity: Error