### PR TITLE
feat: ZC1822 — error on csrutil disable / spctl --master-disable disabling macOS SIP

### DIFF
--- a/pkg/katas/katatests/zc1822_test.go
+++ b/pkg/katas/katatests/zc1822_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1822(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `csrutil status` (read only)",
+			input:    `csrutil status`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `spctl --status`",
+			input:    `spctl --status`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `csrutil disable`",
+			input: `csrutil disable`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1822",
+					Message: "`csrutil disable` disables macOS SIP / Gatekeeper / kext-consent — every malware analyst's favorite persistence primitive. Re-enable (`csrutil enable` in recovery, `spctl --master-enable`) and keep the default policy on.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `spctl kext-consent disable`",
+			input: `spctl kext-consent disable`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1822",
+					Message: "`spctl kext-consent disable` disables macOS SIP / Gatekeeper / kext-consent — every malware analyst's favorite persistence primitive. Re-enable (`csrutil enable` in recovery, `spctl --master-enable`) and keep the default policy on.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1822")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1822.go
+++ b/pkg/katas/zc1822.go
@@ -1,0 +1,74 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1822",
+		Title:    "Error on `csrutil disable` / `spctl --master-disable` — disables macOS system integrity / Gatekeeper",
+		Severity: SeverityError,
+		Description: "`csrutil disable` turns off System Integrity Protection: the kernel stops " +
+			"blocking writes under `/System`, `/bin`, `/sbin`, runtime attachment to " +
+			"protected processes becomes possible, and unsigned kexts can load. `spctl " +
+			"--master-disable` (and `--global-disable`, `kext-consent disable`) removes " +
+			"Gatekeeper / kext-consent enforcement, so any downloaded binary or kernel " +
+			"extension runs without the user being prompted. Neither has a legitimate " +
+			"provisioning use; both belong to ad-hoc developer workflows and are high-value " +
+			"persistence steps for malware. Re-enable with `csrutil enable` in recovery mode " +
+			"and `spctl --master-enable`.",
+		Check: checkZC1822,
+	})
+}
+
+func checkZC1822(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `spctl --master-disable` mangles to name=`master-disable`,
+	// `spctl --global-disable` to `global-disable`.
+	switch ident.Value {
+	case "master-disable", "global-disable":
+		return zc1822Hit(cmd, "spctl --"+ident.Value)
+	}
+
+	switch ident.Value {
+	case "csrutil":
+		if len(cmd.Arguments) > 0 && cmd.Arguments[0].String() == "disable" {
+			return zc1822Hit(cmd, "csrutil disable")
+		}
+	case "spctl":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "--master-disable" || v == "--global-disable" {
+				return zc1822Hit(cmd, "spctl "+v)
+			}
+		}
+		if len(cmd.Arguments) >= 2 &&
+			cmd.Arguments[0].String() == "kext-consent" &&
+			cmd.Arguments[1].String() == "disable" {
+			return zc1822Hit(cmd, "spctl kext-consent disable")
+		}
+	}
+	return nil
+}
+
+func zc1822Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1822",
+		Message: "`" + what + "` disables macOS SIP / Gatekeeper / kext-consent — " +
+			"every malware analyst's favorite persistence primitive. Re-enable " +
+			"(`csrutil enable` in recovery, `spctl --master-enable`) and keep " +
+			"the default policy on.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 818 Katas = 0.8.18
-const Version = "0.8.18"
+// 819 Katas = 0.8.19
+const Version = "0.8.19"


### PR DESCRIPTION
ZC1822 — disabling macOS system integrity / Gatekeeper

What: detect csrutil disable, spctl --master-disable, spctl --global-disable, spctl kext-consent disable (plus parser-mangled master-disable / global-disable forms).
Why: csrutil disable turns off System Integrity Protection — the kernel stops blocking writes under /System, /bin, /sbin and unsigned kexts can load. spctl --master-disable / --global-disable removes Gatekeeper enforcement so any downloaded binary runs without a prompt. Neither has a legitimate provisioning use; both are high-value persistence steps for malware.
Fix suggestion: re-enable with csrutil enable (in recovery) and spctl --master-enable.
Severity: Error