### PR TITLE
feat: ZC1759 — flag `vault login TOKEN` / `password=…` (Vault cred in argv)

### DIFF
--- a/pkg/katas/katatests/zc1759_test.go
+++ b/pkg/katas/katatests/zc1759_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1759(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `vault login -` (reads token from stdin)",
+			input:    `vault login -`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `vault login -method=userpass username=alice` (no secret key)",
+			input:    `vault login -method=userpass username=alice`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `vault login mytoken` (positional token)",
+			input: `vault login mytoken`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1759",
+					Message: "`vault login mytoken` puts the Vault credential in argv — visible in `ps`, `/proc`, history, Vault audit log. Use `vault login -` with stdin or source `VAULT_TOKEN` from a secrets file.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `vault login -method=userpass username=alice password=hunter2`",
+			input: `vault login -method=userpass username=alice password=hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1759",
+					Message: "`vault login password=hunter2` puts the Vault credential in argv — visible in `ps`, `/proc`, history, Vault audit log. Use `vault login -` with stdin or source `VAULT_TOKEN` from a secrets file.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `vault auth mytoken`",
+			input: `vault auth mytoken`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1759",
+					Message: "`vault auth mytoken` puts the Vault credential in argv — visible in `ps`, `/proc`, history, Vault audit log. Use `vault login -` with stdin or source `VAULT_TOKEN` from a secrets file.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1759")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1759.go
+++ b/pkg/katas/zc1759.go
@@ -1,0 +1,82 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1759SecretKeys = []string{
+	"password", "passwd",
+	"token", "secret",
+	"apikey", "api_key", "api-key",
+	"accesskey", "access_key", "access-key",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1759",
+		Title:    "Error on `vault login TOKEN` / `login -method=… password=…` — credential in process list",
+		Severity: SeverityError,
+		Description: "Vault accepts credentials on its `login` / `auth` subcommands in two " +
+			"argv-leaking shapes: a positional token (`vault login <TOKEN>`) and KEY=VALUE " +
+			"pairs for non-token methods (`vault login -method=userpass username=U " +
+			"password=P`). Both land the secret in `ps`, `/proc/<pid>/cmdline`, shell " +
+			"history, and Vault's audit log request payload. Read the token from stdin " +
+			"(`vault login -` with `printf %s \"$TOKEN\" |`) or source `VAULT_TOKEN` from " +
+			"a secrets file and run `vault login -method=token`.",
+		Check: checkZC1759,
+	})
+}
+
+func checkZC1759(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "vault" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	if sub != "login" && sub != "auth" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		// Stdin sentinel, file sentinel, flag-forms are safe.
+		if v == "-" || strings.HasPrefix(v, "-") || strings.HasPrefix(v, "@") {
+			continue
+		}
+		// KEY=VALUE pair: flag secret-named keys.
+		if eq := strings.IndexByte(v, '='); eq > 0 {
+			key := strings.ToLower(v[:eq])
+			for _, secret := range zc1759SecretKeys {
+				if strings.Contains(key, secret) {
+					return zc1759Hit(cmd, sub, v)
+				}
+			}
+			continue
+		}
+		// Bare positional token.
+		return zc1759Hit(cmd, sub, v)
+	}
+	return nil
+}
+
+func zc1759Hit(cmd *ast.SimpleCommand, sub, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1759",
+		Message: "`vault " + sub + " " + what + "` puts the Vault credential in argv — " +
+			"visible in `ps`, `/proc`, history, Vault audit log. Use `vault login -` " +
+			"with stdin or source `VAULT_TOKEN` from a secrets file.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 755 Katas = 0.7.55
-const Version = "0.7.55"
+// 756 Katas = 0.7.56
+const Version = "0.7.56"


### PR DESCRIPTION
ZC1759 — `vault login TOKEN` / `-method=userpass password=…`

What: Detect `vault login` / `vault auth` with either a positional token or a secret-keyed KEY=VALUE (`password=`, `token=`, `api_key=`, etc.).
Why: Credential lands in argv — visible in `ps`, `/proc/<pid>/cmdline`, history, and Vault's audit-log request payload.
Fix suggestion: Use `vault login -` to read from stdin (`printf %s "$TOKEN" | vault login -`) or source `VAULT_TOKEN` from a secrets file.
Severity: Error