### PR TITLE
feat: ZC1788 — warn on ssh/scp/sftp -F config from mutable path

### DIFF
--- a/pkg/katas/katatests/zc1788_test.go
+++ b/pkg/katas/katatests/zc1788_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1788(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ssh user@host` (default config)",
+			input:    `ssh user@host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ssh -F ~/.ssh/config user@host`",
+			input:    `ssh -F ~/.ssh/config user@host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ssh -F /tmp/ssh.conf user@host`",
+			input: `ssh -F /tmp/ssh.conf user@host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1788",
+					Message: "`ssh -F /tmp/ssh.conf` loads an alternate config from a mutable path — a tamper on that file can pin `ProxyCommand` to arbitrary code. Keep the config in `~/.ssh/config` (or a repo-owned path with `0600` perms).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `scp -F/var/tmp/conf src host:dst` (attached form)",
+			input: `scp -F/var/tmp/conf src host:dst`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1788",
+					Message: "`scp -F /var/tmp/conf` loads an alternate config from a mutable path — a tamper on that file can pin `ProxyCommand` to arbitrary code. Keep the config in `~/.ssh/config` (or a repo-owned path with `0600` perms).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1788")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1788.go
+++ b/pkg/katas/zc1788.go
@@ -1,0 +1,85 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1788SSHMutablePrefixes = []string{
+	"/tmp/",
+	"/var/tmp/",
+	"/dev/shm/",
+	"/home/",
+	"/root/",
+	"/opt/",
+	"/srv/",
+	"/mnt/",
+	"/media/",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1788",
+		Title:    "Warn on `ssh -F /tmp/config` — config from a mutable path can pin `ProxyCommand` to arbitrary code",
+		Severity: SeverityWarning,
+		Description: "`ssh -F PATH` (and `scp -F PATH`, `sftp -F PATH`) loads a user-supplied " +
+			"config file. Anything in `/etc/ssh/ssh_config` can be overridden — notably " +
+			"`ProxyCommand`, `LocalCommand`, `PermitLocalCommand`, and `Include` — which means " +
+			"a mutable source path is an execution primitive: another local user flips " +
+			"`ProxyCommand` to `/tmp/pwn`, and the next `ssh` run launches it with the " +
+			"caller's credentials and forwarded agent. Keep the config in `~/.ssh/config` (or " +
+			"a repo-owned path with the same owner and `0600` perms) and never pass `-F` to " +
+			"`/tmp`, `/var/tmp`, `/dev/shm`, another user's `/home`, `/opt`, `/srv`, or `/mnt`.",
+		Check: checkZC1788,
+	})
+}
+
+func checkZC1788(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ssh" && ident.Value != "scp" && ident.Value != "sftp" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		var path string
+		switch {
+		case v == "-F":
+			if i+1 >= len(cmd.Arguments) {
+				return nil
+			}
+			path = cmd.Arguments[i+1].String()
+		case strings.HasPrefix(v, "-F"):
+			path = v[2:]
+		default:
+			continue
+		}
+		path = strings.Trim(path, "\"'")
+		if !strings.HasPrefix(path, "/") {
+			continue
+		}
+		for _, prefix := range zc1788SSHMutablePrefixes {
+			if strings.HasPrefix(path, prefix) {
+				return []Violation{{
+					KataID: "ZC1788",
+					Message: "`" + ident.Value + " -F " + path + "` loads an alternate " +
+						"config from a mutable path — a tamper on that file can pin " +
+						"`ProxyCommand` to arbitrary code. Keep the config in " +
+						"`~/.ssh/config` (or a repo-owned path with `0600` perms).",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityWarning,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 784 Katas = 0.7.84
-const Version = "0.7.84"
+// 785 Katas = 0.7.85
+const Version = "0.7.85"


### PR DESCRIPTION
ZC1788 — ssh -F config from a mutable path

What: detect ssh -F / scp -F / sftp -F pointing at a path under /tmp, /var/tmp, /dev/shm, /home, /root, /opt, /srv, /mnt, /media.
Why: ssh -F loads a user-supplied config file. Anything in ssh_config can be overridden — notably ProxyCommand, LocalCommand, PermitLocalCommand, Include — so a mutable source file is an execution primitive for the ssh CLI. A local attacker flips ProxyCommand to /tmp/pwn and the next ssh run launches it with the caller's credentials and forwarded keys.
Fix suggestion: keep the config in ~/.ssh/config (or a repo-owned path with 0600 perms).
Severity: Warning