### PR TITLE
feat: ZC1744 — flag `kubectl port-forward --address 0.0.0.0` (pod exposed LAN-wide)

### DIFF
--- a/pkg/katas/katatests/zc1744_test.go
+++ b/pkg/katas/katatests/zc1744_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1744(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `kubectl port-forward pod/mypod 8080:8080` (loopback default)",
+			input:    `kubectl port-forward pod/mypod 8080:8080`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `kubectl port-forward --address 127.0.0.1 pod/mypod 8080:8080`",
+			input:    `kubectl port-forward --address 127.0.0.1 pod/mypod 8080:8080`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `kubectl port-forward pod/mypod 8080:8080 --address 0.0.0.0`",
+			input: `kubectl port-forward pod/mypod 8080:8080 --address 0.0.0.0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1744",
+					Message: "`kubectl port-forward --address 0.0.0.0` binds the local end of the tunnel on every interface — anyone on the LAN / VPN can reach the pod. Drop `--address` (loopback default) or pick a trusted-network interface IP.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `kubectl port-forward pod/mypod 8080:8080 --address=0.0.0.0`",
+			input: `kubectl port-forward pod/mypod 8080:8080 --address=0.0.0.0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1744",
+					Message: "`kubectl port-forward --address=0.0.0.0` binds the local end of the tunnel on every interface — anyone on the LAN / VPN can reach the pod. Drop `--address` (loopback default) or pick a trusted-network interface IP.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1744")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1744.go
+++ b/pkg/katas/zc1744.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1744",
+		Title:    "Warn on `kubectl port-forward --address 0.0.0.0` — cluster port exposed to every interface",
+		Severity: SeverityWarning,
+		Description: "`kubectl port-forward` defaults to binding the local end of the tunnel on " +
+			"`127.0.0.1`. `--address 0.0.0.0` (or a specific non-loopback IP) exposes the " +
+			"target pod's port to every interface on the developer's workstation or the " +
+			"bastion host running the command. Anyone on the LAN / VPN can reach internal " +
+			"cluster services that never meant to be externally reachable. Drop the flag " +
+			"(loopback default), or pick a specific interface that is already scoped to a " +
+			"trusted network.",
+		Check: checkZC1744,
+	})
+}
+
+func checkZC1744(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kubectl" && ident.Value != "oc" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "port-forward" {
+		return nil
+	}
+
+	prevAddress := false
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if prevAddress {
+			if v == "0.0.0.0" || v == "::" {
+				return zc1744Hit(cmd, "--address "+v)
+			}
+			prevAddress = false
+			continue
+		}
+		switch {
+		case v == "--address":
+			prevAddress = true
+		case strings.HasPrefix(v, "--address="):
+			val := strings.TrimPrefix(v, "--address=")
+			if val == "0.0.0.0" || val == "::" {
+				return zc1744Hit(cmd, v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1744Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1744",
+		Message: "`kubectl port-forward " + what + "` binds the local end of the tunnel " +
+			"on every interface — anyone on the LAN / VPN can reach the pod. Drop " +
+			"`--address` (loopback default) or pick a trusted-network interface IP.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 740 Katas = 0.7.40
-const Version = "0.7.40"
+// 741 Katas = 0.7.41
+const Version = "0.7.41"


### PR DESCRIPTION
ZC1744 — `kubectl port-forward --address 0.0.0.0`

What: Detect `kubectl` (or `oc`) `port-forward` with `--address 0.0.0.0` / `::` / joined `=` form.
Why: Default loopback binding is replaced by every-interface binding — anyone on the LAN or VPN of the workstation / bastion can reach the pod's port.
Fix suggestion: Drop `--address` (loopback default) or pick a trusted-network interface IP.
Severity: Warning