### PR TITLE
feat: ZC1825 — warn on scp -O forcing legacy SCP wire protocol

### DIFF
--- a/pkg/katas/katatests/zc1825_test.go
+++ b/pkg/katas/katatests/zc1825_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1825(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `scp src user@host:dst` (default SFTP on OpenSSH 9+)",
+			input:    `scp src user@host:dst`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `scp -r dir user@host:/path`",
+			input:    `scp -r dir user@host:/path`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `scp -O src user@host:dst`",
+			input: `scp -O src user@host:dst`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1825",
+					Message: "`scp -O` forces the legacy SCP wire protocol — the one exposed to filename-injection (CVE-2020-15778 class). Drop `-O` (default SFTP is safer), or use `sftp` / upgrade the remote server.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1825")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1825.go
+++ b/pkg/katas/zc1825.go
@@ -1,0 +1,47 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1825",
+		Title:    "Warn on `scp -O` — forces legacy SCP wire protocol exposed to filename-injection CVEs",
+		Severity: SeverityWarning,
+		Description: "OpenSSH 9.0 switched `scp` to use the SFTP protocol by default — SFTP performs " +
+			"structured file transfer instead of piping a remote shell, and closes the " +
+			"filename-injection class that the old SCP wire protocol was vulnerable to " +
+			"(CVE-2020-15778 and friends). `scp -O` forces the legacy SCP protocol, putting " +
+			"the connection back on the old code path where a server (or a man-in-the-middle " +
+			"in the remote host's shell) can inject shell metacharacters into filenames. If a " +
+			"remote endpoint genuinely needs SCP, use `sftp` instead or upgrade the remote " +
+			"server. Drop `-O` unless you have a named compatibility bug that requires it.",
+		Check: checkZC1825,
+	})
+}
+
+func checkZC1825(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "scp" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-O" {
+			return []Violation{{
+				KataID: "ZC1825",
+				Message: "`scp -O` forces the legacy SCP wire protocol — the one exposed " +
+					"to filename-injection (CVE-2020-15778 class). Drop `-O` (default " +
+					"SFTP is safer), or use `sftp` / upgrade the remote server.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 821 Katas = 0.8.21
-const Version = "0.8.21"
+// 822 Katas = 0.8.22
+const Version = "0.8.22"


### PR DESCRIPTION
ZC1825 — scp -O downgrades to legacy protocol

What: detect scp -O anywhere in the argument list.
Why: OpenSSH 9.0 switched scp to SFTP by default to close the filename-injection class (CVE-2020-15778 and friends) that came from piping through a remote shell. -O forces the legacy SCP wire protocol, putting the connection back on the old code path.
Fix suggestion: drop -O; use sftp or upgrade the remote server if SFTP is the problem. Reserve -O for a named compatibility bug.
Severity: Warning