### PR TITLE
feat: ZC1724 — flag `pacman -Sy <pkg>` (partial-upgrade footgun)

### DIFF
--- a/pkg/katas/katatests/zc1724_test.go
+++ b/pkg/katas/katatests/zc1724_test.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1724(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `pacman -Syu package` (full upgrade then install)",
+			input:    `pacman -Syu package`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `pacman -S package` (install without DB refresh)",
+			input:    `pacman -S package`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `pacman -Sy` (refresh DB, no install)",
+			input:    `pacman -Sy`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `pacman -Sy package`",
+			input: `pacman -Sy package`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1724",
+					Message: "`pacman -Sy <pkg>` is a partial-upgrade footgun — refresh the DB but install only one package against the newer metadata. Use `pacman -Syu` first, then `pacman -S <pkg>` (or `pacman -Syu --noconfirm <pkg>` to keep it atomic).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1724")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1724.go
+++ b/pkg/katas/zc1724.go
@@ -1,0 +1,69 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1724",
+		Title:    "Warn on `pacman -Sy <pkg>` — partial upgrade, breaks dependency closure",
+		Severity: SeverityWarning,
+		Description: "Arch Linux is rolling-release on the invariant that the local package " +
+			"database and the installed package set move together. `pacman -Sy <pkg>` " +
+			"refreshes the database and installs ONE package against the new metadata while " +
+			"every other installed package stays at its old version. The new package's " +
+			"dependency closure pulls libraries newer than what the rest of the system has, " +
+			"leaving a half-upgraded state that often manifests as `error while loading " +
+			"shared libraries`. Run a full `pacman -Syu` first, then install (`pacman -S " +
+			"<pkg>`); for CI use `pacman -Syu --noconfirm <pkg>` so the upgrade and install " +
+			"are atomic.",
+		Check: checkZC1724,
+	})
+}
+
+func checkZC1724(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "pacman" {
+		return nil
+	}
+
+	hasSyNoU := false
+	hasPkg := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "-") && len(v) >= 2 {
+			letters := v[1:]
+			// Must contain both 'S' and 'y' but not 'u' (would be -Syu).
+			if strings.Contains(letters, "S") && strings.Contains(letters, "y") && !strings.Contains(letters, "u") {
+				hasSyNoU = true
+			}
+			continue
+		}
+		if v != "" {
+			hasPkg = true
+		}
+	}
+
+	if !hasSyNoU || !hasPkg {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1724",
+		Message: "`pacman -Sy <pkg>` is a partial-upgrade footgun — refresh the DB but " +
+			"install only one package against the newer metadata. Use `pacman -Syu` " +
+			"first, then `pacman -S <pkg>` (or `pacman -Syu --noconfirm <pkg>` to keep " +
+			"it atomic).",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 720 Katas = 0.7.20
-const Version = "0.7.20"
+// 721 Katas = 0.7.21
+const Version = "0.7.21"


### PR DESCRIPTION
ZC1724 — `pacman -Sy <pkg>`

What: Detect `pacman -Sy <pkg>` (or any `-Sy*` flag combination without `u`) followed by a package name.
Why: Refreshes the package DB and installs ONE package against newer metadata while every other installed package stays at its old version. Dependency closure pulls libraries newer than the rest of the system → `error while loading shared libraries`.
Fix suggestion: Use `pacman -Syu` first, then `pacman -S <pkg>`. For CI, `pacman -Syu --noconfirm <pkg>` keeps the upgrade and install atomic.
Severity: Warning