### PR TITLE
feat: ZC1728 — flag `pip install --index-url http://...` (plaintext index, MITM)

### DIFF
--- a/pkg/katas/katatests/zc1728_test.go
+++ b/pkg/katas/katatests/zc1728_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1728(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `pip install --index-url https://pypi.org/simple pkg`",
+			input:    `pip install --index-url https://pypi.org/simple pkg`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `pip install pkg` (default https index)",
+			input:    `pip install pkg`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `pip install --index-url http://internal/simple pkg`",
+			input: `pip install --index-url http://internal/simple pkg`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1728",
+					Message: "`pip install --index-url http://internal/simple` fetches packages over plaintext HTTP — any MITM swaps the wheel for code execution on the host. Use `https://`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `pip install -i http://internal/simple pkg`",
+			input: `pip install -i http://internal/simple pkg`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1728",
+					Message: "`pip install --index-url http://internal/simple` fetches packages over plaintext HTTP — any MITM swaps the wheel for code execution on the host. Use `https://`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `pip install --extra-index-url=http://internal/simple pkg`",
+			input: `pip install --extra-index-url=http://internal/simple pkg`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1728",
+					Message: "`pip install --index-url --extra-index-url=http://internal/simple` fetches packages over plaintext HTTP — any MITM swaps the wheel for code execution on the host. Use `https://`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1728")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1728.go
+++ b/pkg/katas/zc1728.go
@@ -1,0 +1,77 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1728",
+		Title:    "Error on `pip install --index-url http://...` — plaintext index allows MITM",
+		Severity: SeverityError,
+		Description: "`pip install --index-url http://...`, `--extra-index-url http://...`, " +
+			"and `-i http://...` tell pip to fetch packages over plaintext HTTP. Any " +
+			"network-position attacker (open Wi-Fi, hostile transit, MITM proxy) can " +
+			"replace package metadata or wheel contents in flight — direct code execution " +
+			"on the install host. Switch to `https://`, or on internal networks terminate " +
+			"TLS at the mirror and only configure the `https://` URL.",
+		Check: checkZC1728,
+	})
+}
+
+func checkZC1728(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "pip", "pip3", "pip2":
+	default:
+		return nil
+	}
+
+	prevURL := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevURL {
+			if zc1728PlainHTTP(v) {
+				return zc1728Hit(cmd, v)
+			}
+			prevURL = false
+			continue
+		}
+		switch {
+		case v == "--index-url" || v == "--extra-index-url" || v == "-i":
+			prevURL = true
+		case strings.HasPrefix(v, "--index-url="), strings.HasPrefix(v, "--extra-index-url="):
+			eq := strings.IndexByte(v, '=')
+			if zc1728PlainHTTP(v[eq+1:]) {
+				return zc1728Hit(cmd, v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1728PlainHTTP(url string) bool {
+	return strings.HasPrefix(url, "http://")
+}
+
+func zc1728Hit(cmd *ast.SimpleCommand, url string) []Violation {
+	return []Violation{{
+		KataID: "ZC1728",
+		Message: "`pip install --index-url " + url + "` fetches packages over plaintext " +
+			"HTTP — any MITM swaps the wheel for code execution on the host. Use " +
+			"`https://`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 724 Katas = 0.7.24
-const Version = "0.7.24"
+// 725 Katas = 0.7.25
+const Version = "0.7.25"


### PR DESCRIPTION
ZC1728 — `pip install --index-url http://...`

What: Detect `pip install --index-url`, `--extra-index-url`, or `-i` followed by an `http://` URL (joined `=` form too).
Why: Plaintext HTTP fetches let any MITM swap package metadata or wheel contents — direct code execution on the install host.
Fix suggestion: Use `https://`. On internal networks, terminate TLS at the mirror and only configure the `https://` URL.
Severity: Error