### PR TITLE
feat: ZC1779 — error on az role assignment create --role Owner/Contributor/UAA

### DIFF
--- a/pkg/katas/katatests/zc1779_test.go
+++ b/pkg/katas/katatests/zc1779_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1779(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `az role assignment create --role Reader --assignee u --scope s`",
+			input:    `az role assignment create --role Reader --assignee u --scope s`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `az role assignment list` (read-only)",
+			input:    `az role assignment list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `az role assignment create --role Owner --assignee u --scope s`",
+			input: `az role assignment create --role Owner --assignee u --scope s`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1779",
+					Message: "`az role assignment create --role Owner` grants a top-of-chain role. Pick a narrower built-in role (`Reader`, specific-service Contributor) or a custom role whose permission list you can enumerate.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `az role assignment create --role=\"User Access Administrator\" --assignee u --scope s`",
+			input: `az role assignment create --role="User Access Administrator" --assignee u --scope s`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1779",
+					Message: "`az role assignment create --role User Access Administrator` grants a top-of-chain role. Pick a narrower built-in role (`Reader`, specific-service Contributor) or a custom role whose permission list you can enumerate.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1779")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1779.go
+++ b/pkg/katas/zc1779.go
@@ -1,0 +1,96 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1779AdminRoles = map[string]bool{
+	"owner":                     true,
+	"contributor":               true,
+	"user access administrator": true,
+	"useraccessadministrator":   true,
+	"role based access control administrator": true,
+	"security admin":       true,
+	"global administrator": true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1779",
+		Title:    "Error on `az role assignment create --role Owner|Contributor|User Access Administrator`",
+		Severity: SeverityError,
+		Description: "`az role assignment create --role Owner` grants full control over the " +
+			"target scope (subscription, resource group, resource). `Contributor` grants " +
+			"everything except role assignment, and `User Access Administrator` grants the " +
+			"ability to assign any role — including Owner — elsewhere in the directory. Any " +
+			"of the three is effectively top-of-chain in the assigned scope. In provisioning " +
+			"automation this breaks least privilege, invites blast-radius escalations, and " +
+			"sidesteps any review that would flag the permission grant. Assign a narrower " +
+			"built-in role (Reader, specific-service Contributor) or a custom role whose " +
+			"permission list you can enumerate.",
+		Check: checkZC1779,
+	})
+}
+
+func checkZC1779(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "az" {
+		return nil
+	}
+	if len(cmd.Arguments) < 4 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "role" ||
+		cmd.Arguments[1].String() != "assignment" ||
+		cmd.Arguments[2].String() != "create" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments[3:] {
+		v := arg.String()
+		if v == "--role" {
+			if i+4 < len(cmd.Arguments) {
+				role := cmd.Arguments[3+i+1].String()
+				role = strings.Trim(role, "\"'")
+				if zc1779IsAdminRole(role) {
+					return zc1779Hit(cmd, role)
+				}
+			}
+			continue
+		}
+		if strings.HasPrefix(v, "--role=") {
+			role := strings.TrimPrefix(v, "--role=")
+			role = strings.Trim(role, "\"'")
+			if zc1779IsAdminRole(role) {
+				return zc1779Hit(cmd, role)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1779IsAdminRole(role string) bool {
+	r := strings.ToLower(strings.TrimSpace(role))
+	r = strings.ReplaceAll(r, "_", " ")
+	r = strings.ReplaceAll(r, "-", " ")
+	r = strings.Join(strings.Fields(r), " ")
+	return zc1779AdminRoles[r]
+}
+
+func zc1779Hit(cmd *ast.SimpleCommand, role string) []Violation {
+	return []Violation{{
+		KataID: "ZC1779",
+		Message: "`az role assignment create --role " + role + "` grants a top-of-chain " +
+			"role. Pick a narrower built-in role (`Reader`, specific-service Contributor) " +
+			"or a custom role whose permission list you can enumerate.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 775 Katas = 0.7.75
-const Version = "0.7.75"
+// 776 Katas = 0.7.76
+const Version = "0.7.76"


### PR DESCRIPTION
ZC1779 — Azure privileged role assignment

What: detect az role assignment create --role <top-of-chain role> for Owner, Contributor, User Access Administrator, Role Based Access Control Administrator, Security Admin, Global Administrator.
Why: these roles grant effective top-of-chain authority in the assigned scope. Contributor can modify every resource, User Access Administrator can grant any role (including Owner) elsewhere, and Owner does both. In automation this breaks least privilege and makes every mis-scoped scope a blast-radius amplifier.
Fix suggestion: pick a narrower built-in role (Reader, specific-service Contributor) or a custom role whose permission list you can enumerate.
Severity: Error