### PR TITLE
feat: ZC1768 — flag `sqlcmd/bcp/osql -P PASSWORD` (SQL Server pass in argv)

### DIFF
--- a/pkg/katas/katatests/zc1768_test.go
+++ b/pkg/katas/katatests/zc1768_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1768(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `sqlcmd -S server -U user -P` (prompt)",
+			input:    `sqlcmd -S server -U user -P`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `sqlcmd -S server -E` (Windows auth, no password)",
+			input:    `sqlcmd -S server -E`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `sqlcmd -S server -U user -P hunter2`",
+			input: `sqlcmd -S server -U user -P hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1768",
+					Message: "`sqlcmd -P hunter2` puts the SQL Server password in argv — visible in `ps`, `/proc`, history, SQL Server audit. Use `-P` with no arg (prompt) or `SQLCMDPASSWORD` env var.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `bcp mydb in data.csv -U user -P hunter2`",
+			input: `bcp mydb in data.csv -U user -P hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1768",
+					Message: "`bcp -P hunter2` puts the SQL Server password in argv — visible in `ps`, `/proc`, history, SQL Server audit. Use `-P` with no arg (prompt) or `SQLCMDPASSWORD` env var.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1768")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1768.go
+++ b/pkg/katas/zc1768.go
@@ -1,0 +1,66 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1768",
+		Title:    "Error on `sqlcmd -P PASSWORD` / `bcp -P PASSWORD` — SQL Server password in argv",
+		Severity: SeverityError,
+		Description: "Microsoft's SQL Server CLI tools (`sqlcmd`, `bcp`, `osql`) accept the " +
+			"password via `-P PASSWORD` as a positional argument value. The password lands " +
+			"in argv — visible in `ps`, `/proc/<pid>/cmdline`, shell history, CI logs, and " +
+			"SQL Server's audit trace for the session. Use `-P` with no value (prompts), " +
+			"or read the password from the environment variable `SQLCMDPASSWORD` (sourced " +
+			"from a secrets file). On modern sqlcmd, `-G` + Azure AD integration avoids the " +
+			"password altogether.",
+		Check: checkZC1768,
+	})
+}
+
+func checkZC1768(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "sqlcmd", "bcp", "osql":
+	default:
+		return nil
+	}
+
+	prevP := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevP {
+			prevP = false
+			if v == "" || v == "-" {
+				continue
+			}
+			// Any other flag-looking value means `-P` ran as bare (prompt).
+			if len(v) > 1 && v[0] == '-' {
+				continue
+			}
+			return []Violation{{
+				KataID: "ZC1768",
+				Message: "`" + ident.Value + " -P " + v + "` puts the SQL Server password " +
+					"in argv — visible in `ps`, `/proc`, history, SQL Server audit. " +
+					"Use `-P` with no arg (prompt) or `SQLCMDPASSWORD` env var.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+		if v == "-P" {
+			prevP = true
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 764 Katas = 0.7.64
-const Version = "0.7.64"
+// 765 Katas = 0.7.65
+const Version = "0.7.65"


### PR DESCRIPTION
ZC1768 — `sqlcmd/bcp/osql -P PASSWORD`

What: Detect Microsoft SQL Server CLI tools (`sqlcmd`, `bcp`, `osql`) paired with `-P` followed by a password value.
Why: Password lands in argv — visible in `ps`, `/proc/<pid>/cmdline`, history, CI logs, and SQL Server's audit trace.
Fix suggestion: Use `-P` with no value (prompts), or set `SQLCMDPASSWORD` env var from a secrets file; `-G` + Azure AD avoids the password entirely.
Severity: Error