### PR TITLE
feat: ZC1735 — flag `efibootmgr -B` (deletes UEFI boot entry, may brick boot)

### DIFF
--- a/pkg/katas/katatests/zc1735_test.go
+++ b/pkg/katas/katatests/zc1735_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1735(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `efibootmgr -v` (inspect)",
+			input:    `efibootmgr -v`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `efibootmgr -o 0001,0002` (reorder)",
+			input:    `efibootmgr -o 0001,0002`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `efibootmgr -B`",
+			input: `efibootmgr -B`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1735",
+					Message: "`efibootmgr -B` deletes a UEFI boot entry — wrong BOOTNUM (or missing fallback) leaves the box at the UEFI shell on next reboot. Inspect `efibootmgr -v` first; demote via `-o NEW,ORDER` instead of deleting.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `efibootmgr -B -b 0001`",
+			input: `efibootmgr -B -b 0001`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1735",
+					Message: "`efibootmgr -B` deletes a UEFI boot entry — wrong BOOTNUM (or missing fallback) leaves the box at the UEFI shell on next reboot. Inspect `efibootmgr -v` first; demote via `-o NEW,ORDER` instead of deleting.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1735")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1735.go
+++ b/pkg/katas/zc1735.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1735",
+		Title:    "Error on `efibootmgr -B` — deletes UEFI boot entry, may brick boot",
+		Severity: SeverityError,
+		Description: "`efibootmgr -B` deletes the currently-selected UEFI boot entry; combined " +
+			"with `-b BOOTNUM` it removes the specific entry instead. If that entry was " +
+			"the only viable bootloader (or the firmware's removable-media fallback is " +
+			"not present), the next reboot drops into the UEFI shell or picks an " +
+			"unexpected device — recovery needs console access. Run `efibootmgr -v` first " +
+			"to inspect `BootOrder`, ensure a fallback (`/EFI/BOOT/BOOTX64.EFI`) is in " +
+			"place, and prefer `efibootmgr -o NEW,ORDER` to demote rather than delete.",
+		Check: checkZC1735,
+	})
+}
+
+func checkZC1735(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "efibootmgr" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-B" {
+			return []Violation{{
+				KataID: "ZC1735",
+				Message: "`efibootmgr -B` deletes a UEFI boot entry — wrong BOOTNUM (or " +
+					"missing fallback) leaves the box at the UEFI shell on next reboot. " +
+					"Inspect `efibootmgr -v` first; demote via `-o NEW,ORDER` instead " +
+					"of deleting.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 731 Katas = 0.7.31
-const Version = "0.7.31"
+// 732 Katas = 0.7.32
+const Version = "0.7.32"


### PR DESCRIPTION
ZC1735 — `efibootmgr -B`

What: Detect `efibootmgr -B` (delete boot entry) — short form. Combined with `-b BOOTNUM` removes the specific entry.
Why: If the deleted entry is the only viable bootloader (and removable-media fallback is missing), next reboot drops at the UEFI shell — recovery needs console access.
Fix suggestion: Run `efibootmgr -v` to inspect `BootOrder`, ensure a fallback exists, prefer `efibootmgr -o NEW,ORDER` to demote rather than delete.
Severity: Error