### PR TITLE
feat: ZC1801 — warn on fwupdmgr update / install flashing firmware

### DIFF
--- a/pkg/katas/katatests/zc1801_test.go
+++ b/pkg/katas/katatests/zc1801_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1801(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `fwupdmgr get-devices` (read only)",
+			input:    `fwupdmgr get-devices`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `fwupdmgr refresh` (metadata, not flash)",
+			input:    `fwupdmgr refresh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `fwupdmgr update` (all devices)",
+			input: `fwupdmgr update`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1801",
+					Message: "`fwupdmgr update` flashes firmware — a mid-write interruption can brick BIOS, SSD, Thunderbolt, or NIC microcontrollers. Inhibit reboot triggers (`systemd-inhibit`) and ensure battery / UPS before running.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `fwupdmgr install firmware.cab`",
+			input: `fwupdmgr install firmware.cab`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1801",
+					Message: "`fwupdmgr install` flashes firmware — a mid-write interruption can brick BIOS, SSD, Thunderbolt, or NIC microcontrollers. Inhibit reboot triggers (`systemd-inhibit`) and ensure battery / UPS before running.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1801")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1801.go
+++ b/pkg/katas/zc1801.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1801",
+		Title:    "Warn on `fwupdmgr update` / `install` — mid-flash interruption can brick firmware",
+		Severity: SeverityWarning,
+		Description: "`fwupdmgr update`, `fwupdmgr upgrade`, and `fwupdmgr install FIRMWARE` push " +
+			"new firmware into BIOS / UEFI, SSD, Thunderbolt controller, NIC, or dock " +
+			"microcontroller. Most of those devices have no A/B rollback — an interrupted " +
+			"flash (power cut, unexpected reboot, PSU toggle) leaves the chip in an " +
+			"unbootable state that needs vendor-recovery hardware. Run from a battery-backed " +
+			"session, mask reboot triggers with `systemd-inhibit`, pin the power supply, and " +
+			"verify the update history with `fwupdmgr get-history` once the device returns.",
+		Check: checkZC1801,
+	})
+}
+
+func checkZC1801(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "fwupdmgr" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	switch cmd.Arguments[0].String() {
+	case "update", "upgrade", "install", "reinstall", "downgrade":
+		return []Violation{{
+			KataID: "ZC1801",
+			Message: "`fwupdmgr " + cmd.Arguments[0].String() + "` flashes firmware — a " +
+				"mid-write interruption can brick BIOS, SSD, Thunderbolt, or NIC " +
+				"microcontrollers. Inhibit reboot triggers (`systemd-inhibit`) and " +
+				"ensure battery / UPS before running.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 797 Katas = 0.7.97
-const Version = "0.7.97"
+// 798 Katas = 0.7.98
+const Version = "0.7.98"


### PR DESCRIPTION
ZC1801 — firmware flash can brick the device on interruption

What: detect fwupdmgr update, upgrade, install, reinstall, downgrade.
Why: fwupdmgr pushes new firmware into BIOS / UEFI, SSDs, Thunderbolt controllers, NICs, dock microcontrollers. Most of those chips have no A/B rollback — an interrupted flash (power cut, unexpected reboot, PSU toggle) leaves the device unbootable and requires vendor recovery hardware.
Fix suggestion: run from a battery-backed session, mask reboot triggers with systemd-inhibit, pin the power supply, and verify the update history with fwupdmgr get-history once the device returns.
Severity: Warning