### PR TITLE
feat: ZC1829 — warn on tailscale/wg-quick/nmcli down dropping VPN-carried SSH

### DIFF
--- a/pkg/katas/katatests/zc1829_test.go
+++ b/pkg/katas/katatests/zc1829_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1829(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `tailscale status`",
+			input:    `tailscale status`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `nmcli connection show`",
+			input:    `nmcli connection show`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `tailscale down`",
+			input: `tailscale down`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1829",
+					Message: "`tailscale down` tears down the VPN — if the SSH session rides on it, the script cuts itself off with no rollback. Schedule recovery via `systemd-run --on-active=30s`, or run from console / out-of-band.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `wg-quick down wg0`",
+			input: `wg-quick down wg0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1829",
+					Message: "`wg-quick down` tears down the VPN — if the SSH session rides on it, the script cuts itself off with no rollback. Schedule recovery via `systemd-run --on-active=30s`, or run from console / out-of-band.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1829")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1829.go
+++ b/pkg/katas/zc1829.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1829",
+		Title:    "Warn on `tailscale down` / `wg-quick down` / `nmcli con down` — drops the VPN that may carry the SSH session",
+		Severity: SeverityWarning,
+		Description: "A script that closes the VPN tunnel from within a remote session cuts " +
+			"itself off whenever the admin SSH rides over that tunnel. `tailscale down`, " +
+			"`wg-quick down WG0`, `openvpn` teardown, and `nmcli connection down NAME` all " +
+			"tear the link down in place with no grace or rollback. Schedule the teardown " +
+			"behind `systemd-run --on-active=30s --unit=recover <cmd to bring it back up>` " +
+			"so the VPN is back before the unit expires, or run the command from the " +
+			"host's console / out-of-band path rather than over the VPN itself.",
+		Check: checkZC1829,
+	})
+}
+
+func checkZC1829(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "tailscale":
+		if len(cmd.Arguments) > 0 && cmd.Arguments[0].String() == "down" {
+			return zc1829Hit(cmd, "tailscale down")
+		}
+	case "wg-quick":
+		if len(cmd.Arguments) > 0 && cmd.Arguments[0].String() == "down" {
+			return zc1829Hit(cmd, "wg-quick down")
+		}
+	case "nmcli":
+		// `nmcli connection down <name>` / `nmcli con down <name>`.
+		if len(cmd.Arguments) >= 2 {
+			first := cmd.Arguments[0].String()
+			if (first == "connection" || first == "con" || first == "c") &&
+				cmd.Arguments[1].String() == "down" {
+				return zc1829Hit(cmd, "nmcli connection down")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1829Hit(cmd *ast.SimpleCommand, what string) []Violation {
+	return []Violation{{
+		KataID: "ZC1829",
+		Message: "`" + what + "` tears down the VPN — if the SSH session rides on it, " +
+			"the script cuts itself off with no rollback. Schedule recovery via " +
+			"`systemd-run --on-active=30s`, or run from console / out-of-band.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 825 Katas = 0.8.25
-const Version = "0.8.25"
+// 826 Katas = 0.8.26
+const Version = "0.8.26"


### PR DESCRIPTION
ZC1829 — tearing down the VPN from within an SSH session

What: detect tailscale down, wg-quick down <iface>, and nmcli connection / con / c down <name>.
Why: these commands tear the VPN link down in place with no grace or rollback. If the admin SSH session rides over the tunnel, the script cuts itself off mid-run — the TCP connection freezes and recovery needs console / out-of-band access.
Fix suggestion: schedule recovery via systemd-run --on-active=30s --unit=recover <bring-it-back-up> so the VPN returns before the timer expires, or run the command from the host's console / out-of-band path.
Severity: Warning