### PR TITLE
feat: ZC1827 — error on npm/pnpm/yarn unpublish breaking pinned downstreams

### DIFF
--- a/pkg/katas/katatests/zc1827_test.go
+++ b/pkg/katas/katatests/zc1827_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1827(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `npm deprecate mypkg@1.2.3 'use 1.2.4'`",
+			input:    `npm deprecate mypkg@1.2.3 'use 1.2.4'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `npm publish`",
+			input:    `npm publish`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `npm unpublish mypkg@1.2.3`",
+			input: `npm unpublish mypkg@1.2.3`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1827",
+					Message: "`npm unpublish` removes a published version — every downstream that pinned it fails to install on next CI run (the left-pad pattern). Use `npm deprecate PKG@VERSION 'reason'` so the version stays resolvable with a warning.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1827")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1827.go
+++ b/pkg/katas/zc1827.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1827",
+		Title:    "Error on `npm unpublish` — breaks every downstream that pinned the version",
+		Severity: SeverityError,
+		Description: "`npm unpublish PKG@VERSION` removes a published version from the registry. " +
+			"Every downstream that pinned to that version — directly or through a transitive " +
+			"lockfile entry — fails to install on the next `npm ci` / CI run. This is the " +
+			"exact mechanism behind the 2016 `left-pad` outage; npm has since limited " +
+			"unpublish to within 72 hours and added the `--force` gate, but within the " +
+			"window the blast radius is still the whole ecosystem that pulled the package. " +
+			"Use `npm deprecate PKG@VERSION 'reason'` instead — the version stays resolvable, " +
+			"but installs print a warning and users can pin forward on their own schedule.",
+		Check: checkZC1827,
+	})
+}
+
+func checkZC1827(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "npm" && ident.Value != "pnpm" && ident.Value != "yarn" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "unpublish" {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1827",
+		Message: "`" + ident.Value + " unpublish` removes a published version — every " +
+			"downstream that pinned it fails to install on next CI run (the left-pad " +
+			"pattern). Use `npm deprecate PKG@VERSION 'reason'` so the version stays " +
+			"resolvable with a warning.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 823 Katas = 0.8.23
-const Version = "0.8.23"
+// 824 Katas = 0.8.24
+const Version = "0.8.24"


### PR DESCRIPTION
ZC1827 — npm unpublish breaks the dependency graph

What: detect npm / pnpm / yarn with unpublish as the subcommand.
Why: npm unpublish PKG@VERSION removes a published version from the registry. Every downstream that pinned that version — directly or through a transitive lockfile entry — fails to install on the next npm ci / CI run. This is the 2016 left-pad pattern; npm now restricts unpublish to 72 hours and gates behind --force, but the blast radius within the window is the whole ecosystem that depended on the package.
Fix suggestion: use npm deprecate PKG@VERSION 'reason' — the version stays resolvable, installs print a warning, and downstreams can pin forward on their own schedule.
Severity: Error