### PR TITLE
feat: ZC1758 — flag `gh codespace delete --force` (drops uncommitted work)

### DIFF
--- a/pkg/katas/katatests/zc1758_test.go
+++ b/pkg/katas/katatests/zc1758_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1758(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gh codespace delete -c mycodespace` (prompt kept)",
+			input:    `gh codespace delete -c mycodespace`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gh codespace list`",
+			input:    `gh codespace list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gh codespace delete --force`",
+			input: `gh codespace delete --force`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1758",
+					Message: "`gh codespace delete --force` skips the prompt and drops uncommitted work along with the codespace. Let the prompt list what's about to go and verify `git status` inside first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gh codespace delete -f --all`",
+			input: `gh codespace delete -f --all`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1758",
+					Message: "`gh codespace delete -f` skips the prompt and drops uncommitted work along with the codespace. Let the prompt list what's about to go and verify `git status` inside first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1758")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1758.go
+++ b/pkg/katas/zc1758.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1758",
+		Title:    "Warn on `gh codespace delete --force` — destroys codespace with uncommitted work",
+		Severity: SeverityWarning,
+		Description: "`gh codespace delete --force` (alias `-f`) skips the confirmation prompt " +
+			"and deletes the target codespace along with any uncommitted, unpushed, or " +
+			"unstaged work inside it. Combined with `--all`, one line wipes every codespace " +
+			"on the account. Drop the flag, let the prompt enumerate what is about to go, " +
+			"and only confirm after verifying no local state would be lost — `git status` " +
+			"/ `git stash list` inside the codespace first.",
+		Check: checkZC1758,
+	})
+}
+
+func checkZC1758(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "gh" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "codespace" || cmd.Arguments[1].String() != "delete" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[2:] {
+		v := arg.String()
+		if v == "--force" || v == "-f" {
+			return []Violation{{
+				KataID: "ZC1758",
+				Message: "`gh codespace delete " + v + "` skips the prompt and drops " +
+					"uncommitted work along with the codespace. Let the prompt list " +
+					"what's about to go and verify `git status` inside first.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 754 Katas = 0.7.54
-const Version = "0.7.54"
+// 755 Katas = 0.7.55
+const Version = "0.7.55"


### PR DESCRIPTION
ZC1758 — `gh codespace delete --force`

What: Detect `gh codespace delete` paired with `--force` or `-f`.
Why: Skips the confirmation prompt and drops uncommitted / unpushed work along with the codespace. Combined with `--all`, wipes every codespace on the account in one line.
Fix suggestion: Drop the flag, let the prompt enumerate the target, and verify `git status` / `git stash list` inside the codespace first.
Severity: Warning