### PR TITLE
feat: ZC1722 — flag `ssh-keyscan HOST >> known_hosts` (TOFU bypass)

### DIFF
--- a/pkg/katas/katatests/zc1722_test.go
+++ b/pkg/katas/katatests/zc1722_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1722(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ssh-keyscan HOST` (no redirect; fingerprint check separately)",
+			input:    `ssh-keyscan HOST`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ssh-keyscan HOST > /tmp/scan.tmp` (not known_hosts)",
+			input:    `ssh-keyscan HOST > /tmp/scan.tmp`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ssh-keyscan HOST >> ~/.ssh/known_hosts`",
+			input: `ssh-keyscan HOST >> ~/.ssh/known_hosts`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1722",
+					Message: "`ssh-keyscan ... >> ~/.ssh/known_hosts` accepts the first-served host key without verifying its fingerprint. Pipe to `ssh-keygen -lf -` and assert the fingerprint first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ssh-keyscan -H HOST > known_hosts`",
+			input: `ssh-keyscan -H HOST > known_hosts`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1722",
+					Message: "`ssh-keyscan ... > known_hosts` accepts the first-served host key without verifying its fingerprint. Pipe to `ssh-keygen -lf -` and assert the fingerprint first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1722")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1722.go
+++ b/pkg/katas/zc1722.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1722",
+		Title:    "Warn on `ssh-keyscan HOST >> known_hosts` — TOFU bypass, blind-trust new host key",
+		Severity: SeverityWarning,
+		Description: "`ssh-keyscan` fetches whatever host key the remote serves on its first reply. " +
+			"Appending the result straight to `known_hosts` is the exact step the host-key " +
+			"check is meant to defend against: a man-in-the-middle on first contact wins " +
+			"permanently. Pin the expected fingerprint via a side channel (vendor docs, prior " +
+			"verified contact) and assert it matches `ssh-keyscan HOST | ssh-keygen -lf -` " +
+			"before the append.",
+		Check: checkZC1722,
+	})
+}
+
+func checkZC1722(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "ssh-keyscan" {
+		return nil
+	}
+
+	prevRedir := ""
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevRedir != "" {
+			if strings.Contains(v, "known_hosts") {
+				return []Violation{{
+					KataID: "ZC1722",
+					Message: "`ssh-keyscan ... " + prevRedir + " " + v + "` accepts the " +
+						"first-served host key without verifying its fingerprint. Pipe " +
+						"to `ssh-keygen -lf -` and assert the fingerprint first.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+			prevRedir = ""
+			continue
+		}
+		if v == ">>" || v == ">" {
+			prevRedir = v
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 718 Katas = 0.7.18
-const Version = "0.7.18"
+// 719 Katas = 0.7.19
+const Version = "0.7.19"


### PR DESCRIPTION
ZC1722 — `ssh-keyscan HOST >> known_hosts`

What: Detect `ssh-keyscan` output redirected (`>>` or `>`) into a `known_hosts` file.
Why: Accepts whatever host key the remote serves on first contact — exactly the case the host-key check guards against. MITM on first contact wins permanently.
Fix suggestion: Pin the expected fingerprint via a side-channel and verify with `ssh-keyscan HOST | ssh-keygen -lf -` before the append.
Severity: Warning