### PR TITLE
feat: ZC1804 — warn on aws ec2 destructive actions without --dry-run

### DIFF
--- a/pkg/katas/katatests/zc1804_test.go
+++ b/pkg/katas/katatests/zc1804_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1804(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `aws ec2 describe-instances`",
+			input:    `aws ec2 describe-instances`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `aws ec2 terminate-instances --instance-ids i-1 --dry-run`",
+			input:    `aws ec2 terminate-instances --instance-ids i-1 --dry-run`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `aws ec2 terminate-instances --instance-ids i-1 i-2`",
+			input: `aws ec2 terminate-instances --instance-ids i-1 i-2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1804",
+					Message: "`aws ec2 terminate-instances` tears down EC2 instance(s) and their instance-store volumes with no automatic backup. Review with `aws ec2 describe-…`, add `--dry-run` to verify the target, and pin IDs through `--cli-input-json`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `aws ec2 delete-snapshot --snapshot-id snap-abc`",
+			input: `aws ec2 delete-snapshot --snapshot-id snap-abc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1804",
+					Message: "`aws ec2 delete-snapshot` deletes the EBS / RDS snapshot with no automatic backup. Review with `aws ec2 describe-…`, add `--dry-run` to verify the target, and pin IDs through `--cli-input-json`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1804")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1804.go
+++ b/pkg/katas/zc1804.go
@@ -1,0 +1,73 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1804Ec2Destructive = map[string]string{
+	"terminate-instances":      "tears down EC2 instance(s) and their instance-store volumes",
+	"delete-volume":            "deletes the EBS volume and its data",
+	"delete-snapshot":          "deletes the EBS / RDS snapshot",
+	"delete-vpc":               "removes the VPC along with its routing / dependencies",
+	"delete-internet-gateway":  "detaches / removes the IGW",
+	"delete-network-interface": "removes the ENI",
+	"delete-security-group":    "removes the security group",
+	"delete-launch-template":   "removes the launch template",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1804",
+		Title:    "Warn on `aws ec2 terminate-instances` / `delete-volume` / `delete-snapshot` — destructive cloud state change",
+		Severity: SeverityWarning,
+		Description: "AWS EC2 destructive actions (`terminate-instances`, `delete-volume`, " +
+			"`delete-snapshot`, `delete-vpc`, and friends) drop cloud state without any " +
+			"automatic backup: instance-store volumes vanish on terminate, EBS volumes and " +
+			"snapshots cannot be restored from the AWS side once deleted, and a mis-typed " +
+			"VPC / ENI / security-group ID can take down workloads in the same account. " +
+			"Review the target list with `aws ec2 describe-…`, pair destructive commands " +
+			"with `--dry-run`, and keep the IDs pinned in a file that `aws ... --cli-input-" +
+			"json` can consume rather than passing them inline.",
+		Check: checkZC1804,
+	})
+}
+
+func checkZC1804(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "aws" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "ec2" {
+		return nil
+	}
+	action := cmd.Arguments[1].String()
+	note, ok := zc1804Ec2Destructive[action]
+	if !ok {
+		return nil
+	}
+
+	// `--dry-run` makes the command a no-op. Allow it.
+	for _, arg := range cmd.Arguments[2:] {
+		v := arg.String()
+		if v == "--dry-run" {
+			return nil
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1804",
+		Message: "`aws ec2 " + action + "` " + note + " with no automatic backup. " +
+			"Review with `aws ec2 describe-…`, add `--dry-run` to verify the target, " +
+			"and pin IDs through `--cli-input-json`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 800 Katas = 0.8.0
-const Version = "0.8.0"
+// 801 Katas = 0.8.1
+const Version = "0.8.1"


### PR DESCRIPTION
ZC1804 — AWS EC2 destructive actions

What: detect aws ec2 terminate-instances, delete-volume, delete-snapshot, delete-vpc, delete-internet-gateway, delete-network-interface, delete-security-group, delete-launch-template when the call does not include --dry-run.
Why: these drop cloud state with no automatic backup — instance-store volumes vanish on terminate, EBS volumes / snapshots cannot be restored AWS-side once deleted, and a mis-typed VPC / ENI / SG ID can take down unrelated workloads in the same account.
Fix suggestion: review the target list with aws ec2 describe-…, pair destructive commands with --dry-run, and pin IDs through --cli-input-json instead of passing them inline.
Severity: Warning