### PR TITLE
feat: ZC1830 — warn on unsetopt NOMATCH silencing unmatched-glob safety

### DIFF
--- a/pkg/katas/katatests/zc1830_test.go
+++ b/pkg/katas/katatests/zc1830_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1830(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt NOMATCH`",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt HIST_IGNORE_DUPS` (unrelated)",
+			input:    `unsetopt HIST_IGNORE_DUPS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt NOMATCH`",
+			input: `unsetopt NOMATCH`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1830",
+					Message: "`unsetopt NOMATCH` silences Zsh's unmatched-glob error — typos pass through literally. Use `*(N)` per-glob or scope inside a function with `setopt LOCAL_OPTIONS; setopt NULL_GLOB`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_NOMATCH`",
+			input: `setopt NO_NOMATCH`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1830",
+					Message: "`setopt NO_NOMATCH` silences Zsh's unmatched-glob error — typos pass through literally. Use `*(N)` per-glob or scope inside a function with `setopt LOCAL_OPTIONS; setopt NULL_GLOB`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1830")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1830.go
+++ b/pkg/katas/zc1830.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1830",
+		Title:    "Warn on `unsetopt NOMATCH` — unmatched glob becomes the literal pattern, silent bugs",
+		Severity: SeverityWarning,
+		Description: "`NOMATCH` is on by default in Zsh — an unmatched glob (`*.log` with no matching " +
+			"files) errors out instead of silently passing through. Disabling it " +
+			"(`unsetopt NOMATCH` or the equivalent `setopt NO_NOMATCH`) reverts to POSIX-sh " +
+			"behaviour: the pattern is handed to the command verbatim, so `rm *.log` with no " +
+			"matches runs `rm '*.log'` — which fails noisily for `rm` but, for commands that " +
+			"accept arbitrary strings, silently processes the literal `*.log` instead of " +
+			"files. Prefer scoped `*(N)` null-glob qualifier or `setopt LOCAL_OPTIONS; setopt " +
+			"NULL_GLOB` inside a function, so the rest of the script keeps the default safety.",
+		Check: checkZC1830,
+	})
+}
+
+func checkZC1830(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			if zc1830IsNomatch(arg.String()) {
+				return zc1830Hit(cmd, "unsetopt "+arg.String())
+			}
+		}
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NONOMATCH" {
+				return zc1830Hit(cmd, "setopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1830IsNomatch(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "NOMATCH"
+}
+
+func zc1830Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1830",
+		Message: "`" + where + "` silences Zsh's unmatched-glob error — typos pass " +
+			"through literally. Use `*(N)` per-glob or scope inside a function " +
+			"with `setopt LOCAL_OPTIONS; setopt NULL_GLOB`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 826 Katas = 0.8.26
-const Version = "0.8.26"
+// 827 Katas = 0.8.27
+const Version = "0.8.27"


### PR DESCRIPTION
ZC1830 — silencing the unmatched-glob error

What: detect unsetopt NOMATCH and setopt NO_NOMATCH (case/underscore folded).
Why: NOMATCH is on by default in Zsh — an unmatched glob errors out instead of silently passing through. Disabling it reverts to POSIX-sh behaviour: the pattern is handed to the command verbatim. rm *.lgo fails loudly, but commands that accept arbitrary strings silently process the literal *.log pattern instead of files.
Fix suggestion: use the (N) null-glob qualifier per glob (*.log(N)) or scope the change inside a function with setopt LOCAL_OPTIONS; setopt NULL_GLOB so the rest of the script keeps the default safety.
Severity: Warning