### PR TITLE
feat: ZC1762 — flag `kubeadm join --discovery-token-unsafe-skip-ca-verification`

### DIFF
--- a/pkg/katas/katatests/zc1762_test.go
+++ b/pkg/katas/katatests/zc1762_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1762(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `kubeadm join ... --discovery-token-ca-cert-hash sha256:xxx`",
+			input:    `kubeadm join 10.0.0.1:6443 --token abc --discovery-token-ca-cert-hash sha256:xxx`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `kubeadm token create`",
+			input:    `kubeadm token create --print-join-command`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `kubeadm join ... --discovery-token-unsafe-skip-ca-verification`",
+			input: `kubeadm join 10.0.0.1:6443 --token abc --discovery-token-unsafe-skip-ca-verification`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1762",
+					Message: "`kubeadm join --discovery-token-unsafe-skip-ca-verification` skips CA verification of the control-plane — MITM steals the bootstrap token. Pin the CA with `--discovery-token-ca-cert-hash sha256:<digest>`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1762")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1762.go
+++ b/pkg/katas/zc1762.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1762",
+		Title:    "Error on `kubeadm join --discovery-token-unsafe-skip-ca-verification` — cluster CA not checked",
+		Severity: SeverityError,
+		Description: "`kubeadm join` verifies the control-plane API server's CA before accepting " +
+			"the kubelet bootstrap token. `--discovery-token-unsafe-skip-ca-verification` " +
+			"skips that check, so a network-position attacker can impersonate the API " +
+			"server, harvest the bootstrap token, and seed malicious workloads onto the " +
+			"joining node. Always pin the CA with `--discovery-token-ca-cert-hash sha256:" +
+			"<digest>` (emitted by `kubeadm token create --print-join-command`) or supply " +
+			"a kubeconfig discovery file that has the CA baked in.",
+		Check: checkZC1762,
+	})
+}
+
+func checkZC1762(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "kubeadm" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "join" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		if arg.String() == "--discovery-token-unsafe-skip-ca-verification" {
+			return []Violation{{
+				KataID: "ZC1762",
+				Message: "`kubeadm join --discovery-token-unsafe-skip-ca-verification` " +
+					"skips CA verification of the control-plane — MITM steals the " +
+					"bootstrap token. Pin the CA with `--discovery-token-ca-cert-hash " +
+					"sha256:<digest>`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 758 Katas = 0.7.58
-const Version = "0.7.58"
+// 759 Katas = 0.7.59
+const Version = "0.7.59"


### PR DESCRIPTION
ZC1762 — `kubeadm join --discovery-token-unsafe-skip-ca-verification`

What: Detect `kubeadm join` paired with `--discovery-token-unsafe-skip-ca-verification`.
Why: Skips CA verification of the control-plane API server; an on-path attacker impersonates the API, harvests the bootstrap token, and seeds malicious workloads on the joining node.
Fix suggestion: Pin the CA with `--discovery-token-ca-cert-hash sha256:<digest>` or supply a kubeconfig discovery file with the CA pinned.
Severity: Error