### PR TITLE
feat: ZC1769 — flag `vagrant destroy --force` (VM wiped without prompt)

### DIFF
--- a/pkg/katas/katatests/zc1769_test.go
+++ b/pkg/katas/katatests/zc1769_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1769(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `vagrant destroy` (prompt kept)",
+			input:    `vagrant destroy`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `vagrant halt`",
+			input:    `vagrant halt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `vagrant destroy --force`",
+			input: `vagrant destroy --force`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1769",
+					Message: "`vagrant destroy --force` skips the prompt and drops the VM (and any un-exported data inside). Drop the flag, or use `vagrant halt` + `vagrant up` to cycle without destroy.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `vagrant destroy -f myvm`",
+			input: `vagrant destroy -f myvm`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1769",
+					Message: "`vagrant destroy -f` skips the prompt and drops the VM (and any un-exported data inside). Drop the flag, or use `vagrant halt` + `vagrant up` to cycle without destroy.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1769")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1769.go
+++ b/pkg/katas/zc1769.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1769",
+		Title:    "Warn on `vagrant destroy --force` — VM destroyed without confirmation",
+		Severity: SeverityWarning,
+		Description: "`vagrant destroy --force` (alias `-f`) tears every VM in the Vagrantfile " +
+			"down — and their ephemeral filesystem state — without prompting. Any data " +
+			"provisioned into the VM that was never exported back to the host (database " +
+			"seeds, build caches, local-only test fixtures) goes with it. In unattended " +
+			"scripts, drop the flag so the prompt still gates the destroy; for CI cycles, " +
+			"`vagrant halt` + `vagrant up` reuses the same box without losing state.",
+		Check: checkZC1769,
+	})
+}
+
+func checkZC1769(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "vagrant" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "destroy" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--force" || v == "-f" {
+			return []Violation{{
+				KataID: "ZC1769",
+				Message: "`vagrant destroy " + v + "` skips the prompt and drops the VM " +
+					"(and any un-exported data inside). Drop the flag, or use `vagrant " +
+					"halt` + `vagrant up` to cycle without destroy.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 765 Katas = 0.7.65
-const Version = "0.7.65"
+// 766 Katas = 0.7.66
+const Version = "0.7.66"


### PR DESCRIPTION
ZC1769 — `vagrant destroy --force`

What: Detect `vagrant destroy` paired with `--force` or `-f`.
Why: Skips the confirmation and tears down every VM in the Vagrantfile — any un-exported data inside (seeds, caches, fixtures) goes with the VM.
Fix suggestion: Drop the flag so the prompt gates the destroy; cycle CI boxes with `vagrant halt` + `vagrant up` instead of destroy.
Severity: Warning