### PR TITLE
feat: ZC1751 — flag `rpm/dnf/yum remove --nodeps` (bypasses dependency check)

### DIFF
--- a/pkg/katas/katatests/zc1751_test.go
+++ b/pkg/katas/katatests/zc1751_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1751(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `rpm -e libfoo`",
+			input:    `rpm -e libfoo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `dnf remove libfoo`",
+			input:    `dnf remove libfoo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `rpm -q libfoo --nodeps` (query, not erase)",
+			input:    `rpm -q libfoo --nodeps`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `rpm -e --nodeps libfoo`",
+			input: `rpm -e --nodeps libfoo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1751",
+					Message: "`rpm ... --nodeps` removes the package without the dependency solver — dependents break (libc, openssl, systemd units). Resolve the conflict explicitly instead of bypassing.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `dnf remove --nodeps libfoo`",
+			input: `dnf remove --nodeps libfoo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1751",
+					Message: "`dnf ... --nodeps` removes the package without the dependency solver — dependents break (libc, openssl, systemd units). Resolve the conflict explicitly instead of bypassing.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1751")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1751.go
+++ b/pkg/katas/zc1751.go
@@ -1,0 +1,86 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1751",
+		Title:    "Error on `rpm/dnf/yum remove --nodeps` — bypasses dependency check, breaks dependents",
+		Severity: SeverityError,
+		Description: "`rpm -e --nodeps PKG` (also `dnf remove --nodeps`, `yum remove --nodeps`, " +
+			"`zypper remove --force`) removes the package while skipping the dependency " +
+			"solver. Anything transitively depending on the target immediately breaks — " +
+			"`libc`, `openssl`, `systemd` units, even `dnf` itself can get pulled out, " +
+			"leaving the host unbootable or unpackageable. Resolve the dependency conflict " +
+			"explicitly (`dnf swap`, `rpm -e --rebuilddb` never, pin the conflicting package) " +
+			"instead of bypassing the check.",
+		Check: checkZC1751,
+	})
+}
+
+func checkZC1751(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var tool string
+	var verbOK bool
+	switch ident.Value {
+	case "rpm":
+		tool = "rpm"
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "-e" || v == "--erase" {
+				verbOK = true
+				break
+			}
+		}
+	case "dnf", "yum", "microdnf":
+		tool = ident.Value
+		if len(cmd.Arguments) == 0 {
+			return nil
+		}
+		sub := cmd.Arguments[0].String()
+		if sub == "remove" || sub == "erase" {
+			verbOK = true
+		}
+	case "zypper":
+		tool = "zypper"
+		if len(cmd.Arguments) == 0 {
+			return nil
+		}
+		sub := cmd.Arguments[0].String()
+		if sub == "remove" || sub == "rm" {
+			verbOK = true
+		}
+	default:
+		return nil
+	}
+	if !verbOK {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--nodeps" || v == "--no-deps" {
+			return []Violation{{
+				KataID: "ZC1751",
+				Message: "`" + tool + " ... " + v + "` removes the package without the " +
+					"dependency solver — dependents break (libc, openssl, systemd " +
+					"units). Resolve the conflict explicitly instead of bypassing.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 747 Katas = 0.7.47
-const Version = "0.7.47"
+// 748 Katas = 0.7.48
+const Version = "0.7.48"


### PR DESCRIPTION
ZC1751 — `rpm -e --nodeps` / `dnf remove --nodeps` / `zypper remove --force`

What: Detect remove-verb invocations of rpm / dnf / yum / microdnf / zypper paired with `--nodeps` / `--no-deps`.
Why: Skips the dependency solver — dependents break (libc, openssl, systemd units, even dnf itself), leaving the host unbootable or unpackageable.
Fix suggestion: Resolve the dependency conflict explicitly (`dnf swap`, pin the conflicting package) instead of bypassing.
Severity: Error