### PR TITLE
feat: ZC1790 — warn on unsetopt PIPE_FAIL / setopt NOPIPEFAIL

### DIFF
--- a/pkg/katas/katatests/zc1790_test.go
+++ b/pkg/katas/katatests/zc1790_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1790(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt PIPE_FAIL` (enabling)",
+			input:    `setopt PIPE_FAIL`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt PIPE_FAIL`",
+			input: `unsetopt PIPE_FAIL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1790",
+					Message: "`unsetopt PIPE_FAIL` returns the shell to last-command-only pipeline exit — `cmd1 | cmd2` now ignores `cmd1` failures. Scope the change to a subshell or function with `emulate -L zsh` instead of flipping it globally.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NOPIPEFAIL`",
+			input: `setopt NOPIPEFAIL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1790",
+					Message: "`setopt NOPIPEFAIL` returns the shell to last-command-only pipeline exit — `cmd1 | cmd2` now ignores `cmd1` failures. Scope the change to a subshell or function with `emulate -L zsh` instead of flipping it globally.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1790")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1790.go
+++ b/pkg/katas/zc1790.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1790",
+		Title:    "Warn on `unsetopt PIPE_FAIL` — pipeline exit status reverts to last-command-only",
+		Severity: SeverityWarning,
+		Description: "With `PIPE_FAIL` off (the shell default), `cmd1 | cmd2 | cmd3` exits with " +
+			"`cmd3`'s status; failures in `cmd1` and `cmd2` are silently dropped. " +
+			"`unsetopt PIPE_FAIL` (or the equivalent `setopt NOPIPEFAIL`) mid-script turns a " +
+			"previously-enabled error check back off — typically because a known-flaky pipe " +
+			"stage was tripping `set -e`, and the author reached for the global off-switch. " +
+			"Undo the change in a subshell (`( unsetopt pipefail; …; )`) or a function with " +
+			"`emulate -L zsh; unsetopt pipefail` so the rest of the script keeps strict-pipe " +
+			"error propagation.",
+		Check: checkZC1790,
+	})
+}
+
+func checkZC1790(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			if zc1790IsPipeFail(arg.String()) {
+				return zc1790Hit(cmd, "unsetopt "+arg.String())
+			}
+		}
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOPIPEFAIL" {
+				return zc1790Hit(cmd, "setopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1790IsPipeFail(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "PIPEFAIL"
+}
+
+func zc1790Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1790",
+		Message: "`" + where + "` returns the shell to last-command-only pipeline exit — " +
+			"`cmd1 | cmd2` now ignores `cmd1` failures. Scope the change to a subshell " +
+			"or function with `emulate -L zsh` instead of flipping it globally.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 786 Katas = 0.7.86
-const Version = "0.7.86"
+// 787 Katas = 0.7.87
+const Version = "0.7.87"


### PR DESCRIPTION
ZC1790 — globally disabling pipefail

What: detect unsetopt PIPE_FAIL and setopt NOPIPEFAIL (case/underscore folded).
Why: with PIPE_FAIL off, cmd1 | cmd2 | cmd3 exits with cmd3's status and failures in cmd1 / cmd2 are silently dropped. Disabling it mid-script typically happens because a flaky pipe stage was tripping set -e, and the global off-switch is the wrong fix.
Fix suggestion: scope the change to a subshell ( ( unsetopt pipefail; …; ) ) or a function with emulate -L zsh so the rest of the script keeps strict-pipe error propagation.
Severity: Warning