### PR TITLE
feat: ZC1808 — warn on kubectl replace --force deleting and recreating resource

### DIFF
--- a/pkg/katas/katatests/zc1808_test.go
+++ b/pkg/katas/katatests/zc1808_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1808(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `kubectl apply -f deploy.yaml`",
+			input:    `kubectl apply -f deploy.yaml`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `kubectl replace -f deploy.yaml` (no --force)",
+			input:    `kubectl replace -f deploy.yaml`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `kubectl replace --force -f deploy.yaml`",
+			input: `kubectl replace --force -f deploy.yaml`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1808",
+					Message: "`kubectl replace --force` is delete + create — pods die, PDBs are ignored, in-flight requests drop. Prefer `kubectl apply -f FILE` and reserve `replace --force` for schema changes `apply` cannot patch, after draining traffic.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1808")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1808.go
+++ b/pkg/katas/zc1808.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1808",
+		Title:    "Warn on `kubectl replace --force` — deletes + recreates resource, drops running pods",
+		Severity: SeverityWarning,
+		Description: "`kubectl replace --force -f FILE` is `delete` followed by `create`: the " +
+			"existing resource (and every dependent pod / replicaset / endpoint) is removed " +
+			"before the new manifest is applied. In-flight requests drop, PodDisruptionBudget " +
+			"is ignored, and controllers that watch the object see it disappear and reappear. " +
+			"Prefer `kubectl apply -f FILE` — same manifest, server-side merge that preserves " +
+			"running pods — and reach for `replace --force` only when the resource schema has " +
+			"changed in a way `apply` cannot patch, with traffic drained beforehand.",
+		Check: checkZC1808,
+	})
+}
+
+func checkZC1808(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "kubectl" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "replace" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--force" || v == "-f=--force" {
+			return []Violation{{
+				KataID: "ZC1808",
+				Message: "`kubectl replace --force` is delete + create — pods die, " +
+					"PDBs are ignored, in-flight requests drop. Prefer `kubectl " +
+					"apply -f FILE` and reserve `replace --force` for schema changes " +
+					"`apply` cannot patch, after draining traffic.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 804 Katas = 0.8.4
-const Version = "0.8.4"
+// 805 Katas = 0.8.5
+const Version = "0.8.5"


### PR DESCRIPTION
ZC1808 — kubectl replace --force

What: detect kubectl replace --force (any args).
Why: --force makes replace perform delete + create instead of in-place update. Pods die, PodDisruptionBudgets are ignored, controllers watching the object see it disappear and reappear, and in-flight requests drop.
Fix suggestion: use kubectl apply -f FILE (server-side merge that preserves running pods) and reserve replace --force for schema changes apply cannot patch — with traffic drained first.
Severity: Warning