### PR TITLE
feat: ZC1772 — error on hdparm --security-erase / --trim-sector-ranges

### DIFF
--- a/pkg/katas/katatests/zc1772_test.go
+++ b/pkg/katas/katatests/zc1772_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1772(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `hdparm -I $DISK` (info only)",
+			input:    `hdparm -I $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `hdparm -tT $DISK` (benchmark)",
+			input:    `hdparm -tT $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `hdparm --security-erase PASS $DISK`",
+			input: `hdparm --security-erase PASS $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1772",
+					Message: "`hdparm --security-erase` issues an ATA-level operation that ignores filesystems and cannot be rolled back. Pin the disk by `/dev/disk/by-id/…`, keep it behind a runbook, keep the password out of argv.",
+					Line:    1,
+					Column:  10,
+				},
+			},
+		},
+		{
+			name:  "invalid — `hdparm --trim-sector-ranges 0:1 $DISK`",
+			input: `hdparm --trim-sector-ranges 0:1 $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1772",
+					Message: "`hdparm --trim-sector-ranges` issues an ATA-level operation that ignores filesystems and cannot be rolled back. Pin the disk by `/dev/disk/by-id/…`, keep it behind a runbook, keep the password out of argv.",
+					Line:    1,
+					Column:  10,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1772")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1772.go
+++ b/pkg/katas/zc1772.go
@@ -1,0 +1,85 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1772EraseFlags = map[string]bool{
+	"--security-erase":          true,
+	"--security-erase-enhanced": true,
+	"--security-set-pass":       true,
+	"--security-unlock":         true,
+	"--security-disable":        true,
+	"--security-freeze":         true,
+	"--trim-sector-ranges":      true,
+}
+
+// Parser caveat: a leading long flag can mangle hdparm into a SimpleCommand
+// whose name is the bare flag without leading dashes.
+var zc1772MangledNames = map[string]bool{
+	"security-erase":          true,
+	"security-erase-enhanced": true,
+	"security-set-pass":       true,
+	"security-unlock":         true,
+	"security-disable":        true,
+	"security-freeze":         true,
+	"trim-sector-ranges":      true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1772",
+		Title:    "Error on `hdparm --security-erase` / `--trim-sector-ranges` — ATA-level data destruction",
+		Severity: SeverityError,
+		Description: "`hdparm --security-erase PASS $DISK` issues the ATA `SECURITY ERASE UNIT` " +
+			"command: the drive firmware wipes every block, ignoring filesystem or partition " +
+			"boundaries, and the operation cannot be interrupted or rolled back. " +
+			"`--security-erase-enhanced` is the same but also clears reallocated sectors, and " +
+			"`--trim-sector-ranges` discards the listed LBAs on any TRIM-capable device. " +
+			"`--security-set-pass`, `--security-disable`, `--security-unlock`, and " +
+			"`--security-freeze` alter the drive-level password state and, if misused in a " +
+			"script, lock the device out of future access. Keep these calls behind a guarded " +
+			"runbook with the exact disk pinned by `/dev/disk/by-id/…` and the password stored " +
+			"outside argv.",
+		Check: checkZC1772,
+	})
+}
+
+func checkZC1772(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if zc1772MangledNames[ident.Value] {
+		return zc1772Hit(cmd, "--"+ident.Value)
+	}
+
+	if ident.Value != "hdparm" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if zc1772EraseFlags[v] {
+			return zc1772Hit(cmd, v)
+		}
+	}
+	return nil
+}
+
+func zc1772Hit(cmd *ast.SimpleCommand, flag string) []Violation {
+	return []Violation{{
+		KataID: "ZC1772",
+		Message: "`hdparm " + flag + "` issues an ATA-level operation that ignores " +
+			"filesystems and cannot be rolled back. Pin the disk by " +
+			"`/dev/disk/by-id/…`, keep it behind a runbook, keep the password out of argv.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 768 Katas = 0.7.68
-const Version = "0.7.68"
+// 769 Katas = 0.7.69
+const Version = "0.7.69"


### PR DESCRIPTION
ZC1772 — hdparm destructive ATA commands

What: detect hdparm called with --security-erase, --security-erase-enhanced, --security-set-pass, --security-unlock, --security-disable, --security-freeze, or --trim-sector-ranges.
Why: these flags talk to the drive firmware directly — filesystem and partition boundaries are ignored, the operation cannot be rolled back, and credential flags can lock the device out of future access.
Fix suggestion: keep the call behind a runbook, pin the disk via /dev/disk/by-id/…, and keep the password out of argv.
Severity: Error