### PR TITLE
feat: ZC1726 — flag `gcloud ... delete --quiet` (silent GCP destruction)

### DIFF
--- a/pkg/katas/katatests/zc1726_test.go
+++ b/pkg/katas/katatests/zc1726_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1726(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gcloud projects delete PROJECT_ID` (no --quiet)",
+			input:    `gcloud projects delete PROJECT_ID`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gcloud projects list --quiet` (not delete)",
+			input:    `gcloud projects list --quiet`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gcloud projects delete PROJECT_ID --quiet`",
+			input: `gcloud projects delete PROJECT_ID --quiet`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1726",
+					Message: "`gcloud ... delete --quiet` skips confirmation — a wrong argument wipes the resource (compute disks, secrets, BigQuery tables have no soft-delete). Drop `--quiet` or destroy through a Terraform plan with review.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gcloud sql instances delete INSTANCE -q`",
+			input: `gcloud sql instances delete INSTANCE -q`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1726",
+					Message: "`gcloud ... delete --quiet` skips confirmation — a wrong argument wipes the resource (compute disks, secrets, BigQuery tables have no soft-delete). Drop `--quiet` or destroy through a Terraform plan with review.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1726")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1726.go
+++ b/pkg/katas/zc1726.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1726",
+		Title:    "Error on `gcloud ... delete --quiet` — silent destruction of GCP resources",
+		Severity: SeverityError,
+		Description: "`gcloud` accepts `--quiet` (`-q`) globally to suppress every confirmation " +
+			"prompt. Combined with `delete` on projects, SQL instances, GKE clusters, " +
+			"compute VMs, secrets, or storage buckets, a single misresolved variable wipes " +
+			"the resource with no human-in-the-loop. Project deletion has a 30-day soft " +
+			"window but compute disks, secrets, and BigQuery tables are gone immediately. " +
+			"Drop `--quiet` from delete commands or route the bulk-destroy through a " +
+			"Terraform plan that surfaces the diff for review.",
+		Check: checkZC1726,
+	})
+}
+
+func checkZC1726(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "gcloud" {
+		return nil
+	}
+
+	hasDelete, hasQuiet := false, false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "delete":
+			hasDelete = true
+		case "--quiet", "-q":
+			hasQuiet = true
+		}
+	}
+	if !hasDelete || !hasQuiet {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1726",
+		Message: "`gcloud ... delete --quiet` skips confirmation — a wrong argument " +
+			"wipes the resource (compute disks, secrets, BigQuery tables have no soft-" +
+			"delete). Drop `--quiet` or destroy through a Terraform plan with review.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 722 Katas = 0.7.22
-const Version = "0.7.22"
+// 723 Katas = 0.7.23
+const Version = "0.7.23"


### PR DESCRIPTION
ZC1726 — `gcloud ... delete --quiet`

What: Detect `gcloud` invocations that combine a `delete` subcommand with `--quiet` (or `-q`).
Why: `--quiet` suppresses every confirmation. With `delete` on compute disks, secrets, or BigQuery tables (no soft-delete), a misresolved variable wipes the resource immediately.
Fix suggestion: Drop `--quiet` from delete commands or route the destroy through a Terraform plan with explicit review.
Severity: Error