### PR TITLE
feat: ZC1815 — warn on systemctl restart NetworkManager / systemd-networkd dropping SSH session

### DIFF
--- a/pkg/katas/katatests/zc1815_test.go
+++ b/pkg/katas/katatests/zc1815_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1815(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `systemctl status NetworkManager` (read only)",
+			input:    `systemctl status NetworkManager`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `systemctl restart nginx`",
+			input:    `systemctl restart nginx`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `systemctl restart NetworkManager`",
+			input: `systemctl restart NetworkManager`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1815",
+					Message: "`systemctl restart NetworkManager` drops every connection the manager supervises — the SSH session freezes. Use `nmcli connection reload` / `networkctl reload`, or a `systemd-run --on-active=30s` rollback.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `systemctl restart systemd-networkd.service`",
+			input: `systemctl restart systemd-networkd.service`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1815",
+					Message: "`systemctl restart systemd-networkd.service` drops every connection the manager supervises — the SSH session freezes. Use `nmcli connection reload` / `networkctl reload`, or a `systemd-run --on-active=30s` rollback.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1815")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1815.go
+++ b/pkg/katas/zc1815.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1815NetUnits = map[string]bool{
+	"NetworkManager":           true,
+	"NetworkManager.service":   true,
+	"systemd-networkd":         true,
+	"systemd-networkd.service": true,
+	"networking":               true,
+	"networking.service":       true,
+	"network":                  true,
+	"network.service":          true,
+	"wpa_supplicant":           true,
+	"wpa_supplicant.service":   true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1815",
+		Title:    "Warn on `systemctl restart NetworkManager` / `systemd-networkd` — drops the SSH session",
+		Severity: SeverityWarning,
+		Description: "Restarting the network manager from an SSH session tears down every active " +
+			"connection the daemon supervises, including the one the script is running over. " +
+			"The script freezes, the client sees a broken pipe, and recovery usually requires " +
+			"console access. Route the change through `nmcli connection reload` + `nmcli " +
+			"connection up <name>` (NetworkManager), `networkctl reload` (systemd-networkd), " +
+			"or schedule the restart behind `systemd-run --on-active=30s` with a rollback " +
+			"timer that re-enables the previous config if SSH does not reconnect.",
+		Check: checkZC1815,
+	})
+}
+
+func checkZC1815(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "systemctl" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	action := cmd.Arguments[0].String()
+	if action != "restart" && action != "stop" && action != "reload-or-restart" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments[1:] {
+		unit := strings.Trim(arg.String(), "\"'")
+		if zc1815NetUnits[unit] {
+			return []Violation{{
+				KataID: "ZC1815",
+				Message: "`systemctl " + action + " " + unit + "` drops every " +
+					"connection the manager supervises — the SSH session freezes. " +
+					"Use `nmcli connection reload` / `networkctl reload`, or a " +
+					"`systemd-run --on-active=30s` rollback.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 811 Katas = 0.8.11
-const Version = "0.8.11"
+// 812 Katas = 0.8.12
+const Version = "0.8.12"


### PR DESCRIPTION
ZC1815 — restarting the network manager over SSH

What: detect systemctl restart / stop / reload-or-restart of NetworkManager, systemd-networkd, networking, network, wpa_supplicant (including .service suffixes).
Why: these units supervise every active connection the host holds open. Restarting them from an SSH session tears down the one the script runs over — the script freezes and recovery usually needs console access.
Fix suggestion: use nmcli connection reload + nmcli connection up <name> for NetworkManager, networkctl reload for systemd-networkd, or schedule the restart behind systemd-run --on-active=30s with a rollback timer.
Severity: Warning