### PR TITLE
feat: ZC1834 — error on `tc qdisc … netem loss 100%` blackholing live interface

### DIFF
--- a/pkg/katas/katatests/zc1834_test.go
+++ b/pkg/katas/katatests/zc1834_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1834(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `tc qdisc add dev eth0 root netem loss 5%` (partial)",
+			input:    `tc qdisc add dev eth0 root netem loss 5%`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `tc qdisc del dev eth0 root` (cleanup)",
+			input:    `tc qdisc del dev eth0 root`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `tc qdisc add … netem loss 100%`",
+			input: `tc qdisc add dev eth0 root netem loss 100%`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1834",
+					Message: "`tc qdisc add … netem loss 100%` black-holes every packet on the target interface — remote SSH dies instantly. Stage on a secondary dev or wrap in a timed recovery (`at now + N minutes … tc qdisc del …`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `tc qdisc replace … netem corrupt 100%`",
+			input: `tc qdisc replace dev eth0 root netem corrupt 100%`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1834",
+					Message: "`tc qdisc replace … netem corrupt 100%` black-holes every packet on the target interface — remote SSH dies instantly. Stage on a secondary dev or wrap in a timed recovery (`at now + N minutes … tc qdisc del …`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1834")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1834.go
+++ b/pkg/katas/zc1834.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1834",
+		Title:    "Error on `tc qdisc … root netem loss 100%` — hard blackhole on a live interface",
+		Severity: SeverityError,
+		Description: "`tc qdisc add/replace dev IFACE root netem loss 100%` (also `corrupt 100%` " +
+			"or `duplicate 100%` with no buffering) installs a Linux kernel qdisc that " +
+			"drops every outbound packet on the named interface. Running this on the " +
+			"interface that carries your SSH session is the canonical way to lock " +
+			"yourself out of a remote host — the `tc` command returns success, the kernel " +
+			"happily applies the rule, and the next TCP segment ACK never arrives. Even on " +
+			"the console it halts any process that depends on the interface. Stage netem " +
+			"experiments on a secondary interface, wrap them in `at now + 5 minutes` (or a " +
+			"`timeout … tc qdisc del …` recovery trap) so a partial failure does not leave " +
+			"the link permanently black-holed.",
+		Check: checkZC1834,
+	})
+}
+
+func checkZC1834(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "tc" {
+		return nil
+	}
+	args := cmd.Arguments
+	if len(args) < 3 {
+		return nil
+	}
+	if args[0].String() != "qdisc" {
+		return nil
+	}
+	action := args[1].String()
+	if action != "add" && action != "replace" && action != "change" {
+		return nil
+	}
+	// Walk remaining args looking for `netem <mode> 100%`.
+	for i := 2; i+2 < len(args); i++ {
+		if args[i].String() != "netem" {
+			continue
+		}
+		for j := i + 1; j+1 < len(args); j++ {
+			mode := args[j].String()
+			if mode != "loss" && mode != "corrupt" && mode != "duplicate" {
+				continue
+			}
+			val := args[j+1].String()
+			if val == "100%" || val == "100" {
+				return []Violation{{
+					KataID: "ZC1834",
+					Message: "`tc qdisc " + action + " … netem " + mode + " 100%` " +
+						"black-holes every packet on the target interface — remote SSH " +
+						"dies instantly. Stage on a secondary dev or wrap in a timed " +
+						"recovery (`at now + N minutes … tc qdisc del …`).",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityError,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 830 Katas = 0.8.30
-const Version = "0.8.30"
+// 831 Katas = 0.8.31
+const Version = "0.8.31"


### PR DESCRIPTION
ZC1834 — error on `tc qdisc add/replace dev X root netem loss 100%`

What: installs a netem qdisc that drops 100% of packets (or 100% corrupt/duplicate).
Why: canonical remote-SSH lockout — the kernel applies it, the next ACK never arrives.
Fix suggestion: stage on a secondary interface, or wrap with `at now + N minutes … tc qdisc del …` auto-recovery.
Severity: Error