### PR TITLE
feat: ZC1832 — warn on Zsh limit coredumpsize unlimited enabling core dumps

### DIFF
--- a/pkg/katas/katatests/zc1832_test.go
+++ b/pkg/katas/katatests/zc1832_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1832(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `limit coredumpsize 0` (disable cores)",
+			input:    `limit coredumpsize 0`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `limit stacksize unlimited` (unrelated resource)",
+			input:    `limit stacksize unlimited`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `limit coredumpsize unlimited`",
+			input: `limit coredumpsize unlimited`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1832",
+					Message: "`limit coredumpsize unlimited` enables unbounded core dumps (Zsh-specific `limit` spelling of `ulimit -c unlimited`). A setuid crash drops its memory to disk as a world-readable file — leave the ceiling at the distro default.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unlimit coredumpsize`",
+			input: `unlimit coredumpsize`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1832",
+					Message: "`unlimit coredumpsize` enables unbounded core dumps (Zsh-specific `limit` spelling of `ulimit -c unlimited`). A setuid crash drops its memory to disk as a world-readable file — leave the ceiling at the distro default.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1832")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1832.go
+++ b/pkg/katas/zc1832.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1832",
+		Title:    "Warn on Zsh `limit coredumpsize unlimited` — setuid memory landing in core files",
+		Severity: SeverityWarning,
+		Description: "Zsh's `limit` builtin is the csh-style sibling of `ulimit`; `limit " +
+			"coredumpsize unlimited` is the Zsh equivalent of `ulimit -c unlimited` and has " +
+			"the same consequence: a crashing setuid or key-holding process leaves its " +
+			"address space on disk as a world-readable core file. Leave the coredump " +
+			"ceiling at the distro default (usually 0 for non-debug sessions), or use " +
+			"`systemd-coredump` with restricted permissions when you need post-mortem data. " +
+			"`ulimit -c unlimited` is covered by ZC1495; this kata catches the Zsh-specific " +
+			"`limit`/`unlimit coredumpsize` spelling.",
+		Check: checkZC1832,
+	})
+}
+
+func checkZC1832(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "limit":
+		// `limit coredumpsize unlimited` (with optional -h for hard limit).
+		argIdx := 0
+		if argIdx < len(cmd.Arguments) && cmd.Arguments[argIdx].String() == "-h" {
+			argIdx++
+		}
+		if argIdx+1 >= len(cmd.Arguments) {
+			return nil
+		}
+		resource := strings.ToLower(cmd.Arguments[argIdx].String())
+		value := strings.ToLower(cmd.Arguments[argIdx+1].String())
+		if (resource == "coredumpsize" || resource == "coredump") && value == "unlimited" {
+			return zc1832Hit(cmd, "limit coredumpsize unlimited")
+		}
+	case "unlimit":
+		for _, arg := range cmd.Arguments {
+			v := strings.ToLower(arg.String())
+			if v == "coredumpsize" || v == "coredump" {
+				return zc1832Hit(cmd, "unlimit coredumpsize")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1832Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1832",
+		Message: "`" + where + "` enables unbounded core dumps (Zsh-specific `limit` " +
+			"spelling of `ulimit -c unlimited`). A setuid crash drops its memory to " +
+			"disk as a world-readable file — leave the ceiling at the distro default.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 828 Katas = 0.8.28
-const Version = "0.8.28"
+// 829 Katas = 0.8.29
+const Version = "0.8.29"


### PR DESCRIPTION
ZC1832 — Zsh limit builtin enabling unbounded core dumps

What: detect Zsh limit coredumpsize unlimited (with optional -h hard-limit flag) and unlimit coredumpsize.
Why: Zsh's limit is the csh-style sibling of ulimit. limit coredumpsize unlimited has the same effect as ulimit -c unlimited (covered by ZC1495): a crashing setuid or key-holding process leaves its address space on disk as a world-readable core file.
Fix suggestion: leave the coredump ceiling at the distro default (usually 0 for non-debug sessions), or use systemd-coredump with restricted permissions when post-mortem data is genuinely needed.
Severity: Warning