### PR TITLE
feat: ZC1783 — error on podman system reset / nerdctl prune -a --volumes

### DIFF
--- a/pkg/katas/katatests/zc1783_test.go
+++ b/pkg/katas/katatests/zc1783_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1783(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `podman rmi myimage:old`",
+			input:    `podman rmi myimage:old`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `podman system df` (read only)",
+			input:    `podman system df`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `nerdctl system prune` (no -a, no --volumes)",
+			input:    `nerdctl system prune`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `podman system reset --force`",
+			input: `podman system reset --force`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1783",
+					Message: "`podman system reset` wipes every container artifact on the host — images, volumes, networks, pods. Use narrower removals (`rmi`, `volume rm`, scoped `prune`) against the specific resource you intend to delete.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `nerdctl system prune -af --volumes`",
+			input: `nerdctl system prune -af --volumes`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1783",
+					Message: "`nerdctl system prune -a --volumes` wipes every container artifact on the host — images, volumes, networks, pods. Use narrower removals (`rmi`, `volume rm`, scoped `prune`) against the specific resource you intend to delete.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1783")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1783.go
+++ b/pkg/katas/zc1783.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1783",
+		Title:    "Error on `podman system reset` / `nerdctl system prune -af --volumes` — wipes every container artifact",
+		Severity: SeverityError,
+		Description: "`podman system reset` removes every podman container, image, volume, " +
+			"network, pod, secret, and storage driver scratch area — a full factory reset " +
+			"of the local engine. `nerdctl system prune -af --volumes` achieves the same for " +
+			"containerd. On a developer workstation this wipes cached images for unrelated " +
+			"projects; on a CI runner or build host it invalidates every warm artifact the " +
+			"job relies on; on a prod host it drops the volumes the workload stores data in. " +
+			"Use narrower commands (`podman rmi`, `podman volume rm`, scoped `podman prune`) " +
+			"that only touch the resource you intend to remove, and never pair the reset with " +
+			"`--force`.",
+		Check: checkZC1783,
+	})
+}
+
+func checkZC1783(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "podman":
+		if len(cmd.Arguments) >= 2 &&
+			cmd.Arguments[0].String() == "system" &&
+			cmd.Arguments[1].String() == "reset" {
+			return zc1783Hit(cmd, "podman system reset")
+		}
+	case "nerdctl":
+		if len(cmd.Arguments) >= 2 &&
+			cmd.Arguments[0].String() == "system" &&
+			cmd.Arguments[1].String() == "prune" {
+			hasAll := false
+			hasVolumes := false
+			for _, arg := range cmd.Arguments[2:] {
+				v := arg.String()
+				if v == "-af" || v == "-fa" || v == "-a" || v == "--all" {
+					hasAll = true
+				}
+				if v == "--volumes" {
+					hasVolumes = true
+				}
+			}
+			if hasAll && hasVolumes {
+				return zc1783Hit(cmd, "nerdctl system prune -a --volumes")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1783Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1783",
+		Message: "`" + what + "` wipes every container artifact on the host — images, " +
+			"volumes, networks, pods. Use narrower removals (`rmi`, `volume rm`, scoped " +
+			"`prune`) against the specific resource you intend to delete.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 779 Katas = 0.7.79
-const Version = "0.7.79"
+// 780 Katas = 0.7.80
+const Version = "0.7.80"


### PR DESCRIPTION
ZC1783 — factory-reset the local container engine

What: detect podman system reset (any flags) and nerdctl system prune -a --volumes.
Why: both wipe every local container artifact — images, volumes, networks, pods — not just the ones related to the current project. On a dev workstation this drops caches for unrelated work; on a CI runner it invalidates every warm artifact the job depends on; on a prod host it loses the volumes the workload stores data in.
Fix suggestion: use narrower removals (podman rmi, podman volume rm, scoped prune) targeting the specific resource you intend to delete.
Severity: Error