### PR TITLE
feat: ZC1716 — flag `uname -m` / `-p` (use $CPUTYPE / $MACHTYPE)

### DIFF
--- a/pkg/katas/katatests/zc1716_test.go
+++ b/pkg/katas/katatests/zc1716_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1716(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — Zsh-idiomatic `$CPUTYPE`",
+			input:    `print -r -- $CPUTYPE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `uname -r` (kernel release, no Zsh equivalent)",
+			input:    `uname -r`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `uname -m`",
+			input: `uname -m`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1716",
+					Message: "Use Zsh `$CPUTYPE` / `$MACHTYPE` instead of `uname -m` — parameter expansion avoids forking an external for an answer Zsh already cached at startup.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `uname -p`",
+			input: `uname -p`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1716",
+					Message: "Use Zsh `$CPUTYPE` / `$MACHTYPE` instead of `uname -p` — parameter expansion avoids forking an external for an answer Zsh already cached at startup.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1716")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1716.go
+++ b/pkg/katas/zc1716.go
@@ -1,0 +1,47 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1716",
+		Title:    "Use Zsh `$CPUTYPE` / `$MACHTYPE` instead of `uname -m` / `-p`",
+		Severity: SeverityStyle,
+		Description: "Zsh maintains `$CPUTYPE` (e.g. `x86_64`, `aarch64`) and `$MACHTYPE` " +
+			"(the GNU triplet) as built-in parameters. Reading them is a constant-time " +
+			"parameter expansion, while `uname -m` / `uname -p` forks an external for the " +
+			"same answer. The Zsh values are populated at shell start from the same `uname(2)` " +
+			"call, so they stay in lockstep with what `uname` would print.",
+		Check: checkZC1716,
+	})
+}
+
+func checkZC1716(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "uname" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-m" || v == "-p" {
+			return []Violation{{
+				KataID: "ZC1716",
+				Message: "Use Zsh `$CPUTYPE` / `$MACHTYPE` instead of `uname " + v + "` — " +
+					"parameter expansion avoids forking an external for an answer Zsh " +
+					"already cached at startup.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 712 Katas = 0.7.12
-const Version = "0.7.12"
+// 713 Katas = 0.7.13
+const Version = "0.7.13"


### PR DESCRIPTION
ZC1716 — `uname -m` / `uname -p` for architecture

What: Detect `uname -m` and `uname -p` calls.
Why: Zsh maintains `$CPUTYPE` (e.g. `x86_64`) and `$MACHTYPE` (GNU triplet) populated at startup from the same `uname(2)` call. Forking `uname` for the same answer is wasted work.
Fix suggestion: Read `$CPUTYPE` (architecture) or `$MACHTYPE` (full triplet) instead.
Severity: Style