### PR TITLE
feat: ZC1736 — flag `pulumi destroy --yes` / `up -y` (silent IaC mutation)

### DIFF
--- a/pkg/katas/katatests/zc1736_test.go
+++ b/pkg/katas/katatests/zc1736_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1736(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `pulumi preview`",
+			input:    `pulumi preview`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `pulumi up` (interactive prompt kept)",
+			input:    `pulumi up`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `pulumi stack ls --yes` (not up/destroy/refresh)",
+			input:    `pulumi stack ls --yes`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `pulumi destroy --yes`",
+			input: `pulumi destroy --yes`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1736",
+					Message: "`pulumi destroy --yes` skips the preview-and-confirm — a misresolved stack or credential wipes / mutates infrastructure with no review. Gate behind `pulumi preview` plus a manual approval step.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `pulumi up -y`",
+			input: `pulumi up -y`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1736",
+					Message: "`pulumi up -y` skips the preview-and-confirm — a misresolved stack or credential wipes / mutates infrastructure with no review. Gate behind `pulumi preview` plus a manual approval step.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `pulumi refresh --yes`",
+			input: `pulumi refresh --yes`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1736",
+					Message: "`pulumi refresh --yes` skips the preview-and-confirm — a misresolved stack or credential wipes / mutates infrastructure with no review. Gate behind `pulumi preview` plus a manual approval step.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1736")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1736.go
+++ b/pkg/katas/zc1736.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1736",
+		Title:    "Error on `pulumi destroy --yes` / `up --yes` — silent infra mutation in CI",
+		Severity: SeverityError,
+		Description: "`pulumi destroy --yes` (or `-y`) skips the preview-and-confirm step that " +
+			"normally surfaces every resource scheduled for deletion. A single misresolved " +
+			"stack name or wrong AWS credential resolves to a one-shot wipe of cloud " +
+			"infrastructure. `pulumi up --yes` and `pulumi refresh --yes` carry the same " +
+			"footgun for resource creation/replacement. Pipe `pulumi preview` output into " +
+			"a review step (manual approval, GitHub Actions environment protection rule) " +
+			"before applying, and never combine `--yes` with the `destroy` verb in " +
+			"automation.",
+		Check: checkZC1736,
+	})
+}
+
+func checkZC1736(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "pulumi" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+
+	sub := cmd.Arguments[0].String()
+	switch sub {
+	case "destroy", "up", "refresh":
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--yes" || v == "-y" {
+			return []Violation{{
+				KataID: "ZC1736",
+				Message: "`pulumi " + sub + " " + v + "` skips the preview-and-confirm — " +
+					"a misresolved stack or credential wipes / mutates infrastructure " +
+					"with no review. Gate behind `pulumi preview` plus a manual " +
+					"approval step.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 732 Katas = 0.7.32
-const Version = "0.7.32"
+// 733 Katas = 0.7.33
+const Version = "0.7.33"


### PR DESCRIPTION
ZC1736 — `pulumi destroy --yes` / `up --yes` / `refresh --yes`

What: Detect `pulumi {up,destroy,refresh}` paired with `--yes` or `-y`.
Why: Skips the preview-and-confirm step. A misresolved stack name or wrong credential resolves to a one-shot wipe / mutation of cloud infrastructure.
Fix suggestion: Gate behind `pulumi preview` plus a manual approval (CI environment protection rule, manual review).
Severity: Error