### PR TITLE
feat: ZC1774 — warn on setopt GLOB_SUBST / set -o globsubst

### DIFF
--- a/pkg/katas/katatests/zc1774_test.go
+++ b/pkg/katas/katatests/zc1774_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1774(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt EXTENDED_GLOB` (unrelated option)",
+			input:    `setopt EXTENDED_GLOB`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `set -e` (unrelated short option)",
+			input:    `set -e`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt GLOB_SUBST`",
+			input: `setopt GLOB_SUBST`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1774",
+					Message: "`setopt GLOB_SUBST` enables `GLOB_SUBST` — every unquoted `$var` expansion is rescanned as a glob pattern. User-controlled data becomes a filesystem query. Scope this in a subshell / function, or use explicit expansion flags.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt globsubst` (Zsh lower/underscore folded)",
+			input: `setopt globsubst`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1774",
+					Message: "`setopt globsubst` enables `GLOB_SUBST` — every unquoted `$var` expansion is rescanned as a glob pattern. User-controlled data becomes a filesystem query. Scope this in a subshell / function, or use explicit expansion flags.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `set -o GLOB_SUBST`",
+			input: `set -o GLOB_SUBST`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1774",
+					Message: "`set -o GLOB_SUBST` enables `GLOB_SUBST` — every unquoted `$var` expansion is rescanned as a glob pattern. User-controlled data becomes a filesystem query. Scope this in a subshell / function, or use explicit expansion flags.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1774")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1774.go
+++ b/pkg/katas/zc1774.go
@@ -1,0 +1,73 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1774",
+		Title:    "Warn on `setopt GLOB_SUBST` — `$var` starts glob-expanding, user data becomes a pattern",
+		Severity: SeverityWarning,
+		Description: "With `GLOB_SUBST` enabled, the result of any parameter expansion is " +
+			"rescanned for filename-generation metacharacters (`*`, `?`, `[`, `^`, `~`, " +
+			"brace ranges, qualifiers). Zsh's default — `NO_GLOB_SUBST` — keeps `$var` literal " +
+			"and matches the behavior most script authors expect after moving from Bash or " +
+			"POSIX sh. Turning `GLOB_SUBST` on globally means any unquoted `$var` that " +
+			"contains a metacharacter (environment, argv, file contents, user prompt) is " +
+			"expanded against the filesystem — an injection vector, and a subtle source of " +
+			"`no matches found` failures on empty variables. Keep `setopt GLOB_SUBST` inside a " +
+			"narrow subshell or function body, or use explicit `~` / `(e)` / `(P)` flags where " +
+			"you actually want the rescan.",
+		Check: checkZC1774,
+	})
+}
+
+func checkZC1774(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := strings.ToUpper(strings.ReplaceAll(arg.String(), "_", ""))
+			if v == "GLOBSUBST" {
+				return zc1774Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "set":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "-G" {
+				return zc1774Hit(cmd, "set -G")
+			}
+			if v == "-o" || v == "--option" {
+				continue
+			}
+			if strings.EqualFold(strings.ReplaceAll(v, "_", ""), "globsubst") {
+				return zc1774Hit(cmd, "set -o "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1774Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1774",
+		Message: "`" + where + "` enables `GLOB_SUBST` — every unquoted `$var` expansion " +
+			"is rescanned as a glob pattern. User-controlled data becomes a filesystem " +
+			"query. Scope this in a subshell / function, or use explicit expansion flags.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 770 Katas = 0.7.70
-const Version = "0.7.70"
+// 771 Katas = 0.7.71
+const Version = "0.7.71"


### PR DESCRIPTION
ZC1774 — setopt GLOB_SUBST

What: detect setopt GLOB_SUBST, set -G, and set -o GLOB_SUBST (also case/underscore folded).
Why: with GLOB_SUBST on, every unquoted $var expansion is rescanned as a filename glob. User-controlled data becomes a filesystem query — an injection vector and a subtle source of no-matches-found failures on empty variables.
Fix suggestion: scope the option inside a narrow subshell / function, or use explicit expansion flags (~, (e), (P)) where you actually want the rescan.
Severity: Warning