### PR TITLE
feat: ZC1750 — flag `kubectl proxy --address 0.0.0.0` (cluster API on every interface)

### DIFF
--- a/pkg/katas/katatests/zc1750_test.go
+++ b/pkg/katas/katatests/zc1750_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1750(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `kubectl proxy --port 8001` (loopback default)",
+			input:    `kubectl proxy --port 8001`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `kubectl proxy --address 127.0.0.1`",
+			input:    `kubectl proxy --address 127.0.0.1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `kubectl proxy --address 0.0.0.0`",
+			input: `kubectl proxy --address 0.0.0.0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1750",
+					Message: "`kubectl proxy --address 0.0.0.0` exposes the cluster-admin API tunnel to every reachable interface. Keep the loopback default and tunnel over SSH, or restrict `--address` to a firewalled interface.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `kubectl proxy --address=0.0.0.0`",
+			input: `kubectl proxy --address=0.0.0.0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1750",
+					Message: "`kubectl proxy --address=0.0.0.0` exposes the cluster-admin API tunnel to every reachable interface. Keep the loopback default and tunnel over SSH, or restrict `--address` to a firewalled interface.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1750")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1750.go
+++ b/pkg/katas/zc1750.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1750",
+		Title:    "Error on `kubectl proxy --address 0.0.0.0` — cluster API proxy on every interface",
+		Severity: SeverityError,
+		Description: "`kubectl proxy` tunnels Kubernetes API requests authenticated with the " +
+			"local kubeconfig's credentials. Defaults bind to `127.0.0.1` and accept only " +
+			"`localhost` hosts. `--address 0.0.0.0` (or a specific non-loopback IP) exposes " +
+			"that tunnel to every interface on the workstation / bastion, so anyone on the " +
+			"LAN or VPN gets the cluster admin the kubeconfig holds. Same risk applies to " +
+			"`--accept-hosts '.*'`. Keep the loopback default and scope with SSH port " +
+			"forwarding, or restrict `--address` to an interface behind a tight firewall.",
+		Check: checkZC1750,
+	})
+}
+
+func checkZC1750(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kubectl" && ident.Value != "oc" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "proxy" {
+		return nil
+	}
+
+	prevAddress := false
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if prevAddress {
+			if v == "0.0.0.0" || v == "::" {
+				return zc1750Hit(cmd, "--address "+v)
+			}
+			prevAddress = false
+			continue
+		}
+		switch {
+		case v == "--address":
+			prevAddress = true
+		case strings.HasPrefix(v, "--address="):
+			val := strings.TrimPrefix(v, "--address=")
+			if val == "0.0.0.0" || val == "::" {
+				return zc1750Hit(cmd, v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1750Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1750",
+		Message: "`kubectl proxy " + what + "` exposes the cluster-admin API tunnel to every " +
+			"reachable interface. Keep the loopback default and tunnel over SSH, or " +
+			"restrict `--address` to a firewalled interface.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 746 Katas = 0.7.46
-const Version = "0.7.46"
+// 747 Katas = 0.7.47
+const Version = "0.7.47"


### PR DESCRIPTION
ZC1750 — `kubectl proxy --address 0.0.0.0`

What: Detect `kubectl` (or `oc`) `proxy` with `--address 0.0.0.0` / `::` / joined `=` form.
Why: Default loopback binding is replaced by every-interface binding — anyone on the LAN or VPN gets the cluster admin credentials the kubeconfig holds.
Fix suggestion: Keep the loopback default and tunnel over SSH, or scope `--address` to a firewalled interface.
Severity: Error