### PR TITLE
feat: ZC1806 — warn on zmv without -n dry-run or -i interactive guard

### DIFF
--- a/pkg/katas/katatests/zc1806_test.go
+++ b/pkg/katas/katatests/zc1806_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1806(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `zmv -n '*.JPG' '*.jpg'` (dry-run)",
+			input:    `zmv -n '*.JPG' '*.jpg'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `zmv -i '(*).txt' '$1.md'` (interactive)",
+			input:    `zmv -i '(*).txt' '$1.md'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `zmv` alone (help)",
+			input:    `zmv`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `zmv '*.txt' '*.md'`",
+			input: `zmv '*.txt' '*.md'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1806",
+					Message: "`zmv` without `-n` (dry-run) or `-i` (interactive) renames every matched file in one shot — a pattern typo can collide names. Preview with `zmv -n`, then re-run once the list looks right.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `zmv -W '(*).jpg' 'archive/$1.jpg'`",
+			input: `zmv -W '(*).jpg' 'archive/$1.jpg'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1806",
+					Message: "`zmv` without `-n` (dry-run) or `-i` (interactive) renames every matched file in one shot — a pattern typo can collide names. Preview with `zmv -n`, then re-run once the list looks right.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1806")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1806.go
+++ b/pkg/katas/zc1806.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1806",
+		Title:    "Warn on `zmv 'PAT' 'REP'` without `-n` / `-i` — silent bulk rename",
+		Severity: SeverityWarning,
+		Description: "`zmv` (autoloaded from Zsh's functions) rewrites every filename that matches " +
+			"the pattern in one shot. A small typo in the source pattern or replacement — " +
+			"`*.jpg` vs `*.JPG`, a misplaced `(..)`, forgetting `**` recursion — can collide " +
+			"names and silently overwrite files, since `zmv` aborts the batch only on its " +
+			"own conflict check, not on semantic errors. Use `zmv -n 'PAT' 'REP'` first to " +
+			"see the rename list, or `zmv -i` to prompt per file. Only drop the guard once " +
+			"the preview matches what you expect.",
+		Check: checkZC1806,
+	})
+}
+
+func checkZC1806(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "zmv" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-n" || v == "--dry-run" || v == "-i" || v == "--interactive" {
+			return nil
+		}
+		// combined short flags like `-Mn` or `-wn`.
+		if len(v) > 1 && v[0] == '-' && v[1] != '-' {
+			for _, c := range v[1:] {
+				if c == 'n' || c == 'i' {
+					return nil
+				}
+			}
+		}
+	}
+	return []Violation{{
+		KataID: "ZC1806",
+		Message: "`zmv` without `-n` (dry-run) or `-i` (interactive) renames every " +
+			"matched file in one shot — a pattern typo can collide names. Preview " +
+			"with `zmv -n`, then re-run once the list looks right.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 802 Katas = 0.8.2
-const Version = "0.8.2"
+// 803 Katas = 0.8.3
+const Version = "0.8.3"


### PR DESCRIPTION
ZC1806 — zmv silent bulk rename

What: detect zmv invocations (2+ args) with no -n / --dry-run or -i / --interactive, including combined short-flag forms (-Wn, -Mi, etc.).
Why: zmv rewrites every filename matching the pattern in one shot. A small typo — *.jpg vs *.JPG, a misplaced (..), forgetting ** recursion — collides names and can silently overwrite files. zmv's own conflict detector catches same-target collisions but not semantic errors.
Fix suggestion: preview with zmv -n 'PAT' 'REP' to see the rename list, or zmv -i to prompt per file. Drop the guard only after the preview matches expectations.
Severity: Warning