### PR TITLE
feat: ZC1767 — flag `mongod --bind_ip 0.0.0.0` (Mongo exposed on every interface)

### DIFF
--- a/pkg/katas/katatests/zc1767_test.go
+++ b/pkg/katas/katatests/zc1767_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1767(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `mongod --bind_ip 127.0.0.1`",
+			input:    `mongod --bind_ip 127.0.0.1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `mongod --bind_ip 0.0.0.0` (leading-flag mangled)",
+			input: `mongod --bind_ip 0.0.0.0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1767",
+					Message: "`mongod --bind_ip 0.0.0.0` exposes MongoDB on every interface — 2017 ransomware-wave target. Bind to `127.0.0.1` or a private-network IP, enable `--auth`, firewall port 27017.",
+					Line:    1,
+					Column:  10,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1767")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1767.go
+++ b/pkg/katas/zc1767.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1767",
+		Title:    "Error on `mongod --bind_ip 0.0.0.0` — MongoDB exposed on every interface",
+		Severity: SeverityError,
+		Description: "`mongod --bind_ip 0.0.0.0` (or `::`) binds MongoDB's listener to every " +
+			"interface on the host. Combined with no-auth defaults (pre-3.4) or a wildcard " +
+			"database user, this was the source of the 2017 ransomware wave that wiped " +
+			"tens of thousands of public MongoDB instances. Bind to `127.0.0.1` or a " +
+			"private-network IP, enable authentication with `--auth`, and firewall port " +
+			"`27017`.",
+		Check: checkZC1767,
+	})
+}
+
+func checkZC1767(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	// Parser caveat: `mongod --bind_ip 0.0.0.0` mangles to SimpleCommand name
+	// "bind_ip" with the IP as the first arg.
+	if ident.Value != "bind_ip" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	first := cmd.Arguments[0].String()
+	if first != "0.0.0.0" && first != "::" && first != "[::]" {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1767",
+		Message: "`mongod --bind_ip " + first + "` exposes MongoDB on every interface — " +
+			"2017 ransomware-wave target. Bind to `127.0.0.1` or a private-network IP, " +
+			"enable `--auth`, firewall port 27017.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 763 Katas = 0.7.63
-const Version = "0.7.63"
+// 764 Katas = 0.7.64
+const Version = "0.7.64"


### PR DESCRIPTION
ZC1767 — `mongod --bind_ip 0.0.0.0`

What: Detect `mongod` binding to `0.0.0.0` / `::` (uses parser leading-flag mangling — SimpleCommand name becomes `bind_ip`).
Why: Combined with no-auth defaults or a wildcard user, this is the 2017 MongoDB-ransomware-wave recipe — tens of thousands of public instances wiped.
Fix suggestion: Bind to `127.0.0.1` or a private-network IP, enable `--auth`, firewall port 27017.
Severity: Error