### PR TITLE
feat: ZC1730 — flag `brew install --HEAD` (unrepeatable upstream-HEAD build)

### DIFF
--- a/pkg/katas/katatests/zc1730_test.go
+++ b/pkg/katas/katatests/zc1730_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1730(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `brew install foo` (stable release)",
+			input:    `brew install foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `brew list --HEAD` (not install/upgrade)",
+			input:    `brew list --HEAD`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `brew install --HEAD foo`",
+			input: `brew install --HEAD foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1730",
+					Message: "`brew install --HEAD` builds from upstream HEAD — every run pulls a different commit. Pin to a stable formula release or vendor a private tap with a fixed revision.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `brew reinstall --HEAD foo`",
+			input: `brew reinstall --HEAD foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1730",
+					Message: "`brew reinstall --HEAD` builds from upstream HEAD — every run pulls a different commit. Pin to a stable formula release or vendor a private tap with a fixed revision.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1730")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1730.go
+++ b/pkg/katas/zc1730.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1730",
+		Title:    "Warn on `brew install --HEAD <pkg>` — pulls upstream HEAD, no version stability",
+		Severity: SeverityWarning,
+		Description: "`brew install --HEAD <pkg>` (also `reinstall --HEAD`, `upgrade --HEAD`) " +
+			"builds the formula from the upstream source repository's HEAD branch. The " +
+			"build is unrepeatable — every run pulls a different commit — and any " +
+			"compromised upstream commit lands directly on the install host. Pin to a " +
+			"stable release of the formula, or if HEAD is genuinely required, vendor the " +
+			"build into a private tap that fixes a specific revision.",
+		Check: checkZC1730,
+	})
+}
+
+func checkZC1730(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "brew" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+
+	switch cmd.Arguments[0].String() {
+	case "install", "reinstall", "upgrade":
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--HEAD" {
+			return []Violation{{
+				KataID: "ZC1730",
+				Message: "`brew " + cmd.Arguments[0].String() + " --HEAD` builds from " +
+					"upstream HEAD — every run pulls a different commit. Pin to a " +
+					"stable formula release or vendor a private tap with a fixed " +
+					"revision.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 726 Katas = 0.7.26
-const Version = "0.7.26"
+// 727 Katas = 0.7.27
+const Version = "0.7.27"


### PR DESCRIPTION
ZC1730 — `brew install --HEAD <pkg>`

What: Detect `brew install`, `reinstall`, or `upgrade` with `--HEAD`.
Why: Builds the formula from the upstream source repository's HEAD branch — every run pulls a different commit, no version stability, and any compromised upstream lands directly on the host.
Fix suggestion: Pin to a stable formula release; if HEAD is genuinely required, vendor a private tap with a fixed revision.
Severity: Warning