### PR TITLE
feat: ZC1785 — error on ufw default allow flipping firewall baseline

### DIFF
--- a/pkg/katas/katatests/zc1785_test.go
+++ b/pkg/katas/katatests/zc1785_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1785(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ufw default deny incoming`",
+			input:    `ufw default deny incoming`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ufw allow 22/tcp`",
+			input:    `ufw allow 22/tcp`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ufw default allow incoming`",
+			input: `ufw default allow incoming`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1785",
+					Message: "`ufw default allow incoming` flips the firewall baseline to accept every port that is not explicitly denied. Restore with `ufw default deny incoming` and add narrow `ufw allow <port>` rules for the services that must be reachable.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ufw default allow` (direction omitted)",
+			input: `ufw default allow`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1785",
+					Message: "`ufw default allow incoming` flips the firewall baseline to accept every port that is not explicitly denied. Restore with `ufw default deny incoming` and add narrow `ufw allow <port>` rules for the services that must be reachable.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1785")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1785.go
+++ b/pkg/katas/zc1785.go
@@ -1,0 +1,62 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1785",
+		Title:    "Error on `ufw default allow` — flips host firewall from deny-by-default to allow-by-default",
+		Severity: SeverityError,
+		Description: "`ufw default allow incoming` (or `allow outgoing`, `allow routed`) changes " +
+			"the chain's baseline verdict — instead of only what you explicitly opened, every " +
+			"port that does not have a matching `deny` rule is accepted. On an internet-facing " +
+			"host this is effectively \"turn the firewall off\", and the effect survives reboots " +
+			"because the default is persisted to `/etc/default/ufw`. Restore with `ufw default " +
+			"deny incoming` and add narrow `ufw allow <port>` rules for the services that " +
+			"actually need to be reachable.",
+		Check: checkZC1785,
+	})
+}
+
+func checkZC1785(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "ufw" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "default" {
+		return nil
+	}
+
+	verdict := cmd.Arguments[1].String()
+	if verdict != "allow" {
+		return nil
+	}
+
+	direction := "incoming"
+	if len(cmd.Arguments) >= 3 {
+		d := cmd.Arguments[2].String()
+		if d == "incoming" || d == "outgoing" || d == "routed" {
+			direction = d
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1785",
+		Message: "`ufw default allow " + direction + "` flips the firewall baseline to " +
+			"accept every port that is not explicitly denied. Restore with `ufw default " +
+			"deny incoming` and add narrow `ufw allow <port>` rules for the services that " +
+			"must be reachable.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 781 Katas = 0.7.81
-const Version = "0.7.81"
+// 782 Katas = 0.7.82
+const Version = "0.7.82"


### PR DESCRIPTION
ZC1785 — ufw default allow

What: detect ufw default allow [incoming|outgoing|routed].
Why: flips the chain baseline from deny-by-default to allow-by-default — every port without an explicit deny is accepted. On an internet-facing host this is effectively \"firewall off\", and the change persists to /etc/default/ufw so it survives reboots.
Fix suggestion: restore ufw default deny incoming and add narrow ufw allow <port> rules only for services that must be reachable.
Severity: Error