### PR TITLE
feat: ZC1754 — flag `gh auth status -t` / `--show-token` (token in stdout)

### DIFF
--- a/pkg/katas/katatests/zc1754_test.go
+++ b/pkg/katas/katatests/zc1754_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1754(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gh auth status`",
+			input:    `gh auth status`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gh auth token`",
+			input:    `gh auth token`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gh auth status -t`",
+			input: `gh auth status -t`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1754",
+					Message: "`gh auth status -t` prints the OAuth token in the status output — CI logs and scrollback become a repo-admin leak. Use `gh auth token` in automation so the secret path is explicit.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gh auth status --show-token`",
+			input: `gh auth status --show-token`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1754",
+					Message: "`gh auth status --show-token` prints the OAuth token in the status output — CI logs and scrollback become a repo-admin leak. Use `gh auth token` in automation so the secret path is explicit.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1754")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1754.go
+++ b/pkg/katas/zc1754.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1754",
+		Title:    "Error on `gh auth status -t` / `--show-token` — prints OAuth token to stdout",
+		Severity: SeverityError,
+		Description: "`gh auth status -t` (alias `--show-token`) prints the stored GitHub OAuth " +
+			"token alongside the status summary. In CI logs, shared terminals, piped to " +
+			"`less`/`tee`, or captured via `script`, the token ends up on disk or in " +
+			"scrollback where anyone with log access becomes repo-admin. Never combine " +
+			"`-t` with `auth status` in automation; if a machine-readable token is needed, " +
+			"`gh auth token` prints only the token and makes the secret-handling path " +
+			"explicit.",
+		Check: checkZC1754,
+	})
+}
+
+func checkZC1754(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "gh" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "auth" || cmd.Arguments[1].String() != "status" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[2:] {
+		v := arg.String()
+		if v == "-t" || v == "--show-token" {
+			return []Violation{{
+				KataID: "ZC1754",
+				Message: "`gh auth status " + v + "` prints the OAuth token in the status " +
+					"output — CI logs and scrollback become a repo-admin leak. Use " +
+					"`gh auth token` in automation so the secret path is explicit.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 750 Katas = 0.7.50
-const Version = "0.7.50"
+// 751 Katas = 0.7.51
+const Version = "0.7.51"


### PR DESCRIPTION
ZC1754 — `gh auth status -t` / `--show-token`

What: Detect `gh auth status` paired with `-t` or `--show-token`.
Why: Prints the OAuth token in the status output — CI logs, scrollback, and `script`-captured sessions become a repo-admin leak.
Fix suggestion: Use `gh auth token` in automation so the secret-handling path is explicit, or drop the flag for human-readable status.
Severity: Error