### PR TITLE
feat: ZC1813 — warn on cryptsetup luksFormat / reencrypt destructive LUKS write

### DIFF
--- a/pkg/katas/katatests/zc1813_test.go
+++ b/pkg/katas/katatests/zc1813_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1813(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `cryptsetup status cryptroot` (read only)",
+			input:    `cryptsetup status cryptroot`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `cryptsetup open $DEV cryptroot`",
+			input:    `cryptsetup open $DEV cryptroot`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `cryptsetup luksFormat $DEV`",
+			input: `cryptsetup luksFormat $DEV`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1813",
+					Message: "`cryptsetup luksFormat` rewrites the LUKS header / device. Verify the target (`lsblk`), back up with `luksHeaderBackup`, and run on an unmounted volume with UPS.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `cryptsetup reencrypt $DEV`",
+			input: `cryptsetup reencrypt $DEV`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1813",
+					Message: "`cryptsetup reencrypt` rewrites the LUKS header / device. Verify the target (`lsblk`), back up with `luksHeaderBackup`, and run on an unmounted volume with UPS.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1813")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1813.go
+++ b/pkg/katas/zc1813.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1813",
+		Title:    "Warn on `cryptsetup luksFormat` / `reencrypt` — destructive LUKS header write",
+		Severity: SeverityWarning,
+		Description: "`cryptsetup luksFormat DEV` writes a new LUKS2 header at the start of DEV " +
+			"and marks the remaining space as fresh ciphertext — any pre-existing filesystem " +
+			"or LUKS metadata is gone. `cryptsetup reencrypt DEV` rewrites the entire device " +
+			"in place, and an interruption mid-write leaves the volume partially re-encrypted " +
+			"and dependent on the `--resume-only` recovery path. Pair `luksFormat` with " +
+			"`--batch-mode` only after verifying DEV via `lsblk -o NAME,MODEL,SERIAL`, always " +
+			"back up the header (`cryptsetup luksHeaderBackup`) before touching it, and run " +
+			"`reencrypt` on an unmounted volume with UPS-backed power.",
+		Check: checkZC1813,
+	})
+}
+
+func checkZC1813(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cryptsetup" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "luksFormat", "reencrypt", "luks-format":
+			return []Violation{{
+				KataID: "ZC1813",
+				Message: "`cryptsetup " + v + "` rewrites the LUKS header / device. " +
+					"Verify the target (`lsblk`), back up with " +
+					"`luksHeaderBackup`, and run on an unmounted volume with UPS.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 809 Katas = 0.8.9
-const Version = "0.8.9"
+// 810 Katas = 0.8.10
+const Version = "0.8.10"


### PR DESCRIPTION
ZC1813 — destructive LUKS header / reencrypt

What: detect cryptsetup with luksFormat, luks-format, or reencrypt as a subcommand arg.
Why: luksFormat writes a fresh LUKS2 header and treats remaining space as new ciphertext — any pre-existing filesystem or LUKS metadata is gone. reencrypt rewrites the whole device in place, and an interruption mid-write leaves the volume partially re-encrypted and dependent on --resume-only recovery.
Fix suggestion: verify DEV with lsblk -o NAME,MODEL,SERIAL, back up with cryptsetup luksHeaderBackup, and run on an unmounted volume with UPS-backed power.
Severity: Warning