### PR TITLE
feat: ZC1734 — flag overwrites of `/etc/passwd|shadow|group|gshadow` (lock bypass)

### DIFF
--- a/pkg/katas/katatests/zc1734_test.go
+++ b/pkg/katas/katatests/zc1734_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1734(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `useradd alice`",
+			input:    `useradd alice`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `cat /etc/passwd` (read-only)",
+			input:    `cat /etc/passwd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `cp /tmp/passwd /etc/passwd`",
+			input: `cp /tmp/passwd /etc/passwd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1734",
+					Message: "`cp /etc/passwd` bypasses the lock that `vipw` / `vigr` / `useradd` use on the user-identity files. Edit through `vipw -e` / `vigr -e`, or mutate a single entry with `useradd` / `usermod` / `passwd`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `tee /etc/shadow`",
+			input: `tee /etc/shadow`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1734",
+					Message: "`tee /etc/shadow` bypasses the lock that `vipw` / `vigr` / `useradd` use on the user-identity files. Edit through `vipw -e` / `vigr -e`, or mutate a single entry with `useradd` / `usermod` / `passwd`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `echo entry >> /etc/group`",
+			input: `echo entry >> /etc/group`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1734",
+					Message: "`>> /etc/group` bypasses the lock that `vipw` / `vigr` / `useradd` use on the user-identity files. Edit through `vipw -e` / `vigr -e`, or mutate a single entry with `useradd` / `usermod` / `passwd`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1734")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1734.go
+++ b/pkg/katas/zc1734.go
@@ -1,0 +1,80 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1734IdentityFiles = map[string]bool{
+	"/etc/passwd":  true,
+	"/etc/shadow":  true,
+	"/etc/group":   true,
+	"/etc/gshadow": true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1734",
+		Title:    "Error on `cp/mv/tee` overwriting `/etc/passwd|shadow|group|gshadow`",
+		Severity: SeverityError,
+		Description: "The user-identity files are managed by `useradd` / `usermod` / `vipw` / " +
+			"`vigr`, which take a file lock and keep `passwd` / `shadow` (and `group` / " +
+			"`gshadow`) in sync. Replacing them with `cp`, `mv`, `tee`, or a redirect " +
+			"(`echo … > /etc/passwd`) bypasses the lock: concurrent edits race, malformed " +
+			"entries lock the whole system out, and the shadow file ends up pointing at " +
+			"users that no longer exist. Use `vipw -e` / `vigr -e` to edit, or `useradd` " +
+			"/ `usermod` / `passwd` to mutate one entry at a time.",
+		Check: checkZC1734,
+	})
+}
+
+func checkZC1734(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "cp", "mv", "tee", "install", "dd":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if zc1734IdentityFiles[v] {
+				return zc1734Hit(cmd, ident.Value+" "+v)
+			}
+		}
+	}
+
+	// Redirect form: any command whose args contain `>` or `>>` followed by an
+	// identity file path.
+	prevRedir := ""
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevRedir != "" {
+			if zc1734IdentityFiles[v] {
+				return zc1734Hit(cmd, prevRedir+" "+v)
+			}
+			prevRedir = ""
+			continue
+		}
+		if v == ">" || v == ">>" {
+			prevRedir = v
+		}
+	}
+	return nil
+}
+
+func zc1734Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1734",
+		Message: "`" + what + "` bypasses the lock that `vipw` / `vigr` / `useradd` use " +
+			"on the user-identity files. Edit through `vipw -e` / `vigr -e`, or mutate " +
+			"a single entry with `useradd` / `usermod` / `passwd`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 730 Katas = 0.7.30
-const Version = "0.7.30"
+// 731 Katas = 0.7.31
+const Version = "0.7.31"


### PR DESCRIPTION
ZC1734 — `cp/mv/tee` overwriting user-identity files

What: Detect `cp`, `mv`, `tee`, `install`, `dd` writing to `/etc/passwd|shadow|group|gshadow`, plus `>` / `>>` redirects to those paths from any command.
Why: Bypasses the lock that `vipw` / `vigr` / `useradd` use — concurrent edits race, malformed entries lock everyone out, shadow file falls out of sync.
Fix suggestion: Edit through `vipw -e` / `vigr -e`, or mutate one entry with `useradd` / `usermod` / `passwd`.
Severity: Error