### PR TITLE
feat: ZC1823 — warn on keytool -import -noprompt trust store poisoning

### DIFF
--- a/pkg/katas/katatests/zc1823_test.go
+++ b/pkg/katas/katatests/zc1823_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1823(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `keytool -list -keystore trust.jks`",
+			input:    `keytool -list -keystore trust.jks`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `keytool -import -alias ca -file ca.pem -keystore trust.jks` (prompt)",
+			input:    `keytool -import -alias ca -file ca.pem -keystore trust.jks`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `keytool -import -noprompt -alias ca -file ca.pem -keystore trust.jks`",
+			input: `keytool -import -noprompt -alias ca -file ca.pem -keystore trust.jks`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1823",
+					Message: "`keytool -import -noprompt` pins a cert to the Java trust store without a fingerprint check. Drop `-noprompt`, verify with `keytool -printcert -file CERT`, and store (alias, SHA-256) pairs in an audited inventory.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `keytool -importcert -noprompt -file ca.pem -keystore cacerts`",
+			input: `keytool -importcert -noprompt -file ca.pem -keystore cacerts`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1823",
+					Message: "`keytool -import -noprompt` pins a cert to the Java trust store without a fingerprint check. Drop `-noprompt`, verify with `keytool -printcert -file CERT`, and store (alias, SHA-256) pairs in an audited inventory.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1823")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1823.go
+++ b/pkg/katas/zc1823.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1823",
+		Title:    "Warn on `keytool -import -noprompt` — Java trust store imports without fingerprint check",
+		Severity: SeverityWarning,
+		Description: "`keytool -import -noprompt -trustcacerts -alias X -file CERT -keystore KS` " +
+			"adds CERT to the Java trust store without showing its SHA-256 fingerprint or " +
+			"asking the operator to confirm. If CERT came from an HTTP download, an attacker " +
+			"wrote it in a shared temp dir, or a provisioning step fetched the wrong file, the " +
+			"JVM will happily pin the attacker's CA as trusted and verify everything signed " +
+			"against it. Drop `-noprompt`, or pre-verify with `keytool -printcert -file CERT` " +
+			"and keep the alias+fingerprint pair in a versioned inventory before adding to any " +
+			"trust store.",
+		Check: checkZC1823,
+	})
+}
+
+func checkZC1823(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "keytool" {
+		return nil
+	}
+
+	hasImport := false
+	hasNoPrompt := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-import" || v == "-importcert" || v == "-importkeystore" {
+			hasImport = true
+		}
+		if v == "-noprompt" {
+			hasNoPrompt = true
+		}
+	}
+	if !hasImport || !hasNoPrompt {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1823",
+		Message: "`keytool -import -noprompt` pins a cert to the Java trust store " +
+			"without a fingerprint check. Drop `-noprompt`, verify with " +
+			"`keytool -printcert -file CERT`, and store (alias, SHA-256) pairs in " +
+			"an audited inventory.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 819 Katas = 0.8.19
-const Version = "0.8.19"
+// 820 Katas = 0.8.20
+const Version = "0.8.20"


### PR DESCRIPTION
ZC1823 — Java trust store import without fingerprint check

What: detect keytool -import / -importcert / -importkeystore paired with -noprompt.
Why: keytool -import -noprompt adds the target certificate to the JVM trust store without showing its SHA-256 fingerprint or asking for confirmation. If the cert came from an HTTP download, a shared temp dir, or was fetched by a wrong provisioning step, the JVM pins an attacker's CA as trusted and happily verifies everything signed against it.
Fix suggestion: drop -noprompt; pre-verify with keytool -printcert -file CERT and store (alias, fingerprint) pairs in an audited inventory before touching the trust store.
Severity: Warning