### PR TITLE
feat: ZC1723 — flag `gpg --delete-secret-keys` (irreversible key destruction)

### DIFF
--- a/pkg/katas/katatests/zc1723_test.go
+++ b/pkg/katas/katatests/zc1723_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1723(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gpg --list-keys`",
+			input:    `gpg --list-keys`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gpg KEYID --export-secret-keys`",
+			input:    `gpg KEYID --export-secret-keys`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gpg --delete-secret-keys KEYID` (leading-flag form)",
+			input: `gpg --delete-secret-keys KEYID`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1723",
+					Message: "`gpg --delete-secret-keys` permanently destroys keyring entries — no recovery without a separate backup. Export with `gpg --export-secret-keys --armor KEYID` first; never pair this flag with `--batch --yes`.",
+					Line:    1,
+					Column:  7,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gpg --batch --yes --delete-secret-and-public-keys KEYID`",
+			input: `gpg --batch --yes --delete-secret-and-public-keys KEYID`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1723",
+					Message: "`gpg --delete-secret-and-public-keys` permanently destroys keyring entries — no recovery without a separate backup. Export with `gpg --export-secret-keys --armor KEYID` first; never pair this flag with `--batch --yes`.",
+					Line:    1,
+					Column:  21,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gpg KEYID --delete-key` (trailing-flag form)",
+			input: `gpg KEYID --delete-key`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1723",
+					Message: "`gpg --delete-key` permanently destroys keyring entries — no recovery without a separate backup. Export with `gpg --export-secret-keys --armor KEYID` first; never pair this flag with `--batch --yes`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1723")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1723.go
+++ b/pkg/katas/zc1723.go
@@ -1,0 +1,77 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1723DeleteFlags = map[string]bool{
+	"--delete-secret-keys":            true,
+	"--delete-secret-and-public-keys": true,
+	"--delete-keys":                   true,
+	"--delete-key":                    true,
+}
+
+// Parser caveat: a leading `--long-flag` mangles the GPG name so the next
+// SimpleCommand becomes the bare flag without the leading dashes.
+var zc1723MangledNames = map[string]bool{
+	"delete-secret-keys":            true,
+	"delete-secret-and-public-keys": true,
+	"delete-keys":                   true,
+	"delete-key":                    true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1723",
+		Title:    "Error on `gpg --delete-secret-keys` / `--delete-key` — irreversible key destruction",
+		Severity: SeverityError,
+		Description: "GPG key deletion is permanent. Once `--delete-secret-keys`, " +
+			"`--delete-secret-and-public-keys`, `--delete-keys`, or `--delete-key` removes " +
+			"the keyring entry there is no recovery short of a separate backup or off-card " +
+			"reimport. Combined with `--batch --yes`, the confirmation prompt is bypassed " +
+			"and a single accidental KEYID resolves to a one-shot wipe. Export the key " +
+			"first (`gpg --export-secret-keys --armor KEYID > backup.asc`, store offline) " +
+			"and never pair the delete flag with `--batch --yes` in automation.",
+		Check: checkZC1723,
+	})
+}
+
+func checkZC1723(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if zc1723MangledNames[ident.Value] {
+		return zc1723Hit(cmd, "--"+ident.Value)
+	}
+
+	if ident.Value != "gpg" && ident.Value != "gpg2" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if zc1723DeleteFlags[v] {
+			return zc1723Hit(cmd, v)
+		}
+	}
+	return nil
+}
+
+func zc1723Hit(cmd *ast.SimpleCommand, flag string) []Violation {
+	return []Violation{{
+		KataID: "ZC1723",
+		Message: "`gpg " + flag + "` permanently destroys keyring entries — no recovery " +
+			"without a separate backup. Export with `gpg --export-secret-keys --armor " +
+			"KEYID` first; never pair this flag with `--batch --yes`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 719 Katas = 0.7.19
-const Version = "0.7.19"
+// 720 Katas = 0.7.20
+const Version = "0.7.20"


### PR DESCRIPTION
ZC1723 — `gpg --delete-secret-keys`

What: Detect `gpg --delete-secret-keys`, `--delete-secret-and-public-keys`, `--delete-keys`, `--delete-key` (leading or trailing flag form).
Why: Removes keyring entries with no recovery short of a separate backup. Combined with `--batch --yes` the prompt is bypassed — a single accidental KEYID wipes the key.
Fix suggestion: Export with `gpg --export-secret-keys --armor KEYID > backup.asc` first; never combine the delete flag with `--batch --yes` in automation.
Severity: Error