### PR TITLE
feat: ZC1802 — warn on dnf/yum history undo|rollback reverting transaction

### DIFF
--- a/pkg/katas/katatests/zc1802_test.go
+++ b/pkg/katas/katatests/zc1802_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1802(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `dnf history list`",
+			input:    `dnf history list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `dnf history info 5`",
+			input:    `dnf history info 5`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `dnf history undo 5`",
+			input: `dnf history undo 5`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1802",
+					Message: "`dnf history undo` reverses the past transaction — deps downgrade, security patches can get reverted. Review with `dnf history info`, or restore a filesystem snapshot.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `yum history rollback 3`",
+			input: `yum history rollback 3`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1802",
+					Message: "`yum history rollback` reverses the past transaction — deps downgrade, security patches can get reverted. Review with `dnf history info`, or restore a filesystem snapshot.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1802")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1802.go
+++ b/pkg/katas/zc1802.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1802",
+		Title:    "Warn on `dnf history undo N` / `rollback N` — reverses transactions without compat check",
+		Severity: SeverityWarning,
+		Description: "`dnf history undo N` reverts the exact package set of transaction N — every " +
+			"install turns into a remove, every remove into an install, every update into a " +
+			"downgrade. `dnf history rollback N` does the same for every transaction after " +
+			"N. Neither checks that the older versions still resolve cleanly against the " +
+			"current package graph: dependencies that moved forward for other reasons end up " +
+			"downgraded alongside, security patches get reverted, and services whose " +
+			"configuration was migrated fail to start on the older binary. Review the plan " +
+			"with `dnf history info N`, pin the rollback scope with `--exclude=` / `--assumeyes` " +
+			"only after review, or restore from a filesystem snapshot taken before the " +
+			"original transaction.",
+		Check: checkZC1802,
+	})
+}
+
+func checkZC1802(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "dnf" && ident.Value != "yum" && ident.Value != "dnf5" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "history" {
+		return nil
+	}
+	action := cmd.Arguments[1].String()
+	if action != "undo" && action != "rollback" {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1802",
+		Message: "`" + ident.Value + " history " + action + "` reverses the past " +
+			"transaction — deps downgrade, security patches can get reverted. " +
+			"Review with `dnf history info`, or restore a filesystem snapshot.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 798 Katas = 0.7.98
-const Version = "0.7.98"
+// 799 Katas = 0.7.99
+const Version = "0.7.99"


### PR DESCRIPTION
ZC1802 — reverting a package transaction without compat check

What: detect dnf / dnf5 / yum history undo N and history rollback N.
Why: undo reverts the exact package set of transaction N (installs → removes, removes → installs, updates → downgrades). rollback does the same for every transaction since N. Neither rechecks that older versions still resolve against the current package graph — dependencies can downgrade, security patches get reverted, and services whose configuration was migrated can fail to start on the older binary.
Fix suggestion: review with dnf history info N, pin scope with --exclude=, or restore a filesystem snapshot taken before the original transaction.
Severity: Warning