### PR TITLE
feat: ZC1828 — warn on gcore / strace -p dumping target process memory

### DIFF
--- a/pkg/katas/katatests/zc1828_test.go
+++ b/pkg/katas/katatests/zc1828_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1828(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gcore --help`",
+			input:    `gcore --help`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `strace ls` (trace a child, not ptrace-attach)",
+			input:    `strace ls`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gcore 1234`",
+			input: `gcore 1234`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1828",
+					Message: "`gcore PID` attaches via ptrace — target memory, env, and syscall args are exposed. Production scripts should not run ptrace; use `coredumpctl` on a captured core instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `strace -f -p 1234`",
+			input: `strace -f -p 1234`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1828",
+					Message: "`strace -p PID` attaches via ptrace — target memory, env, and syscall args are exposed. Production scripts should not run ptrace; use `coredumpctl` on a captured core instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1828")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1828.go
+++ b/pkg/katas/zc1828.go
@@ -1,0 +1,69 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1828",
+		Title:    "Warn on `gcore PID` / `strace -p PID` — live ptrace attach dumps target memory",
+		Severity: SeverityWarning,
+		Description: "`gcore PID` writes a core dump of the running process to disk; `strace -p " +
+			"PID` streams every syscall the process makes. Both attach via ptrace and expose " +
+			"the target's memory, stack, environment variables, and argument buffers — " +
+			"credentials, TLS session keys, and `$AWS_SECRET_ACCESS_KEY`-style env vars are " +
+			"all readable. A root-run script that attaches to another user's process extracts " +
+			"whatever that user has. Keep production scripts off ptrace; reach for " +
+			"`coredumpctl` with a captured core or vendor-specific `perf` counters when you " +
+			"only need syscall statistics.",
+		Check: checkZC1828,
+	})
+}
+
+func checkZC1828(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "gcore":
+		if len(cmd.Arguments) > 0 && !zc1828IsHelp(cmd.Arguments) {
+			return zc1828Hit(cmd, "gcore")
+		}
+	case "strace":
+		for _, arg := range cmd.Arguments {
+			if arg.String() == "-p" {
+				return zc1828Hit(cmd, ident.Value+" -p")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1828IsHelp(args []ast.Expression) bool {
+	for _, a := range args {
+		v := a.String()
+		if v == "-h" || v == "--help" || v == "-?" || v == "--version" {
+			return true
+		}
+	}
+	return false
+}
+
+func zc1828Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1828",
+		Message: "`" + what + " PID` attaches via ptrace — target memory, env, and " +
+			"syscall args are exposed. Production scripts should not run ptrace; " +
+			"use `coredumpctl` on a captured core instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 824 Katas = 0.8.24
-const Version = "0.8.24"
+// 825 Katas = 0.8.25
+const Version = "0.8.25"


### PR DESCRIPTION
ZC1828 — ptrace attach dumps target memory

What: detect gcore PID and strace -p PID (excluding help / version flags).
Why: gcore writes a core dump of the running process to disk; strace -p streams every syscall. Both attach via ptrace and expose target memory, stack, environment variables, and argument buffers. Credentials, TLS session keys, and env-var secrets are all readable. A root-run script that attaches to another user's process extracts whatever the user has.
Fix suggestion: keep production scripts off ptrace; use coredumpctl on a captured core, or perf counters for syscall statistics without memory read. ZC1603 already covers gdb/ltrace; this kata adds the gcore / strace siblings.
Severity: Warning