### PR TITLE
feat: ZC1820 — warn on netplan apply without prior netplan try rollback

### DIFF
--- a/pkg/katas/katatests/zc1820_test.go
+++ b/pkg/katas/katatests/zc1820_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1820(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `netplan try` (auto-reverting try)",
+			input:    `netplan try`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `netplan get`",
+			input:    `netplan get`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `netplan apply`",
+			input: `netplan apply`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1820",
+					Message: "`netplan apply` commits the YAML immediately — a mistake drops the admin SSH session with no automatic rollback. Run `netplan try` first (auto-reverts if no keypress within the timeout), then `netplan apply`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `netplan apply --debug`",
+			input: `netplan apply --debug`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1820",
+					Message: "`netplan apply` commits the YAML immediately — a mistake drops the admin SSH session with no automatic rollback. Run `netplan try` first (auto-reverts if no keypress within the timeout), then `netplan apply`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1820")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1820.go
+++ b/pkg/katas/zc1820.go
@@ -1,0 +1,47 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1820",
+		Title:    "Warn on `netplan apply` — applies network config immediately with no rollback timer",
+		Severity: SeverityWarning,
+		Description: "`netplan apply` regenerates the rendered backend config (systemd-networkd " +
+			"or NetworkManager) and brings it live right away. A mistake in the YAML — wrong " +
+			"interface name, missing `dhcp4`, bad addresses, conflicting routes — drops the " +
+			"admin SSH session, and recovery needs console access. Run `netplan try` first: " +
+			"it applies the new config, waits for confirmation, and rolls back automatically " +
+			"if no keypress arrives within the timeout. Only fall through to `netplan apply` " +
+			"after the try window has elapsed successfully.",
+		Check: checkZC1820,
+	})
+}
+
+func checkZC1820(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "netplan" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "apply" {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1820",
+		Message: "`netplan apply` commits the YAML immediately — a mistake drops the " +
+			"admin SSH session with no automatic rollback. Run `netplan try` first " +
+			"(auto-reverts if no keypress within the timeout), then `netplan apply`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 816 Katas = 0.8.16
-const Version = "0.8.16"
+// 817 Katas = 0.8.17
+const Version = "0.8.17"


### PR DESCRIPTION
ZC1820 — netplan apply without rollback window

What: detect netplan apply (any additional flags).
Why: apply regenerates the rendered backend config (systemd-networkd / NetworkManager) and brings it live right away. A mistake in the YAML — wrong interface name, missing dhcp4, bad addresses, conflicting routes — drops the admin SSH session, and recovery needs console access.
Fix suggestion: run netplan try first (applies the config, waits for confirmation, auto-reverts if no keypress within the timeout), then fall through to netplan apply once the try window elapses successfully.
Severity: Warning