### PR TITLE
feat: ZC1805 — warn on destructive aws cloudformation/dynamodb/logs/kms/lambda/ecr actions

### DIFF
--- a/pkg/katas/katatests/zc1805_test.go
+++ b/pkg/katas/katatests/zc1805_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1805(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `aws dynamodb describe-table --table-name mytbl`",
+			input:    `aws dynamodb describe-table --table-name mytbl`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `aws cloudformation list-stacks`",
+			input:    `aws cloudformation list-stacks`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `aws cloudformation delete-stack --stack-name prod`",
+			input: `aws cloudformation delete-stack --stack-name prod`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1805",
+					Message: "`aws cloudformation delete-stack` removes every resource the stack manages, no rollback. Stage a confirmation, pin IDs via `--cli-input-json`, and export a backup first where the service supports one.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `aws kms schedule-key-deletion --key-id k`",
+			input: `aws kms schedule-key-deletion --key-id k`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1805",
+					Message: "`aws kms schedule-key-deletion` queues CMK deletion — ciphertext becomes unreadable after the grace window. Stage a confirmation, pin IDs via `--cli-input-json`, and export a backup first where the service supports one.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1805")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1805.go
+++ b/pkg/katas/zc1805.go
@@ -1,0 +1,90 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1805AwsDestructive = map[string]map[string]string{
+	"cloudformation": {
+		"delete-stack":     "removes every resource the stack manages, no rollback",
+		"delete-stack-set": "deletes the stack set and all its instances",
+	},
+	"dynamodb": {
+		"delete-table":  "drops the table and its data",
+		"delete-backup": "drops the backup record",
+	},
+	"logs": {
+		"delete-log-group":  "loses the audit trail in that group",
+		"delete-log-stream": "drops the stream's events",
+	},
+	"kms": {
+		"schedule-key-deletion": "queues CMK deletion — ciphertext becomes unreadable after the grace window",
+	},
+	"lambda": {
+		"delete-function":             "removes the function and its versions",
+		"delete-event-source-mapping": "drops the trigger wiring",
+	},
+	"ecr": {
+		"delete-repository":  "deletes the image repository and every tag",
+		"batch-delete-image": "drops tagged images in bulk",
+	},
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1805",
+		Title:    "Warn on `aws cloudformation delete-stack` / `dynamodb delete-table` / `logs delete-log-group` / `kms schedule-key-deletion` — destructive AWS state change",
+		Severity: SeverityWarning,
+		Description: "Each of these AWS actions drops state that AWS cannot restore: " +
+			"`cloudformation delete-stack` tears down every resource the stack manages in " +
+			"dependency order and has no rollback, `dynamodb delete-table` removes a table " +
+			"and its items, `logs delete-log-group` erases the CloudWatch audit trail, and " +
+			"`kms schedule-key-deletion` makes every ciphertext encrypted with the CMK " +
+			"unreadable after the grace window. Add `--dry-run` where supported, stage the " +
+			"call behind a typed confirmation, pin IDs through `--cli-input-json`, and " +
+			"export backups (`dynamodb export-table-to-point-in-time`, `logs " +
+			"create-export-task`) before pulling the trigger.",
+		Check: checkZC1805,
+	})
+}
+
+func checkZC1805(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "aws" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	service := cmd.Arguments[0].String()
+	action := cmd.Arguments[1].String()
+
+	actions, ok := zc1805AwsDestructive[service]
+	if !ok {
+		return nil
+	}
+	note, ok := actions[action]
+	if !ok {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[2:] {
+		if arg.String() == "--dry-run" {
+			return nil
+		}
+	}
+
+	return []Violation{{
+		KataID: "ZC1805",
+		Message: "`aws " + service + " " + action + "` " + note + ". Stage a " +
+			"confirmation, pin IDs via `--cli-input-json`, and export a backup " +
+			"first where the service supports one.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 801 Katas = 0.8.1
-const Version = "0.8.1"
+// 802 Katas = 0.8.2
+const Version = "0.8.2"


### PR DESCRIPTION
ZC1805 — non-EC2 AWS destructive actions

What: detect aws cloudformation delete-stack / delete-stack-set, dynamodb delete-table / delete-backup, logs delete-log-group / delete-log-stream, kms schedule-key-deletion, lambda delete-function / delete-event-source-mapping, ecr delete-repository / batch-delete-image — when the call does not include --dry-run.
Why: each drops state AWS cannot restore: CloudFormation tears down every managed resource with no rollback, dynamodb delete-table loses items, logs delete-log-group erases the audit trail, and kms schedule-key-deletion makes every ciphertext unreadable after the grace window.
Fix suggestion: stage a typed confirmation, pin IDs via --cli-input-json, and export a backup first where the service supports one (dynamodb export-table-to-point-in-time, logs create-export-task).
Severity: Warning