### PR TITLE
feat: ZC1727 — flag `curl/wget --proxy http://USER:PASS@HOST` (proxy creds in argv)

### DIFF
--- a/pkg/katas/katatests/zc1727_test.go
+++ b/pkg/katas/katatests/zc1727_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1727(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `curl URL --proxy http://PROXY:8080` (no creds in URL)",
+			input:    `curl URL --proxy http://PROXY:8080`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `curl URL` (no proxy)",
+			input:    `curl URL`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `wget URL` (no proxy creds)",
+			input:    `wget URL`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `curl URL --proxy http://USER:PASS@PROXY:8080`",
+			input: `curl URL --proxy http://USER:PASS@PROXY:8080`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1727",
+					Message: "`curl --proxy http://USER:PASS@PROXY:8080` puts proxy credentials in argv — visible in `ps`, `/proc`, history. Move them into `~/.curlrc` / `~/.netrc` (chmod 600) or `~/.wgetrc`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `curl URL -x http://USER:PASS@PROXY:8080`",
+			input: `curl URL -x http://USER:PASS@PROXY:8080`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1727",
+					Message: "`curl --proxy http://USER:PASS@PROXY:8080` puts proxy credentials in argv — visible in `ps`, `/proc`, history. Move them into `~/.curlrc` / `~/.netrc` (chmod 600) or `~/.wgetrc`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `wget URL --proxy-password=hunter2`",
+			input: `wget URL --proxy-password=hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1727",
+					Message: "`wget --proxy-password=hunter2` puts proxy credentials in argv — visible in `ps`, `/proc`, history. Move them into `~/.curlrc` / `~/.netrc` (chmod 600) or `~/.wgetrc`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1727")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1727.go
+++ b/pkg/katas/zc1727.go
@@ -1,0 +1,118 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1727",
+		Title:    "Error on `curl/wget --proxy http://USER:PASS@HOST` — proxy credentials in argv",
+		Severity: SeverityError,
+		Description: "Embedding the proxy username and password in the URL passed to `--proxy` " +
+			"(curl), `-x` (curl short form), or `--proxy-password=` (wget) lands the " +
+			"credential in argv — visible in `ps`, `/proc/<pid>/cmdline`, shell history, " +
+			"and CI logs. Configure the proxy through `~/.curlrc` / `~/.netrc` (chmod 600) " +
+			"for curl, or `~/.wgetrc` for wget, so the secret never reaches the command " +
+			"line.",
+		Check: checkZC1727,
+	})
+}
+
+func checkZC1727(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "curl":
+		return zc1727Curl(cmd)
+	case "wget":
+		return zc1727Wget(cmd)
+	}
+	return nil
+}
+
+func zc1727Curl(cmd *ast.SimpleCommand) []Violation {
+	prevProxy := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevProxy {
+			if zc1727URLHasCreds(v) {
+				return zc1727Hit(cmd, "curl --proxy "+v)
+			}
+			prevProxy = false
+			continue
+		}
+		switch {
+		case v == "--proxy" || v == "-x":
+			prevProxy = true
+		case strings.HasPrefix(v, "--proxy="):
+			val := strings.TrimPrefix(v, "--proxy=")
+			if zc1727URLHasCreds(val) {
+				return zc1727Hit(cmd, "curl "+v)
+			}
+		case strings.HasPrefix(v, "-x"):
+			val := v[2:]
+			if zc1727URLHasCreds(val) {
+				return zc1727Hit(cmd, "curl "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1727Wget(cmd *ast.SimpleCommand) []Violation {
+	prevPwd := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevPwd {
+			return zc1727Hit(cmd, "wget --proxy-password "+v)
+		}
+		switch {
+		case v == "--proxy-password":
+			prevPwd = true
+		case strings.HasPrefix(v, "--proxy-password="):
+			return zc1727Hit(cmd, "wget "+v)
+		}
+	}
+	return nil
+}
+
+// zc1727URLHasCreds returns true when the URL contains a `userinfo` portion
+// (text between `://` and the next `@` before any `/`).
+func zc1727URLHasCreds(url string) bool {
+	scheme := strings.Index(url, "://")
+	if scheme < 0 {
+		return false
+	}
+	rest := url[scheme+3:]
+	at := strings.Index(rest, "@")
+	if at < 0 {
+		return false
+	}
+	if slash := strings.Index(rest, "/"); slash >= 0 && slash < at {
+		return false
+	}
+	return true
+}
+
+func zc1727Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1727",
+		Message: "`" + what + "` puts proxy credentials in argv — visible in `ps`, " +
+			"`/proc`, history. Move them into `~/.curlrc` / `~/.netrc` (chmod 600) or " +
+			"`~/.wgetrc`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 723 Katas = 0.7.23
-const Version = "0.7.23"
+// 724 Katas = 0.7.24
+const Version = "0.7.24"


### PR DESCRIPTION
ZC1727 — proxy credentials in argv

What: Detect `curl --proxy http://USER:PASS@HOST`, `curl -x http://USER:PASS@HOST`, and `wget --proxy-password=PASS` (and joined `--proxy=...` form).
Why: Credentials land in argv — visible in `ps`, `/proc/<pid>/cmdline`, history, CI logs.
Fix suggestion: Move the secret into `~/.curlrc` / `~/.netrc` (chmod 600) for curl, or `~/.wgetrc` for wget.
Severity: Error