### PR TITLE
feat: ZC1745 — flag `poetry publish / twine upload --password` (PyPI creds in argv)

### DIFF
--- a/pkg/katas/katatests/zc1745_test.go
+++ b/pkg/katas/katatests/zc1745_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1745(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `poetry publish --repository myrepo` (no password)",
+			input:    `poetry publish --repository myrepo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `twine upload dist/*` (token via env)",
+			input:    `twine upload dist/*`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `poetry publish --username u --password hunter2`",
+			input: `poetry publish --username u --password hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1745",
+					Message: "`poetry publish --password hunter2` puts the registry password in argv — visible in `ps`, `/proc`, history. Use env vars (`POETRY_PYPI_TOKEN_<NAME>`, `TWINE_PASSWORD`) or a `0600` `~/.pypirc` file.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `twine upload -u u -p hunter2 dist/*`",
+			input: `twine upload -u u -p hunter2 dist/*`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1745",
+					Message: "`twine upload --password hunter2` puts the registry password in argv — visible in `ps`, `/proc`, history. Use env vars (`POETRY_PYPI_TOKEN_<NAME>`, `TWINE_PASSWORD`) or a `0600` `~/.pypirc` file.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `poetry publish --password=hunter2`",
+			input: `poetry publish --password=hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1745",
+					Message: "`poetry publish --password=hunter2` puts the registry password in argv — visible in `ps`, `/proc`, history. Use env vars (`POETRY_PYPI_TOKEN_<NAME>`, `TWINE_PASSWORD`) or a `0600` `~/.pypirc` file.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1745")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1745.go
+++ b/pkg/katas/zc1745.go
@@ -1,0 +1,78 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1745",
+		Title:    "Error on `poetry publish --password PASS` / `twine upload -p PASS` — registry secret in argv",
+		Severity: SeverityError,
+		Description: "Poetry's `publish --username USER --password PASS` and Twine's `upload " +
+			"--username USER --password PASS` (or the short `-u`/`-p` forms) put the PyPI / " +
+			"private-index password in argv — visible in `ps`, `/proc/<pid>/cmdline`, shell " +
+			"history, and CI logs. Use the `POETRY_PYPI_TOKEN_<NAME>` / `TWINE_USERNAME` + " +
+			"`TWINE_PASSWORD` environment variables (sourced from a secrets manager) or a " +
+			"`~/.pypirc` file with `0600` perms so the credential never reaches the command " +
+			"line.",
+		Check: checkZC1745,
+	})
+}
+
+func checkZC1745(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var tool string
+	switch ident.Value {
+	case "poetry":
+		if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "publish" {
+			return nil
+		}
+		tool = "poetry publish"
+	case "twine":
+		if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "upload" {
+			return nil
+		}
+		tool = "twine upload"
+	default:
+		return nil
+	}
+
+	prevPwd := false
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if prevPwd {
+			return zc1745Hit(cmd, tool, "--password "+v)
+		}
+		switch {
+		case v == "--password" || v == "-p":
+			prevPwd = true
+		case strings.HasPrefix(v, "--password="):
+			return zc1745Hit(cmd, tool, v)
+		}
+	}
+	return nil
+}
+
+func zc1745Hit(cmd *ast.SimpleCommand, tool, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1745",
+		Message: "`" + tool + " " + what + "` puts the registry password in argv — " +
+			"visible in `ps`, `/proc`, history. Use env vars (`POETRY_PYPI_TOKEN_<" +
+			"NAME>`, `TWINE_PASSWORD`) or a `0600` `~/.pypirc` file.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 741 Katas = 0.7.41
-const Version = "0.7.41"
+// 742 Katas = 0.7.42
+const Version = "0.7.42"


### PR DESCRIPTION
ZC1745 — `poetry publish` / `twine upload` password in argv

What: Detect `poetry publish` or `twine upload` paired with `--password`, `--password=`, or `-p`.
Why: PyPI / private-index password lands in argv — visible in `ps`, `/proc/<pid>/cmdline`, history, CI logs.
Fix suggestion: Use env vars (`POETRY_PYPI_TOKEN_<NAME>`, `TWINE_PASSWORD`) or a `0600` `~/.pypirc`.
Severity: Error