### PR TITLE
feat: ZC1740 — flag `gh release upload --clobber` (silent asset overwrite)

### DIFF
--- a/pkg/katas/katatests/zc1740_test.go
+++ b/pkg/katas/katatests/zc1740_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1740(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gh release upload v1.0 file.tar.gz`",
+			input:    `gh release upload v1.0 file.tar.gz`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gh release create v1.0 file.tar.gz`",
+			input:    `gh release create v1.0 file.tar.gz`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gh release upload v1.0 file.tar.gz --clobber`",
+			input: `gh release upload v1.0 file.tar.gz --clobber`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1740",
+					Message: "`gh release upload --clobber` silently replaces an existing asset — a re-run can downgrade the user-facing download. Drop `--clobber` or version the asset name so each upload has a unique slot.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1740")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1740.go
+++ b/pkg/katas/zc1740.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1740",
+		Title:    "Warn on `gh release upload --clobber` — silent overwrite of release asset",
+		Severity: SeverityWarning,
+		Description: "`gh release upload TAG FILE --clobber` replaces an existing asset with the " +
+			"same name without prompting. In production this is how a release artifact " +
+			"gets silently downgraded — a CI job re-runs with a stale build and the user-" +
+			"facing download moves backward without anyone noticing. Drop `--clobber` so " +
+			"the second upload errors out, or version the asset name (`mytool-1.2.3-linux." +
+			"tar.gz` instead of `mytool-linux.tar.gz`) so each upload has a unique slot.",
+		Check: checkZC1740,
+	})
+}
+
+func checkZC1740(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "gh" {
+		return nil
+	}
+	if len(cmd.Arguments) < 3 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "release" || cmd.Arguments[1].String() != "upload" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[2:] {
+		if arg.String() == "--clobber" {
+			return []Violation{{
+				KataID: "ZC1740",
+				Message: "`gh release upload --clobber` silently replaces an existing " +
+					"asset — a re-run can downgrade the user-facing download. Drop " +
+					"`--clobber` or version the asset name so each upload has a " +
+					"unique slot.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 736 Katas = 0.7.36
-const Version = "0.7.36"
+// 737 Katas = 0.7.37
+const Version = "0.7.37"


### PR DESCRIPTION
ZC1740 — `gh release upload --clobber`

What: Detect `gh release upload TAG FILE --clobber`.
Why: Silently replaces an existing asset with the same name — a re-running CI job can downgrade the user-facing download with no audit trail.
Fix suggestion: Drop `--clobber` so the second upload errors out, or version the asset name (`mytool-1.2.3-linux.tar.gz`) so each upload has a unique slot.
Severity: Warning