### PR TITLE
feat: ZC1787 — warn on setopt AUTO_CD / set -o autocd in scripts

### DIFF
--- a/pkg/katas/katatests/zc1787_test.go
+++ b/pkg/katas/katatests/zc1787_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1787(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt EXTENDED_GLOB` (unrelated)",
+			input:    `setopt EXTENDED_GLOB`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `set -e` (unrelated)",
+			input:    `set -e`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt AUTO_CD`",
+			input: `setopt AUTO_CD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1787",
+					Message: "`setopt AUTO_CD` turns any bare directory name into a silent `cd`. A typo or a user-controlled value reshapes `$PWD`; keep this in `~/.zshrc`, not in scripts.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt autocd` (lowercase / no underscore)",
+			input: `setopt autocd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1787",
+					Message: "`setopt autocd` turns any bare directory name into a silent `cd`. A typo or a user-controlled value reshapes `$PWD`; keep this in `~/.zshrc`, not in scripts.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `set -o autocd`",
+			input: `set -o autocd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1787",
+					Message: "`set -o autocd` turns any bare directory name into a silent `cd`. A typo or a user-controlled value reshapes `$PWD`; keep this in `~/.zshrc`, not in scripts.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1787")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1787.go
+++ b/pkg/katas/zc1787.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1787",
+		Title:    "Warn on `setopt AUTO_CD` — bare word that names a directory silently changes `$PWD`",
+		Severity: SeverityWarning,
+		Description: "With `AUTO_CD` on, any bare word that happens to name an existing directory " +
+			"is executed as `cd <word>` — no command name, no error. This is a pleasant " +
+			"interactive shortcut and an absolute footgun in scripts: a typo in a command " +
+			"name (`doker` → a directory called `doker` that was left lying around) or a " +
+			"user-controlled variable that expands to a path silently reshapes `$PWD` for " +
+			"every later relative path. Keep `AUTO_CD` inside `~/.zshrc` where it belongs, " +
+			"not in a `.zsh` script, and never turn it on inside a function that an external " +
+			"caller depends on.",
+		Check: checkZC1787,
+	})
+}
+
+func checkZC1787(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			if zc1787IsAutoCd(arg.String()) {
+				return zc1787Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "set":
+		for i, arg := range cmd.Arguments {
+			v := arg.String()
+			if (v == "-o" || v == "--option") && i+1 < len(cmd.Arguments) {
+				next := cmd.Arguments[i+1].String()
+				if zc1787IsAutoCd(next) {
+					return zc1787Hit(cmd, "set -o "+next)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func zc1787IsAutoCd(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "AUTOCD"
+}
+
+func zc1787Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1787",
+		Message: "`" + where + "` turns any bare directory name into a silent `cd`. " +
+			"A typo or a user-controlled value reshapes `$PWD`; keep this in " +
+			"`~/.zshrc`, not in scripts.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 783 Katas = 0.7.83
-const Version = "0.7.83"
+// 784 Katas = 0.7.84
+const Version = "0.7.84"


### PR DESCRIPTION
ZC1787 — AUTO_CD in a script silently cd's

What: detect setopt AUTO_CD, setopt autocd, set -o autocd (case/underscore folded).
Why: with AUTO_CD on, any bare word that happens to name an existing directory becomes cd <word>. A typo in a command, or a user-controlled variable that expands to a path, silently reshapes $PWD for every later relative path.
Fix suggestion: keep AUTO_CD in ~/.zshrc where it belongs, not in .zsh scripts. Never toggle it inside a function that external callers depend on.
Severity: Warning