### PR TITLE
feat: ZC1746 — flag `sysctl kernel.randomize_va_space=0|1` (ASLR weakened)

### DIFF
--- a/pkg/katas/katatests/zc1746_test.go
+++ b/pkg/katas/katatests/zc1746_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1746(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `sysctl -w kernel.randomize_va_space=2` (default ASLR)",
+			input:    `sysctl -w kernel.randomize_va_space=2`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `sysctl kernel.randomize_va_space`",
+			input:    `sysctl kernel.randomize_va_space`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `sysctl -w kernel.randomize_va_space=0`",
+			input: `sysctl -w kernel.randomize_va_space=0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1746",
+					Message: "`sysctl kernel.randomize_va_space=0` weakens ASLR — absolute-address exploits become deterministic (stack overflows, ROP). Keep `kernel.randomize_va_space=2` outside a sandboxed debug context.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `sysctl kernel.randomize_va_space=1`",
+			input: `sysctl kernel.randomize_va_space=1`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1746",
+					Message: "`sysctl kernel.randomize_va_space=1` weakens ASLR — absolute-address exploits become deterministic (stack overflows, ROP). Keep `kernel.randomize_va_space=2` outside a sandboxed debug context.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1746")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1746.go
+++ b/pkg/katas/zc1746.go
@@ -1,0 +1,48 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1746",
+		Title:    "Error on `sysctl -w kernel.randomize_va_space=0|1` — weakens or disables ASLR",
+		Severity: SeverityError,
+		Description: "`kernel.randomize_va_space` controls Address Space Layout Randomization. " +
+			"Value `2` (default) randomizes stack, heap, VDSO, and mmap regions; value `1` " +
+			"omits the heap; value `0` disables ASLR entirely, making every memory layout " +
+			"deterministic. Exploits that rely on absolute addresses — stack overflows, ROP " +
+			"chains, kernel gadgets — become one-shot instead of brute-forceable. Never " +
+			"lower this below `2` outside a sandboxed kernel-debug context.",
+		Check: checkZC1746,
+	})
+}
+
+func checkZC1746(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sysctl" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "kernel.randomize_va_space=0" || v == "kernel.randomize_va_space=1" {
+			return []Violation{{
+				KataID: "ZC1746",
+				Message: "`sysctl " + v + "` weakens ASLR — absolute-address exploits " +
+					"become deterministic (stack overflows, ROP). Keep " +
+					"`kernel.randomize_va_space=2` outside a sandboxed debug context.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 742 Katas = 0.7.42
-const Version = "0.7.42"
+// 743 Katas = 0.7.43
+const Version = "0.7.43"


### PR DESCRIPTION
ZC1746 — `sysctl kernel.randomize_va_space=0|1`

What: Detect `sysctl` setting `kernel.randomize_va_space` to `0` or `1` (with or without `-w`).
Why: `0` disables ASLR entirely; `1` omits the heap. Exploits relying on absolute addresses (stack overflows, ROP chains) become deterministic instead of brute-forceable.
Fix suggestion: Keep `kernel.randomize_va_space=2` (default) outside a sandboxed kernel-debug context.
Severity: Error