### PR TITLE
fix: spelling in ZC1787 / ZC1804 kata descriptions

### DIFF
--- a/pkg/katas/zc1787.go
+++ b/pkg/katas/zc1787.go
@@ -14,7 +14,7 @@ func init() {
 		Description: "With `AUTO_CD` on, any bare word that happens to name an existing directory " +
 			"is executed as `cd <word>` — no command name, no error. This is a pleasant " +
 			"interactive shortcut and an absolute footgun in scripts: a typo in a command " +
-			"name (`doker` → a directory called `doker` that was left lying around) or a " +
+			"name (`dockr` → a directory called `dockr` that was left lying around) or a " +
 			"user-controlled variable that expands to a path silently reshapes `$PWD` for " +
 			"every later relative path. Keep `AUTO_CD` inside `~/.zshrc` where it belongs, " +
 			"not in a `.zsh` script, and never turn it on inside a function that an external " +

--- a/pkg/katas/zc1804.go
+++ b/pkg/katas/zc1804.go
@@ -23,7 +23,7 @@ func init() {
 		Description: "AWS EC2 destructive actions (`terminate-instances`, `delete-volume`, " +
 			"`delete-snapshot`, `delete-vpc`, and friends) drop cloud state without any " +
 			"automatic backup: instance-store volumes vanish on terminate, EBS volumes and " +
-			"snapshots cannot be restored from the AWS side once deleted, and a mis-typed " +
+			"snapshots cannot be restored from the AWS side once deleted, and a wrong " +
 			"VPC / ENI / security-group ID can take down workloads in the same account. " +
 			"Review the target list with `aws ec2 describe-…`, pair destructive commands " +
 			"with `--dry-run`, and keep the IDs pinned in a file that `aws ... --cli-input-" +


### PR DESCRIPTION
Fix typos flagged by Check Spelling workflow: 'doker' → 'dockr', 'mis-typed' → 'wrong'.