### PR TITLE
feat: ZC1797 — warn on ip link set <iface> down / ifdown locking out remote admin

### DIFF
--- a/pkg/katas/katatests/zc1797_test.go
+++ b/pkg/katas/katatests/zc1797_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1797(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ip link set eth0 up`",
+			input:    `ip link set eth0 up`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ip addr show` (read only)",
+			input:    `ip addr show`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ip link set eth0 down`",
+			input: `ip link set eth0 down`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1797",
+					Message: "`ip link set … down` disables a network interface — if it carries the SSH session, the script cuts itself off. Schedule a rollback via `systemd-run --on-active=30s ip link set … up` or stage via `nmcli`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ifdown eth0`",
+			input: `ifdown eth0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1797",
+					Message: "`ifdown eth0` disables a network interface — if it carries the SSH session, the script cuts itself off. Schedule a rollback via `systemd-run --on-active=30s ip link set … up` or stage via `nmcli`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1797")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1797.go
+++ b/pkg/katas/zc1797.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1797",
+		Title:    "Warn on `ip link set <iface> down` / `ifdown <iface>` — locks out remote admin on that path",
+		Severity: SeverityWarning,
+		Description: "Taking a network interface down from an SSH session that rides on the same " +
+			"interface cuts the script off mid-run: the TCP connection freezes, any later " +
+			"step silently fails, and recovery requires console / out-of-band access. " +
+			"Common bugs are typos (`eth1` instead of `eth0`), scripts that target the only " +
+			"uplink on a cloud VM, or running the command without first confirming that the " +
+			"interface is not the one carrying the admin session. Wrap the `down` in a " +
+			"`systemd-run --on-active=30s --unit=recover ip link set <iface> up` rollback, " +
+			"or stage both `down` and `up` through `nmcli connection up/down` with a pinned " +
+			"fallback profile.",
+		Check: checkZC1797,
+	})
+}
+
+func checkZC1797(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "ip":
+		// Expect: ip link set IFACE down
+		if len(cmd.Arguments) < 4 {
+			return nil
+		}
+		if cmd.Arguments[0].String() != "link" || cmd.Arguments[1].String() != "set" {
+			return nil
+		}
+		for _, arg := range cmd.Arguments[2:] {
+			if arg.String() == "down" {
+				return zc1797Hit(cmd, "ip link set … down")
+			}
+		}
+	case "ifdown":
+		if len(cmd.Arguments) == 0 {
+			return nil
+		}
+		first := cmd.Arguments[0].String()
+		if first == "--help" || first == "-h" {
+			return nil
+		}
+		return zc1797Hit(cmd, "ifdown "+first)
+	}
+	return nil
+}
+
+func zc1797Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1797",
+		Message: "`" + what + "` disables a network interface — if it carries the " +
+			"SSH session, the script cuts itself off. Schedule a rollback via " +
+			"`systemd-run --on-active=30s ip link set … up` or stage via `nmcli`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 793 Katas = 0.7.93
-const Version = "0.7.93"
+// 794 Katas = 0.7.94
+const Version = "0.7.94"


### PR DESCRIPTION
ZC1797 — disabling a network interface from a remote session

What: detect ip link set IFACE down and ifdown IFACE.
Why: running either from an SSH session that rides on the same interface cuts the script off mid-run — the TCP connection freezes, later steps silently fail, and recovery requires console / out-of-band access. Common bugs: typoed interface name, scripts that target the only uplink on a cloud VM, or running the command without confirming which interface carries the admin session.
Fix suggestion: wrap the down in a systemd-run --on-active=30s --unit=recover ip link set IFACE up rollback, or stage down and up through nmcli connection up/down with a pinned fallback profile.
Severity: Warning