### PR TITLE
feat: ZC1800 — warn on pg_ctl stop -m immediate skipping shutdown checkpoint

### DIFF
--- a/pkg/katas/katatests/zc1800_test.go
+++ b/pkg/katas/katatests/zc1800_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1800(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `pg_ctl stop -m fast`",
+			input:    `pg_ctl stop -m fast`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `pg_ctl start` (no stop)",
+			input:    `pg_ctl start`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `pg_ctl stop -m immediate -D /var/lib/pg`",
+			input: `pg_ctl stop -m immediate -D /var/lib/pg`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1800",
+					Message: "`pg_ctl stop -m immediate` kills the postmaster without a shutdown checkpoint — WAL replay on restart can lose committed transactions if WAL is corrupt. Use `-m smart` or `-m fast` for routine shutdowns.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `pg_ctl restart --mode=immediate`",
+			input: `pg_ctl restart --mode=immediate`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1800",
+					Message: "`pg_ctl stop -m immediate` kills the postmaster without a shutdown checkpoint — WAL replay on restart can lose committed transactions if WAL is corrupt. Use `-m smart` or `-m fast` for routine shutdowns.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1800")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1800.go
+++ b/pkg/katas/zc1800.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1800",
+		Title:    "Warn on `pg_ctl stop -m immediate` — abrupt shutdown skips checkpoint, forces WAL recovery",
+		Severity: SeverityWarning,
+		Description: "`pg_ctl stop -m immediate` sends `SIGQUIT` to the postmaster. Server " +
+			"processes drop connections, no checkpoint is taken, and buffered changes are " +
+			"left in memory. Recovery on the next start has to replay every record since the " +
+			"last checkpoint; if WAL is corrupt, lost, or on different storage, committed " +
+			"transactions can be lost. Use `-m smart` (default) or `-m fast` so the server " +
+			"issues a shutdown checkpoint and closes cleanly; reserve `immediate` for the " +
+			"\"the node is on fire\" case and pair it with a tested PITR procedure.",
+		Check: checkZC1800,
+	})
+}
+
+func checkZC1800(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "pg_ctl" {
+		return nil
+	}
+	hasStop := false
+	hasImmediate := false
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "stop" || v == "restart" {
+			hasStop = true
+		}
+		if v == "-m" && i+1 < len(cmd.Arguments) {
+			if cmd.Arguments[i+1].String() == "immediate" {
+				hasImmediate = true
+			}
+		}
+		if strings.HasPrefix(v, "-m") && len(v) > 2 && v[2:] == "immediate" {
+			hasImmediate = true
+		}
+		if v == "--mode=immediate" {
+			hasImmediate = true
+		}
+	}
+	if !hasStop || !hasImmediate {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1800",
+		Message: "`pg_ctl stop -m immediate` kills the postmaster without a shutdown " +
+			"checkpoint — WAL replay on restart can lose committed transactions " +
+			"if WAL is corrupt. Use `-m smart` or `-m fast` for routine shutdowns.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 796 Katas = 0.7.96
-const Version = "0.7.96"
+// 797 Katas = 0.7.97
+const Version = "0.7.97"


### PR DESCRIPTION
ZC1800 — pg_ctl immediate shutdown

What: detect pg_ctl stop or pg_ctl restart with -m immediate (short or --mode=immediate).
Why: immediate shutdown sends SIGQUIT to the postmaster. Server processes drop connections, no checkpoint is taken, and buffered changes stay in memory. Recovery on the next start replays WAL; if WAL is corrupt or on unhealthy storage, committed transactions can be lost.
Fix suggestion: use -m smart (default) or -m fast so the server issues a shutdown checkpoint and closes cleanly. Reserve -m immediate for emergencies paired with a tested PITR procedure.
Severity: Warning