### PR TITLE
feat: ZC1809 — error on gsutil rm -r / rb -f bulk GCS deletion

### DIFF
--- a/pkg/katas/katatests/zc1809_test.go
+++ b/pkg/katas/katatests/zc1809_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1809(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gsutil ls gs://bucket`",
+			input:    `gsutil ls gs://bucket`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gsutil rm gs://bucket/specific-object` (single object)",
+			input:    `gsutil rm gs://bucket/specific-object`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gsutil -m rm -r gs://bucket/prefix`",
+			input: `gsutil -m rm -r gs://bucket/prefix`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1809",
+					Message: "`gsutil rm` with recursive/force deletes every matching GCS object (or the bucket itself). Preview with `gsutil ls`, enable Object Versioning / retention locks ahead of time, and prefer narrower object-level `gsutil rm` calls.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gsutil rb -f gs://bucket`",
+			input: `gsutil rb -f gs://bucket`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1809",
+					Message: "`gsutil rb` with recursive/force deletes every matching GCS object (or the bucket itself). Preview with `gsutil ls`, enable Object Versioning / retention locks ahead of time, and prefer narrower object-level `gsutil rm` calls.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1809")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1809.go
+++ b/pkg/katas/zc1809.go
@@ -1,0 +1,71 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1809",
+		Title:    "Error on `gsutil rm -r gs://…` / `gsutil rb -f gs://…` — bulk GCS deletion",
+		Severity: SeverityError,
+		Description: "`gsutil rm -r gs://bucket/prefix` and `gsutil rm -rf gs://bucket` delete " +
+			"every object under the prefix — with `-m` (parallel) they do it faster than any " +
+			"undo window. `gsutil rb -f gs://bucket` removes the bucket after force-deleting " +
+			"the contents. Neither soft-deletes; Object Versioning can help only if it is " +
+			"turned on in advance, and `gsutil rb` leaves no retention grace. Preview with " +
+			"`gsutil ls`, enable Object Versioning or retention locks before the fact, and " +
+			"prefer narrower `gsutil rm gs://bucket/specific-object` calls.",
+		Check: checkZC1809,
+	})
+}
+
+func checkZC1809(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "gsutil" {
+		return nil
+	}
+
+	subIdx := -1
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "rm" || v == "rb" {
+			subIdx = i
+			break
+		}
+	}
+	if subIdx == -1 {
+		return nil
+	}
+	sub := cmd.Arguments[subIdx].String()
+
+	hasDestFlag := false
+	for _, arg := range cmd.Arguments[subIdx+1:] {
+		v := arg.String()
+		if sub == "rm" && (v == "-r" || v == "-R" || v == "-rf" || v == "-fr" || v == "--recursive") {
+			hasDestFlag = true
+			break
+		}
+		if sub == "rb" && (v == "-f" || v == "--force") {
+			hasDestFlag = true
+			break
+		}
+	}
+	if !hasDestFlag {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1809",
+		Message: "`gsutil " + sub + "` with recursive/force deletes every matching " +
+			"GCS object (or the bucket itself). Preview with `gsutil ls`, enable " +
+			"Object Versioning / retention locks ahead of time, and prefer narrower " +
+			"object-level `gsutil rm` calls.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 805 Katas = 0.8.5
-const Version = "0.8.5"
+// 806 Katas = 0.8.6
+const Version = "0.8.6"


### PR DESCRIPTION
ZC1809 — bulk GCS deletion

What: detect gsutil rm with -r / -R / --recursive / -rf and gsutil rb with -f / --force.
Why: gsutil rm -r gs://bucket/prefix removes every object under the prefix (with -m in parallel, faster than any undo window). gsutil rb -f removes the bucket after force-deleting contents. Neither soft-deletes, Object Versioning helps only if enabled beforehand, and rb leaves no retention grace.
Fix suggestion: preview with gsutil ls, enable Object Versioning / retention locks ahead of time, and prefer narrower object-level gsutil rm calls.
Severity: Error