### PR TITLE
feat: ZC1833 — warn on `unsetopt WARN_CREATE_GLOBAL` hiding accidental globals

### DIFF
--- a/pkg/katas/katatests/zc1833_test.go
+++ b/pkg/katas/katatests/zc1833_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1833(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt WARN_CREATE_GLOBAL`",
+			input:    `setopt WARN_CREATE_GLOBAL`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt WARN_CREATE_GLOBAL`",
+			input: `unsetopt WARN_CREATE_GLOBAL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1833",
+					Message: "`unsetopt WARN_CREATE_GLOBAL` silences Zsh's warning for assignments leaking out of function scope — classic caller-variable stomping. Declare `local`/`typeset`; scope with `LOCAL_OPTIONS` if you must disable.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_WARN_CREATE_GLOBAL`",
+			input: `setopt NO_WARN_CREATE_GLOBAL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1833",
+					Message: "`setopt NO_WARN_CREATE_GLOBAL` silences Zsh's warning for assignments leaking out of function scope — classic caller-variable stomping. Declare `local`/`typeset`; scope with `LOCAL_OPTIONS` if you must disable.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1833")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1833.go
+++ b/pkg/katas/zc1833.go
@@ -1,0 +1,73 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1833",
+		Title:    "Warn on `unsetopt WARN_CREATE_GLOBAL` — silent accidental-global bugs inside functions",
+		Severity: SeverityWarning,
+		Description: "`WARN_CREATE_GLOBAL` makes Zsh warn when a function assigns to a name " +
+			"that is not declared `local` / `typeset` in the current scope — the single " +
+			"highest-value guardrail against the classic Bash-ism where a helper function " +
+			"silently stomps on a caller's variable (`tmp=`, `i=`, `result=`). Disabling it " +
+			"(`unsetopt WARN_CREATE_GLOBAL` or the equivalent `setopt NO_WARN_CREATE_GLOBAL`) " +
+			"reverts to permissive behaviour: every unqualified assignment inside a function " +
+			"escapes to global scope with no diagnostic. Leave the option on and fix the " +
+			"offending function by adding `local` / `typeset` declarations, or — if you " +
+			"really must silence it for a specific block — use `setopt LOCAL_OPTIONS; " +
+			"unsetopt WARN_CREATE_GLOBAL` inside a function so the rest of the script keeps " +
+			"the safety.",
+		Check: checkZC1833,
+	})
+}
+
+func checkZC1833(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			if zc1833IsWarnCreateGlobal(arg.String()) {
+				return zc1833Hit(cmd, "unsetopt "+arg.String())
+			}
+		}
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOWARNCREATEGLOBAL" {
+				return zc1833Hit(cmd, "setopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1833IsWarnCreateGlobal(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "WARNCREATEGLOBAL"
+}
+
+func zc1833Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1833",
+		Message: "`" + where + "` silences Zsh's warning for assignments leaking " +
+			"out of function scope — classic caller-variable stomping. Declare " +
+			"`local`/`typeset`; scope with `LOCAL_OPTIONS` if you must disable.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 829 Katas = 0.8.29
-const Version = "0.8.29"
+// 830 Katas = 0.8.30
+const Version = "0.8.30"


### PR DESCRIPTION
ZC1833 — warn on `unsetopt WARN_CREATE_GLOBAL`

What: `unsetopt WARN_CREATE_GLOBAL` (or `setopt NO_WARN_CREATE_GLOBAL`).
Why: disables Zsh's warning when a function assigns to a name without `local`/`typeset` — leaks state into caller scope.
Fix suggestion: leave the option on; declare variables with `local`/`typeset`; scope with `LOCAL_OPTIONS` if you must disable.
Severity: Warning