### PR TITLE
feat: ZC1760 — flag `openssl rand -hex|-base64 N` with N<16 (weak entropy)

### DIFF
--- a/pkg/katas/katatests/zc1760_test.go
+++ b/pkg/katas/katatests/zc1760_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1760(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `openssl rand -hex 32`",
+			input:    `openssl rand -hex 32`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `openssl rand -hex 16` (borderline but accepted)",
+			input:    `openssl rand -hex 16`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `openssl rand 24` (no encoding flag)",
+			input:    `openssl rand 24`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `openssl rand -hex 8`",
+			input: `openssl rand -hex 8`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1760",
+					Message: "`openssl rand -hex 8` produces a sub-128-bit value — brute-forceable offline. Use `-hex 32` for secrets / long-lived tokens.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `openssl rand -base64 12`",
+			input: `openssl rand -base64 12`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1760",
+					Message: "`openssl rand -base64 12` produces a sub-128-bit value — brute-forceable offline. Use `-hex 32` for secrets / long-lived tokens.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1760")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1760.go
+++ b/pkg/katas/zc1760.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"strconv"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1760",
+		Title:    "Warn on `openssl rand -hex|-base64 N` with N < 16 — generated value too short",
+		Severity: SeverityWarning,
+		Description: "`openssl rand -hex N` (and `-base64 N`) outputs N random bytes encoded into " +
+			"the requested form. N below 16 (128 bits) produces a value short enough that " +
+			"an attacker with modest GPU resources can brute-force it offline — too weak " +
+			"for passwords, API tokens, reset URLs, or any other secret that sits at rest. " +
+			"Use `-hex 32` (256-bit) for secrets and long-lived tokens; `-hex 16` is " +
+			"acceptable only for short-validity nonces paired with rate-limited consumers.",
+		Check: checkZC1760,
+	})
+}
+
+func checkZC1760(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "openssl" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "rand" {
+		return nil
+	}
+
+	prevEnc := ""
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if prevEnc != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 && n < 16 {
+				return zc1760Hit(cmd, prevEnc+" "+v)
+			}
+			prevEnc = ""
+			continue
+		}
+		if v == "-hex" || v == "-base64" {
+			prevEnc = v
+		}
+	}
+	return nil
+}
+
+func zc1760Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1760",
+		Message: "`openssl rand " + what + "` produces a sub-128-bit value — brute-forceable " +
+			"offline. Use `-hex 32` for secrets / long-lived tokens.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 756 Katas = 0.7.56
-const Version = "0.7.56"
+// 757 Katas = 0.7.57
+const Version = "0.7.57"


### PR DESCRIPTION
ZC1760 — `openssl rand -hex N` / `-base64 N` with N < 16

What: Detect `openssl rand -hex N` or `openssl rand -base64 N` where N < 16.
Why: Sub-128-bit output is brute-forceable offline with modest GPU resources — too weak for passwords, tokens, reset URLs, or any persistent secret.
Fix suggestion: Use `-hex 32` (256-bit) for secrets; `-hex 16` is only acceptable for short-validity nonces paired with rate-limited consumers.
Severity: Warning