### PR TITLE
feat: ZC1786 — error on mount.cifs / mount -t cifs with password= in argv

### DIFF
--- a/pkg/katas/katatests/zc1786_test.go
+++ b/pkg/katas/katatests/zc1786_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1786(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `mount.cifs //h/s /mnt -o credentials=/etc/cifs-creds`",
+			input:    `mount.cifs //h/s /mnt -o credentials=/etc/cifs-creds`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `mount.cifs //h/s /mnt -o guest`",
+			input:    `mount.cifs //h/s /mnt -o guest`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `mount.cifs //h/s /mnt -o username=u,password=hunter2`",
+			input: `mount.cifs //h/s /mnt -o username=u,password=hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1786",
+					Message: "`mount.cifs ... password=…` leaks the SMB password into argv / `ps` / `/proc/PID/cmdline`. Use `credentials=/path/to/creds` (mode 0600) or `$PASSWD` env var instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `mount -t cifs //h/s /mnt -o user=u,password=hunter2`",
+			input: `mount -t cifs //h/s /mnt -o user=u,password=hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1786",
+					Message: "`mount ... password=…` leaks the SMB password into argv / `ps` / `/proc/PID/cmdline`. Use `credentials=/path/to/creds` (mode 0600) or `$PASSWD` env var instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1786")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1786.go
+++ b/pkg/katas/zc1786.go
@@ -1,0 +1,98 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1786",
+		Title:    "Error on `mount.cifs ... -o password=SECRET` — SMB password in argv",
+		Severity: SeverityError,
+		Description: "Passing `password=` (or `pass=`) inside `mount.cifs` / `mount -t cifs` " +
+			"options puts the SMB password in argv. Any local user who can read `ps`, " +
+			"`/proc/PID/cmdline`, or process-accounting records gets the cleartext, and the " +
+			"line also ends up in shell history and — if captured — in CI logs. Use a " +
+			"`credentials=/etc/cifs-creds` file (`0600`, `username=` and `password=` lines), " +
+			"the `$USER`/`$PASSWD` env vars `mount.cifs` reads when those options are " +
+			"missing, or `pam_mount` for login-time mounts.",
+		Check: checkZC1786,
+	})
+}
+
+func checkZC1786(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "mount.cifs":
+		// direct form
+	case "mount":
+		isCifs := false
+		for i, arg := range cmd.Arguments {
+			v := arg.String()
+			if (v == "-t" || v == "--types") && i+1 < len(cmd.Arguments) {
+				t := cmd.Arguments[i+1].String()
+				if t == "cifs" || t == "smb3" {
+					isCifs = true
+					break
+				}
+			}
+		}
+		if !isCifs {
+			return nil
+		}
+	default:
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		var opts string
+		if strings.HasPrefix(v, "-o") && len(v) > 2 {
+			opts = v[2:]
+		} else if v == "-o" && i+1 < len(cmd.Arguments) {
+			opts = cmd.Arguments[i+1].String()
+		}
+		if opts == "" {
+			continue
+		}
+		opts = strings.Trim(opts, "\"'")
+		if zc1786OptsHavePassword(opts) {
+			return []Violation{{
+				KataID: "ZC1786",
+				Message: "`" + ident.Value + " ... password=…` leaks the SMB password " +
+					"into argv / `ps` / `/proc/PID/cmdline`. Use `credentials=/path/" +
+					"to/creds` (mode 0600) or `$PASSWD` env var instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1786OptsHavePassword(opts string) bool {
+	for _, field := range strings.Split(opts, ",") {
+		key, value, ok := strings.Cut(strings.TrimSpace(field), "=")
+		if !ok {
+			continue
+		}
+		switch strings.ToLower(key) {
+		case "password", "pass", "password2":
+			if value != "" {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 782 Katas = 0.7.82
-const Version = "0.7.82"
+// 783 Katas = 0.7.83
+const Version = "0.7.83"


### PR DESCRIPTION
ZC1786 — SMB password in mount options

What: detect mount.cifs or mount -t cifs/smb3 called with -o ...password=SECRET or ...pass=SECRET.
Why: the password shows up in argv — readable via ps, /proc/PID/cmdline, process accounting, shell history, and any captured CI log.
Fix suggestion: use -o credentials=/path/to/cifs-creds (mode 0600 with username= and password= lines), let mount.cifs read $USER/$PASSWD from env, or use pam_mount for login-time mounts.
Severity: Error