### PR TITLE
feat: ZC1789 — warn on setopt CORRECT / CORRECT_ALL in scripts

### DIFF
--- a/pkg/katas/katatests/zc1789_test.go
+++ b/pkg/katas/katatests/zc1789_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1789(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt EXTENDED_GLOB`",
+			input:    `setopt EXTENDED_GLOB`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt CORRECT` (turning off is fine)",
+			input:    `unsetopt CORRECT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt CORRECT`",
+			input: `setopt CORRECT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1789",
+					Message: "`setopt CORRECT` enables `CORRECT` — Zsh spellcheck silently rewrites tokens that look mistyped. In a script that corrupts file paths and steals stdin for the correction prompt. Keep in `~/.zshrc`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt CORRECT_ALL`",
+			input: `setopt CORRECT_ALL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1789",
+					Message: "`setopt CORRECT_ALL` enables `CORRECT_ALL` — Zsh spellcheck silently rewrites tokens that look mistyped. In a script that corrupts file paths and steals stdin for the correction prompt. Keep in `~/.zshrc`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `set -o correctall`",
+			input: `set -o correctall`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1789",
+					Message: "`set -o correctall` enables `CORRECT_ALL` — Zsh spellcheck silently rewrites tokens that look mistyped. In a script that corrupts file paths and steals stdin for the correction prompt. Keep in `~/.zshrc`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1789")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1789.go
+++ b/pkg/katas/zc1789.go
@@ -1,0 +1,77 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1789",
+		Title:    "Warn on `setopt CORRECT` / `CORRECT_ALL` — Zsh spellcheck silently rewrites script tokens",
+		Severity: SeverityWarning,
+		Description: "`setopt CORRECT` prompts to rewrite command names that look mistyped; " +
+			"`CORRECT_ALL` extends the check to every argument on the line. In an interactive " +
+			"shell this is a friendly nudge. In a script it becomes a footgun: a filename " +
+			"that is *close enough* to an existing file gets silently replaced with that " +
+			"other file, and the \"nlh?\" prompt reads from stdin — which may be the input " +
+			"the script was supposed to process. Keep `CORRECT` / `CORRECT_ALL` in " +
+			"`~/.zshrc` only and never toggle them inside a function a script calls.",
+		Check: checkZC1789,
+	})
+}
+
+func checkZC1789(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			if name, hit := zc1789Matches(arg.String()); hit {
+				return zc1789Hit(cmd, "setopt "+arg.String(), name)
+			}
+		}
+	case "set":
+		for i, arg := range cmd.Arguments {
+			v := arg.String()
+			if (v == "-o" || v == "--option") && i+1 < len(cmd.Arguments) {
+				next := cmd.Arguments[i+1].String()
+				if name, hit := zc1789Matches(next); hit {
+					return zc1789Hit(cmd, "set -o "+next, name)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func zc1789Matches(v string) (string, bool) {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	switch norm {
+	case "CORRECT":
+		return "CORRECT", true
+	case "CORRECTALL":
+		return "CORRECT_ALL", true
+	}
+	return "", false
+}
+
+func zc1789Hit(cmd *ast.SimpleCommand, where, canonical string) []Violation {
+	return []Violation{{
+		KataID: "ZC1789",
+		Message: "`" + where + "` enables `" + canonical + "` — Zsh spellcheck " +
+			"silently rewrites tokens that look mistyped. In a script that corrupts " +
+			"file paths and steals stdin for the correction prompt. Keep in `~/.zshrc`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 785 Katas = 0.7.85
-const Version = "0.7.85"
+// 786 Katas = 0.7.86
+const Version = "0.7.86"


### PR DESCRIPTION
ZC1789 — Zsh spellcheck in a script silently rewrites tokens

What: detect setopt CORRECT, setopt CORRECT_ALL, set -o correct, set -o correctall (case/underscore folded).
Why: CORRECT prompts to rewrite mistyped command names; CORRECT_ALL extends that to every argument on the line. In a script a filename that is close enough to an existing file gets silently replaced, and the correction prompt reads from stdin — which may be the data the script was supposed to process.
Fix suggestion: keep CORRECT / CORRECT_ALL in ~/.zshrc only; never toggle inside a function a script calls.
Severity: Warning