### PR TITLE
feat: ZC1757 — flag `gh auth refresh --scopes delete_repo|admin:*` (token escalation)

### DIFF
--- a/pkg/katas/katatests/zc1757_test.go
+++ b/pkg/katas/katatests/zc1757_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1757(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gh auth refresh --scopes repo`",
+			input:    `gh auth refresh --scopes repo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gh auth login --scopes workflow,read:org`",
+			input:    `gh auth login --scopes workflow,read:org`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gh auth refresh --scopes delete_repo`",
+			input: `gh auth refresh --scopes delete_repo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1757",
+					Message: "`gh auth refresh --scopes delete_repo` escalates the token to destructive privileges that outlast the script. Request the minimum scope (`repo`, `workflow`) and rotate the token when done.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gh auth refresh -s admin:org`",
+			input: `gh auth refresh -s admin:org`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1757",
+					Message: "`gh auth refresh --scopes admin:org` escalates the token to destructive privileges that outlast the script. Request the minimum scope (`repo`, `workflow`) and rotate the token when done.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gh auth login --scopes=repo,delete_repo`",
+			input: `gh auth login --scopes=repo,delete_repo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1757",
+					Message: "`gh auth login --scopes delete_repo` escalates the token to destructive privileges that outlast the script. Request the minimum scope (`repo`, `workflow`) and rotate the token when done.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1757")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1757.go
+++ b/pkg/katas/zc1757.go
@@ -1,0 +1,100 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1757DangerousScopes = []string{
+	"delete_repo",
+	"admin:org",
+	"admin:enterprise",
+	"admin:public_key",
+	"admin:org_hook",
+	"site_admin",
+	"admin:repo_hook",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1757",
+		Title:    "Warn on `gh auth refresh --scopes delete_repo|admin:*` — token escalated to destructive perms",
+		Severity: SeverityWarning,
+		Description: "`gh auth refresh --scopes <list>` (also `gh auth login --scopes`) rotates " +
+			"the stored OAuth token with additional scopes. `delete_repo`, `admin:org`, " +
+			"`admin:enterprise`, `admin:public_key`, and `admin:*_hook` give the token " +
+			"permanent destructive perms that outlast the script that asked for them — a " +
+			"compromised token now carries repo-deletion, org-membership, and SSH-key " +
+			"manipulation rights. Request the minimum scope the task needs (`repo`, " +
+			"`workflow`) and rotate the token off when the elevated operation completes.",
+		Check: checkZC1757,
+	})
+}
+
+func checkZC1757(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "gh" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "auth" {
+		return nil
+	}
+	sub := cmd.Arguments[1].String()
+	if sub != "refresh" && sub != "login" {
+		return nil
+	}
+
+	prevScopes := false
+	for _, arg := range cmd.Arguments[2:] {
+		v := arg.String()
+		if prevScopes {
+			if hit := zc1757MatchScopes(v); hit != "" {
+				return zc1757Hit(cmd, sub, hit)
+			}
+			prevScopes = false
+			continue
+		}
+		switch {
+		case v == "--scopes" || v == "-s":
+			prevScopes = true
+		case strings.HasPrefix(v, "--scopes="):
+			if hit := zc1757MatchScopes(strings.TrimPrefix(v, "--scopes=")); hit != "" {
+				return zc1757Hit(cmd, sub, hit)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1757MatchScopes(list string) string {
+	for _, scope := range strings.Split(list, ",") {
+		scope = strings.TrimSpace(scope)
+		for _, danger := range zc1757DangerousScopes {
+			if scope == danger {
+				return scope
+			}
+		}
+	}
+	return ""
+}
+
+func zc1757Hit(cmd *ast.SimpleCommand, sub, scope string) []Violation {
+	return []Violation{{
+		KataID: "ZC1757",
+		Message: "`gh auth " + sub + " --scopes " + scope + "` escalates the token to " +
+			"destructive privileges that outlast the script. Request the minimum " +
+			"scope (`repo`, `workflow`) and rotate the token when done.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 753 Katas = 0.7.53
-const Version = "0.7.53"
+// 754 Katas = 0.7.54
+const Version = "0.7.54"


### PR DESCRIPTION
ZC1757 — `gh auth refresh --scopes <destructive>`

What: Detect `gh auth refresh` / `login` with `--scopes` containing `delete_repo`, `admin:org`, `admin:enterprise`, `admin:public_key`, `admin:org_hook`, `admin:repo_hook`, `site_admin`.
Why: Rotates the stored OAuth token with permanent destructive perms. A compromised token now carries repo-deletion, org-membership, and SSH-key manipulation rights.
Fix suggestion: Request the minimum scope the task needs (`repo`, `workflow`) and rotate the token off when the elevated operation completes.
Severity: Warning