### PR TITLE
feat: ZC1738 — flag `aws rds delete --skip-final-snapshot` (DB lost, no recovery)

### DIFF
--- a/pkg/katas/katatests/zc1738_test.go
+++ b/pkg/katas/katatests/zc1738_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1738(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `aws rds delete-db-instance` with explicit final snapshot",
+			input:    `aws rds delete-db-instance --db-instance-identifier mydb --final-db-snapshot-identifier mydb-final`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `aws rds describe-db-instances`",
+			input:    `aws rds describe-db-instances`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `aws rds delete-db-instance ... --skip-final-snapshot`",
+			input: `aws rds delete-db-instance --db-instance-identifier mydb --skip-final-snapshot`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1738",
+					Message: "`aws rds delete-db-instance --skip-final-snapshot` deletes the database with no recovery snapshot. Drop the flag or pass `--final-db-snapshot-identifier <name>` so the snapshot is explicit and verifiable.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `aws rds delete-db-cluster ... --skip-final-snapshot`",
+			input: `aws rds delete-db-cluster --db-cluster-identifier mycluster --skip-final-snapshot`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1738",
+					Message: "`aws rds delete-db-cluster --skip-final-snapshot` deletes the database with no recovery snapshot. Drop the flag or pass `--final-db-snapshot-identifier <name>` so the snapshot is explicit and verifiable.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1738")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1738.go
+++ b/pkg/katas/zc1738.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1738",
+		Title:    "Error on `aws rds delete-db-instance --skip-final-snapshot` — DB destroyed unrecoverable",
+		Severity: SeverityError,
+		Description: "RDS keeps a final snapshot when an instance or cluster is deleted — the only " +
+			"path back from a typo'd identifier or wrong account. `--skip-final-snapshot` " +
+			"opts out of that snapshot, so the database is gone the moment the API call " +
+			"returns; same applies to `aws rds delete-db-cluster --skip-final-snapshot`. " +
+			"Drop the flag (or pass `--final-db-snapshot-identifier <name>` so the snapshot " +
+			"name is explicit) and verify the snapshot lands before reusing the identifier.",
+		Check: checkZC1738,
+	})
+}
+
+func checkZC1738(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "aws" {
+		return nil
+	}
+	if len(cmd.Arguments) < 3 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "rds" {
+		return nil
+	}
+	sub := cmd.Arguments[1].String()
+	if sub != "delete-db-instance" && sub != "delete-db-cluster" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[2:] {
+		if arg.String() == "--skip-final-snapshot" {
+			return []Violation{{
+				KataID: "ZC1738",
+				Message: "`aws rds " + sub + " --skip-final-snapshot` deletes the database " +
+					"with no recovery snapshot. Drop the flag or pass `--final-db-" +
+					"snapshot-identifier <name>` so the snapshot is explicit and " +
+					"verifiable.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 734 Katas = 0.7.34
-const Version = "0.7.34"
+// 735 Katas = 0.7.35
+const Version = "0.7.35"


### PR DESCRIPTION
ZC1738 — `aws rds delete-db-instance --skip-final-snapshot`

What: Detect `aws rds delete-db-instance` or `aws rds delete-db-cluster` paired with `--skip-final-snapshot`.
Why: RDS keeps a final snapshot on delete — the only path back from a typo'd identifier or wrong account. The flag opts out of that snapshot; the database is gone the moment the API returns.
Fix suggestion: Drop `--skip-final-snapshot`, or pass `--final-db-snapshot-identifier <name>` so the snapshot is explicit and verifiable.
Severity: Error