### PR TITLE
feat: ZC1795 — error on git remote add/set-url persisting credentials in .git/config

### DIFF
--- a/pkg/katas/katatests/zc1795_test.go
+++ b/pkg/katas/katatests/zc1795_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1795(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `git remote add origin git@github.com:owner/repo.git`",
+			input:    `git remote add origin git@github.com:owner/repo.git`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `git remote set-url origin https://github.com/owner/repo.git`",
+			input:    `git remote set-url origin https://github.com/owner/repo.git`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `git remote add origin https://user:ghp_xxx@github.com/owner/repo.git`",
+			input: `git remote add origin https://user:ghp_xxx@github.com/owner/repo.git`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1795",
+					Message: "`git remote add … https://user:ghp_xxx@github.com/owner/repo.git` stores the token in `.git/config` and leaks it via argv at creation. Use a credential helper, `GIT_ASKPASS`, or an SSH deploy key instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `git remote set-url origin https://u:p@host/repo`",
+			input: `git remote set-url origin https://u:p@host/repo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1795",
+					Message: "`git remote set-url … https://u:p@host/repo` stores the token in `.git/config` and leaks it via argv at creation. Use a credential helper, `GIT_ASKPASS`, or an SSH deploy key instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1795")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1795.go
+++ b/pkg/katas/zc1795.go
@@ -1,0 +1,86 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1795RemoteActions = map[string]bool{
+	"add":     true,
+	"set-url": true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1795",
+		Title:    "Error on `git remote add NAME https://user:token@host/repo` — credentials persisted in `.git/config`",
+		Severity: SeverityError,
+		Description: "`git remote add NAME URL` and `git remote set-url NAME URL` write the URL " +
+			"into `.git/config` verbatim. When the URL embeds a `user:token@host` credential " +
+			"segment, every reader of the repo — other local users, a compromised backup, a " +
+			"CI cache, or anyone who runs `git config --list` — picks up the secret. It also " +
+			"shows up in argv at the moment of creation (visible via `ps` / " +
+			"`/proc/PID/cmdline`). Use a credential helper (`git credential-store`, " +
+			"`credential-osxkeychain`), `GIT_ASKPASS` sourced from an env var, or HTTPS + a " +
+			"deploy SSH key.",
+		Check: checkZC1795,
+	})
+}
+
+func checkZC1795(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "git" {
+		return nil
+	}
+	if len(cmd.Arguments) < 4 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "remote" {
+		return nil
+	}
+	if !zc1795RemoteActions[cmd.Arguments[1].String()] {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[2:] {
+		v := strings.Trim(arg.String(), "\"'")
+		if zc1795UrlHasCreds(v) {
+			return []Violation{{
+				KataID: "ZC1795",
+				Message: "`git remote " + cmd.Arguments[1].String() + " … " + v + "` " +
+					"stores the token in `.git/config` and leaks it via argv at " +
+					"creation. Use a credential helper, `GIT_ASKPASS`, or an SSH " +
+					"deploy key instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1795UrlHasCreds(v string) bool {
+	for _, scheme := range []string{"https://", "http://", "git+https://", "git+http://"} {
+		if !strings.HasPrefix(v, scheme) {
+			continue
+		}
+		rest := v[len(scheme):]
+		at := strings.Index(rest, "@")
+		if at <= 0 {
+			return false
+		}
+		userinfo := rest[:at]
+		colon := strings.Index(userinfo, ":")
+		if colon <= 0 || colon == len(userinfo)-1 {
+			return false
+		}
+		return true
+	}
+	return false
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 791 Katas = 0.7.91
-const Version = "0.7.91"
+// 792 Katas = 0.7.92
+const Version = "0.7.92"


### PR DESCRIPTION
ZC1795 — git remote URL with credentials

What: detect git remote add NAME URL and git remote set-url NAME URL where URL embeds https://user:token@host/path (or http / git+https / git+http variants).
Why: the URL is persisted verbatim to .git/config. Every reader of the repo — other local users, a backup, a CI cache, or anyone who runs git config --list — sees the secret. The command also leaks it via argv at creation time (ps, /proc/PID/cmdline).
Fix suggestion: use a credential helper (git credential-store, credential-osxkeychain), GIT_ASKPASS reading from an env-sourced secret, or HTTPS + an SSH deploy key.
Severity: Error