### PR TITLE
feat: ZC1819 — warn on xattr -d com.apple.quarantine / -cr stripping Gatekeeper

### DIFF
--- a/pkg/katas/katatests/zc1819_test.go
+++ b/pkg/katas/katatests/zc1819_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1819(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `xattr file` (read only)",
+			input:    `xattr file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `xattr -d com.apple.metadata:kMDLabel_xxx file` (unrelated xattr)",
+			input:    `xattr -d com.apple.metadata:kMDLabel_xxx file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `xattr -d com.apple.quarantine /Applications/MyApp.app`",
+			input: `xattr -d com.apple.quarantine /Applications/MyApp.app`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1819",
+					Message: "`xattr -d com.apple.quarantine` / `-cr` strips the macOS Gatekeeper quarantine — the binary runs with no signature / notarization check. Verify with `codesign --verify` and `spctl --assess --type execute` before stripping.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `xattr -cr $HOME/Downloads`",
+			input: `xattr -cr $HOME/Downloads`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1819",
+					Message: "`xattr -d com.apple.quarantine` / `-cr` strips the macOS Gatekeeper quarantine — the binary runs with no signature / notarization check. Verify with `codesign --verify` and `spctl --assess --type execute` before stripping.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1819")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1819.go
+++ b/pkg/katas/zc1819.go
@@ -1,0 +1,78 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1819",
+		Title:    "Warn on `xattr -d com.apple.quarantine` / `xattr -cr` — removes macOS Gatekeeper quarantine",
+		Severity: SeverityWarning,
+		Description: "macOS sets the `com.apple.quarantine` extended attribute on every file " +
+			"downloaded from the internet — Gatekeeper uses it to trigger the first-run " +
+			"notarization / signature check. `xattr -d com.apple.quarantine FILE` strips the " +
+			"attribute and lets the binary run with no prompt, and `xattr -cr DIR` does the " +
+			"same recursively for every file in the tree. In a script that processes " +
+			"downloaded artifacts this turns \"we vetted the binary\" into \"we trust whatever " +
+			"landed in the download folder\". Verify the signature (`codesign --verify`) and " +
+			"notarization (`spctl --assess --type execute`) first, or use " +
+			"`xip`/`installer` packages so Gatekeeper stays in the loop.",
+		Check: checkZC1819,
+	})
+}
+
+func checkZC1819(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "xattr" {
+		return nil
+	}
+
+	hasQuarantineDelete := false
+	hasRecursiveClear := false
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-d" || v == "--delete" {
+			if i+1 < len(cmd.Arguments) &&
+				cmd.Arguments[i+1].String() == "com.apple.quarantine" {
+				hasQuarantineDelete = true
+			}
+		}
+		if strings.HasPrefix(v, "-") && !strings.HasPrefix(v, "--") && len(v) > 1 {
+			hasC := false
+			hasR := false
+			for _, c := range v[1:] {
+				if c == 'c' {
+					hasC = true
+				}
+				if c == 'r' {
+					hasR = true
+				}
+			}
+			if hasC && hasR {
+				hasRecursiveClear = true
+			}
+		}
+	}
+
+	if !hasQuarantineDelete && !hasRecursiveClear {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1819",
+		Message: "`xattr -d com.apple.quarantine` / `-cr` strips the macOS Gatekeeper " +
+			"quarantine — the binary runs with no signature / notarization check. " +
+			"Verify with `codesign --verify` and `spctl --assess --type execute` " +
+			"before stripping.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 815 Katas = 0.8.15
-const Version = "0.8.15"
+// 816 Katas = 0.8.16
+const Version = "0.8.16"


### PR DESCRIPTION
ZC1819 — stripping macOS Gatekeeper quarantine

What: detect xattr -d com.apple.quarantine FILE and xattr -cr PATH (clear recursively).
Why: macOS sets com.apple.quarantine on every file downloaded from the internet, and Gatekeeper uses it to trigger the first-run notarization / signature check. Removing the xattr lets the binary run with no prompt — \"we vetted the binary\" becomes \"we trust whatever landed in the download folder\".
Fix suggestion: verify the signature (codesign --verify) and notarization (spctl --assess --type execute) before stripping, or install via xip/installer packages so Gatekeeper stays in the loop.
Severity: Warning