### PR TITLE
feat: ZC1753 — flag `rclone purge REMOTE:PATH` (bulk delete, no dry-run)

### DIFF
--- a/pkg/katas/katatests/zc1753_test.go
+++ b/pkg/katas/katatests/zc1753_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1753(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `rclone delete myremote:bucket/path`",
+			input:    `rclone delete myremote:bucket/path`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `rclone sync src dst`",
+			input:    `rclone sync src dst`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `rclone purge myremote:bucket/path`",
+			input: `rclone purge myremote:bucket/path`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1753",
+					Message: "`rclone purge` removes every object under the remote path with no dry-run or soft-delete. Preview with `rclone lsf` / `rclone delete --dry-run` and prefer narrower `rclone delete`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1753")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1753.go
+++ b/pkg/katas/zc1753.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1753",
+		Title:    "Error on `rclone purge REMOTE:PATH` — bulk delete of every object under the remote path",
+		Severity: SeverityError,
+		Description: "`rclone purge REMOTE:PATH` removes every object and empty directory under " +
+			"PATH on the remote — no dry-run gate, no confirmation, no soft-delete unless " +
+			"the backend happens to version. A typo'd path or a stale variable turns one " +
+			"line into a bucket-wide wipe (S3, GCS, Azure, Swift all honour the same API " +
+			"call). Preview with `rclone lsf REMOTE:PATH` or `rclone delete --dry-run`, " +
+			"then use `rclone delete` scoped narrower; enable object versioning on the " +
+			"backend so a bad run can roll back.",
+		Check: checkZC1753,
+	})
+}
+
+func checkZC1753(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "rclone" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "purge" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1753",
+		Message: "`rclone purge` removes every object under the remote path with no dry-run " +
+			"or soft-delete. Preview with `rclone lsf` / `rclone delete --dry-run` and " +
+			"prefer narrower `rclone delete`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 749 Katas = 0.7.49
-const Version = "0.7.49"
+// 750 Katas = 0.7.50
+const Version = "0.7.50"


### PR DESCRIPTION
ZC1753 — `rclone purge REMOTE:PATH`

What: Detect `rclone purge REMOTE:PATH` invocations.
Why: Removes every object and empty directory under PATH — no dry-run gate, no soft-delete unless the backend happens to version. A typo'd path turns one line into a bucket-wide wipe.
Fix suggestion: Preview with `rclone lsf REMOTE:PATH` or `rclone delete --dry-run`, then `rclone delete` narrower; enable backend versioning for rollback.
Severity: Error