### PR TITLE
feat: ZC1835 — warn on `smartctl -s off` disabling drive SMART monitoring

### DIFF
--- a/pkg/katas/katatests/zc1835_test.go
+++ b/pkg/katas/katatests/zc1835_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1835(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `smartctl -s on $DISK` (default)",
+			input:    `smartctl -s on $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `smartctl -a $DISK` (just report)",
+			input:    `smartctl -a $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `smartctl -s off $DISK`",
+			input: `smartctl -s off $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1835",
+					Message: "`smartctl -s off` disables the drive's SMART attribute collection — `smartctl -H` keeps reporting PASSED until the disk falls off the bus. Leave it `on` and configure `smartd.conf` for proactive alerts.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1835")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1835.go
+++ b/pkg/katas/zc1835.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1835",
+		Title:    "Warn on `smartctl -s off` — drive self-monitoring (SMART) disabled, silent failure",
+		Severity: SeverityWarning,
+		Description: "`smartctl -s off DEV` tells the drive firmware to stop recording the SMART " +
+			"attribute counters that warn operators about pending failure — reallocated " +
+			"sectors, pending sectors, uncorrectable errors, temperature excursions. " +
+			"Rotating disks and SSDs both ship with the monitoring on; disabling it keeps " +
+			"`smartctl -H` reporting PASSED right up until the drive falls off the bus, so " +
+			"the periodic fleet health scan never escalates until data loss is already " +
+			"happening. Use `smartctl -s on DEV` (default) and configure `smartd.conf` for " +
+			"proactive alerts instead of muting the source.",
+		Check: checkZC1835,
+	})
+}
+
+func checkZC1835(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "smartctl" {
+		return nil
+	}
+	args := cmd.Arguments
+	for i := 0; i+1 < len(args); i++ {
+		flag := args[i].String()
+		if flag != "-s" && flag != "--smart" {
+			continue
+		}
+		val := args[i+1].String()
+		if val == "off" {
+			return []Violation{{
+				KataID: "ZC1835",
+				Message: "`smartctl -s off` disables the drive's SMART attribute " +
+					"collection — `smartctl -H` keeps reporting PASSED until the " +
+					"disk falls off the bus. Leave it `on` and configure " +
+					"`smartd.conf` for proactive alerts.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 831 Katas = 0.8.31
-const Version = "0.8.31"
+// 832 Katas = 0.8.32
+const Version = "0.8.32"


### PR DESCRIPTION
ZC1835 — warn on `smartctl -s off DEV`

What: disables the drive's SMART attribute collection.
Why: `smartctl -H DEV` keeps reporting PASSED after monitoring is muted — silent failure mode.
Fix suggestion: leave `-s on` (default); configure `smartd.conf` for proactive alerts.
Severity: Warning