### PR TITLE
feat: ZC1719 — flag `git filter-branch` (deprecated, use `git filter-repo`)

### DIFF
--- a/pkg/katas/katatests/zc1719_test.go
+++ b/pkg/katas/katatests/zc1719_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1719(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `git filter-repo`",
+			input:    `git filter-repo --path secret.txt --invert-paths`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `git rebase`",
+			input:    `git rebase main`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `git filter-branch --tree-filter`",
+			input: `git filter-branch --tree-filter rm secret.txt HEAD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1719",
+					Message: "`git filter-branch` is deprecated (Git 2.24+) and its manpage redirects to `git filter-repo`. Use that instead — faster, safer defaults, no orphaned objects.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — bare `git filter-branch`",
+			input: `git filter-branch`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1719",
+					Message: "`git filter-branch` is deprecated (Git 2.24+) and its manpage redirects to `git filter-repo`. Use that instead — faster, safer defaults, no orphaned objects.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1719")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1719.go
+++ b/pkg/katas/zc1719.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1719",
+		Title:    "Warn on `git filter-branch` — deprecated since Git 2.24, use `git filter-repo`",
+		Severity: SeverityWarning,
+		Description: "`git filter-branch` is deprecated as of Git 2.24; its manpage opens with " +
+			"\"WARNING: this command is deprecated\" and points users at `git filter-repo`. " +
+			"`filter-branch` is single-process slow, mishandles common cases (tag rewrites, " +
+			"refs/notes/*, signed commits), and leaves orphaned objects behind. The modern " +
+			"replacement is `git filter-repo` (separate package; `apt/brew install git-" +
+			"filter-repo`) — much faster, safer defaults, and what GitHub / GitLab guidance " +
+			"recommends for secret-removal rewrites.",
+		Check: checkZC1719,
+	})
+}
+
+func checkZC1719(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "git" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "filter-branch" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1719",
+		Message: "`git filter-branch` is deprecated (Git 2.24+) and its manpage redirects to " +
+			"`git filter-repo`. Use that instead — faster, safer defaults, no orphaned " +
+			"objects.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 715 Katas = 0.7.15
-const Version = "0.7.15"
+// 716 Katas = 0.7.16
+const Version = "0.7.16"


### PR DESCRIPTION
ZC1719 — `git filter-branch`

What: Detect `git filter-branch` invocations.
Why: Deprecated since Git 2.24; the manpage opens with a deprecation warning. Slow, mishandles tag rewrites and signed commits, leaves orphaned objects.
Fix suggestion: Use `git filter-repo` (separate package) — faster, safer, recommended by GitHub / GitLab guidance.
Severity: Warning