### PR TITLE
feat: ZC1766 — flag `memcached -l 0.0.0.0` (unauthenticated cache exposed)

### DIFF
--- a/pkg/katas/katatests/zc1766_test.go
+++ b/pkg/katas/katatests/zc1766_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1766(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `memcached -l 127.0.0.1`",
+			input:    `memcached -l 127.0.0.1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `memcached -l 10.0.0.5 -p 11211`",
+			input:    `memcached -l 10.0.0.5 -p 11211`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `memcached -l 0.0.0.0`",
+			input: `memcached -l 0.0.0.0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1766",
+					Message: "`memcached -l 0.0.0.0` exposes the unauthenticated cache to every interface on the host. Bind to `127.0.0.1` or a private-network IP and firewall the port.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `memcached -l0.0.0.0` (joined form)",
+			input: `memcached -l0.0.0.0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1766",
+					Message: "`memcached -l0.0.0.0` exposes the unauthenticated cache to every interface on the host. Bind to `127.0.0.1` or a private-network IP and firewall the port.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1766")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1766.go
+++ b/pkg/katas/zc1766.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1766",
+		Title:    "Error on `memcached -l 0.0.0.0` — memcached exposed on every interface",
+		Severity: SeverityError,
+		Description: "`memcached -l 0.0.0.0` (or `::`, `--listen=0.0.0.0`) binds memcached's TCP " +
+			"listener to every interface on the host. Memcached has no authentication and, " +
+			"before `-U 0` became default, its UDP handler was the largest DDoS-" +
+			"amplification vector on the internet. Bind to `127.0.0.1` or a private-" +
+			"network IP only, and put memcached behind a firewall / security group scoped " +
+			"to the application that consumes it.",
+		Check: checkZC1766,
+	})
+}
+
+func checkZC1766(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "memcached" {
+		return nil
+	}
+
+	prevListen := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevListen {
+			if zc1766IsUnrestrictedBind(v) {
+				return zc1766Hit(cmd, "-l "+v)
+			}
+			prevListen = false
+			continue
+		}
+		switch {
+		case v == "-l":
+			prevListen = true
+		case strings.HasPrefix(v, "-l") && len(v) > 2:
+			if zc1766IsUnrestrictedBind(v[2:]) {
+				return zc1766Hit(cmd, v)
+			}
+		case strings.HasPrefix(v, "--listen="):
+			if zc1766IsUnrestrictedBind(strings.TrimPrefix(v, "--listen=")) {
+				return zc1766Hit(cmd, v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1766IsUnrestrictedBind(s string) bool {
+	return s == "0.0.0.0" || s == "::" || s == "[::]"
+}
+
+func zc1766Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1766",
+		Message: "`memcached " + what + "` exposes the unauthenticated cache to every " +
+			"interface on the host. Bind to `127.0.0.1` or a private-network IP and " +
+			"firewall the port.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 762 Katas = 0.7.62
-const Version = "0.7.62"
+// 763 Katas = 0.7.63
+const Version = "0.7.63"


### PR DESCRIPTION
ZC1766 — `memcached -l 0.0.0.0`

What: Detect `memcached` binding its listener to an unrestricted address (`0.0.0.0` / `::` / joined `-l0.0.0.0`).
Why: Memcached has no auth; the UDP handler used to be the largest DDoS-amplification vector on the internet. Binding to 0.0.0.0 exposes it to every reachable interface.
Fix suggestion: Bind to `127.0.0.1` or a private-network IP and firewall the port.
Severity: Error