### PR TITLE
feat: ZC1782 — error on flatpak remote-add --no-gpg-verify

### DIFF
--- a/pkg/katas/katatests/zc1782_test.go
+++ b/pkg/katas/katatests/zc1782_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1782(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `flatpak remote-add flathub https://flathub.org/repo/flathub.flatpakrepo`",
+			input:    `flatpak remote-add flathub https://flathub.org/repo/flathub.flatpakrepo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `flatpak install flathub org.gimp.GIMP`",
+			input:    `flatpak install flathub org.gimp.GIMP`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `flatpak remote-add --no-gpg-verify local /srv/repo`",
+			input: `flatpak remote-add --no-gpg-verify local /srv/repo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1782",
+					Message: "`flatpak remote-add --no-gpg-verify` disables signature verification — updates from this remote are accepted with only HTTPS as identity. Sign the repo (`ostree gpg-sign`) and import the key with `--gpg-import=KEYFILE`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `flatpak remote-modify --gpg-verify=false myrepo`",
+			input: `flatpak remote-modify --gpg-verify=false myrepo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1782",
+					Message: "`flatpak remote-modify --gpg-verify=false` disables signature verification — updates from this remote are accepted with only HTTPS as identity. Sign the repo (`ostree gpg-sign`) and import the key with `--gpg-import=KEYFILE`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1782")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1782.go
+++ b/pkg/katas/zc1782.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1782",
+		Title:    "Error on `flatpak remote-add --no-gpg-verify` — trust chain disabled for the repo",
+		Severity: SeverityError,
+		Description: "A Flatpak remote without GPG verification accepts any OSTree update that " +
+			"the server (or anyone on the path) cares to send. Signatures are what connect " +
+			"`flatpak install FOO` to the operator that actually built `FOO` — strip them and " +
+			"the install reduces to a plain HTTPS download with no identity attached. If you " +
+			"genuinely need a local / air-gapped repo, sign it yourself with `ostree gpg-sign` " +
+			"and add the key via `--gpg-import=KEYFILE`. Never leave `--no-gpg-verify` in " +
+			"provisioning scripts for production systems.",
+		Check: checkZC1782,
+	})
+}
+
+func checkZC1782(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "flatpak" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "remote-add" && cmd.Arguments[0].String() != "remote-modify" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--no-gpg-verify" ||
+			v == "--gpg-verify=false" ||
+			v == "--no-gpg-verify=true" {
+			return []Violation{{
+				KataID: "ZC1782",
+				Message: "`flatpak " + cmd.Arguments[0].String() + " " + v + "` disables " +
+					"signature verification — updates from this remote are accepted with " +
+					"only HTTPS as identity. Sign the repo (`ostree gpg-sign`) and import " +
+					"the key with `--gpg-import=KEYFILE`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 778 Katas = 0.7.78
-const Version = "0.7.78"
+// 779 Katas = 0.7.79
+const Version = "0.7.79"


### PR DESCRIPTION
ZC1782 — flatpak remote without GPG verification

What: detect flatpak remote-add / remote-modify with --no-gpg-verify, --gpg-verify=false, or --no-gpg-verify=true.
Why: signatures tie flatpak install FOO to the operator that actually built FOO. Without them the install reduces to an HTTPS download with no identity, and any update that the remote server (or anyone on the path) sends is accepted.
Fix suggestion: sign the repo with ostree gpg-sign and import the key via --gpg-import=KEYFILE.
Severity: Error