### PR TITLE
feat: ZC1807 — warn on gh api -X DELETE bypassing gh subcommand confirmations

### DIFF
--- a/pkg/katas/katatests/zc1807_test.go
+++ b/pkg/katas/katatests/zc1807_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1807(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gh api /repos/owner/repo`",
+			input:    `gh api /repos/owner/repo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gh api -X GET /repos/owner/repo`",
+			input:    `gh api -X GET /repos/owner/repo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gh api -X DELETE /repos/owner/repo`",
+			input: `gh api -X DELETE /repos/owner/repo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1807",
+					Message: "`gh api -X DELETE` sends a raw DELETE to the GitHub API with the caller's token — no `--yes` guard, no dry-run. Use the high-level `gh` subcommand for the target, or wrap with a preflight GET + explicit confirmation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gh api --method=DELETE /repos/owner/repo/releases/123`",
+			input: `gh api --method=DELETE /repos/owner/repo/releases/123`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1807",
+					Message: "`gh api -X DELETE` sends a raw DELETE to the GitHub API with the caller's token — no `--yes` guard, no dry-run. Use the high-level `gh` subcommand for the target, or wrap with a preflight GET + explicit confirmation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1807")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1807.go
+++ b/pkg/katas/zc1807.go
@@ -1,0 +1,69 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1807",
+		Title:    "Warn on `gh api -X DELETE` — raw GitHub DELETE bypasses `gh` command confirmations",
+		Severity: SeverityWarning,
+		Description: "`gh api -X DELETE /repos/OWNER/REPO` (and `--method=DELETE` variants) " +
+			"sends a raw GitHub API request with the caller's token. There is no confirmation " +
+			"prompt, no `--yes` guard, and no friendly dry-run — a script that builds the " +
+			"path from a variable can wipe repos, releases, deploy keys, workflow runs, " +
+			"issue comments, or whole organisations in one call. Use the high-level `gh` " +
+			"subcommand for the target (`gh repo delete`, `gh release delete`, `gh workflow " +
+			"disable`) which still at least requires `--yes`, or wrap the raw call with a " +
+			"preflight `gh api -X GET /path` and an explicit confirmation in the script.",
+		Check: checkZC1807,
+	})
+}
+
+func checkZC1807(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "gh" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "api" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		switch {
+		case v == "-X" || v == "--method":
+			if 1+i+1 < len(cmd.Arguments) {
+				next := cmd.Arguments[1+i+1].String()
+				if strings.EqualFold(next, "DELETE") {
+					return zc1807Hit(cmd)
+				}
+			}
+		case strings.EqualFold(v, "-XDELETE"):
+			return zc1807Hit(cmd)
+		case strings.EqualFold(v, "--method=DELETE"):
+			return zc1807Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1807Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1807",
+		Message: "`gh api -X DELETE` sends a raw DELETE to the GitHub API with the " +
+			"caller's token — no `--yes` guard, no dry-run. Use the high-level `gh` " +
+			"subcommand for the target, or wrap with a preflight GET + explicit " +
+			"confirmation.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 803 Katas = 0.8.3
-const Version = "0.8.3"
+// 804 Katas = 0.8.4
+const Version = "0.8.4"


### PR DESCRIPTION
ZC1807 — raw GitHub DELETE via gh api

What: detect gh api -X DELETE <path>, gh api --method DELETE, and gh api --method=DELETE forms.
Why: raw API DELETE uses the caller's token and has no --yes guard, no dry-run, and no friendly prompt. A script that builds the path from a variable can wipe repos, releases, deploy keys, workflow runs, issue comments, or whole organisations in one call.
Fix suggestion: use the high-level gh subcommand for the target (gh repo delete, gh release delete, gh workflow disable) which at least requires --yes, or wrap the raw call with a preflight gh api -X GET + explicit confirmation.
Severity: Warning