### PR TITLE
feat: ZC1771 — warn on alias -g / alias -s in scripts

### DIFF
--- a/pkg/katas/katatests/zc1771_test.go
+++ b/pkg/katas/katatests/zc1771_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1771(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `alias ll='ls -l'` (regular alias)",
+			input:    `alias ll='ls -l'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `alias` (no args, lists aliases)",
+			input:    `alias`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `alias -g G='| grep'`",
+			input: `alias -g G='| grep'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1771",
+					Message: "`alias -g` defines a global alias that expands outside command position — a surprise for anyone reading the script later. Prefer a function, or keep global aliases in `~/.zshrc` where they are discoverable.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `alias -s log=less`",
+			input: `alias -s log=less`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1771",
+					Message: "`alias -s` defines a suffix alias that expands outside command position — a surprise for anyone reading the script later. Prefer a function, or keep suffix aliases in `~/.zshrc` where they are discoverable.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1771")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1771.go
+++ b/pkg/katas/zc1771.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1771",
+		Title:    "Warn on `alias -g` / `alias -s` — global and suffix aliases surprise script readers",
+		Severity: SeverityWarning,
+		Description: "`alias -g NAME=value` defines a global alias that expands anywhere on the " +
+			"command line, not just in command position. `alias -s ext=cmd` (suffix alias) runs " +
+			"`cmd file.ext` whenever a bare `file.ext` appears as a command. Both forms are " +
+			"Zsh-idiomatic interactive conveniences; in scripts they produce surprising " +
+			"substitutions that a reader cannot infer from local context — a bare word like " +
+			"`G` or `foo.log` stops meaning what it looks like. Use a function or a regular " +
+			"alias instead, and keep `alias -g` / `alias -s` in your `~/.zshrc` where the " +
+			"definition is discoverable.",
+		Check: checkZC1771,
+	})
+}
+
+func checkZC1771(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "alias" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	first := cmd.Arguments[0].String()
+	switch {
+	case first == "-g":
+		return zc1771Hit(cmd, "-g", "global")
+	case first == "-s":
+		return zc1771Hit(cmd, "-s", "suffix")
+	case strings.HasPrefix(first, "-") && !strings.HasPrefix(first, "--"):
+		if strings.ContainsRune(first, 'g') {
+			return zc1771Hit(cmd, first, "global")
+		}
+		if strings.ContainsRune(first, 's') {
+			return zc1771Hit(cmd, first, "suffix")
+		}
+	}
+	return nil
+}
+
+func zc1771Hit(cmd *ast.SimpleCommand, flag, kind string) []Violation {
+	return []Violation{{
+		KataID: "ZC1771",
+		Message: "`alias " + flag + "` defines a " + kind + " alias that expands outside " +
+			"command position — a surprise for anyone reading the script later. Prefer a " +
+			"function, or keep " + kind + " aliases in `~/.zshrc` where they are discoverable.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 767 Katas = 0.7.67
-const Version = "0.7.67"
+// 768 Katas = 0.7.68
+const Version = "0.7.68"


### PR DESCRIPTION
ZC1771 — alias -g / alias -s in scripts

What: detect `alias -g NAME=value` (global) or `alias -s ext=cmd` (suffix) definitions.
Why: both forms expand outside command position, producing surprising substitutions for anyone reading the script. Works as designed in interactive rc files but confuses script readers.
Fix suggestion: prefer a regular function; keep global/suffix aliases in `~/.zshrc` where the definition is discoverable.
Severity: Warning