### PR TITLE
feat: ZC1791 — error on curl --unix-socket to docker/containerd/crio/podman daemon

### DIFF
--- a/pkg/katas/katatests/zc1791_test.go
+++ b/pkg/katas/katatests/zc1791_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1791(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `curl https://example.com`",
+			input:    `curl https://example.com`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `curl --unix-socket /run/user/1000/bus http://localhost/` (dbus)",
+			input:    `curl --unix-socket /run/user/1000/bus http://localhost/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `curl --unix-socket /var/run/docker.sock http://localhost/containers/json`",
+			input: `curl --unix-socket /var/run/docker.sock http://localhost/containers/json`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1791",
+					Message: "`curl --unix-socket /var/run/docker.sock` speaks the container-daemon API — a `POST /containers/create` with `Privileged=true` is a host-root primitive. Use the CLI (`docker`/`podman`) instead.",
+					Line:    1,
+					Column:  8,
+				},
+			},
+		},
+		{
+			name:  "invalid — `curl http://localhost/v1/services --unix-socket /run/containerd/containerd.sock` (trailing form)",
+			input: `curl http://localhost/v1/services --unix-socket /run/containerd/containerd.sock`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1791",
+					Message: "`curl --unix-socket /run/containerd/containerd.sock` speaks the container-daemon API — a `POST /containers/create` with `Privileged=true` is a host-root primitive. Use the CLI (`docker`/`podman`) instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1791")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1791.go
+++ b/pkg/katas/zc1791.go
@@ -1,0 +1,97 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1791DaemonSockets = []string{
+	"/var/run/docker.sock",
+	"/run/docker.sock",
+	"/var/run/podman/podman.sock",
+	"/run/podman/podman.sock",
+	"/run/containerd/containerd.sock",
+	"/run/crio/crio.sock",
+	"/var/run/docker/containerd/containerd.sock",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1791",
+		Title:    "Error on `curl --unix-socket /var/run/docker.sock` — direct container-daemon API access",
+		Severity: SeverityError,
+		Description: "A curl request to `docker.sock` / `containerd.sock` / `crio.sock` speaks " +
+			"the container-daemon HTTP API with no authentication beyond the socket's " +
+			"filesystem permissions. Anyone who can invoke curl as that uid can `POST " +
+			"/containers/create` with `HostConfig.Privileged=true` and a bind mount of `/` " +
+			"and land a root shell on the host — the primitive every \"docker socket " +
+			"escape\" write-up leans on. Use the real CLI (`docker`, `podman`, `nerdctl`) " +
+			"which enforces its own policy, or access the daemon over a TLS-protected TCP " +
+			"endpoint with mutual auth.",
+		Check: checkZC1791,
+	})
+}
+
+func checkZC1791(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `curl --unix-socket PATH URL` mangles so the SimpleCommand
+	// name becomes `unix-socket` and `PATH` is arg[0].
+	if ident.Value == "unix-socket" {
+		if len(cmd.Arguments) == 0 {
+			return nil
+		}
+		path := strings.Trim(cmd.Arguments[0].String(), "\"'")
+		return zc1791MatchSocket(cmd, path)
+	}
+
+	if ident.Value != "curl" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		var path string
+		switch {
+		case v == "--unix-socket":
+			if i+1 >= len(cmd.Arguments) {
+				return nil
+			}
+			path = cmd.Arguments[i+1].String()
+		case strings.HasPrefix(v, "--unix-socket="):
+			path = strings.TrimPrefix(v, "--unix-socket=")
+		default:
+			continue
+		}
+		path = strings.Trim(path, "\"'")
+		if hit := zc1791MatchSocket(cmd, path); hit != nil {
+			return hit
+		}
+	}
+	return nil
+}
+
+func zc1791MatchSocket(cmd *ast.SimpleCommand, path string) []Violation {
+	for _, sock := range zc1791DaemonSockets {
+		if path == sock {
+			return []Violation{{
+				KataID: "ZC1791",
+				Message: "`curl --unix-socket " + path + "` speaks the container-daemon " +
+					"API — a `POST /containers/create` with `Privileged=true` is a " +
+					"host-root primitive. Use the CLI (`docker`/`podman`) instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 787 Katas = 0.7.87
-const Version = "0.7.87"
+// 788 Katas = 0.7.88
+const Version = "0.7.88"


### PR DESCRIPTION
ZC1791 — curl talking directly to the container daemon

What: detect curl --unix-socket PATH where PATH is a known container-daemon socket (/var/run/docker.sock, /run/docker.sock, /run/containerd/containerd.sock, /run/crio/crio.sock, /run/podman/podman.sock and variants).
Why: a raw HTTP call to the daemon has no authentication beyond socket filesystem permissions. A POST to /containers/create with HostConfig.Privileged=true and a bind mount of / lands a root shell on the host — the primitive every docker-socket escape leans on.
Fix suggestion: use the real CLI (docker, podman, nerdctl) which enforces its own policy, or access the daemon over a TLS-protected TCP endpoint with mutual auth.
Severity: Error