### PR TITLE
feat: ZC1824 — warn on kubectl drain --disable-eviction bypassing PodDisruptionBudget

### DIFF
--- a/pkg/katas/katatests/zc1824_test.go
+++ b/pkg/katas/katatests/zc1824_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1824(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `kubectl drain node-1 --ignore-daemonsets`",
+			input:    `kubectl drain node-1 --ignore-daemonsets`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `kubectl cordon node-1`",
+			input:    `kubectl cordon node-1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `kubectl drain node-1 --disable-eviction`",
+			input: `kubectl drain node-1 --disable-eviction`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1824",
+					Message: "`kubectl drain --disable-eviction` deletes pods via raw API DELETE — PodDisruptionBudgets are ignored and the workload owner's availability contract is voided. Fix the blocking PDB instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1824")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1824.go
+++ b/pkg/katas/zc1824.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1824",
+		Title:    "Warn on `kubectl drain --disable-eviction` — bypasses PodDisruptionBudget via raw DELETE",
+		Severity: SeverityWarning,
+		Description: "`kubectl drain --disable-eviction` tells the client to delete pods directly " +
+			"via the API instead of issuing Eviction requests. The Eviction pathway is what " +
+			"honours PodDisruptionBudget — `--disable-eviction` drops pods regardless of the " +
+			"minAvailable / maxUnavailable contract the workload owner defined. On a " +
+			"multi-replica service this turns a rolling drain into a hard outage. Fix the " +
+			"blocking PDB (raise minAvailable, wait for replicas to reschedule, or negotiate " +
+			"with the owner) instead of flipping the flag off.",
+		Check: checkZC1824,
+	})
+}
+
+func checkZC1824(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "kubectl" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "drain" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "--disable-eviction" || v == "--disable-eviction=true" {
+			return []Violation{{
+				KataID: "ZC1824",
+				Message: "`kubectl drain --disable-eviction` deletes pods via raw API " +
+					"DELETE — PodDisruptionBudgets are ignored and the workload " +
+					"owner's availability contract is voided. Fix the blocking PDB " +
+					"instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 820 Katas = 0.8.20
-const Version = "0.8.20"
+// 821 Katas = 0.8.21
+const Version = "0.8.21"


### PR DESCRIPTION
ZC1824 — drain that ignores PodDisruptionBudget

What: detect kubectl drain <node> --disable-eviction / --disable-eviction=true.
Why: the Eviction API honours PodDisruptionBudget contracts (minAvailable, maxUnavailable). --disable-eviction falls back to raw DELETE, so pods are removed regardless of the PDB. On a multi-replica service a rolling drain turns into a hard outage.
Fix suggestion: fix the blocking PDB — raise minAvailable, wait for replicas to reschedule, or negotiate with the workload owner — instead of flipping the flag off.
Severity: Warning