### PR TITLE
feat: ZC1718 — flag `gh secret set --body SECRET` (secret in argv)

### DIFF
--- a/pkg/katas/katatests/zc1718_test.go
+++ b/pkg/katas/katatests/zc1718_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1718(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gh secret set NAME --body-file path`",
+			input:    `gh secret set NAME --body-file /run/secrets/foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gh secret set NAME --body -` (read stdin)",
+			input:    `gh secret set NAME --body -`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gh variable set NAME --body val` (non-secret)",
+			input:    `gh variable set NAME --body publicvalue`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gh secret set NAME --body SECRET`",
+			input: `gh secret set NAME --body hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1718",
+					Message: "`gh secret set ... --body hunter2` puts the secret in argv — visible in `ps`, `/proc`, history. Use `--body-file PATH` or pipe via stdin (`... --body -` with `printf %s \"$SECRET\" |`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gh secret set NAME --body=SECRET`",
+			input: `gh secret set NAME --body=hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1718",
+					Message: "`gh secret set ... --body=hunter2` puts the secret in argv — visible in `ps`, `/proc`, history. Use `--body-file PATH` or pipe via stdin (`... --body -` with `printf %s \"$SECRET\" |`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gh secret set NAME -b SECRET`",
+			input: `gh secret set NAME -b hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1718",
+					Message: "`gh secret set ... --body hunter2` puts the secret in argv — visible in `ps`, `/proc`, history. Use `--body-file PATH` or pipe via stdin (`... --body -` with `printf %s \"$SECRET\" |`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1718")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1718.go
+++ b/pkg/katas/zc1718.go
@@ -1,0 +1,73 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1718",
+		Title:    "Error on `gh secret set --body SECRET` / `-b SECRET` — secret in process list",
+		Severity: SeverityError,
+		Description: "`gh secret set NAME --body VALUE` (or `-b VALUE`, `--body=VALUE`) puts the " +
+			"secret on the command line. The cleartext appears in `ps`, `/proc/<pid>/cmdline`, " +
+			"shell history, and the audit log of the host running `gh`. Pipe the value via " +
+			"stdin (`gh secret set NAME < file`, `printf %s \"$SECRET\" | gh secret set NAME " +
+			"--body -`) or use `--body-file PATH` so the value never lands in argv.",
+		Check: checkZC1718,
+	})
+}
+
+func checkZC1718(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "gh" {
+		return nil
+	}
+	if len(cmd.Arguments) < 3 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "secret" || cmd.Arguments[1].String() != "set" {
+		return nil
+	}
+
+	prevBody := false
+	for _, arg := range cmd.Arguments[2:] {
+		v := arg.String()
+		if prevBody {
+			if v == "-" {
+				return nil
+			}
+			return zc1718Hit(cmd, "--body "+v)
+		}
+		switch {
+		case v == "--body" || v == "-b":
+			prevBody = true
+		case strings.HasPrefix(v, "--body="):
+			val := strings.TrimPrefix(v, "--body=")
+			if val == "-" {
+				return nil
+			}
+			return zc1718Hit(cmd, v)
+		}
+	}
+	return nil
+}
+
+func zc1718Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1718",
+		Message: "`gh secret set ... " + what + "` puts the secret in argv — visible in " +
+			"`ps`, `/proc`, history. Use `--body-file PATH` or pipe via stdin " +
+			"(`... --body -` with `printf %s \"$SECRET\" |`).",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 714 Katas = 0.7.14
-const Version = "0.7.14"
+// 715 Katas = 0.7.15
+const Version = "0.7.15"


### PR DESCRIPTION
ZC1718 — `gh secret set --body SECRET`

What: Detect `gh secret set NAME --body VALUE`, `--body=VALUE`, or `-b VALUE`.
Why: The secret value lands in argv — visible in `ps`, `/proc/<pid>/cmdline`, history, host audit logs.
Fix suggestion: Use `--body-file PATH` or `--body -` with `printf %s "$SECRET" |` piped to stdin.
Severity: Error