### PR TITLE
feat: ZC1775 — warn on timeout without --kill-after / -k

### DIFF
--- a/pkg/katas/katatests/zc1775_test.go
+++ b/pkg/katas/katatests/zc1775_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1775(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `timeout -k 5 30 cmd` (escalation configured)",
+			input:    `timeout -k 5 30 cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `timeout --kill-after=5 30 cmd`",
+			input:    `timeout --kill-after=5 30 cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `timeout` alone (no command, probably listing help)",
+			input:    `timeout`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `timeout 30 cmd` (no escalation)",
+			input: `timeout 30 cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1775",
+					Message: "`timeout` without `--kill-after` / `-k` only sends `SIGTERM` — a child that blocks or ignores it hangs the pipeline past the deadline. Add `--kill-after=N` so timeout escalates to `SIGKILL`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `timeout 5m long-running-job`",
+			input: `timeout 5m long-running-job`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1775",
+					Message: "`timeout` without `--kill-after` / `-k` only sends `SIGTERM` — a child that blocks or ignores it hangs the pipeline past the deadline. Add `--kill-after=N` so timeout escalates to `SIGKILL`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1775")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1775.go
+++ b/pkg/katas/zc1775.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1775",
+		Title:    "Warn on `timeout DURATION cmd` without `--kill-after` / `-k` — hang on SIGTERM-resistant child",
+		Severity: SeverityWarning,
+		Description: "`timeout DURATION cmd` sends `SIGTERM` once the duration elapses and then " +
+			"waits for the child to exit. A child that blocks or ignores `SIGTERM` (long-running " +
+			"daemons, processes stuck in `D` state, a trapped / reset signal handler) never " +
+			"dies, so the entire pipeline hangs past the intended bound. Add `--kill-after=N` " +
+			"(`-k N`) so timeout escalates to `SIGKILL` after N seconds, guaranteeing exit. " +
+			"Typical choice: a few seconds shorter than your CI step budget, so the overall " +
+			"wait remains bounded.",
+		Check: checkZC1775,
+	})
+}
+
+func checkZC1775(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "timeout" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-k" || v == "--kill-after" {
+			return nil
+		}
+		if strings.HasPrefix(v, "--kill-after=") {
+			return nil
+		}
+	}
+	return []Violation{{
+		KataID: "ZC1775",
+		Message: "`timeout` without `--kill-after` / `-k` only sends `SIGTERM` — a child " +
+			"that blocks or ignores it hangs the pipeline past the deadline. Add " +
+			"`--kill-after=N` so timeout escalates to `SIGKILL`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 771 Katas = 0.7.71
-const Version = "0.7.71"
+// 772 Katas = 0.7.72
+const Version = "0.7.72"


### PR DESCRIPTION
ZC1775 — timeout without --kill-after / -k

What: detect timeout DURATION cmd when no --kill-after or -k flag is present.
Why: timeout only sends SIGTERM after the duration. A child that blocks or ignores SIGTERM (long-running daemon, stuck in D state, trapped handler) keeps running, so the pipeline hangs past the intended bound.
Fix suggestion: add --kill-after=N so timeout escalates to SIGKILL after N seconds, guaranteeing exit within DURATION + N.
Severity: Warning