### PR TITLE
feat: ZC1755 — flag `gcloud sql users ... --password PASS` (Cloud SQL pass in argv)

### DIFF
--- a/pkg/katas/katatests/zc1755_test.go
+++ b/pkg/katas/katatests/zc1755_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1755(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gcloud sql users create ... --prompt-for-password`",
+			input:    `gcloud sql users create myuser --instance myinst --prompt-for-password`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gcloud sql users list --instance myinst`",
+			input:    `gcloud sql users list --instance myinst`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gcloud sql users create ... --password PASS`",
+			input: `gcloud sql users create myuser --instance myinst --password hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1755",
+					Message: "`gcloud sql users create --password hunter2` puts the Cloud SQL password in argv — visible in `ps`, `/proc`, history, and Cloud Audit Logs. Use `--prompt-for-password` or call the SQL Admin API with a body file.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gcloud sql users set-password ... --password=PASS`",
+			input: `gcloud sql users set-password myuser --instance myinst --password=hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1755",
+					Message: "`gcloud sql users set-password --password=hunter2` puts the Cloud SQL password in argv — visible in `ps`, `/proc`, history, and Cloud Audit Logs. Use `--prompt-for-password` or call the SQL Admin API with a body file.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1755")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1755.go
+++ b/pkg/katas/zc1755.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1755",
+		Title:    "Error on `gcloud sql users {create,set-password} --password PASS` — DB password in argv",
+		Severity: SeverityError,
+		Description: "`gcloud sql users create USER --instance INST --password PASS` (and the " +
+			"`set-password` variant) place the Cloud SQL user password on the command " +
+			"line — visible in `ps`, `/proc/<pid>/cmdline`, shell history, and CI logs, " +
+			"and stored in Cloud Audit Logs' request payload. Use `--prompt-for-password` " +
+			"(interactive) or generate the password server-side in Secret Manager and post " +
+			"to the SQL Admin API via `gcloud auth print-access-token` piped to `curl` with " +
+			"the body sourced from a file.",
+		Check: checkZC1755,
+	})
+}
+
+func checkZC1755(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "gcloud" {
+		return nil
+	}
+	if len(cmd.Arguments) < 4 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "sql" || cmd.Arguments[1].String() != "users" {
+		return nil
+	}
+	sub := cmd.Arguments[2].String()
+	if sub != "create" && sub != "set-password" {
+		return nil
+	}
+
+	prevPwd := false
+	for _, arg := range cmd.Arguments[3:] {
+		v := arg.String()
+		if prevPwd {
+			return zc1755Hit(cmd, sub, "--password "+v)
+		}
+		switch {
+		case v == "--password":
+			prevPwd = true
+		case strings.HasPrefix(v, "--password="):
+			return zc1755Hit(cmd, sub, v)
+		}
+	}
+	return nil
+}
+
+func zc1755Hit(cmd *ast.SimpleCommand, sub, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1755",
+		Message: "`gcloud sql users " + sub + " " + what + "` puts the Cloud SQL password " +
+			"in argv — visible in `ps`, `/proc`, history, and Cloud Audit Logs. Use " +
+			"`--prompt-for-password` or call the SQL Admin API with a body file.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 751 Katas = 0.7.51
-const Version = "0.7.51"
+// 752 Katas = 0.7.52
+const Version = "0.7.52"


### PR DESCRIPTION
ZC1755 — `gcloud sql users create|set-password --password PASS`

What: Detect `gcloud sql users {create,set-password}` paired with `--password` / `--password=`.
Why: Password lands in argv — visible in `ps`, `/proc/<pid>/cmdline`, history, CI logs, and Cloud Audit Logs' request payload.
Fix suggestion: Use `--prompt-for-password` or call the SQL Admin API with a body file via `gcloud auth print-access-token | curl`.
Severity: Error