### PR TITLE
feat: ZC1741 — flag `mkpasswd PASSWORD` (cleartext password in argv)

### DIFF
--- a/pkg/katas/katatests/zc1741_test.go
+++ b/pkg/katas/katatests/zc1741_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1741(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `mkpasswd -s` (read from stdin)",
+			input:    `mkpasswd -s`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `mkpasswd -m sha-512 -s`",
+			input:    `mkpasswd -m sha-512 -s`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `mkpasswd --stdin`",
+			input:    `mkpasswd --stdin`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `mkpasswd hunter2`",
+			input: `mkpasswd hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1741",
+					Message: "`mkpasswd PASSWORD` puts the cleartext password in argv — visible in `ps`, `/proc`, history. Use `mkpasswd -s` and pipe the secret via stdin (`printf %s \"$PASSWORD\" | mkpasswd -s`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `mkpasswd -m sha-512 hunter2`",
+			input: `mkpasswd -m sha-512 hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1741",
+					Message: "`mkpasswd PASSWORD` puts the cleartext password in argv — visible in `ps`, `/proc`, history. Use `mkpasswd -s` and pipe the secret via stdin (`printf %s \"$PASSWORD\" | mkpasswd -s`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1741")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1741.go
+++ b/pkg/katas/zc1741.go
@@ -1,0 +1,73 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+// mkpasswd flags that take a value as the next argument.
+var zc1741ValueFlags = map[string]bool{
+	"-m": true, "-S": true, "-R": true, "-P": true,
+	"--method": true, "--salt": true, "--rounds": true, "--password-fd": true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1741",
+		Title:    "Error on `mkpasswd PASSWORD` — clear-text password in process list",
+		Severity: SeverityError,
+		Description: "`mkpasswd PASSWORD` (whatwg/Debian `whois`-package version) and `mkpasswd " +
+			"-m METHOD PASSWORD` hash the password and print the crypt(3) string on stdout. " +
+			"Putting PASSWORD on the command line lands it in `ps`, `/proc/<pid>/cmdline`, " +
+			"shell history, and the host audit log. Drop the positional password and read " +
+			"from stdin (`mkpasswd -s` reads the password from stdin) — pipe the secret " +
+			"from a credentials file or vault: `printf %s \"$PASSWORD\" | mkpasswd -s`.",
+		Check: checkZC1741,
+	})
+}
+
+func checkZC1741(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "mkpasswd" {
+		return nil
+	}
+
+	skipNext := false
+	hasPositional := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if v == "-s" || v == "--stdin" {
+			return nil
+		}
+		if zc1741ValueFlags[v] {
+			skipNext = true
+			continue
+		}
+		if v == "" || v[0] == '-' {
+			continue
+		}
+		hasPositional = true
+	}
+
+	if !hasPositional {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1741",
+		Message: "`mkpasswd PASSWORD` puts the cleartext password in argv — visible in " +
+			"`ps`, `/proc`, history. Use `mkpasswd -s` and pipe the secret via stdin " +
+			"(`printf %s \"$PASSWORD\" | mkpasswd -s`).",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 737 Katas = 0.7.37
-const Version = "0.7.37"
+// 738 Katas = 0.7.38
+const Version = "0.7.38"


### PR DESCRIPTION
ZC1741 — `mkpasswd PASSWORD`

What: Detect `mkpasswd` (Debian whois-package) with a positional password argument, including `mkpasswd -m METHOD PASSWORD`.
Why: Cleartext password lands in argv — visible in `ps`, `/proc/<pid>/cmdline`, history, host audit logs.
Fix suggestion: Use `mkpasswd -s` and pipe the password via stdin (`printf %s "$PASSWORD" | mkpasswd -s`).
Severity: Error