### PR TITLE
feat: ZC1729 — flag `ip route flush all` / `del default` (network lockout)

### DIFF
--- a/pkg/katas/katatests/zc1729_test.go
+++ b/pkg/katas/katatests/zc1729_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1729(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ip route flush dev eth1`",
+			input:    `ip route flush dev eth1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ip route add default via 192.168.1.1`",
+			input:    `ip route add default via 192.168.1.1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ip route replace default via 192.168.1.1`",
+			input:    `ip route replace default via 192.168.1.1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ip route flush all`",
+			input: `ip route flush all`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1729",
+					Message: "`ip route flush all` removes the default gateway — the SSH session that just ran it loses connectivity. Scope the flush (`flush dev <iface>`) or use `ip route replace default via <gw>` so the new route is in place first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ip route del default`",
+			input: `ip route del default`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1729",
+					Message: "`ip route del default` removes the default gateway — the SSH session that just ran it loses connectivity. Scope the flush (`flush dev <iface>`) or use `ip route replace default via <gw>` so the new route is in place first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ip -6 route flush all`",
+			input: `ip -6 route flush all`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1729",
+					Message: "`ip route flush all` removes the default gateway — the SSH session that just ran it loses connectivity. Scope the flush (`flush dev <iface>`) or use `ip route replace default via <gw>` so the new route is in place first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1729")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1729.go
+++ b/pkg/katas/zc1729.go
@@ -1,0 +1,74 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1729",
+		Title:    "Error on `ip route flush all` / `ip route del default` — script loses network connectivity",
+		Severity: SeverityError,
+		Description: "`ip route flush all` (or `flush table main`) wipes every routing entry, " +
+			"including the default gateway. `ip route del default` removes only the default " +
+			"route — same outcome. The remote SSH session that just ran the command can " +
+			"no longer talk to the host, and any subsequent step that needs the network " +
+			"hangs until manual console intervention. Scope the flush (`flush dev <iface>`, " +
+			"`flush scope link`) or use `ip route replace default via <gw>` so the new " +
+			"route is in place before the old one disappears.",
+		Check: checkZC1729,
+	})
+}
+
+func checkZC1729(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "ip" {
+		return nil
+	}
+
+	args := make([]string, 0, len(cmd.Arguments))
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		// Skip leading short flags like `-4`, `-6`, `-s`, `-d`.
+		if len(args) == 0 && strings.HasPrefix(v, "-") {
+			continue
+		}
+		args = append(args, v)
+	}
+
+	if len(args) < 3 || args[0] != "route" {
+		return nil
+	}
+
+	switch args[1] {
+	case "flush":
+		if args[2] == "all" || args[2] == "table" {
+			return zc1729Hit(cmd, "ip route flush "+args[2])
+		}
+	case "del", "delete":
+		if args[2] == "default" {
+			return zc1729Hit(cmd, "ip route "+args[1]+" default")
+		}
+	}
+	return nil
+}
+
+func zc1729Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1729",
+		Message: "`" + what + "` removes the default gateway — the SSH session that " +
+			"just ran it loses connectivity. Scope the flush (`flush dev <iface>`) or " +
+			"use `ip route replace default via <gw>` so the new route is in place " +
+			"first.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 725 Katas = 0.7.25
-const Version = "0.7.25"
+// 726 Katas = 0.7.26
+const Version = "0.7.26"


### PR DESCRIPTION
ZC1729 — `ip route flush all` / `ip route del default`

What: Detect `ip route flush all`, `ip route flush table ...`, and `ip route del default` (handles `ip -4`, `-6`, etc.).
Why: Wipes the default gateway — the SSH session that just ran the command loses connectivity, subsequent steps hang.
Fix suggestion: Scope the flush (`flush dev <iface>`) or use `ip route replace default via <gw>` so the new route is in place before the old one disappears.
Severity: Error