### PR TITLE
feat: ZC1748 — flag `helm repo add NAME http://...` (plaintext chart repo)

### DIFF
--- a/pkg/katas/katatests/zc1748_test.go
+++ b/pkg/katas/katatests/zc1748_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1748(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `helm repo add bitnami https://charts.bitnami.com/bitnami`",
+			input:    `helm repo add bitnami https://charts.bitnami.com/bitnami`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `helm repo update`",
+			input:    `helm repo update`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `helm repo add myrepo http://internal/charts`",
+			input: `helm repo add myrepo http://internal/charts`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1748",
+					Message: "`helm repo add myrepo http://internal/charts` fetches charts over plaintext HTTP — any MITM swaps the chart and its referenced images. Use `https://` and `helm install --verify` for provenance.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1748")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1748.go
+++ b/pkg/katas/zc1748.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1748",
+		Title:    "Error on `helm repo add NAME http://...` — plaintext chart repo allows MITM",
+		Severity: SeverityError,
+		Description: "`helm repo add NAME http://URL` registers a chart repository reached over " +
+			"plaintext HTTP. Any network-position attacker can swap `index.yaml` or a " +
+			"chart tarball in flight, and subsequent `helm install` pulls container images " +
+			"and Kubernetes manifests straight from the substituted content — fast path to " +
+			"cluster-wide code execution. Use `https://`, and pair it with chart provenance " +
+			"(`helm install --verify` or OCI signatures) to pin the digest.",
+		Check: checkZC1748,
+	})
+}
+
+func checkZC1748(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "helm" {
+		return nil
+	}
+	if len(cmd.Arguments) < 4 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "repo" || cmd.Arguments[1].String() != "add" {
+		return nil
+	}
+
+	url := cmd.Arguments[3].String()
+	if !strings.HasPrefix(url, "http://") {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1748",
+		Message: "`helm repo add " + cmd.Arguments[2].String() + " " + url + "` fetches " +
+			"charts over plaintext HTTP — any MITM swaps the chart and its referenced " +
+			"images. Use `https://` and `helm install --verify` for provenance.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 744 Katas = 0.7.44
-const Version = "0.7.44"
+// 745 Katas = 0.7.45
+const Version = "0.7.45"


### PR DESCRIPTION
ZC1748 — `helm repo add NAME http://URL`

What: Detect `helm repo add NAME URL` where URL begins with `http://`.
Why: Plaintext chart-index fetches let any MITM swap `index.yaml` or chart tarballs. Subsequent `helm install` pulls container images and Kubernetes manifests from the substituted content.
Fix suggestion: Use `https://`, pair with `helm install --verify` or OCI chart signatures to pin provenance.
Severity: Error