### PR TITLE
feat: ZC1837 — error on `chmod` opening /dev/kvm|mem|kmem|port to the world

### DIFF
--- a/pkg/katas/katatests/zc1837_test.go
+++ b/pkg/katas/katatests/zc1837_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1837(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `chmod 660 /dev/kvm` (distro default)",
+			input:    `chmod 660 /dev/kvm`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `chmod 600 /dev/mem`",
+			input:    `chmod 600 /dev/mem`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `chmod 666 /tmp/x` (unrelated file)",
+			input:    `chmod 666 /tmp/x`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `chmod 666 /dev/kvm`",
+			input: `chmod 666 /dev/kvm`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1837",
+					Message: "`chmod 666 /dev/kvm` grants non-owner access to a privileged kernel device — classic local-privesc vector. Use group membership or a udev rule instead of blanket chmod.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `chmod 644 /dev/mem` (world-read)",
+			input: `chmod 644 /dev/mem`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1837",
+					Message: "`chmod 644 /dev/mem` grants non-owner access to a privileged kernel device — classic local-privesc vector. Use group membership or a udev rule instead of blanket chmod.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `chmod a+rw /dev/port` (symbolic)",
+			input: `chmod a+rw /dev/port`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1837",
+					Message: "`chmod a+rw /dev/port` grants non-owner access to a privileged kernel device — classic local-privesc vector. Use group membership or a udev rule instead of blanket chmod.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1837")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1837.go
+++ b/pkg/katas/zc1837.go
@@ -1,0 +1,113 @@
+package katas
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1837",
+		Title:    "Error on `chmod` granting non-owner access to `/dev/kvm` / `/dev/mem` / `/dev/kmem` / `/dev/port`",
+		Severity: SeverityError,
+		Description: "Distros ship `/dev/mem`, `/dev/kmem`, `/dev/port`, and `/dev/kvm` with tight " +
+			"owner-only or group-only permissions managed by udev rules — these nodes hand " +
+			"any process that can read or write them the keys to the kingdom (physical " +
+			"memory, kernel memory, raw I/O ports, full hypervisor API). Flipping the mode " +
+			"from a script (`chmod 666 /dev/kvm`, `chmod a+rw /dev/mem`) is a classic local " +
+			"privilege-escalation vector dressed up as a convenience fix for a permission " +
+			"error. Fix the actual problem: add the user to the `kvm` group, ship a proper " +
+			"udev rule (`/etc/udev/rules.d/*.rules`), or grant the specific capability the " +
+			"tool needs instead of blanket-chmod-ing the device.",
+		Check: checkZC1837,
+	})
+}
+
+var zc1837Devices = map[string]struct{}{
+	"/dev/kvm":  {},
+	"/dev/mem":  {},
+	"/dev/kmem": {},
+	"/dev/port": {},
+}
+
+func checkZC1837(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "chmod" {
+		return nil
+	}
+	args := cmd.Arguments
+	if len(args) < 2 {
+		return nil
+	}
+
+	var mode, target string
+	for _, arg := range args {
+		v := arg.String()
+		if strings.HasPrefix(v, "-") {
+			continue
+		}
+		if mode == "" {
+			mode = v
+			continue
+		}
+		target = v
+		break
+	}
+	if target == "" {
+		return nil
+	}
+	if _, hit := zc1837Devices[target]; !hit {
+		return nil
+	}
+	if !zc1837GrantsNonOwner(mode) {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1837",
+		Message: "`chmod " + mode + " " + target + "` grants non-owner access to " +
+			"a privileged kernel device — classic local-privesc vector. Use " +
+			"group membership or a udev rule instead of blanket chmod.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}
+
+func zc1837GrantsNonOwner(mode string) bool {
+	if mode == "" {
+		return false
+	}
+	// Symbolic: look for tokens that grant to group/other/all.
+	lower := strings.ToLower(mode)
+	if strings.HasPrefix(lower, "+") {
+		return true
+	}
+	for _, frag := range []string{"o+", "o=", "a+", "a=", "ugo+", "ugo="} {
+		if strings.Contains(lower, frag) {
+			return true
+		}
+	}
+	// Numeric: chmod reads the mode as octal. Parser normalises leading-zero
+	// octals to decimal (e.g. "0666" -> "438"), so branch on which one we got.
+	for _, r := range mode {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	var n int64
+	if strings.ContainsAny(mode, "89") {
+		n, _ = strconv.ParseInt(mode, 10, 32)
+	} else {
+		n, _ = strconv.ParseInt(mode, 8, 32)
+	}
+	// Flag only if any "other" (world) bit is set — these devices are managed
+	// with group-only access (e.g. /dev/kvm = 660 kvm:root); tightening to
+	// 660/600 is fine, opening to the world is the privesc case.
+	return (n & 0o007) != 0
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 833 Katas = 0.8.33
-const Version = "0.8.33"
+// 834 Katas = 0.8.34
+const Version = "0.8.34"


### PR DESCRIPTION
ZC1837 — `chmod` granting non-owner access to privileged kernel devices

What: flags `chmod <mode-with-other-bits> /dev/{kvm,mem,kmem,port}`.
Why: these nodes expose physical memory, kernel memory, raw I/O ports, and the full hypervisor API — opening to "other" is a classic local-privesc vector.
Fix suggestion: add the user to the managed group (e.g. `kvm`) or ship a proper udev rule — never blanket-chmod the device from a script.
Severity: Error