### PR TITLE
feat: ZC1793 — warn on kubectl certificate approve signing unreviewed CSR

### DIFF
--- a/pkg/katas/katatests/zc1793_test.go
+++ b/pkg/katas/katatests/zc1793_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1793(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `kubectl certificate deny CSR_NAME`",
+			input:    `kubectl certificate deny CSR_NAME`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `kubectl get csr`",
+			input:    `kubectl get csr`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `kubectl certificate approve CSR_NAME`",
+			input: `kubectl certificate approve CSR_NAME`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1793",
+					Message: "`kubectl certificate approve` signs the identity embedded in the CSR — a `system:masters` request becomes cluster admin. Decode with `openssl req -text` first; use `kubectl certificate deny` otherwise.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1793")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1793.go
+++ b/pkg/katas/zc1793.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1793",
+		Title:    "Warn on `kubectl certificate approve CSR` — signs the identity baked into the CSR",
+		Severity: SeverityWarning,
+		Description: "`kubectl certificate approve NAME` tells the cluster signer to sign the " +
+			"pending CSR unchanged. The signer respects the Subject (CN, O) and the " +
+			"SubjectAltName extensions the caller put in the CSR — approve one that requests " +
+			"`system:masters` and you have handed the requester full admin on the cluster. " +
+			"In automation, review the CSR body first (`kubectl get csr NAME -o " +
+			"jsonpath='{.spec.request}' | base64 -d | openssl req -text`) and reject (`kubectl " +
+			"certificate deny`) any request that names a privileged group, kube-system service " +
+			"account, or hostname outside the intended scope.",
+		Check: checkZC1793,
+	})
+}
+
+func checkZC1793(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "kubectl" {
+		return nil
+	}
+	if len(cmd.Arguments) < 3 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "certificate" {
+		return nil
+	}
+	if cmd.Arguments[1].String() != "approve" {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1793",
+		Message: "`kubectl certificate approve` signs the identity embedded in the CSR " +
+			"— a `system:masters` request becomes cluster admin. Decode with " +
+			"`openssl req -text` first; use `kubectl certificate deny` otherwise.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 789 Katas = 0.7.89
-const Version = "0.7.89"
+// 790 Katas = 0.7.90
+const Version = "0.7.90"


### PR DESCRIPTION
ZC1793 — CSR approval without review

What: detect kubectl certificate approve NAME.
Why: kubectl certificate approve tells the cluster signer to sign the pending CSR unchanged. The signer honors the Subject (CN, O) and SubjectAltName extensions baked into the CSR; approving one that asks for system:masters hands the requester full cluster admin.
Fix suggestion: decode the CSR body first (kubectl get csr NAME -o jsonpath='{.spec.request}' | base64 -d | openssl req -text) and reject with kubectl certificate deny if it requests a privileged group, kube-system service account, or hostname outside the intended scope.
Severity: Warning