### PR TITLE
feat: ZC1792 — warn on btrfs subvolume delete / device remove

### DIFF
--- a/pkg/katas/katatests/zc1792_test.go
+++ b/pkg/katas/katatests/zc1792_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1792(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `btrfs subvolume list /` (read only)",
+			input:    `btrfs subvolume list /`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `btrfs device usage /` (read only)",
+			input:    `btrfs device usage /`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `btrfs subvolume delete /snapshots/2025-01-01`",
+			input: `btrfs subvolume delete /snapshots/2025-01-01`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1792",
+					Message: "`btrfs subvolume delete` drops btrfs state with no automatic rollback — snapshots vanish on `subvolume delete`, and `device remove` can leave the filesystem degraded. Confirm the target explicitly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `btrfs device remove $DEV /mnt/pool`",
+			input: `btrfs device remove $DEV /mnt/pool`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1792",
+					Message: "`btrfs device remove` drops btrfs state with no automatic rollback — snapshots vanish on `subvolume delete`, and `device remove` can leave the filesystem degraded. Confirm the target explicitly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1792")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1792.go
+++ b/pkg/katas/zc1792.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1792",
+		Title:    "Warn on `btrfs subvolume delete` / `btrfs device remove` — unrecoverable btrfs data loss",
+		Severity: SeverityWarning,
+		Description: "`btrfs subvolume delete PATH` unlinks the subvolume and drops all of its " +
+			"extents once cleanup completes — on Snapper / Timeshift systems the argument is " +
+			"often a snapshot that is the only remaining copy of pre-incident state. " +
+			"`btrfs device remove DEV POOL` moves the stored chunks off DEV before detaching " +
+			"it; wrong device, mid-rebalance failure, or insufficient free space across the " +
+			"remaining members puts the filesystem into degraded mode with no automatic " +
+			"rollback. Keep a fresh `btrfs subvolume list`/`btrfs device usage` snapshot and " +
+			"confirm the target explicitly before running either command in automation.",
+		Check: checkZC1792,
+	})
+}
+
+func checkZC1792(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "btrfs" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+
+	sub0 := cmd.Arguments[0].String()
+	sub1 := cmd.Arguments[1].String()
+
+	switch {
+	case sub0 == "subvolume" && sub1 == "delete":
+		return zc1792Hit(cmd, "btrfs subvolume delete")
+	case sub0 == "device" && sub1 == "remove":
+		return zc1792Hit(cmd, "btrfs device remove")
+	}
+	return nil
+}
+
+func zc1792Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1792",
+		Message: "`" + what + "` drops btrfs state with no automatic rollback — " +
+			"snapshots vanish on `subvolume delete`, and `device remove` can leave " +
+			"the filesystem degraded. Confirm the target explicitly.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 788 Katas = 0.7.88
-const Version = "0.7.88"
+// 789 Katas = 0.7.89
+const Version = "0.7.89"


### PR DESCRIPTION
ZC1792 — btrfs destructive ops without automatic rollback

What: detect btrfs subvolume delete PATH and btrfs device remove DEV POOL.
Why: subvolume delete drops all extents once cleanup completes — on Snapper / Timeshift systems that PATH is often the only remaining copy of pre-incident state. device remove tries to move chunks off DEV first; wrong device, mid-rebalance failure, or insufficient free space puts the filesystem into degraded mode with no automatic rollback.
Fix suggestion: keep fresh btrfs subvolume list / btrfs device usage snapshots and confirm the target explicitly before running either command in automation.
Severity: Warning