### PR TITLE
feat: ZC1720 — flag `tput cols` / `tput lines` (use $COLUMNS / $LINES)

### DIFF
--- a/pkg/katas/katatests/zc1720_test.go
+++ b/pkg/katas/katatests/zc1720_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1720(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — Zsh-idiomatic `$COLUMNS`",
+			input:    `print -r -- $COLUMNS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `tput setaf 1` (color, no $COLUMNS equivalent)",
+			input:    `tput setaf 1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `tput cols`",
+			input: `tput cols`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1720",
+					Message: "Use `$COLUMNS` instead of `tput cols` — Zsh keeps the terminal size in parameters, no fork needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `tput lines`",
+			input: `tput lines`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1720",
+					Message: "Use `$LINES` instead of `tput lines` — Zsh keeps the terminal size in parameters, no fork needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1720")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1720.go
+++ b/pkg/katas/zc1720.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1720",
+		Title:    "Use Zsh `$COLUMNS` / `$LINES` instead of `tput cols` / `tput lines`",
+		Severity: SeverityStyle,
+		Description: "Zsh tracks the terminal width and height in `$COLUMNS` and `$LINES`, " +
+			"updated automatically on `SIGWINCH`. Reading them is a constant-time " +
+			"parameter expansion, while `tput cols` / `tput lines` forks the terminfo " +
+			"helper on every call. Use the parameters; reach for `tput` only for terminfo " +
+			"queries Zsh does not surface as parameters.",
+		Check: checkZC1720,
+	})
+}
+
+func checkZC1720(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "tput" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "cols" || v == "lines" {
+			repl := "$COLUMNS"
+			if v == "lines" {
+				repl = "$LINES"
+			}
+			return []Violation{{
+				KataID: "ZC1720",
+				Message: "Use `" + repl + "` instead of `tput " + v + "` — Zsh keeps the " +
+					"terminal size in parameters, no fork needed.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityStyle,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 716 Katas = 0.7.16
-const Version = "0.7.16"
+// 717 Katas = 0.7.17
+const Version = "0.7.17"


### PR DESCRIPTION
ZC1720 — `tput cols` / `tput lines`

What: Detect `tput cols` and `tput lines`.
Why: Zsh tracks terminal size in `$COLUMNS` / `$LINES`, updated on `SIGWINCH`. `tput` forks the terminfo helper for the same value.
Fix suggestion: Use the parameter expansions `$COLUMNS` / `$LINES`.
Severity: Style