### PR TITLE
feat: ZC1732 — flag `flatpak override --filesystem=host` (sandbox break)

### DIFF
--- a/pkg/katas/katatests/zc1732_test.go
+++ b/pkg/katas/katatests/zc1732_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1732(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `flatpak install --user org.example.App`",
+			input:    `flatpak install --user org.example.App`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `flatpak override --filesystem=~/Documents org.example.App`",
+			input:    `flatpak override --filesystem=~/Documents org.example.App`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `flatpak override --filesystem=host org.example.App`",
+			input: `flatpak override --filesystem=host org.example.App`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1732",
+					Message: "`flatpak override --filesystem=host` removes the Flatpak sandbox — the app gets unrestricted host-filesystem access. Grant a specific subdirectory (e.g. `--filesystem=~/Documents:ro`) or use Filesystem portals.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `flatpak override --filesystem=home org.example.App`",
+			input: `flatpak override --filesystem=home org.example.App`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1732",
+					Message: "`flatpak override --filesystem=home` removes the Flatpak sandbox — the app gets unrestricted host-filesystem access. Grant a specific subdirectory (e.g. `--filesystem=~/Documents:ro`) or use Filesystem portals.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `flatpak run --filesystem=host org.example.App`",
+			input: `flatpak run --filesystem=host org.example.App`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1732",
+					Message: "`flatpak run --filesystem=host` removes the Flatpak sandbox — the app gets unrestricted host-filesystem access. Grant a specific subdirectory (e.g. `--filesystem=~/Documents:ro`) or use Filesystem portals.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1732")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1732.go
+++ b/pkg/katas/zc1732.go
@@ -1,0 +1,71 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1732BroadFilesystems = map[string]bool{
+	"--filesystem=host":     true,
+	"--filesystem=host:rw":  true,
+	"--filesystem=home":     true,
+	"--filesystem=home:rw":  true,
+	"--filesystem=/":        true,
+	"--filesystem=/:rw":     true,
+	"--filesystem=host-os":  true,
+	"--filesystem=host-etc": true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1732",
+		Title:    "Warn on `flatpak override --filesystem=host` — removes Flatpak sandbox isolation",
+		Severity: SeverityWarning,
+		Description: "Flatpak's primary security guarantee is filesystem sandboxing — apps see " +
+			"only their own data plus paths the user explicitly grants via portals. " +
+			"`flatpak override --filesystem=host` (also `host-os`, `host-etc`, `home`, `/`) " +
+			"persistently grants the app unrestricted read/write to the host filesystem at " +
+			"every subsequent run. Same risk applies to `flatpak run --filesystem=host`. " +
+			"Grant the specific subdirectory the app actually needs (`--filesystem=" +
+			"~/Documents:ro`) or rely on Filesystem portals so the user picks paths " +
+			"interactively per session.",
+		Check: checkZC1732,
+	})
+}
+
+func checkZC1732(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "flatpak" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+
+	switch cmd.Arguments[0].String() {
+	case "override", "run":
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if zc1732BroadFilesystems[v] {
+			return []Violation{{
+				KataID: "ZC1732",
+				Message: "`flatpak " + cmd.Arguments[0].String() + " " + v + "` removes " +
+					"the Flatpak sandbox — the app gets unrestricted host-filesystem " +
+					"access. Grant a specific subdirectory (e.g. " +
+					"`--filesystem=~/Documents:ro`) or use Filesystem portals.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 728 Katas = 0.7.28
-const Version = "0.7.28"
+// 729 Katas = 0.7.29
+const Version = "0.7.29"


### PR DESCRIPTION
ZC1732 — `flatpak override --filesystem=host`

What: Detect `flatpak override` or `flatpak run` with `--filesystem=host`, `host:rw`, `host-os`, `host-etc`, `home`, `home:rw`, `/`, `/:rw`.
Why: Persistently grants the app unrestricted host-filesystem access — defeats Flatpak's primary sandbox guarantee.
Fix suggestion: Grant the specific subdirectory the app actually needs (`--filesystem=~/Documents:ro`) or use Filesystem portals.
Severity: Warning