### PR TITLE
feat: ZC1817 — warn on git push --delete / -d / :branch remote branch removal

### DIFF
--- a/pkg/katas/katatests/zc1817_test.go
+++ b/pkg/katas/katatests/zc1817_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1817(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `git push origin main`",
+			input:    `git push origin main`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `git push -u origin feature-x`",
+			input:    `git push -u origin feature-x`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `git push --delete origin mybranch`",
+			input: `git push --delete origin mybranch`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1817",
+					Message: "`git push --delete` deletes the remote branch — open PRs are orphaned, CI targets disappear, and the last commit SHA can only come back from someone else's clone. Let the hosting platform auto-delete after merge instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `git push origin :mybranch`",
+			input: `git push origin :mybranch`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1817",
+					Message: "`git push origin :mybranch` deletes the remote branch — open PRs are orphaned, CI targets disappear, and the last commit SHA can only come back from someone else's clone. Let the hosting platform auto-delete after merge instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1817")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1817.go
+++ b/pkg/katas/zc1817.go
@@ -1,0 +1,64 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1817",
+		Title:    "Warn on `git push --delete` / `git push -d` / `git push origin :branch` — remote branch removal",
+		Severity: SeverityWarning,
+		Description: "Deleting a branch on the remote is an irreversible server-side change the " +
+			"local reflog cannot rescue. `git push --delete REMOTE BRANCH`, the short `-d`, " +
+			"and the legacy `git push REMOTE :BRANCH` colon form all produce the same result: " +
+			"the ref vanishes from the server, open pull requests are orphaned, CI runners " +
+			"that pinned to the branch lose the target, and recovery needs the last commit " +
+			"SHA which may only live in somebody else's local clone. Confirm the remote name, " +
+			"check `git branch -r` / `gh pr list --head BRANCH` first, and prefer letting the " +
+			"hosting platform delete the branch after a PR merge (with the auto-delete " +
+			"setting) rather than scripting the push.",
+		Check: checkZC1817,
+	})
+}
+
+func checkZC1817(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "git" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "push" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--delete" || v == "-d" {
+			return zc1817Hit(cmd, v)
+		}
+		// Legacy colon-form: `git push REMOTE :BRANCH` where :BRANCH starts with ":".
+		if strings.HasPrefix(v, ":") && len(v) > 1 {
+			return zc1817Hit(cmd, "origin "+v)
+		}
+	}
+	return nil
+}
+
+func zc1817Hit(cmd *ast.SimpleCommand, flag string) []Violation {
+	return []Violation{{
+		KataID: "ZC1817",
+		Message: "`git push " + flag + "` deletes the remote branch — open PRs are " +
+			"orphaned, CI targets disappear, and the last commit SHA can only come " +
+			"back from someone else's clone. Let the hosting platform auto-delete " +
+			"after merge instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 813 Katas = 0.8.13
-const Version = "0.8.13"
+// 814 Katas = 0.8.14
+const Version = "0.8.14"


### PR DESCRIPTION
ZC1817 — scripted remote branch deletion

What: detect git push with --delete, -d, or the legacy colon form git push REMOTE :BRANCH.
Why: remote branch deletion is irreversible server-side. Local reflog does not cover it. Open pull requests become orphaned, CI runners that pin to the branch lose the target, and recovery needs the last commit SHA which may only live in somebody else's local clone.
Fix suggestion: confirm the remote name, check with git branch -r / gh pr list --head BRANCH first, and prefer the hosting platform's auto-delete-after-merge setting over a scripted push.
Severity: Warning