### PR TITLE
feat: ZC1812 — error on aws ssm put-parameter SecureString with plaintext --value

### DIFF
--- a/pkg/katas/katatests/zc1812_test.go
+++ b/pkg/katas/katatests/zc1812_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1812(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `aws ssm put-parameter --type String --value plain --name /app/region`",
+			input:    `aws ssm put-parameter --type String --value plain --name /app/region`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `aws ssm put-parameter --type SecureString --value file://secret --name /app/token`",
+			input:    `aws ssm put-parameter --type SecureString --value file://secret --name /app/token`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `aws ssm put-parameter --type SecureString --value hunter2 --name /app/token`",
+			input: `aws ssm put-parameter --type SecureString --value hunter2 --name /app/token`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1812",
+					Message: "`aws ssm put-parameter --type SecureString --value …` puts the plaintext in argv — `ps` / `/proc/PID/cmdline` / history / CLI debug logs can read it. Use `--cli-input-json file://…` (mode 0600) or the `file://` form for `--value`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `aws ssm put-parameter --type=SecureString --value=hunter2 --name /app/token`",
+			input: `aws ssm put-parameter --type=SecureString --value=hunter2 --name /app/token`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1812",
+					Message: "`aws ssm put-parameter --type SecureString --value …` puts the plaintext in argv — `ps` / `/proc/PID/cmdline` / history / CLI debug logs can read it. Use `--cli-input-json file://…` (mode 0600) or the `file://` form for `--value`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1812")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1812.go
+++ b/pkg/katas/zc1812.go
@@ -1,0 +1,83 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1812",
+		Title:    "Error on `aws ssm put-parameter --type SecureString --value SECRET` — plaintext in argv",
+		Severity: SeverityError,
+		Description: "`aws ssm put-parameter` stores the value as-is under the given parameter " +
+			"name; the whole point of `--type SecureString` is that the value is sensitive. " +
+			"Passing the plaintext with `--value SECRET` (or `--value=SECRET`) puts the " +
+			"secret in argv where `ps`, `/proc/PID/cmdline`, shell history, and AWS CLI " +
+			"debug logs (`--debug`) can read it. Pipe the value in from stdin with `--cli-" +
+			"input-json file://param.json` (mode 0600) or use `aws secretsmanager " +
+			"create-secret --secret-string file://secret` which supports `file://` in every " +
+			"code path.",
+		Check: checkZC1812,
+	})
+}
+
+func checkZC1812(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "aws" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "ssm" {
+		return nil
+	}
+	if cmd.Arguments[1].String() != "put-parameter" {
+		return nil
+	}
+
+	hasSecureString := false
+	hasInlineValue := false
+	for i, arg := range cmd.Arguments[2:] {
+		v := arg.String()
+		switch {
+		case v == "--type":
+			if 2+i+1 < len(cmd.Arguments) && cmd.Arguments[2+i+1].String() == "SecureString" {
+				hasSecureString = true
+			}
+		case v == "--type=SecureString":
+			hasSecureString = true
+		case v == "--value":
+			if 2+i+1 < len(cmd.Arguments) {
+				next := cmd.Arguments[2+i+1].String()
+				if next != "" && !strings.HasPrefix(next, "file://") && !strings.HasPrefix(next, "-") {
+					hasInlineValue = true
+				}
+			}
+		case strings.HasPrefix(v, "--value="):
+			val := strings.TrimPrefix(v, "--value=")
+			if val != "" && !strings.HasPrefix(val, "file://") {
+				hasInlineValue = true
+			}
+		}
+	}
+	if !hasSecureString || !hasInlineValue {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1812",
+		Message: "`aws ssm put-parameter --type SecureString --value …` puts the " +
+			"plaintext in argv — `ps` / `/proc/PID/cmdline` / history / CLI debug " +
+			"logs can read it. Use `--cli-input-json file://…` (mode 0600) or the " +
+			"`file://` form for `--value`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 808 Katas = 0.8.8
-const Version = "0.8.8"
+// 809 Katas = 0.8.9
+const Version = "0.8.9"


### PR DESCRIPTION
ZC1812 — SecureString plaintext in argv

What: detect aws ssm put-parameter --type SecureString --value SECRET (space or =-form), where SECRET is an inline argument that is neither empty nor file://…
Why: SecureString is the SSM way to mark a parameter sensitive. Passing its plaintext inline puts the secret in argv — readable via ps, /proc/PID/cmdline, shell history, and AWS CLI --debug logs.
Fix suggestion: use --cli-input-json file://param.json (mode 0600) or --value file://secret; for richer secret storage use aws secretsmanager create-secret --secret-string file://secret.
Severity: Error