### PR TITLE
feat: ZC1739 — flag `git submodule update --remote` (unpins from parent index)

### DIFF
--- a/pkg/katas/katatests/zc1739_test.go
+++ b/pkg/katas/katatests/zc1739_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1739(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `git submodule update --init --recursive` (pinned commits)",
+			input:    `git submodule update --init --recursive`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `git submodule add URL path`",
+			input:    `git submodule add https://example.com/repo path`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `git submodule update --remote`",
+			input: `git submodule update --remote`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1739",
+					Message: "`git submodule update --remote` ignores the pinned commits in the parent repo and pulls each submodule's branch HEAD — non-reproducible builds, supply-chain risk. Use `--init --recursive` and bump pins via reviewed PRs.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `git submodule update --remote --recursive`",
+			input: `git submodule update --remote --recursive`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1739",
+					Message: "`git submodule update --remote` ignores the pinned commits in the parent repo and pulls each submodule's branch HEAD — non-reproducible builds, supply-chain risk. Use `--init --recursive` and bump pins via reviewed PRs.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1739")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1739.go
+++ b/pkg/katas/zc1739.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1739",
+		Title:    "Warn on `git submodule update --remote` — pulls upstream HEAD, breaks reproducibility",
+		Severity: SeverityWarning,
+		Description: "`git submodule update --remote` fetches each submodule's tracked branch HEAD " +
+			"instead of the commit pinned in the parent repo's index. Builds become " +
+			"non-reproducible — every CI run pulls a different commit — and any compromised " +
+			"upstream commit lands directly in the build. Use `git submodule update --init " +
+			"--recursive` (defaults to the pinned commit) and bump submodule pins through " +
+			"reviewed PRs.",
+		Check: checkZC1739,
+	})
+}
+
+func checkZC1739(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "git" {
+		return nil
+	}
+	if len(cmd.Arguments) < 3 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "submodule" || cmd.Arguments[1].String() != "update" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[2:] {
+		if arg.String() == "--remote" {
+			return []Violation{{
+				KataID: "ZC1739",
+				Message: "`git submodule update --remote` ignores the pinned commits in the " +
+					"parent repo and pulls each submodule's branch HEAD — non-" +
+					"reproducible builds, supply-chain risk. Use `--init --recursive` " +
+					"and bump pins via reviewed PRs.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 735 Katas = 0.7.35
-const Version = "0.7.35"
+// 736 Katas = 0.7.36
+const Version = "0.7.36"


### PR DESCRIPTION
ZC1739 — `git submodule update --remote`

What: Detect `git submodule update --remote`.
Why: Fetches each submodule's tracked branch HEAD instead of the commit pinned in the parent repo's index — non-reproducible builds, supply-chain risk.
Fix suggestion: Use `git submodule update --init --recursive` (defaults to pinned commit) and bump pins via reviewed PRs.
Severity: Warning