### PR TITLE
feat: ZC1836 — error on `helm uninstall --no-hooks` skipping cleanup

### DIFF
--- a/pkg/katas/katatests/zc1836_test.go
+++ b/pkg/katas/katatests/zc1836_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1836(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `helm uninstall mychart`",
+			input:    `helm uninstall mychart`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `helm uninstall mychart --keep-history` (unrelated)",
+			input:    `helm uninstall mychart --keep-history`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `helm uninstall mychart --no-hooks`",
+			input: `helm uninstall mychart --no-hooks`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1836",
+					Message: "`helm uninstall --no-hooks` skips pre/post-delete cleanup hooks — orphaned locks, DNS, missed PVC backups. Drop the flag; fix stuck hooks via `helm.sh/hook-delete-policy`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `helm delete mychart --no-hooks` (Helm v2 spelling)",
+			input: `helm delete mychart --no-hooks`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1836",
+					Message: "`helm delete --no-hooks` skips pre/post-delete cleanup hooks — orphaned locks, DNS, missed PVC backups. Drop the flag; fix stuck hooks via `helm.sh/hook-delete-policy`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1836")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1836.go
+++ b/pkg/katas/zc1836.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1836",
+		Title:    "Error on `helm uninstall --no-hooks` — skips pre-delete cleanup, orphaned state",
+		Severity: SeverityError,
+		Description: "`helm uninstall RELEASE --no-hooks` (also spelled `helm delete --no-hooks` on " +
+			"Helm v2 / `helm3 --no-hooks` interchangeably) tears down every chart-rendered " +
+			"resource but silently skips the release's `pre-delete` and `post-delete` " +
+			"Jobs / ConfigMap hooks. Those hooks are where production charts flush " +
+			"write-ahead logs, deregister service-discovery entries, back up PVC content " +
+			"before the PVC goes away, and release external locks — skipping them on a " +
+			"live release is one of the classic ways to leave the cluster in a partially " +
+			"deleted state with no way to replay the cleanup. Drop `--no-hooks` and let " +
+			"the chart run as designed; if a hook is genuinely wedged, disable it at the " +
+			"chart level with `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`.",
+		Check: checkZC1836,
+	})
+}
+
+func checkZC1836(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "helm" {
+		return nil
+	}
+	args := cmd.Arguments
+	if len(args) < 2 {
+		return nil
+	}
+	sub := args[0].String()
+	if sub != "uninstall" && sub != "delete" {
+		return nil
+	}
+	for _, arg := range args[1:] {
+		if arg.String() == "--no-hooks" {
+			return []Violation{{
+				KataID: "ZC1836",
+				Message: "`helm " + sub + " --no-hooks` skips pre/post-delete " +
+					"cleanup hooks — orphaned locks, DNS, missed PVC backups. " +
+					"Drop the flag; fix stuck hooks via " +
+					"`helm.sh/hook-delete-policy`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 832 Katas = 0.8.32
-const Version = "0.8.32"
+// 833 Katas = 0.8.33
+const Version = "0.8.33"


### PR DESCRIPTION
ZC1836 — error on `helm uninstall/delete RELEASE --no-hooks`

What: skips the release's `pre-delete`/`post-delete` cleanup hooks.
Why: those hooks flush WALs, back up PVCs, deregister services, release external locks — skipping them orphans external state.
Fix suggestion: drop `--no-hooks`; if a hook is stuck, fix it at the chart level with `helm.sh/hook-delete-policy`.
Severity: Error