### PR TITLE
feat: ZC1761 — flag `gh gist create --public` (file becomes world-indexed)

### DIFF
--- a/pkg/katas/katatests/zc1761_test.go
+++ b/pkg/katas/katatests/zc1761_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1761(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gh gist create secret.env` (secret by default)",
+			input:    `gh gist create secret.env`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gh gist list`",
+			input:    `gh gist list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gh gist create --public secret.env`",
+			input: `gh gist create --public secret.env`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1761",
+					Message: "`gh gist create --public` publishes the file to the public discover feed — search engines crawl it within minutes. Drop the flag unless public exposure is the explicit goal.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gh gist create -p note.md`",
+			input: `gh gist create -p note.md`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1761",
+					Message: "`gh gist create -p` publishes the file to the public discover feed — search engines crawl it within minutes. Drop the flag unless public exposure is the explicit goal.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1761")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1761.go
+++ b/pkg/katas/zc1761.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1761",
+		Title:    "Warn on `gh gist create --public` — file becomes world-visible and indexed on GitHub",
+		Severity: SeverityWarning,
+		Description: "`gh gist create --public FILE` (alias `-p`) creates the gist with `public: " +
+			"true`. Public gists are listed on `gist.github.com/discover`, crawled by " +
+			"search engines, and archived by secondary scrapers — a leaked secret, private " +
+			"company snippet, or unreleased note is effectively permanent the moment it " +
+			"lands. The default (`public: false`) keeps the gist unlisted and reachable " +
+			"only via its URL. Drop `--public` unless public exposure is the explicit " +
+			"goal.",
+		Check: checkZC1761,
+	})
+}
+
+func checkZC1761(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "gh" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "gist" || cmd.Arguments[1].String() != "create" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[2:] {
+		v := arg.String()
+		if v == "--public" || v == "-p" {
+			return []Violation{{
+				KataID: "ZC1761",
+				Message: "`gh gist create " + v + "` publishes the file to the public " +
+					"discover feed — search engines crawl it within minutes. Drop the " +
+					"flag unless public exposure is the explicit goal.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 757 Katas = 0.7.57
-const Version = "0.7.57"
+// 758 Katas = 0.7.58
+const Version = "0.7.58"


### PR DESCRIPTION
ZC1761 — `gh gist create --public`

What: Detect `gh gist create` paired with `--public` or `-p`.
Why: Public gists are listed on `gist.github.com/discover`, crawled by search engines, and archived — a leaked secret or private snippet is effectively permanent the moment it lands.
Fix suggestion: Drop `--public` (default is secret-by-URL) unless public exposure is the explicit goal.
Severity: Warning