### PR TITLE
feat: ZC1799 — warn on rclone sync without --dry-run

### DIFF
--- a/pkg/katas/katatests/zc1799_test.go
+++ b/pkg/katas/katatests/zc1799_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1799(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `rclone sync --dry-run src dst`",
+			input:    `rclone sync --dry-run src dst`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `rclone copy src dst` (copy, not sync)",
+			input:    `rclone copy src dst`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `rclone sync src dst`",
+			input: `rclone sync src dst`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1799",
+					Message: "`rclone sync` deletes anything in DST that's not in SRC — empty / wrong SRC silently wipes DST. Preview with `rclone sync --dry-run`, and pin guards like `--backup-dir`, `--max-delete`, or `--min-age`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `rclone sync local: remote:bucket`",
+			input: `rclone sync local: remote:bucket`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1799",
+					Message: "`rclone sync` deletes anything in DST that's not in SRC — empty / wrong SRC silently wipes DST. Preview with `rclone sync --dry-run`, and pin guards like `--backup-dir`, `--max-delete`, or `--min-age`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1799")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1799.go
+++ b/pkg/katas/zc1799.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1799",
+		Title:    "Warn on `rclone sync SRC DST` without `--dry-run` — one-way mirror can wipe DST",
+		Severity: SeverityWarning,
+		Description: "`rclone sync` makes DST look exactly like SRC: anything in DST that isn't in " +
+			"SRC is deleted, including object versions on providers that support them. If SRC " +
+			"is accidentally empty (typo in path, unmounted drive, wrong credentials " +
+			"pointing at an empty bucket), the command silently wipes every object under DST " +
+			"without a confirmation prompt. Always preview the diff with `rclone sync " +
+			"--dry-run SRC DST` first; when you commit to the sync, keep `--backup-dir`, " +
+			"`--max-delete`, or `--min-age` guards so a bad SRC cannot cascade into " +
+			"unbounded deletion.",
+		Check: checkZC1799,
+	})
+}
+
+func checkZC1799(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "rclone" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "sync" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--dry-run" || v == "-n" || v == "--interactive" || v == "-i" {
+			return nil
+		}
+	}
+	return []Violation{{
+		KataID: "ZC1799",
+		Message: "`rclone sync` deletes anything in DST that's not in SRC — empty / " +
+			"wrong SRC silently wipes DST. Preview with `rclone sync --dry-run`, and " +
+			"pin guards like `--backup-dir`, `--max-delete`, or `--min-age`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 795 Katas = 0.7.95
-const Version = "0.7.95"
+// 796 Katas = 0.7.96
+const Version = "0.7.96"


### PR DESCRIPTION
ZC1799 — rclone sync without a dry-run guard

What: detect rclone sync SRC DST with none of --dry-run / -n / --interactive / -i.
Why: rclone sync is a one-way mirror — anything in DST that is not in SRC gets deleted, including object versions on providers that keep them. An accidentally empty SRC (wrong path, unmounted drive, wrong credentials pointing at an empty bucket) silently wipes every object under DST.
Fix suggestion: preview with rclone sync --dry-run first, and pin guards like --backup-dir, --max-delete, or --min-age so a bad SRC cannot cascade into unbounded deletion.
Severity: Warning