### PR TITLE
feat: ZC1821 — error on diskutil eraseDisk / secureErase / partitionDisk

### DIFF
--- a/pkg/katas/katatests/zc1821_test.go
+++ b/pkg/katas/katatests/zc1821_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1821(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `diskutil list` (read only)",
+			input:    `diskutil list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `diskutil info $DISK`",
+			input:    `diskutil info $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `diskutil eraseDisk JHFS+ NewVol $DISK`",
+			input: `diskutil eraseDisk JHFS+ NewVol $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1821",
+					Message: "`diskutil eraseDisk` reformats the whole disk. Resolve the target by `diskutil info -plist` / mount-point (not by index), run `diskutil list` immediately before, and require a typed confirmation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `diskutil secureErase 0 $DISK`",
+			input: `diskutil secureErase 0 $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1821",
+					Message: "`diskutil secureErase` overwrites every block, no undo. Resolve the target by `diskutil info -plist` / mount-point (not by index), run `diskutil list` immediately before, and require a typed confirmation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1821")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1821.go
+++ b/pkg/katas/zc1821.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1821DiskutilDestructive = map[string]string{
+	"eraseDisk":       "reformats the whole disk",
+	"eraseVolume":     "reformats the volume",
+	"secureErase":     "overwrites every block, no undo",
+	"zeroDisk":        "writes zeros across the whole disk",
+	"randomDisk":      "writes random bytes across the whole disk",
+	"reformat":        "reformats the volume in place",
+	"eraseCD":         "erases the optical disc",
+	"erasePartitions": "removes every partition on the disk",
+	"partitionDisk":   "rewrites the partition table",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1821",
+		Title:    "Error on `diskutil eraseDisk` / `secureErase` / `partitionDisk` — macOS storage reformat",
+		Severity: SeverityError,
+		Description: "The `diskutil` subcommands `eraseDisk`, `eraseVolume`, `secureErase`, " +
+			"`zeroDisk`, `randomDisk`, `reformat`, `erasePartitions`, and `partitionDisk` all " +
+			"rewrite disk or volume state with no Time Machine snapshot or APFS " +
+			"preservation. A wrong `/dev/diskN` (especially after a reboot that reordered " +
+			"the BSD names) erases the wrong drive, and the only recovery is an offline " +
+			"backup. Always pair the call with a typed confirmation, resolve the target by " +
+			"`diskutil info -plist` / mount-point rather than by index, and run " +
+			"`diskutil list` right before the destructive call.",
+		Check: checkZC1821,
+	})
+}
+
+func checkZC1821(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "diskutil" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	note, ok := zc1821DiskutilDestructive[sub]
+	if !ok {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1821",
+		Message: "`diskutil " + sub + "` " + note + ". Resolve the target by " +
+			"`diskutil info -plist` / mount-point (not by index), run " +
+			"`diskutil list` immediately before, and require a typed " +
+			"confirmation.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 817 Katas = 0.8.17
-const Version = "0.8.17"
+// 818 Katas = 0.8.18
+const Version = "0.8.18"


### PR DESCRIPTION
ZC1821 — macOS diskutil destructive subcommands

What: detect diskutil with eraseDisk, eraseVolume, secureErase, zeroDisk, randomDisk, reformat, eraseCD, erasePartitions, or partitionDisk.
Why: each rewrites disk or volume state with no Time Machine snapshot or APFS preservation. A wrong /dev/diskN (especially after a reboot that reordered BSD names) erases the wrong drive, and the only recovery is an offline backup.
Fix suggestion: resolve the target by diskutil info -plist or mount-point (not by index), run diskutil list immediately before, and require a typed confirmation.
Severity: Error