### PR TITLE
feat: ZC1777 — error on tee/cp/mv/install/dd writing /etc/ld.so.preload

### DIFF
--- a/pkg/katas/katatests/zc1777_test.go
+++ b/pkg/katas/katatests/zc1777_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1777(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `cp lib.so /usr/local/lib/` (unrelated file)",
+			input:    `cp lib.so /usr/local/lib/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `cat /etc/ld.so.preload` (read only)",
+			input:    `cat /etc/ld.so.preload`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `tee /etc/ld.so.preload`",
+			input: `tee /etc/ld.so.preload`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1777",
+					Message: "`tee /etc/ld.so.preload` writes `/etc/ld.so.preload` — linker force-loads each listed library into every process. Audit for unexpected entries; for a scoped preload use `LD_PRELOAD=` on a single invocation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `cp /tmp/x.so /etc/ld.so.preload`",
+			input: `cp /tmp/x.so /etc/ld.so.preload`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1777",
+					Message: "`cp /etc/ld.so.preload` writes `/etc/ld.so.preload` — linker force-loads each listed library into every process. Audit for unexpected entries; for a scoped preload use `LD_PRELOAD=` on a single invocation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1777")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1777.go
+++ b/pkg/katas/zc1777.go
@@ -1,0 +1,74 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+const zc1777PreloadPath = "/etc/ld.so.preload"
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1777",
+		Title:    "Error on `tee/cp/mv/install/dd` writing `/etc/ld.so.preload` — classic rootkit persistence",
+		Severity: SeverityError,
+		Description: "`/etc/ld.so.preload` lists shared libraries that the dynamic linker " +
+			"forcibly loads into every dynamically-linked binary, root processes included. " +
+			"The file is almost never needed on a modern distribution — package managers " +
+			"do not touch it, and `LD_PRELOAD` handles the per-invocation case without " +
+			"persisting the change. A script that pipes content into `/etc/ld.so.preload` " +
+			"with `tee` / `cp` / `mv` / `install` / `dd` is a textbook rootkit persistence " +
+			"primitive (`libprocesshider`, `Azazel`, `Jynx`). Remove the line, audit " +
+			"`/etc/ld.so.preload` for unexpected entries (`sha256sum`, `diff` against a " +
+			"known-good backup), and if preloading is legitimately required, use a scoped " +
+			"`LD_PRELOAD=` on the specific invocation.",
+		Check: checkZC1777,
+	})
+}
+
+func checkZC1777(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "cp", "mv", "tee", "install", "dd":
+		for _, arg := range cmd.Arguments {
+			if arg.String() == zc1777PreloadPath {
+				return zc1777Hit(cmd, ident.Value+" "+zc1777PreloadPath)
+			}
+		}
+	}
+
+	prevRedir := ""
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if prevRedir != "" {
+			if v == zc1777PreloadPath {
+				return zc1777Hit(cmd, prevRedir+" "+zc1777PreloadPath)
+			}
+			prevRedir = ""
+			continue
+		}
+		if v == ">" || v == ">>" {
+			prevRedir = v
+		}
+	}
+	return nil
+}
+
+func zc1777Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1777",
+		Message: "`" + what + "` writes `/etc/ld.so.preload` — linker force-loads " +
+			"each listed library into every process. Audit for unexpected entries; " +
+			"for a scoped preload use `LD_PRELOAD=` on a single invocation.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 773 Katas = 0.7.73
-const Version = "0.7.73"
+// 774 Katas = 0.7.74
+const Version = "0.7.74"


### PR DESCRIPTION
ZC1777 — rootkit-persistence via /etc/ld.so.preload

What: detect writes to /etc/ld.so.preload via tee, cp, mv, install, dd, or shell redirection (>, >>).
Why: the linker force-loads every library listed in /etc/ld.so.preload into every dynamically-linked process — a textbook rootkit persistence primitive (libprocesshider, Azazel, Jynx). Package managers do not touch this file; almost every legitimate use case is solved by scoped LD_PRELOAD= on a single invocation.
Fix suggestion: remove the write, audit the file for unexpected entries (sha256sum, diff against backup). If preload is legitimately required, scope it to a single command.
Severity: Error