### PR TITLE
feat: ZC1756 — flag `chmod NNN /run/docker.sock` (root-equiv socket opened)

### DIFF
--- a/pkg/katas/katatests/zc1756_test.go
+++ b/pkg/katas/katatests/zc1756_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1756(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `chmod 660 /var/run/docker.sock` (group only)",
+			input:    `chmod 660 /var/run/docker.sock`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `chmod 666 /tmp/file` (not a runtime socket)",
+			input:    `chmod 666 /tmp/file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `chmod 666 /var/run/docker.sock`",
+			input: `chmod 666 /var/run/docker.sock`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1756",
+					Message: "`chmod 666 /var/run/docker.sock` grants every local user access to a root-equivalent container-runtime socket. Keep `0660` owned by the runtime group (`root:docker` etc.) and restrict membership.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `chmod 777 /run/containerd/containerd.sock`",
+			input: `chmod 777 /run/containerd/containerd.sock`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1756",
+					Message: "`chmod 777 /run/containerd/containerd.sock` grants every local user access to a root-equivalent container-runtime socket. Keep `0660` owned by the runtime group (`root:docker` etc.) and restrict membership.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1756")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1756.go
+++ b/pkg/katas/zc1756.go
@@ -1,0 +1,95 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1756DockerSocketPaths = map[string]bool{
+	"/var/run/docker.sock":              true,
+	"/run/docker.sock":                  true,
+	"/run/containerd/containerd.sock":   true,
+	"/var/run/crio/crio.sock":           true,
+	"/run/crio/crio.sock":               true,
+	"/var/run/podman/podman.sock":       true,
+	"/run/podman/podman.sock":           true,
+	"/run/user/1000/podman/podman.sock": true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1756",
+		Title:    "Error on `chmod NNN /run/docker.sock` — world access is root-equivalent privesc",
+		Severity: SeverityError,
+		Description: "Container-runtime sockets (`/var/run/docker.sock`, `/run/containerd/" +
+			"containerd.sock`, `/run/crio/crio.sock`, `/run/podman/podman.sock`) accept " +
+			"commands that run on the host with root privilege — starting privileged " +
+			"containers, mounting the host filesystem, reading every file on disk. " +
+			"Making the socket world-readable or world-writable (`chmod 644/660/666/777`) " +
+			"hands every local user that root-escalation primitive. Keep the socket " +
+			"`0660 root:docker` (or the equivalent runtime group) and add only trusted " +
+			"accounts to that group.",
+		Check: checkZC1756,
+	})
+}
+
+func checkZC1756(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "chmod" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+
+	var mode, target string
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if zc1756DockerSocketPaths[v] {
+			target = v
+			continue
+		}
+		if mode == "" && zc1756WorldAccess(v) {
+			mode = v
+		}
+	}
+	if mode == "" || target == "" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1756",
+		Message: "`chmod " + mode + " " + target + "` grants every local user access to a " +
+			"root-equivalent container-runtime socket. Keep `0660` owned by the " +
+			"runtime group (`root:docker` etc.) and restrict membership.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}
+
+// zc1756WorldAccess: true when MODE grants world-read or world-write on the
+// target. Handles both octal literal and the parser-normalised decimal form.
+func zc1756WorldAccess(mode string) bool {
+	if mode == "" {
+		return false
+	}
+	if zc1671WorldWritable(mode) {
+		return true
+	}
+	// zc1671WorldWritable catches world-write; also catch world-read (bit 4).
+	// Parse octal, fallback to decimal.
+	for _, c := range mode {
+		if c < '0' || c > '7' {
+			// Decimal fallback (parser-normalised leading-zero octal).
+			return false
+		}
+	}
+	// Simple octal parse: last char is world triad.
+	last := mode[len(mode)-1]
+	return last == '4' || last == '5' || last == '6' || last == '7'
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 752 Katas = 0.7.52
-const Version = "0.7.52"
+// 753 Katas = 0.7.53
+const Version = "0.7.53"


### PR DESCRIPTION
ZC1756 — `chmod` on container-runtime sockets

What: Detect `chmod NNN` on `/var/run/docker.sock`, `/run/docker.sock`, `/run/containerd/containerd.sock`, `/run/crio/crio.sock`, `/run/podman/podman.sock` with world read/write bits.
Why: Container-runtime sockets accept commands that run with host root — privileged containers, host-filesystem mounts, arbitrary file reads. World access = local privilege escalation primitive.
Fix suggestion: Keep `0660` owned by the runtime group (`root:docker` etc.) and restrict group membership to trusted accounts.
Severity: Error