### PR TITLE
feat: ZC1796 — warn on pg_restore -c / --clean dropping objects before restore

### DIFF
--- a/pkg/katas/katatests/zc1796_test.go
+++ b/pkg/katas/katatests/zc1796_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1796(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `pg_restore -d mydb backup.dump`",
+			input:    `pg_restore -d mydb backup.dump`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `pg_restore --list backup.dump` (TOC only)",
+			input:    `pg_restore --list backup.dump`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `pg_restore -c -d mydb backup.dump`",
+			input: `pg_restore -c -d mydb backup.dump`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1796",
+					Message: "`pg_restore -c` drops every object in the target DB before recreating from the archive — stale or wrong-target dump silently loses data. Restore into a fresh DB (`createdb new && pg_restore -d new`), or snapshot first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1796")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1796.go
+++ b/pkg/katas/zc1796.go
@@ -1,0 +1,78 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1796",
+		Title:    "Warn on `pg_restore --clean` / `-c` — drops existing DB objects before recreating",
+		Severity: SeverityWarning,
+		Description: "`pg_restore -c` (also `--clean`) issues `DROP` for every table, index, " +
+			"function, and sequence in the target database before recreating them from the " +
+			"archive. If the backup is stale, incomplete, or points at the wrong database, " +
+			"the destination loses any object that isn't in the dump — including data added " +
+			"after the backup ran. Restore into a fresh empty database (`createdb new && " +
+			"pg_restore -d new`) or snapshot the target (`pg_dump -Fc > pre.dump`) before " +
+			"running `--clean`, and never pair it with `--if-exists` on a live production DB " +
+			"without a tested rollback path.",
+		Check: checkZC1796,
+	})
+}
+
+func checkZC1796(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `pg_restore --clean …` mangles to name=`clean`.
+	// To avoid false positives on unrelated commands with `clean` as name,
+	// require another pg_restore-ish argument to be present.
+	if ident.Value == "clean" {
+		if zc1796HasPgArg(cmd) {
+			return zc1796Hit(cmd, "pg_restore --clean")
+		}
+		return nil
+	}
+
+	if ident.Value != "pg_restore" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-c" || v == "--clean" {
+			return zc1796Hit(cmd, "pg_restore "+v)
+		}
+	}
+	return nil
+}
+
+func zc1796HasPgArg(cmd *ast.SimpleCommand) bool {
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "-d", "--dbname", "-F", "--format", "-U", "--username",
+			"--if-exists", "--no-owner", "--no-acl":
+			return true
+		}
+	}
+	return false
+}
+
+func zc1796Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1796",
+		Message: "`" + what + "` drops every object in the target DB before recreating " +
+			"from the archive — stale or wrong-target dump silently loses data. Restore " +
+			"into a fresh DB (`createdb new && pg_restore -d new`), or snapshot first.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 792 Katas = 0.7.92
-const Version = "0.7.92"
+// 793 Katas = 0.7.93
+const Version = "0.7.93"


### PR DESCRIPTION
ZC1796 — pg_restore --clean drops existing DB objects

What: detect pg_restore -c and pg_restore --clean (including the parser-mangled form where --clean becomes the SimpleCommand name and a pg_restore-shaped flag such as -d / --dbname / -U is present).
Why: -c issues DROP for every table, index, function, sequence in the target DB before recreating them from the archive. A stale / incomplete / wrong-target dump silently loses any object that isn't in the backup, including data added after the dump ran.
Fix suggestion: restore into a fresh empty database (createdb new && pg_restore -d new) or snapshot the target (pg_dump -Fc > pre.dump) before running --clean on a live DB; never pair with --if-exists in production without a tested rollback.
Severity: Warning