### PR TITLE
feat: ZC1764 — flag `git commit --no-verify` / `-n` (skips pre-commit hooks)

### DIFF
--- a/pkg/katas/katatests/zc1764_test.go
+++ b/pkg/katas/katatests/zc1764_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1764(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `git commit -m \"msg\"`",
+			input:    `git commit -m "msg"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `git commit -S -m \"msg\"` (signed)",
+			input:    `git commit -S -m "msg"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `git commit --no-verify -m \"msg\"`",
+			input: `git commit --no-verify -m "msg"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1764",
+					Message: "`git commit --no-verify` skips pre-commit and commit-msg hooks — the last guardrail against secret leaks and broken tests. Fix the hook or carve a narrow exemption instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `git commit -n -m \"msg\"`",
+			input: `git commit -n -m "msg"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1764",
+					Message: "`git commit -n` skips pre-commit and commit-msg hooks — the last guardrail against secret leaks and broken tests. Fix the hook or carve a narrow exemption instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1764")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1764.go
+++ b/pkg/katas/zc1764.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1764",
+		Title:    "Warn on `git commit --no-verify` / `-n` — skips pre-commit and commit-msg hooks",
+		Severity: SeverityWarning,
+		Description: "`git commit --no-verify` (alias `-n`) bypasses both the pre-commit and " +
+			"commit-msg hooks, which are often the last guardrail against leaked secrets, " +
+			"formatting drift, or failing tests. The flag is usually a symptom of a hook " +
+			"that needs fixing rather than silencing — the exception quickly becomes the " +
+			"rule. Fix the blocking hook, carve out a narrow per-file exemption in the " +
+			"hook itself, or file a tracked issue, instead of adding `--no-verify` to " +
+			"every commit in a script.",
+		Check: checkZC1764,
+	})
+}
+
+func checkZC1764(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "git" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "commit" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--no-verify" || v == "-n" {
+			return []Violation{{
+				KataID: "ZC1764",
+				Message: "`git commit " + v + "` skips pre-commit and commit-msg hooks " +
+					"— the last guardrail against secret leaks and broken tests. Fix " +
+					"the hook or carve a narrow exemption instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 760 Katas = 0.7.60
-const Version = "0.7.60"
+// 761 Katas = 0.7.61
+const Version = "0.7.61"


### PR DESCRIPTION
ZC1764 — `git commit --no-verify` / `-n`

What: Detect `git commit` paired with `--no-verify` or `-n`.
Why: Bypasses pre-commit and commit-msg hooks — the last guardrail against leaked secrets, formatting drift, and failing tests.
Fix suggestion: Fix the blocking hook or carve a narrow per-file exemption in the hook itself; don't baked `--no-verify` into automation.
Severity: Warning