### PR TITLE
feat: ZC1778 — warn on systemctl link from mutable source path

### DIFF
--- a/pkg/katas/katatests/zc1778_test.go
+++ b/pkg/katas/katatests/zc1778_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1778(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `systemctl start foo.service`",
+			input:    `systemctl start foo.service`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `systemctl link /etc/systemd/system/foo.service` (immutable path)",
+			input:    `systemctl link /etc/systemd/system/foo.service`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `systemctl link /tmp/foo.service`",
+			input: `systemctl link /tmp/foo.service`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1778",
+					Message: "`systemctl link /tmp/foo.service` keeps the unit in a mutable path — a tamper later changes what systemd runs. Copy the unit into `/etc/systemd/system/` with root-only perms.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `systemctl link /home/user/build/foo.service`",
+			input: `systemctl link /home/user/build/foo.service`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1778",
+					Message: "`systemctl link /home/user/build/foo.service` keeps the unit in a mutable path — a tamper later changes what systemd runs. Copy the unit into `/etc/systemd/system/` with root-only perms.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1778")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1778.go
+++ b/pkg/katas/zc1778.go
@@ -1,0 +1,84 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1778",
+		Title:    "Warn on `systemctl link /path/to/unit` — persistence from a mutable source path",
+		Severity: SeverityWarning,
+		Description: "`systemctl link` symlinks the given unit file into `/etc/systemd/system/` " +
+			"so it can be `enable`d and `start`ed by name, but the unit definition lives at " +
+			"the original path forever. If that path is writable by any non-root user " +
+			"(`/tmp/*`, `/var/tmp/*`, `/home/*`, `/opt/` with wide perms, a build output " +
+			"directory), a later tamper of the source file silently changes what systemd " +
+			"runs the next time the unit starts. Copy the unit into `/etc/systemd/system/` " +
+			"with root-only permissions, or install a package that ships it under " +
+			"`/lib/systemd/system/`, rather than linking from a mutable location.",
+		Check: checkZC1778,
+	})
+}
+
+var zc1778MutablePrefixes = []string{
+	"/tmp/",
+	"/var/tmp/",
+	"/home/",
+	"/root/",
+	"/opt/",
+	"/srv/",
+	"/mnt/",
+	"/media/",
+	"/var/lib/",
+}
+
+func checkZC1778(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "systemctl" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+
+	linkIdx := -1
+	for i, arg := range cmd.Arguments {
+		if arg.String() == "link" {
+			linkIdx = i
+			break
+		}
+	}
+	if linkIdx == -1 {
+		return nil
+	}
+	for _, arg := range cmd.Arguments[linkIdx+1:] {
+		v := arg.String()
+		if strings.HasPrefix(v, "-") {
+			continue
+		}
+		if !strings.HasPrefix(v, "/") {
+			continue
+		}
+		for _, prefix := range zc1778MutablePrefixes {
+			if strings.HasPrefix(v, prefix) {
+				return []Violation{{
+					KataID: "ZC1778",
+					Message: "`systemctl link " + v + "` keeps the unit in a mutable " +
+						"path — a tamper later changes what systemd runs. Copy the " +
+						"unit into `/etc/systemd/system/` with root-only perms.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 774 Katas = 0.7.74
-const Version = "0.7.74"
+// 775 Katas = 0.7.75
+const Version = "0.7.75"


### PR DESCRIPTION
ZC1778 — systemctl link from a mutable path

What: detect systemctl link <path> where the target path lives under /tmp, /var/tmp, /home, /root, /opt, /srv, /mnt, /media, /var/lib.
Why: systemctl link symlinks the unit from its original location. The definition remains at the source path, so a later tamper of that file silently changes what systemd runs on the next start — a persistence primitive the unit owner did not consent to.
Fix suggestion: copy the unit into /etc/systemd/system/ with root-only permissions, or install a package that ships it under /lib/systemd/system/.
Severity: Warning