### PR TITLE
feat: ZC1765 — flag `snap remove --purge` (skips pre-remove data snapshot)

### DIFF
--- a/pkg/katas/katatests/zc1765_test.go
+++ b/pkg/katas/katatests/zc1765_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1765(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `snap remove mysnap` (snapshot kept)",
+			input:    `snap remove mysnap`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `snap list`",
+			input:    `snap list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `snap remove --purge mysnap`",
+			input: `snap remove --purge mysnap`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1765",
+					Message: "`snap remove --purge` skips the pre-remove data snapshot — the snap's files are gone with no rollback. Drop `--purge` or capture a `snap save` set ID first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1765")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1765.go
+++ b/pkg/katas/zc1765.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1765",
+		Title:    "Error on `snap remove --purge SNAP` — skips the automatic data snapshot",
+		Severity: SeverityError,
+		Description: "`snap remove SNAP` takes a snapshot of every writable area (`$SNAP_DATA`, " +
+			"`$SNAP_USER_DATA`, `$SNAP_COMMON`) before uninstalling, so the data can later " +
+			"be restored with `snap restore`. `--purge` skips that snapshot: the snap is " +
+			"gone along with every file it owned, and snapd has no record to roll back. " +
+			"Drop `--purge` unless the snap's data is genuinely disposable; otherwise " +
+			"`snap save SNAP` first, capture the set ID, and only then remove.",
+		Check: checkZC1765,
+	})
+}
+
+func checkZC1765(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "snap" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "remove" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		if arg.String() == "--purge" {
+			return []Violation{{
+				KataID: "ZC1765",
+				Message: "`snap remove --purge` skips the pre-remove data snapshot — the " +
+					"snap's files are gone with no rollback. Drop `--purge` or capture " +
+					"a `snap save` set ID first.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 761 Katas = 0.7.61
-const Version = "0.7.61"
+// 762 Katas = 0.7.62
+const Version = "0.7.62"


### PR DESCRIPTION
ZC1765 — `snap remove --purge SNAP`

What: Detect `snap remove` paired with `--purge`.
Why: Default `snap remove` snapshots the snap's writable areas so data can be restored via `snap restore`. `--purge` skips that snapshot — snap and data gone, no rollback.
Fix suggestion: Drop `--purge` or capture a `snap save` set ID first.
Severity: Error