### PR TITLE
feat: ZC1784 — warn on git config core.hooksPath to mutable path

### DIFF
--- a/pkg/katas/katatests/zc1784_test.go
+++ b/pkg/katas/katatests/zc1784_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1784(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `git config core.hooksPath .githooks` (repo-relative)",
+			input:    `git config core.hooksPath .githooks`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `git config user.email me@example.com`",
+			input:    `git config user.email me@example.com`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `git config core.hooksPath /tmp/hooks`",
+			input: `git config core.hooksPath /tmp/hooks`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1784",
+					Message: "`git config core.hooksPath /tmp/hooks` runs hooks from a mutable path — supply-chain primitive. Keep hooks in the repo's `.git/hooks/` (or a tracked `.githooks/`) and point `core.hooksPath` at repo-owned paths only.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `git config --global core.hooksPath /home/attacker/hooks`",
+			input: `git config --global core.hooksPath /home/attacker/hooks`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1784",
+					Message: "`git config core.hooksPath /home/attacker/hooks` runs hooks from a mutable path — supply-chain primitive. Keep hooks in the repo's `.git/hooks/` (or a tracked `.githooks/`) and point `core.hooksPath` at repo-owned paths only.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1784")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1784.go
+++ b/pkg/katas/zc1784.go
@@ -1,0 +1,85 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1784HooksMutablePrefixes = []string{
+	"/tmp/",
+	"/var/tmp/",
+	"/dev/shm/",
+	"/home/",
+	"/root/",
+	"/opt/",
+	"/srv/",
+	"/mnt/",
+	"/media/",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1784",
+		Title:    "Warn on `git config core.hooksPath /tmp/...` — hook execution from a mutable path",
+		Severity: SeverityWarning,
+		Description: "`core.hooksPath` tells git which directory to run repository hooks from. " +
+			"Any file named `pre-commit`, `post-checkout`, `post-merge`, etc. under that " +
+			"directory becomes executable code invoked by routine git operations. Pointing " +
+			"`core.hooksPath` at `/tmp`, `/var/tmp`, `/dev/shm`, `/home/<other>`, `/opt`, " +
+			"`/srv`, or `/mnt` hands the git CLI an execution primitive from a path that a " +
+			"non-root (or another) user can write at will — a classic supply-chain entry " +
+			"point on shared hosts and CI runners. Keep hooks inside the repo's `.git/hooks/` " +
+			"(or a repo-owned `.githooks/` directory) and configure `core.hooksPath` only to " +
+			"paths that share the repo's owner and permissions.",
+		Check: checkZC1784,
+	})
+}
+
+func checkZC1784(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "git" {
+		return nil
+	}
+	if len(cmd.Arguments) < 3 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "config" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v != "core.hooksPath" {
+			continue
+		}
+		// Path follows.
+		if 1+i+1 >= len(cmd.Arguments) {
+			return nil
+		}
+		path := cmd.Arguments[1+i+1].String()
+		path = strings.Trim(path, "\"'")
+		if !strings.HasPrefix(path, "/") {
+			return nil
+		}
+		for _, prefix := range zc1784HooksMutablePrefixes {
+			if strings.HasPrefix(path, prefix) {
+				return []Violation{{
+					KataID: "ZC1784",
+					Message: "`git config core.hooksPath " + path + "` runs hooks from " +
+						"a mutable path — supply-chain primitive. Keep hooks in the " +
+						"repo's `.git/hooks/` (or a tracked `.githooks/`) and point " +
+						"`core.hooksPath` at repo-owned paths only.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 780 Katas = 0.7.80
-const Version = "0.7.80"
+// 781 Katas = 0.7.81
+const Version = "0.7.81"


### PR DESCRIPTION
ZC1784 — git config core.hooksPath from a mutable path

What: detect git config core.hooksPath <path> where path lives under /tmp, /var/tmp, /dev/shm, /home, /root, /opt, /srv, /mnt, /media.
Why: core.hooksPath turns any file named pre-commit, post-checkout, etc. under the directory into executable code run on routine git ops. Pointing it at a non-repo-owned path (notably /tmp or another user's home) hands the git CLI an execution primitive that a different local user can overwrite at will.
Fix suggestion: keep hooks inside the repo's .git/hooks/ (or a tracked .githooks/) and point core.hooksPath at repo-owned paths only.
Severity: Warning