### PR TITLE
feat: ZC1737 — flag `wpa_passphrase SSID PASSWORD` (Wi-Fi pass in argv)

### DIFF
--- a/pkg/katas/katatests/zc1737_test.go
+++ b/pkg/katas/katatests/zc1737_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1737(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `wpa_passphrase MySSID` (passphrase via stdin)",
+			input:    `wpa_passphrase MySSID`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `wpa_passphrase MySSID < /run/secrets/wifi`",
+			input:    `wpa_passphrase MySSID < /run/secrets/wifi`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `wpa_passphrase MySSID hunter2`",
+			input: `wpa_passphrase MySSID hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1737",
+					Message: "`wpa_passphrase SSID PASSWORD` puts the Wi-Fi passphrase in argv — visible in `ps`, `/proc`, history. Drop the PASSWORD argument and pipe it via stdin (`wpa_passphrase SSID < /run/secrets/wifi`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1737")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1737.go
+++ b/pkg/katas/zc1737.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1737",
+		Title:    "Error on `wpa_passphrase SSID PASSWORD` — Wi-Fi passphrase in process list",
+		Severity: SeverityError,
+		Description: "`wpa_passphrase SSID PASSPHRASE` generates `wpa_supplicant.conf` content " +
+			"on stdout. Putting PASSPHRASE on the command line lands it in `ps`, `/proc/<" +
+			"pid>/cmdline`, shell history, and the audit log of every local user that can " +
+			"list processes. Drop the second positional argument and let `wpa_passphrase " +
+			"SSID < /run/secrets/wifi` (or piped via stdin from a secrets store) read the " +
+			"passphrase from a file descriptor instead.",
+		Check: checkZC1737,
+	})
+}
+
+func checkZC1737(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "wpa_passphrase" {
+		return nil
+	}
+
+	positionals := 0
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		// Skip redirection markers — they aren't true positional args.
+		if v == "<" || v == ">" || v == ">>" || v == "<<" {
+			break
+		}
+		if v == "" {
+			continue
+		}
+		positionals++
+	}
+
+	if positionals < 2 {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1737",
+		Message: "`wpa_passphrase SSID PASSWORD` puts the Wi-Fi passphrase in argv — " +
+			"visible in `ps`, `/proc`, history. Drop the PASSWORD argument and pipe it " +
+			"via stdin (`wpa_passphrase SSID < /run/secrets/wifi`).",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 733 Katas = 0.7.33
-const Version = "0.7.33"
+// 734 Katas = 0.7.34
+const Version = "0.7.34"


### PR DESCRIPTION
ZC1737 — `wpa_passphrase SSID PASSWORD`

What: Detect `wpa_passphrase SSID PASSPHRASE` (two positional args).
Why: Passphrase lands in argv — visible in `ps`, `/proc/<pid>/cmdline`, history, host audit logs.
Fix suggestion: Drop the PASSWORD argument and pipe via stdin (`wpa_passphrase SSID < /run/secrets/wifi`).
Severity: Error