### PR TITLE
feat: ZC1731 — flag `curl -d 'password=…'` / `wget --post-data` (secret in argv)

### DIFF
--- a/pkg/katas/katatests/zc1731_test.go
+++ b/pkg/katas/katatests/zc1731_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1731(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `curl URL --data 'name=John'` (non-secret key)",
+			input:    `curl URL --data 'name=John'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `curl URL --data @secret.txt` (file reference)",
+			input:    `curl URL --data @secret.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `curl URL --data-binary @-` (stdin sentinel)",
+			input:    `curl URL --data-binary @-`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `curl URL -d 'password=hunter2'`",
+			input: `curl URL -d 'password=hunter2'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1731",
+					Message: "`curl -d 'password=hunter2'` puts secret-keyed POST body (`password=…`) in argv — visible in `ps`, `/proc`, history. Read the value from a file with `--data @PATH` or `--data-binary @-` piped from a secrets store.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `curl URL --data-urlencode 'token=ABC123'`",
+			input: `curl URL --data-urlencode 'token=ABC123'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1731",
+					Message: "`curl --data-urlencode 'token=ABC123'` puts secret-keyed POST body (`token=…`) in argv — visible in `ps`, `/proc`, history. Read the value from a file with `--data @PATH` or `--data-binary @-` piped from a secrets store.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `wget URL --post-data='api_key=ABC123'`",
+			input: `wget URL --post-data='api_key=ABC123'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1731",
+					Message: "`wget --post-data='api_key=ABC123'` puts secret-keyed POST body (`api_key=…`) in argv — visible in `ps`, `/proc`, history. Read the value from a file with `--data @PATH` or `--data-binary @-` piped from a secrets store.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1731")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1731.go
+++ b/pkg/katas/zc1731.go
@@ -1,0 +1,129 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1731SecretKeys = []string{
+	"password", "passwd", "pwd",
+	"secret", "token",
+	"apikey", "api_key", "api-key",
+	"accesskey", "access_key", "access-key",
+	"privatekey", "private_key", "private-key",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1731",
+		Title:    "Error on `curl -d 'password=…'` / `wget --post-data='token=…'` — secret in argv",
+		Severity: SeverityError,
+		Description: "`curl -d` / `--data` / `--data-raw` / `--data-urlencode` and `wget " +
+			"--post-data` / `--body-data` put the POST body in argv — visible in `ps`, " +
+			"`/proc/<pid>/cmdline`, shell history, and CI logs. When the body contains a " +
+			"credential-looking key (`password`, `secret`, `token`, `apikey`, `access_key`, " +
+			"`private_key`), the secret leaks the same way an inline `-u user:pass` would. " +
+			"Read the value from a file (`curl --data @secret.txt URL`, `--data-binary @-` " +
+			"piped from a secrets store) so the secret never reaches the command line.",
+		Check: checkZC1731,
+	})
+}
+
+func checkZC1731(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var dataFlags map[string]bool
+	switch ident.Value {
+	case "curl":
+		dataFlags = map[string]bool{
+			"-d":               true,
+			"--data":           true,
+			"--data-raw":       true,
+			"--data-urlencode": true,
+			"--data-binary":    true,
+		}
+	case "wget":
+		dataFlags = map[string]bool{
+			"--post-data": true,
+			"--body-data": true,
+		}
+	default:
+		return nil
+	}
+
+	prevFlag := ""
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevFlag != "" {
+			if hit := zc1731MatchSecret(v); hit != "" {
+				return zc1731Hit(cmd, ident.Value, prevFlag+" "+v, hit)
+			}
+			prevFlag = ""
+			continue
+		}
+		if dataFlags[v] {
+			prevFlag = v
+			continue
+		}
+		// Joined `--data=key=value` form (curl long flags).
+		if eq := strings.IndexByte(v, '='); eq > 0 {
+			flag := v[:eq]
+			if dataFlags[flag] {
+				if hit := zc1731MatchSecret(v[eq+1:]); hit != "" {
+					return zc1731Hit(cmd, ident.Value, v, hit)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func zc1731MatchSecret(value string) string {
+	body := strings.Trim(value, "'\"")
+	if body == "" {
+		return ""
+	}
+	// File reference (curl `@FILE`) or stdin sentinel — safe.
+	if body[0] == '@' || body == "-" {
+		return ""
+	}
+	for _, pair := range strings.Split(body, "&") {
+		eq := strings.IndexByte(pair, '=')
+		if eq <= 0 {
+			continue
+		}
+		key := strings.ToLower(pair[:eq])
+		val := pair[eq+1:]
+		if val == "" {
+			continue
+		}
+		for _, secret := range zc1731SecretKeys {
+			if strings.Contains(key, secret) {
+				return key
+			}
+		}
+	}
+	return ""
+}
+
+func zc1731Hit(cmd *ast.SimpleCommand, tool, flagPart, key string) []Violation {
+	return []Violation{{
+		KataID: "ZC1731",
+		Message: "`" + tool + " " + flagPart + "` puts secret-keyed POST body (`" + key +
+			"=…`) in argv — visible in `ps`, `/proc`, history. Read the value from a " +
+			"file with `--data @PATH` or `--data-binary @-` piped from a secrets " +
+			"store.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 727 Katas = 0.7.27
-const Version = "0.7.27"
+// 728 Katas = 0.7.28
+const Version = "0.7.28"


### PR DESCRIPTION
ZC1731 — POST body credentials in argv

What: Detect `curl -d / --data / --data-raw / --data-urlencode / --data-binary` and `wget --post-data / --body-data` whose value contains a credential-looking key (`password`, `secret`, `token`, `apikey`, `access_key`, `private_key`).
Why: POST body lands in argv — visible in `ps`, `/proc/<pid>/cmdline`, history, CI logs. Same leak surface as inline `-u user:pass`.
Fix suggestion: Read the value from a file (`curl --data @secret.txt URL`) or pipe via stdin (`--data-binary @-`).
Severity: Error