### PR TITLE
feat: ZC1773 — warn on xargs without -r / --no-run-if-empty

### DIFF
--- a/pkg/katas/katatests/zc1773_test.go
+++ b/pkg/katas/katatests/zc1773_test.go
@@ -1,0 +1,68 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1773(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `xargs -r rm` (guard present)",
+			input:    `xargs -r rm`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `xargs --no-run-if-empty rm`",
+			input:    `xargs --no-run-if-empty rm`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `xargs -0r rm` (combined short flags)",
+			input:    `xargs -0r rm`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `xargs` alone (no command, probably a noop / listing)",
+			input:    `xargs`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `xargs rm` (no guard)",
+			input: `xargs rm`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1773",
+					Message: "`xargs` without `-r` / `--no-run-if-empty` runs the child once with no arguments when stdin is empty — a destructive surprise for `xargs rm`, `xargs kill`, etc. Add `-r` or switch to `find ... -exec cmd {} +`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `xargs -0 kill -9`",
+			input: `xargs -0 kill -9`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1773",
+					Message: "`xargs` without `-r` / `--no-run-if-empty` runs the child once with no arguments when stdin is empty — a destructive surprise for `xargs rm`, `xargs kill`, etc. Add `-r` or switch to `find ... -exec cmd {} +`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1773")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1773.go
+++ b/pkg/katas/zc1773.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1773",
+		Title:    "Warn on `xargs` without `-r` / `--no-run-if-empty` — runs once on empty input",
+		Severity: SeverityWarning,
+		Description: "GNU `xargs` (the common default on Linux) invokes the child command once " +
+			"with no arguments when its stdin is empty. Paired with a destructive child " +
+			"(`xargs rm`, `xargs kill`, `xargs docker stop`) a pipeline that produces zero " +
+			"hits silently runs the command with no operand — usually an error at best and a " +
+			"footgun at worst. The flag `-r` (GNU) / `--no-run-if-empty` tells xargs to skip " +
+			"the call when no items arrive. Add `-r` to every `xargs` pipeline whose producer " +
+			"can return no results, or switch to `find ... -exec cmd {} +` which never runs " +
+			"the child on empty input. BSD xargs defaults to this behavior, but the portable " +
+			"and explicit choice is to pass `-r` and document the intent.",
+		Check: checkZC1773,
+	})
+}
+
+func checkZC1773(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "xargs" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-r" || v == "--no-run-if-empty" {
+			return nil
+		}
+		// Combined short-flag form like `-rt` or `-0r`.
+		if len(v) > 1 && v[0] == '-' && v[1] != '-' {
+			for _, c := range v[1:] {
+				if c == 'r' {
+					return nil
+				}
+			}
+		}
+	}
+	return []Violation{{
+		KataID: "ZC1773",
+		Message: "`xargs` without `-r` / `--no-run-if-empty` runs the child once with no " +
+			"arguments when stdin is empty — a destructive surprise for `xargs rm`, " +
+			"`xargs kill`, etc. Add `-r` or switch to `find ... -exec cmd {} +`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 769 Katas = 0.7.69
-const Version = "0.7.69"
+// 770 Katas = 0.7.70
+const Version = "0.7.70"


### PR DESCRIPTION
ZC1773 — xargs without -r / --no-run-if-empty

What: detect xargs invocations that omit -r / --no-run-if-empty.
Why: GNU xargs runs the child command once with no arguments when stdin is empty. Paired with a destructive child (xargs rm, xargs kill, xargs docker stop) an empty producer silently issues a destructive call with no operand.
Fix suggestion: add -r (GNU) / --no-run-if-empty, or switch to find ... -exec cmd {} + which never runs the child on empty input.
Severity: Warning