### PR TITLE
feat: ZC1818 — warn on rsync --delete without --dry-run or --max-delete

### DIFF
--- a/pkg/katas/katatests/zc1818_test.go
+++ b/pkg/katas/katatests/zc1818_test.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1818(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `rsync -avn --delete src/ dst/` (dry-run short)",
+			input:    `rsync -avn --delete src/ dst/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `rsync -av --delete --dry-run src/ dst/`",
+			input:    `rsync -av --delete --dry-run src/ dst/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `rsync -av src/ dst/` (no delete)",
+			input:    `rsync -av src/ dst/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `rsync -av --delete src/ dst/`",
+			input: `rsync -av --delete src/ dst/`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1818",
+					Message: "`rsync --delete` without `--dry-run` removes anything in DST that isn't in SRC. Preview with `rsync -av --delete --dry-run SRC DST`, and pin `--max-delete=N` so an accidentally empty SRC can't cascade.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1818")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1818.go
+++ b/pkg/katas/zc1818.go
@@ -1,0 +1,98 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1818DeleteFlags = []string{
+	"--delete",
+	"--del",
+	"--delete-before",
+	"--delete-during",
+	"--delete-delay",
+	"--delete-after",
+	"--delete-excluded",
+	"--delete-missing-args",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1818",
+		Title:    "Warn on `rsync --delete` without `--dry-run` — empty or wrong SRC wipes DST",
+		Severity: SeverityWarning,
+		Description: "`rsync --delete` (plus `--delete-before/-during/-after/-excluded`) removes " +
+			"anything in DST that is not in SRC. If SRC is accidentally empty (typo in " +
+			"path, unmounted mount point, wrong credentials pointing at an empty remote), " +
+			"the destination loses every file that was there. The command has no undo. " +
+			"Always preview the diff with `rsync -av --delete --dry-run SRC DST` first, " +
+			"and cap the blast radius with `--max-delete=N` so the sync aborts if the plan " +
+			"removes more files than expected.",
+		Check: checkZC1818,
+	})
+}
+
+func checkZC1818(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `rsync --delete SRC DST` mangles name to `delete` or similar.
+	mangled := false
+	switch ident.Value {
+	case "delete", "del", "delete-before", "delete-during", "delete-delay",
+		"delete-after", "delete-excluded", "delete-missing-args":
+		mangled = true
+	}
+
+	if !mangled {
+		if ident.Value != "rsync" {
+			return nil
+		}
+		hasDelete := false
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			for _, flag := range zc1818DeleteFlags {
+				if v == flag || strings.HasPrefix(v, flag+"=") {
+					hasDelete = true
+					break
+				}
+			}
+			if hasDelete {
+				break
+			}
+		}
+		if !hasDelete {
+			return nil
+		}
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--dry-run" || v == "-n" || v == "--itemize-changes" {
+			return nil
+		}
+		if strings.HasPrefix(v, "-") && !strings.HasPrefix(v, "--") && len(v) > 1 {
+			for _, c := range v[1:] {
+				if c == 'n' {
+					return nil
+				}
+			}
+		}
+	}
+	return []Violation{{
+		KataID: "ZC1818",
+		Message: "`rsync --delete` without `--dry-run` removes anything in DST that " +
+			"isn't in SRC. Preview with `rsync -av --delete --dry-run SRC DST`, and " +
+			"pin `--max-delete=N` so an accidentally empty SRC can't cascade.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 814 Katas = 0.8.14
-const Version = "0.8.14"
+// 815 Katas = 0.8.15
+const Version = "0.8.15"


### PR DESCRIPTION
ZC1818 — rsync --delete without a preview

What: detect rsync with --delete / --delete-before / --delete-during / --delete-delay / --delete-after / --delete-excluded / --delete-missing-args, where neither --dry-run / -n / --itemize-changes nor a combined short flag containing n is present. Also catches parser-mangled forms where --delete becomes the SimpleCommand name.
Why: the flag removes anything in DST that is not in SRC. An accidentally empty SRC (typo, unmounted mount point, wrong credentials pointing at an empty remote) wipes DST with no undo.
Fix suggestion: preview with rsync -av --delete --dry-run SRC DST, and cap the blast radius with --max-delete=N so a bad SRC cannot cascade.
Severity: Warning