### PR TITLE
feat: ZC1780 — warn on sysctl disabling fs.protected_* TOCTOU guards

### DIFF
--- a/pkg/katas/katatests/zc1780_test.go
+++ b/pkg/katas/katatests/zc1780_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1780(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `sysctl fs.protected_symlinks=1`",
+			input:    `sysctl fs.protected_symlinks=1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `sysctl -a` (list all)",
+			input:    `sysctl -a`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `sysctl -w fs.protected_symlinks=0`",
+			input: `sysctl -w fs.protected_symlinks=0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1780",
+					Message: "`sysctl fs.protected_symlinks=0` disables symlink follow protection in sticky dirs — re-opens a TOCTOU race in sticky dirs. Leave the default unless you have a specific reason; otherwise scope the change to a mount namespace.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `sysctl fs.protected_hardlinks=0`",
+			input: `sysctl fs.protected_hardlinks=0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1780",
+					Message: "`sysctl fs.protected_hardlinks=0` disables hardlink creation protection in sticky dirs — re-opens a TOCTOU race in sticky dirs. Leave the default unless you have a specific reason; otherwise scope the change to a mount namespace.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1780")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1780.go
+++ b/pkg/katas/zc1780.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1780FsProtections = map[string]string{
+	"fs.protected_symlinks=0":  "symlink follow protection in sticky dirs",
+	"fs.protected_hardlinks=0": "hardlink creation protection in sticky dirs",
+	"fs.protected_fifos=0":     "FIFO open protection in sticky dirs",
+	"fs.protected_regular=0":   "regular-file open protection in sticky dirs",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1780",
+		Title:    "Warn on `sysctl -w fs.protected_symlinks=0|protected_hardlinks=0|…` — TOCTOU guard disabled",
+		Severity: SeverityWarning,
+		Description: "The `fs.protected_*` sysctls close a classic race: in a sticky directory " +
+			"(`/tmp`, `/var/tmp`, `/dev/shm`), a non-owner cannot follow a symlink, create a " +
+			"hardlink to a file they don't own, or open a FIFO / regular file they didn't " +
+			"create. Those four gates block the shape of attack where a privileged program " +
+			"predictably opens a `/tmp/NAME` that an attacker has already placed as a " +
+			"symlink to `/etc/shadow`. Setting any of them to `0` re-enables the race across " +
+			"the whole host. Leave the defaults (`1` / `2`) in place; if a specific " +
+			"application legitimately needs the old behavior, run it in a mount namespace " +
+			"where `/tmp` is not sticky-shared.",
+		Check: checkZC1780,
+	})
+}
+
+func checkZC1780(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sysctl" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if note, ok := zc1780FsProtections[v]; ok {
+			return []Violation{{
+				KataID: "ZC1780",
+				Message: "`sysctl " + v + "` disables " + note + " — re-opens a TOCTOU " +
+					"race in sticky dirs. Leave the default unless you have a specific " +
+					"reason; otherwise scope the change to a mount namespace.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 776 Katas = 0.7.76
-const Version = "0.7.76"
+// 777 Katas = 0.7.77
+const Version = "0.7.77"


### PR DESCRIPTION
ZC1780 — fs.protected_* TOCTOU guards disabled

What: detect sysctl setting fs.protected_symlinks=0, fs.protected_hardlinks=0, fs.protected_fifos=0, fs.protected_regular=0.
Why: these four kernel guards block the classic TOCTOU race where a non-owner plants a symlink/hardlink/FIFO/regular file in a sticky directory (/tmp, /var/tmp, /dev/shm) so a privileged program that opens a predictable name is tricked into reading or writing a sensitive target. Disabling them re-opens the race host-wide.
Fix suggestion: leave the defaults (1 or 2) in place; if a specific application legitimately needs the old behavior, scope it to a mount namespace where /tmp is not sticky-shared.
Severity: Warning