### PR TITLE
feat: ZC1810 — warn on wget -r / --mirror without --level=N bound

### DIFF
--- a/pkg/katas/katatests/zc1810_test.go
+++ b/pkg/katas/katatests/zc1810_test.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1810(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `wget https://example.com/file.tar.gz`",
+			input:    `wget https://example.com/file.tar.gz`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `wget -r --level=2 https://example.com/`",
+			input:    `wget -r --level=2 https://example.com/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `wget -r -l3 https://example.com/`",
+			input:    `wget -r -l3 https://example.com/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `wget -r https://example.com/`",
+			input: `wget -r https://example.com/`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1810",
+					Message: "`wget -r` / `--mirror` without `--level=N` follows links to arbitrary depth — the crawl can exhaust disk and climb into parent paths. Pin `--level=3`, add `--no-parent`, and cap with `--quota=1G`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `wget --mirror https://example.com/`",
+			input: `wget --mirror https://example.com/`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1810",
+					Message: "`wget -r` / `--mirror` without `--level=N` follows links to arbitrary depth — the crawl can exhaust disk and climb into parent paths. Pin `--level=3`, add `--no-parent`, and cap with `--quota=1G`.",
+					Line:    1,
+					Column:  8,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1810")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1810.go
+++ b/pkg/katas/zc1810.go
@@ -1,0 +1,90 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1810",
+		Title:    "Warn on `wget -r` / `--mirror` without `--level=N` — unbounded recursive download",
+		Severity: SeverityWarning,
+		Description: "`wget -r` and `wget --mirror` (short `-m`) follow links to arbitrary depth. " +
+			"Without `--level=N` or `-l N` the crawl keeps going until `wget` hits the " +
+			"remote server's limits, fills the local disk, or climbs into a parent directory " +
+			"the author did not intend to mirror (add `--no-parent` to block that too). " +
+			"Pin a depth (`--level=3`), restrict siblings (`--no-parent`, `--accept=` / " +
+			"`--reject=`), and cap the byte budget (`--quota=1G`) before running a recursive " +
+			"wget in automation.",
+		Check: checkZC1810,
+	})
+}
+
+func checkZC1810(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `wget --mirror URL` mangles to name=`mirror`,
+	// `wget --recursive URL` mangles to name=`recursive`.
+	if ident.Value == "mirror" || ident.Value == "recursive" {
+		if zc1810HasLevel(cmd) {
+			return nil
+		}
+		return zc1810Hit(cmd)
+	}
+
+	if ident.Value != "wget" {
+		return nil
+	}
+
+	hasRecursive := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-r" || v == "--recursive" || v == "-m" || v == "--mirror" {
+			hasRecursive = true
+			break
+		}
+	}
+	if !hasRecursive {
+		return nil
+	}
+	if zc1810HasLevel(cmd) {
+		return nil
+	}
+	return zc1810Hit(cmd)
+}
+
+func zc1810HasLevel(cmd *ast.SimpleCommand) bool {
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch {
+		case v == "-l" || v == "--level":
+			return true
+		case strings.HasPrefix(v, "--level="):
+			return true
+		case strings.HasPrefix(v, "-l") && len(v) > 2:
+			return true
+		}
+	}
+	return false
+}
+
+func zc1810Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1810",
+		Message: "`wget -r` / `--mirror` without `--level=N` follows links to " +
+			"arbitrary depth — the crawl can exhaust disk and climb into parent " +
+			"paths. Pin `--level=3`, add `--no-parent`, and cap with `--quota=1G`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 806 Katas = 0.8.6
-const Version = "0.8.6"
+// 807 Katas = 0.8.7
+const Version = "0.8.7"


### PR DESCRIPTION
ZC1810 — unbounded recursive wget

What: detect wget called with -r / --recursive / -m / --mirror when no --level=N or -l N depth bound is present. Also catches parser-mangled forms where --mirror or --recursive becomes the SimpleCommand name.
Why: wget recursion follows links to arbitrary depth. Without --level the crawl keeps going until wget hits remote limits, fills local disk, or climbs into parent directories that the author did not intend to mirror.
Fix suggestion: pin a depth (--level=3), add --no-parent, and cap the byte budget (--quota=1G) before running a recursive wget in automation.
Severity: Warning