### PR TITLE
feat: ZC1733 — flag `docker plugin install --grant-all-permissions` (silent root grant)

### DIFF
--- a/pkg/katas/katatests/zc1733_test.go
+++ b/pkg/katas/katatests/zc1733_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1733(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `docker plugin install vieux/sshfs` (interactive prompt kept)",
+			input:    `docker plugin install vieux/sshfs`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `docker plugin ls --grant-all-permissions` (not install)",
+			input:    `docker plugin ls --grant-all-permissions`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `docker plugin install --grant-all-permissions vieux/sshfs`",
+			input: `docker plugin install --grant-all-permissions vieux/sshfs`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1733",
+					Message: "`docker plugin install --grant-all-permissions` accepts every capability the plugin requests — root-equivalent on the host. Walk the interactive prompt manually and pin the digest once vetted.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `docker plugin install vieux/sshfs --grant-all-permissions`",
+			input: `docker plugin install vieux/sshfs --grant-all-permissions`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1733",
+					Message: "`docker plugin install --grant-all-permissions` accepts every capability the plugin requests — root-equivalent on the host. Walk the interactive prompt manually and pin the digest once vetted.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1733")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1733.go
+++ b/pkg/katas/zc1733.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1733",
+		Title:    "Error on `docker plugin install --grant-all-permissions` — accepts every requested cap",
+		Severity: SeverityError,
+		Description: "Docker plugins run as root with whatever privileges they ask for at install " +
+			"time — host networking, `/dev/*` mounts, arbitrary capability grants. The " +
+			"interactive prompt enumerates each request so the operator can refuse anything " +
+			"unexpected. `--grant-all-permissions` skips the prompt and accepts the whole " +
+			"list, so a compromised plugin author or a typo-squatted name owns the host " +
+			"on first install. Install plugins by name, walk the prompt manually, then pin " +
+			"the tag (`@sha256:...`) once vetted.",
+		Check: checkZC1733,
+	})
+}
+
+func checkZC1733(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "docker" {
+		return nil
+	}
+	if len(cmd.Arguments) < 3 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "plugin" || cmd.Arguments[1].String() != "install" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[2:] {
+		if arg.String() == "--grant-all-permissions" {
+			return []Violation{{
+				KataID: "ZC1733",
+				Message: "`docker plugin install --grant-all-permissions` accepts every " +
+					"capability the plugin requests — root-equivalent on the host. Walk " +
+					"the interactive prompt manually and pin the digest once vetted.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 729 Katas = 0.7.29
-const Version = "0.7.29"
+// 730 Katas = 0.7.30
+const Version = "0.7.30"


### PR DESCRIPTION
ZC1733 — `docker plugin install --grant-all-permissions`

What: Detect `docker plugin install` with `--grant-all-permissions`.
Why: Docker plugins run as root with whatever caps they request. The flag accepts every requested capability without showing the prompt — root-equivalent install on the host.
Fix suggestion: Walk the interactive prompt manually, refuse anything unexpected, then pin `@sha256:...` once vetted.
Severity: Error