### PR TITLE
feat: ZC1781 — error on git clone/fetch with credentials in URL

### DIFF
--- a/pkg/katas/katatests/zc1781_test.go
+++ b/pkg/katas/katatests/zc1781_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1781(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `git clone https://github.com/owner/repo.git`",
+			input:    `git clone https://github.com/owner/repo.git`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `git clone git@github.com:owner/repo.git` (SSH)",
+			input:    `git clone git@github.com:owner/repo.git`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `git clone https://token@github.com/owner/repo.git` (no password segment)",
+			input:    `git clone https://token@github.com/owner/repo.git`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `git clone https://user:ghp_xxx@github.com/owner/repo.git`",
+			input: `git clone https://user:ghp_xxx@github.com/owner/repo.git`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1781",
+					Message: "`git clone https://user:ghp_xxx@github.com/owner/repo.git` puts the token in argv and `.git/config`. Use a credential helper, `GIT_ASKPASS`, or `http.extraHeader` with an env-sourced bearer.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `git fetch https://u:p@host/repo`",
+			input: `git fetch https://u:p@host/repo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1781",
+					Message: "`git fetch https://u:p@host/repo` puts the token in argv and `.git/config`. Use a credential helper, `GIT_ASKPASS`, or `http.extraHeader` with an env-sourced bearer.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1781")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1781.go
+++ b/pkg/katas/zc1781.go
@@ -1,0 +1,103 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1781GitSubcommands = map[string]bool{
+	"clone":     true,
+	"fetch":     true,
+	"pull":      true,
+	"push":      true,
+	"ls-remote": true,
+	"archive":   true,
+}
+
+var zc1781GitUrlSchemes = []string{
+	"https://",
+	"http://",
+	"git+https://",
+	"git+http://",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1781",
+		Title:    "Error on `git clone https://user:token@host/...` — PAT in argv and git config",
+		Severity: SeverityError,
+		Description: "A git remote URL in the form `https://user:token@host/path` puts the " +
+			"personal access token directly in argv — visible via `ps`, `/proc/PID/cmdline`, " +
+			"shell history, and process accounting. `git clone` additionally records the URL " +
+			"(including the credentials) in `.git/config` as the `origin` remote, so every " +
+			"later `git fetch` / `pull` re-exposes the same token to every user who can read " +
+			"that file. Use a credential helper (`git credential-store`, `git credential-" +
+			"osxkeychain`), `GIT_ASKPASS` with a secret pulled from an env var, HTTPS + an " +
+			"SSH deploy key, or set the token via the `Authorization: Bearer` header with " +
+			"`http.extraHeader` from an env-sourced value.",
+		Check: checkZC1781,
+	})
+}
+
+func checkZC1781(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "git" {
+		return nil
+	}
+
+	subIdx := -1
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "-") {
+			continue
+		}
+		if zc1781GitSubcommands[v] {
+			subIdx = i
+		}
+		break
+	}
+	if subIdx == -1 {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[subIdx+1:] {
+		v := strings.Trim(arg.String(), "\"'")
+		if leak := zc1781HasCredsInURL(v); leak {
+			return []Violation{{
+				KataID: "ZC1781",
+				Message: "`git " + cmd.Arguments[subIdx].String() + " " + v + "` puts " +
+					"the token in argv and `.git/config`. Use a credential helper, " +
+					"`GIT_ASKPASS`, or `http.extraHeader` with an env-sourced bearer.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1781HasCredsInURL(v string) bool {
+	for _, scheme := range zc1781GitUrlSchemes {
+		if !strings.HasPrefix(v, scheme) {
+			continue
+		}
+		rest := v[len(scheme):]
+		at := strings.Index(rest, "@")
+		if at <= 0 {
+			return false
+		}
+		userinfo := rest[:at]
+		colon := strings.Index(userinfo, ":")
+		if colon <= 0 || colon == len(userinfo)-1 {
+			return false
+		}
+		return true
+	}
+	return false
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 777 Katas = 0.7.77
-const Version = "0.7.77"
+// 778 Katas = 0.7.78
+const Version = "0.7.78"


### PR DESCRIPTION
ZC1781 — git URL with user:token@host

What: detect git clone / fetch / pull / push / ls-remote / archive invoked with https://user:secret@host/... (or http/git+https variants).
Why: the credentials show up in argv (ps, /proc/PID/cmdline, shell history, process accounting) and, for clone, in .git/config as the origin remote — every later fetch/pull re-exposes the same token to anyone who can read that file.
Fix suggestion: use a credential helper (git credential-store, credential-osxkeychain), GIT_ASKPASS reading from an env-sourced secret, HTTPS + an SSH deploy key, or set http.extraHeader with an Authorization: Bearer value from env.
Severity: Error