### PR TITLE
feat: ZC1803 — error on mysql --skip-ssl / psql sslmode=disable

### DIFF
--- a/pkg/katas/katatests/zc1803_test.go
+++ b/pkg/katas/katatests/zc1803_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1803(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `mysql --ssl-mode=VERIFY_IDENTITY -h db -u u`",
+			input:    `mysql --ssl-mode=VERIFY_IDENTITY -h db -u u`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `psql postgresql://u@db/mydb`",
+			input:    `psql postgresql://u@db/mydb`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `mysql --skip-ssl -h db -u u`",
+			input: `mysql --skip-ssl -h db -u u`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1803",
+					Message: "`mysql --skip-ssl` disables TLS — login handshake and queries travel in plaintext. Use `--ssl-mode=VERIFY_IDENTITY` (MySQL) / `sslmode=verify-full` (psql) with a pinned CA.",
+					Line:    1,
+					Column:  9,
+				},
+			},
+		},
+		{
+			name:  "invalid — `psql \"host=db sslmode=disable user=u\"`",
+			input: `psql "host=db sslmode=disable user=u"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1803",
+					Message: "`psql host=db sslmode=disable user=u` disables TLS — login handshake and queries travel in plaintext. Use `--ssl-mode=VERIFY_IDENTITY` (MySQL) / `sslmode=verify-full` (psql) with a pinned CA.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1803")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1803.go
+++ b/pkg/katas/zc1803.go
@@ -1,0 +1,89 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1803MySQLClients = map[string]bool{
+	"mysql":         true,
+	"mysqldump":     true,
+	"mysqladmin":    true,
+	"mariadb":       true,
+	"mariadb-dump":  true,
+	"mariadb-admin": true,
+}
+
+var zc1803PgClients = map[string]bool{
+	"psql":       true,
+	"pg_dump":    true,
+	"pgbench":    true,
+	"pg_restore": true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1803",
+		Title:    "Error on `mysql --skip-ssl` / `psql sslmode=disable` — plaintext credentials on the wire",
+		Severity: SeverityError,
+		Description: "Disabling TLS on a MySQL or PostgreSQL client pushes the login handshake " +
+			"(including the password or auth challenge) and every subsequent query and " +
+			"result over plaintext TCP. Anyone in the network path — the cloud VPC, the " +
+			"office LAN, a compromised router — can sniff or modify the stream. The flags " +
+			"vary (`--skip-ssl`, `--ssl=0`, `--ssl-mode=DISABLED` for MySQL / MariaDB; " +
+			"`sslmode=disable` in the connection URI or `PGSSLMODE=disable` env var for " +
+			"PostgreSQL) but the effect is the same. Prefer `--ssl-mode=VERIFY_IDENTITY` " +
+			"(MySQL 8+) and `sslmode=verify-full` (psql) with a pinned CA bundle.",
+		Check: checkZC1803,
+	})
+}
+
+func checkZC1803(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `mysql --skip-ssl …` mangles name to `skip-ssl`.
+	if ident.Value == "skip-ssl" {
+		return zc1803Hit(cmd, "mysql", "--skip-ssl")
+	}
+
+	if zc1803MySQLClients[ident.Value] {
+		for _, arg := range cmd.Arguments {
+			raw := strings.Trim(arg.String(), "\"'")
+			v := strings.ToLower(raw)
+			if v == "--skip-ssl" || v == "--ssl=0" || v == "--ssl=false" ||
+				v == "--ssl-mode=disabled" || v == "--ssl-mode=disable" {
+				return zc1803Hit(cmd, ident.Value, raw)
+			}
+		}
+	}
+
+	if zc1803PgClients[ident.Value] {
+		for _, arg := range cmd.Arguments {
+			raw := strings.Trim(arg.String(), "\"'")
+			if strings.Contains(strings.ToLower(raw), "sslmode=disable") {
+				return zc1803Hit(cmd, ident.Value, raw)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1803Hit(cmd *ast.SimpleCommand, tool, flag string) []Violation {
+	return []Violation{{
+		KataID: "ZC1803",
+		Message: "`" + tool + " " + flag + "` disables TLS — login handshake and " +
+			"queries travel in plaintext. Use `--ssl-mode=VERIFY_IDENTITY` (MySQL) / " +
+			"`sslmode=verify-full` (psql) with a pinned CA.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 799 Katas = 0.7.99
-const Version = "0.7.99"
+// 800 Katas = 0.8.0
+const Version = "0.8.0"


### PR DESCRIPTION
ZC1803 — database client with TLS disabled

What: detect MySQL / MariaDB clients (mysql, mysqldump, mysqladmin, mariadb, mariadb-dump, mariadb-admin) called with --skip-ssl, --ssl=0, --ssl=false, --ssl-mode=DISABLED/disable; and Postgres clients (psql, pg_dump, pg_restore, pgbench) with sslmode=disable in any argument (connection URI or keyword form).
Why: disabling TLS sends the login handshake (including the auth challenge or password) and every query / result over plaintext TCP. Anyone in the network path — cloud VPC, office LAN, compromised router — can sniff or modify the stream.
Fix suggestion: use --ssl-mode=VERIFY_IDENTITY (MySQL 8+) or sslmode=verify-full (psql) with a pinned CA bundle.
Severity: Error