### PR TITLE
feat: ZC1776 — error on DB connection URI with password in argv

### DIFF
--- a/pkg/katas/katatests/zc1776_test.go
+++ b/pkg/katas/katatests/zc1776_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1776(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `psql postgresql://user@host/db` (no password)",
+			input:    `psql postgresql://user@host/db`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `psql postgresql://host:5432/db` (port, not password)",
+			input:    `psql postgresql://host:5432/db`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `psql $PG_URL`",
+			input:    `psql $PG_URL`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `psql postgresql://user:hunter2@host/db`",
+			input: `psql postgresql://user:hunter2@host/db`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1776",
+					Message: "`postgresql://user:SECRET@…` in argv puts the password in `ps` / `/proc/PID/cmdline` / history. Use a password file (`~/.pgpass`, `~/.my.cnf`), `PGPASSWORD` / `REDISCLI_AUTH` env var, or build the URI from a secret variable.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `mongosh mongodb+srv://u:p@cluster/db`",
+			input: `mongosh "mongodb+srv://u:p@cluster/db"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1776",
+					Message: "`mongodb+srv://user:SECRET@…` in argv puts the password in `ps` / `/proc/PID/cmdline` / history. Use a password file (`~/.pgpass`, `~/.my.cnf`), `PGPASSWORD` / `REDISCLI_AUTH` env var, or build the URI from a secret variable.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1776")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1776.go
+++ b/pkg/katas/zc1776.go
@@ -1,0 +1,96 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+// Schemes that commonly embed credentials in a connection URI and are
+// passed to a CLI client that keeps the URI in argv.
+var zc1776CredSchemes = []string{
+	"postgres://",
+	"postgresql://",
+	"mysql://",
+	"mariadb://",
+	"mongodb://",
+	"mongodb+srv://",
+	"redis://",
+	"rediss://",
+	"amqp://",
+	"amqps://",
+	"kafka://",
+	"nats://",
+	"clickhouse://",
+	"cockroachdb://",
+	"db2://",
+	"mssql://",
+	"oracle://",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1776",
+		Title:    "Error on `psql postgresql://user:secret@host/db` — password in argv via connection URI",
+		Severity: SeverityError,
+		Description: "Database and message-broker CLIs accept a single connection URI " +
+			"(`postgresql://`, `mysql://`, `mongodb://`, `redis://`, `amqp://`, `kafka://`, " +
+			"and friends). When the URI embeds a password — `scheme://user:secret@host/db` — " +
+			"the secret lands in argv, visible to every user via `ps`, `/proc/PID/cmdline`, " +
+			"process accounting, and audit trails, and it often survives in shell history. " +
+			"Keep the password out of argv: use the client's password-file / `.pgpass` / " +
+			"`PGPASSWORD` / `REDISCLI_AUTH` equivalent, or interpolate the URI from an " +
+			"environment variable so the secret is not on the command line that other users " +
+			"can see.",
+		Check: checkZC1776,
+	})
+}
+
+func checkZC1776(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	if _, ok := cmd.Name.(*ast.Identifier); !ok {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		v = strings.Trim(v, "\"'")
+		if leak, scheme := zc1776UriHasPassword(v); leak {
+			return []Violation{{
+				KataID: "ZC1776",
+				Message: "`" + scheme + "user:SECRET@…` in argv puts the password in `ps` / " +
+					"`/proc/PID/cmdline` / history. Use a password file (`~/.pgpass`, " +
+					"`~/.my.cnf`), `PGPASSWORD` / `REDISCLI_AUTH` env var, or build the URI " +
+					"from a secret variable.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1776UriHasPassword(v string) (bool, string) {
+	for _, scheme := range zc1776CredSchemes {
+		if !strings.HasPrefix(v, scheme) {
+			continue
+		}
+		rest := v[len(scheme):]
+		at := strings.Index(rest, "@")
+		if at <= 0 {
+			return false, scheme
+		}
+		userinfo := rest[:at]
+		colon := strings.Index(userinfo, ":")
+		if colon <= 0 || colon == len(userinfo)-1 {
+			// No password segment, or empty password.
+			return false, scheme
+		}
+		return true, scheme
+	}
+	return false, ""
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 772 Katas = 0.7.72
-const Version = "0.7.72"
+// 773 Katas = 0.7.73
+const Version = "0.7.73"


### PR DESCRIPTION
ZC1776 — DB / broker URI with password in argv

What: detect scheme://user:password@host/... URIs on the command line (postgres, postgresql, mysql, mariadb, mongodb, mongodb+srv, redis, rediss, amqp, amqps, kafka, nats, clickhouse, cockroachdb, db2, mssql, oracle).
Why: the full URI shows up in ps, /proc/PID/cmdline, process accounting, audit logs, and shell history — everyone on the host who can list processes sees the password.
Fix suggestion: use password files (~/.pgpass, ~/.my.cnf), env vars (PGPASSWORD, REDISCLI_AUTH, etc.), or build the URI from a secret variable so the secret is not in argv.
Severity: Error