### PR TITLE
feat: ZC1798 — warn on ufw reset wiping every firewall rule

### DIFF
--- a/pkg/katas/katatests/zc1798_test.go
+++ b/pkg/katas/katatests/zc1798_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1798(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ufw status numbered`",
+			input:    `ufw status numbered`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ufw delete 3`",
+			input:    `ufw delete 3`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ufw reset`",
+			input: `ufw reset`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1798",
+					Message: "`ufw reset` drops every user-defined firewall rule. Snapshot (`ufw status numbered > /tmp/ufw.bak`) first, and prefer `ufw delete <num>` for targeted removals.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ufw reset --force`",
+			input: `ufw reset --force`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1798",
+					Message: "`ufw reset` drops every user-defined firewall rule. Snapshot (`ufw status numbered > /tmp/ufw.bak`) first, and prefer `ufw delete <num>` for targeted removals.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1798")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1798.go
+++ b/pkg/katas/zc1798.go
@@ -1,0 +1,64 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1798",
+		Title:    "Warn on `ufw reset` — wipes every configured firewall rule",
+		Severity: SeverityWarning,
+		Description: "`ufw reset` returns the firewall to the distro default: every user-defined " +
+			"rule is removed, default incoming policy reverts (usually to `deny`, but the net " +
+			"effect is the loss of every allow-list entry the host relied on). Paired with " +
+			"`--force`, no prompt is issued. In a provisioning script the operation is " +
+			"sometimes desired to start from a clean slate, but running it mid-session or on " +
+			"a host that currently serves traffic drops connections without warning. Snapshot " +
+			"the rules first (`ufw status numbered > /tmp/ufw.bak`), and prefer removing " +
+			"specific rules with `ufw delete <num>` over a full reset.",
+		Check: checkZC1798,
+	})
+}
+
+func checkZC1798(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `ufw --force reset` mangles to name=`force` with `reset` as arg[0].
+	if ident.Value == "force" {
+		if len(cmd.Arguments) > 0 && cmd.Arguments[0].String() == "reset" {
+			return zc1798Hit(cmd, "ufw --force reset")
+		}
+		return nil
+	}
+
+	if ident.Value != "ufw" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "reset" {
+		return nil
+	}
+	return zc1798Hit(cmd, "ufw reset")
+}
+
+func zc1798Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1798",
+		Message: "`" + what + "` drops every user-defined firewall rule. Snapshot " +
+			"(`ufw status numbered > /tmp/ufw.bak`) first, and prefer " +
+			"`ufw delete <num>` for targeted removals.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 794 Katas = 0.7.94
-const Version = "0.7.94"
+// 795 Katas = 0.7.95
+const Version = "0.7.95"


### PR DESCRIPTION
ZC1798 — ufw reset drops every rule

What: detect ufw reset (and the parser-mangled ufw --force reset form).
Why: ufw reset returns the firewall to distro default — every user-defined rule is removed. Mid-session on a production host, the change drops every allow-list entry in one step and breaks whatever traffic relied on them.
Fix suggestion: snapshot first (ufw status numbered > /tmp/ufw.bak), and prefer ufw delete <num> for targeted removals over a full reset.
Severity: Warning