### PR TITLE
feat: ZC1816 — warn on docker/podman/nerdctl commit un-reproducible image

### DIFF
--- a/pkg/katas/katatests/zc1816_test.go
+++ b/pkg/katas/katatests/zc1816_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1816(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `docker build -t myimage .`",
+			input:    `docker build -t myimage .`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `podman ps`",
+			input:    `podman ps`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `docker commit mycontainer myimage:latest`",
+			input: `docker commit mycontainer myimage:latest`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1816",
+					Message: "`docker commit` snapshots a running container — no Dockerfile trail, runtime env / `/tmp` scratch / shell history get baked in, and the layer metadata does not record what was installed. Build from a `Dockerfile` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `podman commit web web:snap`",
+			input: `podman commit web web:snap`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1816",
+					Message: "`podman commit` snapshots a running container — no Dockerfile trail, runtime env / `/tmp` scratch / shell history get baked in, and the layer metadata does not record what was installed. Build from a `Dockerfile` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1816")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1816.go
+++ b/pkg/katas/zc1816.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1816",
+		Title:    "Warn on `docker/podman commit` — produces un-reproducible image, bakes in runtime state",
+		Severity: SeverityWarning,
+		Description: "`docker commit CONTAINER IMAGE` (and the podman / nerdctl equivalents) " +
+			"snapshots a running container's filesystem into a new image. There is no " +
+			"Dockerfile, so the build is not reproducible; the snapshot inherits whatever " +
+			"`/tmp` scratch, shell history, environment variables, and — frequently — " +
+			"credentials the container held at that moment; and the resulting image's layer " +
+			"metadata records only the container id, not what was actually installed. Build " +
+			"from a `Dockerfile` (or `docker buildx build`) so the image can be regenerated " +
+			"from source, and use `docker commit` only for one-off rescue work on a local " +
+			"image you are about to discard.",
+		Check: checkZC1816,
+	})
+}
+
+func checkZC1816(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" && ident.Value != "nerdctl" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "commit" {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1816",
+		Message: "`" + ident.Value + " commit` snapshots a running container — no " +
+			"Dockerfile trail, runtime env / `/tmp` scratch / shell history get baked " +
+			"in, and the layer metadata does not record what was installed. Build from " +
+			"a `Dockerfile` instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 812 Katas = 0.8.12
-const Version = "0.8.12"
+// 813 Katas = 0.8.13
+const Version = "0.8.13"


### PR DESCRIPTION
ZC1816 — snapshot commit produces un-reproducible image

What: detect docker commit, podman commit, nerdctl commit.
Why: the subcommand snapshots a running container's filesystem into a new image. There is no Dockerfile, so the build is not reproducible; the snapshot inherits whatever /tmp scratch, shell history, environment variables, and often credentials the container held; and the image's layer metadata records only the container id, not what was actually installed.
Fix suggestion: build from a Dockerfile (or docker buildx build) so the image can be regenerated from source. Reserve docker commit for one-off rescue work on a local image about to be discarded.
Severity: Warning