### PR TITLE
feat: ZC1763 — flag `docker compose down -v` / `--volumes` (wipes named volumes)

### DIFF
--- a/pkg/katas/katatests/zc1763_test.go
+++ b/pkg/katas/katatests/zc1763_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1763(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `docker compose down`",
+			input:    `docker compose down`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `docker compose up -d`",
+			input:    `docker compose up -d`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `docker compose down -v`",
+			input: `docker compose down -v`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1763",
+					Message: "`docker compose down -v` wipes every named volume declared in the stack — database, cache, uploaded assets go with it. Drop the flag in CI / prod scripts.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `docker compose down --volumes`",
+			input: `docker compose down --volumes`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1763",
+					Message: "`docker compose down --volumes` wipes every named volume declared in the stack — database, cache, uploaded assets go with it. Drop the flag in CI / prod scripts.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `docker-compose down -v` (hyphen form)",
+			input: `docker-compose down -v`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1763",
+					Message: "`docker compose down -v` wipes every named volume declared in the stack — database, cache, uploaded assets go with it. Drop the flag in CI / prod scripts.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1763")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1763.go
+++ b/pkg/katas/zc1763.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1763",
+		Title:    "Error on `docker compose down -v` / `--volumes` — wipes named volumes (data loss)",
+		Severity: SeverityError,
+		Description: "`docker compose down -v` (alias `--volumes`, equivalent in `docker-compose " +
+			"down -v`) tears the stack down AND deletes every named volume declared in the " +
+			"compose file. Database contents, cache state, uploaded assets, and any other " +
+			"volume-backed data goes with them — there is no soft-delete. Drop the flag in " +
+			"CI and production scripts; keep it only for throwaway local testbeds where " +
+			"losing volume state is intentional.",
+		Check: checkZC1763,
+	})
+}
+
+func checkZC1763(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var argsAfterDown []ast.Expression
+	switch ident.Value {
+	case "docker":
+		if len(cmd.Arguments) < 2 {
+			return nil
+		}
+		if cmd.Arguments[0].String() != "compose" || cmd.Arguments[1].String() != "down" {
+			return nil
+		}
+		argsAfterDown = cmd.Arguments[2:]
+	case "docker-compose":
+		if len(cmd.Arguments) < 1 || cmd.Arguments[0].String() != "down" {
+			return nil
+		}
+		argsAfterDown = cmd.Arguments[1:]
+	default:
+		return nil
+	}
+
+	for _, arg := range argsAfterDown {
+		v := arg.String()
+		if v == "-v" || v == "--volumes" {
+			return []Violation{{
+				KataID: "ZC1763",
+				Message: "`docker compose down " + v + "` wipes every named volume declared " +
+					"in the stack — database, cache, uploaded assets go with it. Drop " +
+					"the flag in CI / prod scripts.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 759 Katas = 0.7.59
-const Version = "0.7.59"
+// 760 Katas = 0.7.60
+const Version = "0.7.60"


### PR DESCRIPTION
ZC1763 — `docker compose down -v` / `--volumes`

What: Detect `docker compose down` (or `docker-compose down`) paired with `-v` or `--volumes`.
Why: Tears the stack down AND deletes every named volume — database contents, cache state, uploaded assets. No soft-delete.
Fix suggestion: Drop the flag in CI / prod scripts; keep only for throwaway local testbeds where volume loss is intentional.
Severity: Error