### PR TITLE
feat: ZC1752 — flag `pvcreate/vgcreate/lvcreate -ff|--yes` (force-init LVM)

### DIFF
--- a/pkg/katas/katatests/zc1752_test.go
+++ b/pkg/katas/katatests/zc1752_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1752(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `pvcreate $DISK` (prompts kept)",
+			input:    `pvcreate $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `vgcreate my_vg $DISK`",
+			input:    `vgcreate my_vg $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `pvcreate -ff $DISK`",
+			input: `pvcreate -ff $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1752",
+					Message: "`pvcreate -ff` skips the LVM confirmation — a wrong device gets its filesystem / RAID / LVM signatures wiped. Inspect with `wipefs -n` + `lsblk -f` first, drop the flag, re-run after checking the target.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `pvcreate $DISK --yes`",
+			input: `pvcreate $DISK --yes`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1752",
+					Message: "`pvcreate --yes` skips the LVM confirmation — a wrong device gets its filesystem / RAID / LVM signatures wiped. Inspect with `wipefs -n` + `lsblk -f` first, drop the flag, re-run after checking the target.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `vgcreate -y my_vg $DISK`",
+			input: `vgcreate -y my_vg $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1752",
+					Message: "`vgcreate -y` skips the LVM confirmation — a wrong device gets its filesystem / RAID / LVM signatures wiped. Inspect with `wipefs -n` + `lsblk -f` first, drop the flag, re-run after checking the target.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1752")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1752.go
+++ b/pkg/katas/zc1752.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1752ForceFlags = map[string]bool{
+	"-f": true, "-ff": true, "-fff": true,
+	"--force": true,
+	"-y":      true, "--yes": true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1752",
+		Title:    "Error on `pvcreate/vgcreate/lvcreate -ff|--yes` — force-init LVM over existing data",
+		Severity: SeverityError,
+		Description: "LVM prompts before overwriting existing filesystem, RAID, or LVM signatures " +
+			"on a device — that prompt is the only thing saving you from a typo'd target " +
+			"destroying someone else's data. `pvcreate -ff`, `pvcreate --yes`, and the same " +
+			"flags on `vgcreate` / `lvcreate` skip the prompt. Drop the flag, inspect with " +
+			"`wipefs -n` and `lsblk -f` first, then confirm the target before re-running " +
+			"the create command.",
+		Check: checkZC1752,
+	})
+}
+
+func checkZC1752(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "pvcreate", "vgcreate", "lvcreate":
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if zc1752ForceFlags[v] {
+			return []Violation{{
+				KataID: "ZC1752",
+				Message: "`" + ident.Value + " " + v + "` skips the LVM confirmation — a " +
+					"wrong device gets its filesystem / RAID / LVM signatures wiped. " +
+					"Inspect with `wipefs -n` + `lsblk -f` first, drop the flag, re-" +
+					"run after checking the target.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 748 Katas = 0.7.48
-const Version = "0.7.48"
+// 749 Katas = 0.7.49
+const Version = "0.7.49"


### PR DESCRIPTION
ZC1752 — `pvcreate/vgcreate/lvcreate -ff|--yes|-y|--force`

What: Detect LVM create commands paired with force / auto-yes flags.
Why: LVM's prompt is the last defense against a typo'd device destroying filesystem / RAID / LVM signatures. Skipping it turns one wrong arg into data loss.
Fix suggestion: Inspect the target with `wipefs -n` + `lsblk -f`, drop the flag, re-run deliberately.
Severity: Error