### PR TITLE
feat: ZC1725 — flag `cargo --token` / `npm --otp` (registry credential in argv)

### DIFF
--- a/pkg/katas/katatests/zc1725_test.go
+++ b/pkg/katas/katatests/zc1725_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1725(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `cargo publish` (no inline token)",
+			input:    `cargo publish`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `cargo login --token -` (stdin sentinel)",
+			input:    `cargo login --token -`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `cargo build --token foo` (not a publish subcmd)",
+			input:    `cargo build --token foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `cargo publish --token TOKEN`",
+			input: `cargo publish --token cio_abc123`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1725",
+					Message: "`cargo publish --token cio_abc123` puts the credential in argv — visible in `ps`, `/proc`, history. Pipe via stdin (`--token -`) or use env vars like `CARGO_REGISTRY_TOKEN` / `NPM_TOKEN`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `cargo login --token=TOKEN`",
+			input: `cargo login --token=cio_abc123`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1725",
+					Message: "`cargo login --token=cio_abc123` puts the credential in argv — visible in `ps`, `/proc`, history. Pipe via stdin (`--token -`) or use env vars like `CARGO_REGISTRY_TOKEN` / `NPM_TOKEN`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `npm publish --otp 123456`",
+			input: `npm publish --otp 123456`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1725",
+					Message: "`npm publish --otp 123456` puts the credential in argv — visible in `ps`, `/proc`, history. Pipe via stdin (`--token -`) or use env vars like `CARGO_REGISTRY_TOKEN` / `NPM_TOKEN`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1725")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1725.go
+++ b/pkg/katas/zc1725.go
@@ -1,0 +1,100 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1725",
+		Title:    "Error on `cargo --token TOKEN` / `npm --otp CODE` — registry credential in process list",
+		Severity: SeverityError,
+		Description: "`cargo publish --token TOKEN` (and `cargo login`, `cargo owner`, `cargo " +
+			"yank`) puts the crates.io API token in argv — visible in `ps`, `/proc/<pid>/" +
+			"cmdline`, shell history, and CI logs. `npm publish --otp CODE` leaks the " +
+			"one-time code the same way. Use environment variables (`CARGO_REGISTRY_TOKEN`, " +
+			"`NPM_TOKEN`) or pipe via stdin (`cargo login --token -` reads from stdin), and " +
+			"source credentials from a secrets manager instead of the command line.",
+		Check: checkZC1725,
+	})
+}
+
+func checkZC1725(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var flag, tool string
+	switch ident.Value {
+	case "cargo":
+		flag = "--token"
+		tool = "cargo"
+	case "npm", "yarn", "pnpm":
+		flag = "--otp"
+		tool = ident.Value
+	default:
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+
+	// First arg should be a relevant subcommand.
+	sub := cmd.Arguments[0].String()
+	switch tool {
+	case "cargo":
+		switch sub {
+		case "publish", "login", "owner", "yank":
+		default:
+			return nil
+		}
+	default:
+		switch sub {
+		case "publish", "adduser", "login":
+		default:
+			return nil
+		}
+	}
+
+	prevFlag := false
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if prevFlag {
+			if v == "-" {
+				return nil
+			}
+			return zc1725Hit(cmd, tool, sub, flag+" "+v)
+		}
+		switch {
+		case v == flag:
+			prevFlag = true
+		case strings.HasPrefix(v, flag+"="):
+			val := strings.TrimPrefix(v, flag+"=")
+			if val == "-" {
+				return nil
+			}
+			return zc1725Hit(cmd, tool, sub, v)
+		}
+	}
+	return nil
+}
+
+func zc1725Hit(cmd *ast.SimpleCommand, tool, sub, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1725",
+		Message: "`" + tool + " " + sub + " " + what + "` puts the credential in argv — " +
+			"visible in `ps`, `/proc`, history. Pipe via stdin (`--token -`) or use env " +
+			"vars like `CARGO_REGISTRY_TOKEN` / `NPM_TOKEN`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 721 Katas = 0.7.21
-const Version = "0.7.21"
+// 722 Katas = 0.7.22
+const Version = "0.7.22"


### PR DESCRIPTION
ZC1725 — `cargo --token` / `npm --otp`

What: Detect `cargo {publish,login,owner,yank} --token VALUE` and `npm {publish,adduser,login} --otp CODE` (long or short joined form).
Why: The credential lands in argv — visible in `ps`, `/proc/<pid>/cmdline`, history, and CI logs.
Fix suggestion: Pipe the value via stdin (`cargo login --token -`) or use environment variables (`CARGO_REGISTRY_TOKEN`, `NPM_TOKEN`).
Severity: Error