### PR TITLE
feat: ZC1811 — error on chown/chmod/chgrp --no-preserve-root

### DIFF
--- a/pkg/katas/katatests/zc1811_test.go
+++ b/pkg/katas/katatests/zc1811_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1811(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `chown -R user:group /srv/app`",
+			input:    `chown -R user:group /srv/app`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `chmod -R 0750 /srv/app`",
+			input:    `chmod -R 0750 /srv/app`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `chown -R --no-preserve-root user /target`",
+			input: `chown -R --no-preserve-root user /target`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1811",
+					Message: "`chown --no-preserve-root` disables the GNU safeguard against recursing into `/`. Remove the flag; list explicit paths instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `chmod -R --no-preserve-root 0755 /target`",
+			input: `chmod -R --no-preserve-root 0755 /target`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1811",
+					Message: "`chmod --no-preserve-root` disables the GNU safeguard against recursing into `/`. Remove the flag; list explicit paths instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1811")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1811.go
+++ b/pkg/katas/zc1811.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1811",
+		Title:    "Error on `chown/chmod/chgrp --no-preserve-root` — disables GNU safeguard against recursive `/`",
+		Severity: SeverityError,
+		Description: "GNU `chown`, `chmod`, and `chgrp` refuse to recurse into `/` by default " +
+			"(`--preserve-root` in coreutils). `--no-preserve-root` opts in to walking the " +
+			"entire filesystem, so a stray `$PATH` expansion or wrong variable combined with " +
+			"`-R` rewrites ownership or mode on every file on the host. The flag has no " +
+			"legitimate script use — if a specific top-level target genuinely needs recursion, " +
+			"list that path explicitly and keep the safeguard in place.",
+		Check: checkZC1811,
+	})
+}
+
+func checkZC1811(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: leading `--no-preserve-root` mangles name to `no-preserve-root`.
+	if ident.Value == "no-preserve-root" {
+		return []Violation{{
+			KataID: "ZC1811",
+			Message: "`--no-preserve-root` disables the GNU safeguard against recursing " +
+				"into `/`. Remove the flag; list explicit paths instead.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityError,
+		}}
+	}
+
+	if ident.Value != "chown" && ident.Value != "chmod" && ident.Value != "chgrp" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "--no-preserve-root" {
+			return []Violation{{
+				KataID: "ZC1811",
+				Message: "`" + ident.Value + " --no-preserve-root` disables the GNU " +
+					"safeguard against recursing into `/`. Remove the flag; list " +
+					"explicit paths instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 807 Katas = 0.8.7
-const Version = "0.8.7"
+// 808 Katas = 0.8.8
+const Version = "0.8.8"


### PR DESCRIPTION
ZC1811 — --no-preserve-root on chown/chmod/chgrp

What: detect chown, chmod, chgrp invocations with --no-preserve-root (also the parser-mangled no-preserve-root-as-name form).
Why: GNU coreutils refuses to recurse into / by default (the --preserve-root safeguard). --no-preserve-root opts in to walking the entire filesystem, so a stray variable expansion combined with -R rewrites ownership or mode on every file on the host.
Fix suggestion: remove the flag; list explicit paths. ZC1625 already covers rm --no-preserve-root; this kata covers the ownership/mode siblings.
Severity: Error