### PR TITLE
feat: ZC1770 — warn on gpg --always-trust / --trust-model always

### DIFF
--- a/pkg/katas/katatests/zc1770_test.go
+++ b/pkg/katas/katatests/zc1770_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1770(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gpg --verify sig.asc` (default trust model)",
+			input:    `gpg --verify sig.asc`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gpg --trust-model pgp --verify sig.asc`",
+			input:    `gpg --trust-model pgp --verify sig.asc`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gpg --verify --always-trust sig.asc` (trailing form)",
+			input: `gpg --verify --always-trust sig.asc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1770",
+					Message: "`gpg --always-trust` marks every imported key as fully trusted — a signature from an attacker-supplied key verifies cleanly. Drop the flag and pin the expected fingerprint, or assign trust via `gpg --edit-key KEYID trust`.",
+					Line:    1,
+					Column:  16,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gpg --verify --trust-model always sig.asc`",
+			input: `gpg --verify --trust-model always sig.asc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1770",
+					Message: "`gpg --trust-model always` marks every imported key as fully trusted — a signature from an attacker-supplied key verifies cleanly. Drop the flag and pin the expected fingerprint, or assign trust via `gpg --edit-key KEYID trust`.",
+					Line:    1,
+					Column:  16,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1770")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1770.go
+++ b/pkg/katas/zc1770.go
@@ -1,0 +1,74 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1770",
+		Title:    "Warn on `gpg --always-trust` / `--trust-model always` — bypasses Web-of-Trust",
+		Severity: SeverityWarning,
+		Description: "`gpg --always-trust` (equivalent to `--trust-model always`) accepts every key " +
+			"in the keyring as fully trusted, regardless of signatures from the owner or any " +
+			"introducer. A signature made by an attacker-controlled key pair that was imported " +
+			"with no further vetting will verify cleanly. In automation this turns signature " +
+			"verification into a presence check — any key bundled with the payload satisfies " +
+			"`gpg --verify`. Remove the flag and build a proper trust path: either mark the " +
+			"expected signer key trusted once (`gpg --edit-key KEYID trust`), or pin the " +
+			"expected fingerprint and match it against the signer after `gpg --verify --status-fd 1`.",
+		Check: checkZC1770,
+	})
+}
+
+func checkZC1770(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value == "always-trust" {
+		return zc1770Hit(cmd, "--always-trust")
+	}
+	if ident.Value == "trust-model" {
+		if len(cmd.Arguments) > 0 && cmd.Arguments[0].String() == "always" {
+			return zc1770Hit(cmd, "--trust-model always")
+		}
+		return nil
+	}
+
+	if ident.Value != "gpg" && ident.Value != "gpg2" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--always-trust" {
+			return zc1770Hit(cmd, "--always-trust")
+		}
+		if v == "--trust-model" && i+1 < len(cmd.Arguments) && cmd.Arguments[i+1].String() == "always" {
+			return zc1770Hit(cmd, "--trust-model always")
+		}
+		if v == "--trust-model=always" {
+			return zc1770Hit(cmd, "--trust-model=always")
+		}
+	}
+	return nil
+}
+
+func zc1770Hit(cmd *ast.SimpleCommand, flag string) []Violation {
+	return []Violation{{
+		KataID: "ZC1770",
+		Message: "`gpg " + flag + "` marks every imported key as fully trusted — a " +
+			"signature from an attacker-supplied key verifies cleanly. Drop the flag " +
+			"and pin the expected fingerprint, or assign trust via `gpg --edit-key KEYID trust`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 766 Katas = 0.7.66
-const Version = "0.7.66"
+// 767 Katas = 0.7.67
+const Version = "0.7.67"


### PR DESCRIPTION
ZC1770 — gpg --always-trust / --trust-model always

What: detect gpg / gpg2 called with --always-trust, --trust-model always, or --trust-model=always.
Why: these options mark every imported key as fully trusted; a signature from an attacker-supplied key verifies cleanly.
Fix suggestion: drop the flag and either pin the expected fingerprint and match after --status-fd 1, or set trust once via gpg --edit-key KEYID trust.
Severity: Warning