### PR TITLE
feat: ZC1838 — warn on `setopt GLOB_DOTS` making bare `*` match hidden files

### DIFF
--- a/pkg/katas/katatests/zc1838_test.go
+++ b/pkg/katas/katatests/zc1838_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1838(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt GLOB_DOTS` (explicit default)",
+			input:    `unsetopt GLOB_DOTS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt GLOB_DOTS`",
+			input: `setopt GLOB_DOTS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1838",
+					Message: "`setopt GLOB_DOTS` makes every bare `*` also match hidden files — `rm *` quietly destroys `.git/`, `cp -r *` copies `.env`. Keep the option alone; request dotfiles per-glob with `*(D)`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_GLOB_DOTS`",
+			input: `unsetopt NO_GLOB_DOTS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1838",
+					Message: "`unsetopt NO_GLOB_DOTS` makes every bare `*` also match hidden files — `rm *` quietly destroys `.git/`, `cp -r *` copies `.env`. Keep the option alone; request dotfiles per-glob with `*(D)`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1838")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1838.go
+++ b/pkg/katas/zc1838.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1838",
+		Title:    "Warn on `setopt GLOB_DOTS` — bare `*` silently starts matching hidden files",
+		Severity: SeverityWarning,
+		Description: "`GLOB_DOTS` off is the Zsh default: patterns like `*`, `*.log`, and " +
+			"recursive `**/*` skip filenames that begin with a dot (`.git/`, `.env`, " +
+			"`.ssh/`). Setting `setopt GLOB_DOTS` script-wide reverses that quietly — every " +
+			"subsequent glob now also matches hidden entries, which turns routine " +
+			"maintenance lines (`rm *`, `cp -r * /backup`, `chmod 644 *`) into " +
+			"repository-wiping, secret-copying, permission-flipping bugs. Leave the option " +
+			"alone at the script level and request dot-inclusion per-glob with the " +
+			"Zsh-native `*(D)` qualifier (or `.* *` when you explicitly want both), so the " +
+			"effect is scoped to the exact line that needs it.",
+		Check: checkZC1838,
+	})
+}
+
+func checkZC1838(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if zc1838IsGlobDots(v) {
+				return zc1838Hit(cmd, "setopt "+v)
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOGLOBDOTS" {
+				return zc1838Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1838IsGlobDots(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "GLOBDOTS"
+}
+
+func zc1838Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1838",
+		Message: "`" + where + "` makes every bare `*` also match hidden files — " +
+			"`rm *` quietly destroys `.git/`, `cp -r *` copies `.env`. Keep the " +
+			"option alone; request dotfiles per-glob with `*(D)`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 834 Katas = 0.8.34
-const Version = "0.8.34"
+// 835 Katas = 0.8.35
+const Version = "0.8.35"


### PR DESCRIPTION
ZC1838 — warn on `setopt GLOB_DOTS` / `unsetopt NO_GLOB_DOTS`

What: flips the Zsh default where `*` skips dotfiles.
Why: subsequent `rm *`, `cp -r *`, `chmod *` silently touch `.git/`, `.env`, `.ssh/`.
Fix suggestion: leave the option alone; request dotfiles per-glob with `*(D)` or the explicit `.* *` pattern.
Severity: Warning