### PR TITLE
feat: ZC1743 — flag `npm audit fix --force` (silent major bumps)

### DIFF
--- a/pkg/katas/katatests/zc1743_test.go
+++ b/pkg/katas/katatests/zc1743_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1743(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `npm audit fix` (no --force)",
+			input:    `npm audit fix`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `npm audit` (no fix)",
+			input:    `npm audit`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `npm run build --force` (not audit fix)",
+			input:    `npm run build --force`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `npm audit fix --force`",
+			input: `npm audit fix --force`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1743",
+					Message: "`npm audit ... --force` accepts every major-version bump an advisory triggers — silent breaking changes. Drop `--force` and triage advisories one by one.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `pnpm audit --fix --force`",
+			input: `pnpm audit --fix --force`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1743",
+					Message: "`pnpm audit ... --force` accepts every major-version bump an advisory triggers — silent breaking changes. Drop `--force` and triage advisories one by one.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1743")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1743.go
+++ b/pkg/katas/zc1743.go
@@ -1,0 +1,74 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1743",
+		Title:    "Warn on `npm audit fix --force` — accepts major-version dependency bumps silently",
+		Severity: SeverityWarning,
+		Description: "`npm audit fix --force` (and `pnpm audit --fix --force`) resolves advisories " +
+			"by upgrading dependencies past semver-major boundaries when no backward-" +
+			"compatible patch exists. The flag accepts every upgrade without surfacing the " +
+			"breaking changes — a build can silently move to a new major of a transitive " +
+			"dependency that removes APIs your code calls. Drop `--force` and triage each " +
+			"advisory individually; `npm audit fix` handles compatible patches, and the " +
+			"remaining advisory targets need a pin or a vendored fork.",
+		Check: checkZC1743,
+	})
+}
+
+func checkZC1743(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var matches bool
+	switch ident.Value {
+	case "npm":
+		if len(cmd.Arguments) >= 2 && cmd.Arguments[0].String() == "audit" && cmd.Arguments[1].String() == "fix" {
+			matches = true
+		}
+	case "pnpm":
+		if len(cmd.Arguments) >= 2 && cmd.Arguments[0].String() == "audit" {
+			hasFix := false
+			for _, a := range cmd.Arguments[1:] {
+				if a.String() == "--fix" {
+					hasFix = true
+					break
+				}
+			}
+			if hasFix {
+				matches = true
+			}
+		}
+	default:
+		return nil
+	}
+	if !matches {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "--force" || arg.String() == "-f" {
+			return []Violation{{
+				KataID: "ZC1743",
+				Message: "`" + ident.Value + " audit ... --force` accepts every major-" +
+					"version bump an advisory triggers — silent breaking changes. Drop " +
+					"`--force` and triage advisories one by one.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 738 Katas = 0.7.38
-const Version = "0.7.38"
+// 740 Katas = 0.7.40
+const Version = "0.7.40"


### PR DESCRIPTION
ZC1743 — `npm audit fix --force` / `pnpm audit --fix --force`

What: Detect `npm audit fix --force` and `pnpm audit --fix --force`.
Why: The flag accepts every semver-major bump an advisory triggers, so a build can silently move to a new major that removes APIs your code calls.
Fix suggestion: Drop `--force` and triage advisories one by one; pin or vendor targets that can't take a compatible patch.
Severity: Warning