### PR TITLE
feat: ZC1717 — flag `docker pull/push --disable-content-trust` (signature bypass)

### DIFF
--- a/pkg/katas/katatests/zc1717_test.go
+++ b/pkg/katas/katatests/zc1717_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1717(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `docker pull` (no bypass)",
+			input:    `docker pull nginx:1.27`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `docker push` (no bypass)",
+			input:    `docker push myorg/app:1.2.3`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `docker version --disable-content-trust` (not pull/push subcmd)",
+			input:    `docker version --disable-content-trust`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `docker pull --disable-content-trust`",
+			input: `docker pull --disable-content-trust myorg/app:1.2.3`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1717",
+					Message: "`docker pull --disable-content-trust` overrides `DOCKER_CONTENT_TRUST=1` — unsigned image moves into the registry or local store. Sign the artifact (`docker trust sign`) instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `docker push --disable-content-trust`",
+			input: `docker push --disable-content-trust myorg/app:1.2.3`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1717",
+					Message: "`docker push --disable-content-trust` overrides `DOCKER_CONTENT_TRUST=1` — unsigned image moves into the registry or local store. Sign the artifact (`docker trust sign`) instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1717")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1717.go
+++ b/pkg/katas/zc1717.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1717",
+		Title:    "Warn on `docker pull/push --disable-content-trust` — bypasses image signature checks",
+		Severity: SeverityWarning,
+		Description: "When `DOCKER_CONTENT_TRUST=1` is enforced on a host (or set via `/etc/docker/" +
+			"daemon.json`), Docker rejects unsigned image pulls and signs every push. The " +
+			"`--disable-content-trust` flag overrides that per command: a `pull` accepts a " +
+			"replaced or unsigned image into local storage, a `push` lands an unsigned tag in " +
+			"the registry where downstream pulls cannot verify provenance. Drop the flag and " +
+			"sign the artifact (`docker trust sign IMAGE:TAG`) instead, or scope the bypass " +
+			"with a tight Notary signer policy.",
+		Check: checkZC1717,
+	})
+}
+
+func checkZC1717(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "docker" {
+		return nil
+	}
+
+	var sub string
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if sub == "" {
+			switch v {
+			case "pull", "push", "build", "create", "run":
+				sub = v
+				continue
+			}
+		}
+		if sub != "" && v == "--disable-content-trust" {
+			return []Violation{{
+				KataID: "ZC1717",
+				Message: "`docker " + sub + " --disable-content-trust` overrides " +
+					"`DOCKER_CONTENT_TRUST=1` — unsigned image moves into the registry " +
+					"or local store. Sign the artifact (`docker trust sign`) instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 713 Katas = 0.7.13
-const Version = "0.7.13"
+// 714 Katas = 0.7.14
+const Version = "0.7.14"


### PR DESCRIPTION
ZC1717 — `docker pull/push --disable-content-trust`

What: Detect `docker pull|push|build|create|run --disable-content-trust`.
Why: When `DOCKER_CONTENT_TRUST=1` is enforced, the flag overrides per-command, allowing unsigned image pulls or pushes — supply-chain risk.
Fix suggestion: Drop the flag and sign with `docker trust sign IMAGE:TAG`, or scope the bypass via a Notary signer policy.
Severity: Warning