### PR TITLE
feat: ZC1814 — error on dpkg --force-all enabling every force option

### DIFF
--- a/pkg/katas/katatests/zc1814_test.go
+++ b/pkg/katas/katatests/zc1814_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1814(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `dpkg -i pkg.deb` (no force)",
+			input:    `dpkg -i pkg.deb`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `dpkg --force-overwrite -i pkg.deb` (specific force)",
+			input:    `dpkg --force-overwrite -i pkg.deb`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `dpkg -i --force-all pkg.deb`",
+			input: `dpkg -i --force-all pkg.deb`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1814",
+					Message: "`dpkg --force-all` enables every `--force-*` option at once — overwrite, unsigned, downgrade, essential-removal, broken-deps. Drop it and spell out only the specific `--force-<option>` you need, or fix the upstream conflict.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `apt-get -o Dpkg::Options::=--force-all install pkg`",
+			input: `apt-get -o Dpkg::Options::=--force-all install pkg`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1814",
+					Message: "`dpkg --force-all` enables every `--force-*` option at once — overwrite, unsigned, downgrade, essential-removal, broken-deps. Drop it and spell out only the specific `--force-<option>` you need, or fix the upstream conflict.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1814")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1814.go
+++ b/pkg/katas/zc1814.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1814",
+		Title:    "Error on `dpkg --force-all` — enables every single `--force-*` option at once",
+		Severity: SeverityError,
+		Description: "`dpkg --force-all` is shorthand for ~18 distinct `--force-<option>` flags: " +
+			"overwrite existing files, install unsigned packages, downgrade, install " +
+			"depends-broken, remove essential, and more. The dpkg manual explicitly calls " +
+			"this \"almost always a bad idea\". In provisioning scripts it hides the specific " +
+			"constraint the author was trying to bypass, and when a later install re-triggers " +
+			"the same state the underlying dependency conflict just re-surfaces on the next " +
+			"unattended upgrade. Drop `--force-all` and spell out only the `--force-<option>` " +
+			"you genuinely need, or fix the upstream conflict.",
+		Check: checkZC1814,
+	})
+}
+
+func checkZC1814(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `dpkg --force-all …` mangles to name=`force-all`.
+	if ident.Value == "force-all" {
+		return zc1814Hit(cmd)
+	}
+
+	if ident.Value != "dpkg" && ident.Value != "apt" && ident.Value != "apt-get" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--force-all" {
+			return zc1814Hit(cmd)
+		}
+		if strings.Contains(v, "Dpkg::Options::=--force-all") {
+			return zc1814Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1814Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1814",
+		Message: "`dpkg --force-all` enables every `--force-*` option at once — " +
+			"overwrite, unsigned, downgrade, essential-removal, broken-deps. Drop it " +
+			"and spell out only the specific `--force-<option>` you need, or fix the " +
+			"upstream conflict.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 810 Katas = 0.8.10
-const Version = "0.8.10"
+// 811 Katas = 0.8.11
+const Version = "0.8.11"


### PR DESCRIPTION
ZC1814 — dpkg --force-all

What: detect dpkg --force-all, apt/apt-get -o Dpkg::Options::=--force-all, and the parser-mangled force-all-as-name form.
Why: --force-all enables ~18 distinct --force-<option> flags at once: overwrite, unsigned, downgrade, remove-essential, depends-broken, and more. The dpkg manual says it is \"almost always a bad idea\". In provisioning scripts it hides the specific constraint the author was trying to bypass; the same state re-surfaces on the next unattended upgrade.
Fix suggestion: drop --force-all and spell out only the specific --force-<option> you need, or fix the upstream dependency conflict.
Severity: Error