### PR TITLE
feat: ZC1794 — error on cosign --insecure-ignore-tlog / --allow-insecure-registry

### DIFF
--- a/pkg/katas/katatests/zc1794_test.go
+++ b/pkg/katas/katatests/zc1794_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1794(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `cosign verify registry.example.com/app:1.2.3`",
+			input:    `cosign verify registry.example.com/app:1.2.3`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `cosign sign --key cosign.key registry.example.com/app:1.2.3`",
+			input:    `cosign sign --key cosign.key registry.example.com/app:1.2.3`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `cosign verify --insecure-ignore-tlog img`",
+			input: `cosign verify --insecure-ignore-tlog img`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1794",
+					Message: "`cosign --insecure-ignore-tlog` removes a rung of the signature chain (transparency log / SCT / TLS / HTTPS-only registry). Drop the flag and fix the underlying trust anchor.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `cosign sign --allow-insecure-registry img`",
+			input: `cosign sign --allow-insecure-registry img`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1794",
+					Message: "`cosign --allow-insecure-registry` removes a rung of the signature chain (transparency log / SCT / TLS / HTTPS-only registry). Drop the flag and fix the underlying trust anchor.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1794")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1794.go
+++ b/pkg/katas/zc1794.go
@@ -1,0 +1,64 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1794CosignSkipFlags = map[string]bool{
+	"--insecure-ignore-tlog":    true,
+	"--insecure-ignore-sct":     true,
+	"--insecure-skip-verify":    true,
+	"--allow-insecure-registry": true,
+	"--allow-http-registry":     true,
+	"--allow-insecure-bundle":   true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1794",
+		Title:    "Error on `cosign verify --insecure-ignore-tlog` / `--allow-insecure-registry` — signature chain disabled",
+		Severity: SeverityError,
+		Description: "`cosign verify` with `--insecure-ignore-tlog` skips Rekor transparency-log " +
+			"verification, `--insecure-ignore-sct` skips Fulcio SCT verification, and " +
+			"`--insecure-skip-verify` turns off TLS certificate validation for the registry / " +
+			"Rekor / Fulcio endpoints. `cosign sign --allow-insecure-registry` and " +
+			"`--allow-http-registry` push signatures over plain HTTP. Each flag removes a " +
+			"distinct rung of the signature chain that `cosign` was built to enforce — a " +
+			"malicious registry or on-path attacker now passes verification without detection. " +
+			"Drop the flag, fix the underlying trust anchor (CA bundle, Rekor URL, " +
+			"Fulcio OIDC), and keep signature verification strict.",
+		Check: checkZC1794,
+	})
+}
+
+func checkZC1794(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cosign" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		flag := v
+		if idx := strings.Index(flag, "="); idx >= 0 {
+			flag = flag[:idx]
+		}
+		if zc1794CosignSkipFlags[flag] {
+			return []Violation{{
+				KataID: "ZC1794",
+				Message: "`cosign " + v + "` removes a rung of the signature chain " +
+					"(transparency log / SCT / TLS / HTTPS-only registry). Drop " +
+					"the flag and fix the underlying trust anchor.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 790 Katas = 0.7.90
-const Version = "0.7.90"
+// 791 Katas = 0.7.91
+const Version = "0.7.91"


### PR DESCRIPTION
ZC1794 — cosign signature chain disabled

What: detect cosign with --insecure-ignore-tlog, --insecure-ignore-sct, --insecure-skip-verify, --allow-insecure-registry, --allow-http-registry, or --allow-insecure-bundle.
Why: each flag removes a distinct rung of the signature chain cosign was built to enforce. --insecure-ignore-tlog skips Rekor transparency-log verification, --insecure-ignore-sct skips Fulcio SCT checks, --insecure-skip-verify turns off TLS cert validation, and the --allow-*-registry flags push or pull signatures over plain HTTP. A malicious registry or on-path attacker passes verification without detection.
Fix suggestion: drop the flag, fix the underlying trust anchor (CA bundle, Rekor URL, Fulcio OIDC), and keep verification strict.
Severity: Error