### PR TITLE
feat: ZC1826 — warn on install -m 4xxx/2xxx/6xxx dropping setuid binary

### DIFF
--- a/pkg/katas/katatests/zc1826_test.go
+++ b/pkg/katas/katatests/zc1826_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1826(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `install -m 0755 src /usr/local/bin/app`",
+			input:    `install -m 0755 src /usr/local/bin/app`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `install -d /opt/app` (no mode)",
+			input:    `install -d /opt/app`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `install -m 4755 src /usr/local/bin/myapp`",
+			input: `install -m 4755 src /usr/local/bin/myapp`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1826",
+					Message: "`install -m 4755` drops a setuid/setgid binary in one step. If DEST is on `$PATH`, every local user can invoke the elevated binary. Only install trusted builds, and prefer narrow `setcap` capabilities over setuid.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `install -m 2755 src /usr/local/bin/myapp`",
+			input: `install -m 2755 src /usr/local/bin/myapp`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1826",
+					Message: "`install -m 2755` drops a setuid/setgid binary in one step. If DEST is on `$PATH`, every local user can invoke the elevated binary. Only install trusted builds, and prefer narrow `setcap` capabilities over setuid.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1826")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1826.go
+++ b/pkg/katas/zc1826.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1826",
+		Title:    "Warn on `install -m 4xxx/2xxx/6xxx` — drops a setuid / setgid binary in one step",
+		Severity: SeverityWarning,
+		Description: "`install -m MODE SRC DEST` applies MODE atomically at copy time. A four-digit " +
+			"mode whose leading digit is `4` (setuid), `2` (setgid), or `6` (both) places a " +
+			"setuid / setgid binary into the destination path in a single operation — no " +
+			"intermediate `chmod` step where a privilege-tripwire would fire, no time window " +
+			"where the file exists without the special bit. If DEST is on `$PATH` (`/usr/" +
+			"local/bin`, `/usr/bin`), every user can invoke the elevated binary. Only install " +
+			"setuid / setgid binaries from trusted builds you have reviewed, and prefer " +
+			"narrow capabilities (`setcap cap_net_bind_service+ep`) over broad setuid.",
+		Check: checkZC1826,
+	})
+}
+
+func checkZC1826(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "install" {
+		return nil
+	}
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		var mode string
+		if v == "-m" || v == "--mode" {
+			if i+1 < len(cmd.Arguments) {
+				mode = cmd.Arguments[i+1].String()
+			}
+		} else if strings.HasPrefix(v, "-m") && len(v) > 2 {
+			mode = v[2:]
+		}
+		if mode == "" {
+			continue
+		}
+		mode = strings.TrimSpace(mode)
+		if len(mode) == 4 && (mode[0] == '4' || mode[0] == '2' || mode[0] == '6') {
+			return []Violation{{
+				KataID: "ZC1826",
+				Message: "`install -m " + mode + "` drops a setuid/setgid binary in one " +
+					"step. If DEST is on `$PATH`, every local user can invoke the " +
+					"elevated binary. Only install trusted builds, and prefer narrow " +
+					"`setcap` capabilities over setuid.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 822 Katas = 0.8.22
-const Version = "0.8.22"
+// 823 Katas = 0.8.23
+const Version = "0.8.23"


### PR DESCRIPTION
ZC1826 — install with setuid / setgid mode

What: detect install with -m MODE (or -mMODE attached) where MODE is a four-digit octal whose leading digit is 4 (setuid), 2 (setgid), or 6 (both).
Why: install applies MODE atomically at copy time, so the setuid/setgid bit goes live in a single step with no intermediate chmod where a tripwire would fire. If DEST is on $PATH (e.g. /usr/local/bin) every local user can invoke the elevated binary.
Fix suggestion: only install setuid binaries from trusted builds you have reviewed, and prefer narrow capabilities (setcap cap_net_bind_service+ep) over broad setuid.
Severity: Warning