### PR TITLE
feat: ZC1831 — error on systemctl stop/disable/mask ssh/sshd locking out remote login

### DIFF
--- a/pkg/katas/katatests/zc1831_test.go
+++ b/pkg/katas/katatests/zc1831_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1831(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `systemctl reload sshd`",
+			input:    `systemctl reload sshd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `systemctl status sshd`",
+			input:    `systemctl status sshd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `systemctl stop sshd`",
+			input: `systemctl stop sshd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1831",
+					Message: "`systemctl stop sshd` blocks SSH — existing sessions survive but reconnects fail. `disable`/`mask` persist across reboots. Use `reload sshd` for config changes.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `systemctl mask ssh`",
+			input: `systemctl mask ssh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1831",
+					Message: "`systemctl mask ssh` blocks SSH — existing sessions survive but reconnects fail. `disable`/`mask` persist across reboots. Use `reload sshd` for config changes.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1831")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1831.go
+++ b/pkg/katas/zc1831.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1831SshUnits = map[string]bool{
+	"ssh":            true,
+	"sshd":           true,
+	"ssh.service":    true,
+	"sshd.service":   true,
+	"ssh.socket":     true,
+	"sshd.socket":    true,
+	"openssh-server": true,
+	"openssh":        true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1831",
+		Title:    "Error on `systemctl stop|disable|mask ssh/sshd` — locks out the next remote login",
+		Severity: SeverityError,
+		Description: "Stopping, disabling, or masking the SSH daemon closes the door on the next " +
+			"remote login. Existing connections survive for a while because sshd's spawned " +
+			"per-session process keeps running, but any reconnect / CI follow-up step that " +
+			"needs to ssh back in gets `Connection refused`. `systemctl disable ssh` and " +
+			"`systemctl mask ssh` also survive reboots. Recovery requires console or out-of-" +
+			"band access. If the goal is config reload, use `systemctl reload sshd`; if the " +
+			"host is being retired, make sshd the last service you touch.",
+		Check: checkZC1831,
+	})
+}
+
+func checkZC1831(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "systemctl" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	action := cmd.Arguments[0].String()
+	if action != "stop" && action != "disable" && action != "mask" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments[1:] {
+		unit := arg.String()
+		if zc1831SshUnits[unit] {
+			return []Violation{{
+				KataID: "ZC1831",
+				Message: "`systemctl " + action + " " + unit + "` blocks SSH — " +
+					"existing sessions survive but reconnects fail. `disable`/`mask` " +
+					"persist across reboots. Use `reload sshd` for config changes.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 827 Katas = 0.8.27
-const Version = "0.8.27"
+// 828 Katas = 0.8.28
+const Version = "0.8.28"


### PR DESCRIPTION
ZC1831 — shutting down sshd over SSH

What: detect systemctl stop / disable / mask applied to ssh, sshd, ssh.service, sshd.service, ssh.socket, sshd.socket, openssh-server, openssh.
Why: the SSH daemon owns the next remote login. stop closes it for this boot, disable survives reboot, mask does both and blocks manual start. Existing sessions survive for a while (spawned per-session sshd), but any reconnect / CI follow-up that needs to ssh back in gets Connection refused. Recovery needs console or out-of-band access.
Fix suggestion: use systemctl reload sshd for config changes; if the host is being retired, touch sshd last.
Severity: Error