### PR TITLE
feat: ZC1749 — flag `virsh undefine --remove-all-storage` (wipes VM disks)

### DIFF
--- a/pkg/katas/katatests/zc1749_test.go
+++ b/pkg/katas/katatests/zc1749_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1749(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `virsh undefine mydomain` (config only)",
+			input:    `virsh undefine mydomain`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `virsh list --all`",
+			input:    `virsh list --all`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `virsh undefine mydomain --remove-all-storage`",
+			input: `virsh undefine mydomain --remove-all-storage`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1749",
+					Message: "`virsh undefine ... --remove-all-storage` deletes every disk image the domain references — no soft-delete, no recycle bin. Back up first (`qemu-img convert`), `undefine` without the flag, then `virsh vol-delete` deliberately.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `virsh undefine mydomain --wipe-storage`",
+			input: `virsh undefine mydomain --wipe-storage`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1749",
+					Message: "`virsh undefine ... --wipe-storage` deletes every disk image the domain references — no soft-delete, no recycle bin. Back up first (`qemu-img convert`), `undefine` without the flag, then `virsh vol-delete` deliberately.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1749")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1749.go
+++ b/pkg/katas/zc1749.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1749",
+		Title:    "Error on `virsh undefine DOMAIN --remove-all-storage` — wipes VM disk images",
+		Severity: SeverityError,
+		Description: "`virsh undefine DOMAIN --remove-all-storage` (also `--wipe-storage` and the " +
+			"newer `--storage <vol,vol>`) removes the VM's configuration AND deletes every " +
+			"disk image the domain references. There is no soft-delete and no recycle bin — " +
+			"a misresolved DOMAIN or a shared storage pool turns one typo into data loss " +
+			"across VMs that happened to share a snapshot chain. Split the operation: back " +
+			"up the qcow2 images (`virsh vol-clone` or `qemu-img convert`), then `virsh " +
+			"undefine` without the storage flags, then delete volumes deliberately with " +
+			"`virsh vol-delete` after a review.",
+		Check: checkZC1749,
+	})
+}
+
+func checkZC1749(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "virsh" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "undefine" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--remove-all-storage" || v == "--wipe-storage" {
+			return []Violation{{
+				KataID: "ZC1749",
+				Message: "`virsh undefine ... " + v + "` deletes every disk image the " +
+					"domain references — no soft-delete, no recycle bin. Back up " +
+					"first (`qemu-img convert`), `undefine` without the flag, then " +
+					"`virsh vol-delete` deliberately.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 745 Katas = 0.7.45
-const Version = "0.7.45"
+// 746 Katas = 0.7.46
+const Version = "0.7.46"


### PR DESCRIPTION
ZC1749 — `virsh undefine DOMAIN --remove-all-storage`

What: Detect `virsh undefine` paired with `--remove-all-storage` or `--wipe-storage`.
Why: Removes the VM config AND deletes every referenced disk image — no soft-delete, no recycle bin. A misresolved DOMAIN or shared storage pool turns one typo into data loss across VMs sharing a snapshot chain.
Fix suggestion: Back up qcow2 images first (`qemu-img convert`), `undefine` without the storage flags, then `virsh vol-delete` deliberately.
Severity: Error