### PR TITLE
feat: ZC1721 — flag `chmod NNN /dev/<node>` (world-writable device = LPE)

### DIFF
--- a/pkg/katas/katatests/zc1721_test.go
+++ b/pkg/katas/katatests/zc1721_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1721(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `chmod 660 /dev/kvm` (group, not world)",
+			input:    `chmod 660 /dev/kvm`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `chmod 644 /tmp/file` (not /dev/)",
+			input:    `chmod 644 /tmp/file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `chmod 644 /dev/null` (read-only, ignored)",
+			input:    `chmod 644 /dev/null`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `chmod 666 /dev/kvm`",
+			input: `chmod 666 /dev/kvm`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1721",
+					Message: "`chmod 666 /dev/kvm` opens a kernel device node to every local user — privilege-escalation surface. Use a udev rule that grants the specific group access instead of world-write.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `chmod 0666 /dev/uinput` (leading-zero octal)",
+			input: `chmod 0666 /dev/uinput`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1721",
+					Message: "`chmod 438 /dev/uinput` opens a kernel device node to every local user — privilege-escalation surface. Use a udev rule that grants the specific group access instead of world-write.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `chmod 777 /dev/dri/card0`",
+			input: `chmod 777 /dev/dri/card0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1721",
+					Message: "`chmod 777 /dev/dri/card0` opens a kernel device node to every local user — privilege-escalation surface. Use a udev rule that grants the specific group access instead of world-write.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1721")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1721.go
+++ b/pkg/katas/zc1721.go
@@ -1,0 +1,64 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1721",
+		Title:    "Error on `chmod NNN /dev/<node>` — world-writable device node is local privilege escalation",
+		Severity: SeverityError,
+		Description: "Granting world-write to a device node hands every local user a primitive: " +
+			"`/dev/kvm` becomes a host-root VM-exit gadget, `/dev/uinput` lets any user inject " +
+			"keystrokes into the active session, `/dev/loop-control` forges loop devices, " +
+			"`/dev/dri/cardN` opens GPU shaders for code-exec, `/dev/mem` / `/dev/kmem` (where " +
+			"still permitted) leak kernel state. Keep the kernel-managed default permissions; " +
+			"if userspace needs access, add a udev rule that grants it to a specific group, " +
+			"never `666` to the world.",
+		Check: checkZC1721,
+	})
+}
+
+func checkZC1721(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "chmod" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+
+	var mode, target string
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "/dev/") {
+			target = v
+			continue
+		}
+		if mode == "" && zc1671WorldWritable(v) {
+			mode = v
+		}
+	}
+
+	if mode == "" || target == "" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1721",
+		Message: "`chmod " + mode + " " + target + "` opens a kernel device node to every " +
+			"local user — privilege-escalation surface. Use a udev rule that grants the " +
+			"specific group access instead of world-write.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 717 Katas = 0.7.17
-const Version = "0.7.17"
+// 718 Katas = 0.7.18
+const Version = "0.7.18"


### PR DESCRIPTION
ZC1721 — `chmod NNN /dev/<node>` world-writable

What: Detect `chmod` granting world-write/execute on a `/dev/...` path (e.g. `chmod 666 /dev/kvm`).
Why: `/dev/kvm` is host-root via VM-exit, `/dev/uinput` injects keystrokes, `/dev/dri/cardN` opens GPU shaders for code-exec, `/dev/loop-control` forges loop devices. World access = local privilege escalation surface.
Fix suggestion: Use a udev rule that grants the specific group access; never `666`.
Severity: Error