### PR TITLE
feat: ZC1839 — warn on disabling network time sync (NTP/chronyd/timesyncd)

### DIFF
--- a/pkg/katas/katatests/zc1839_test.go
+++ b/pkg/katas/katatests/zc1839_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1839(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `timedatectl set-ntp true`",
+			input:    `timedatectl set-ntp true`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `systemctl enable chronyd`",
+			input:    `systemctl enable chronyd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `timedatectl set-ntp false`",
+			input: `timedatectl set-ntp false`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1839",
+					Message: "`timedatectl set-ntp false` turns off network time sync — clock drift breaks TLS `notBefore`/`notAfter`, Kerberos, and TOTP. Leave NTP enabled; isolate frozen clocks to namespaces/CI.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `systemctl disable systemd-timesyncd`",
+			input: `systemctl disable systemd-timesyncd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1839",
+					Message: "`systemctl disable systemd-timesyncd` turns off network time sync — clock drift breaks TLS `notBefore`/`notAfter`, Kerberos, and TOTP. Leave NTP enabled; isolate frozen clocks to namespaces/CI.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1839")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1839.go
+++ b/pkg/katas/zc1839.go
@@ -1,0 +1,90 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1839",
+		Title:    "Warn on `timedatectl set-ntp false` / disabling `systemd-timesyncd` / `chronyd`",
+		Severity: SeverityWarning,
+		Description: "`timedatectl set-ntp false` (also spelled `set-ntp no` / `set-ntp 0`) tells " +
+			"systemd to stop the network time client; `systemctl disable systemd-timesyncd` " +
+			"and `systemctl disable chronyd` / `ntpd` have the same effect. With no time " +
+			"source the hardware clock drifts, and within days TLS handshakes begin failing " +
+			"`notBefore`/`notAfter` checks, Kerberos tickets refuse to validate, time-based " +
+			"one-time passwords go out of sync, and log entries arrive in the wrong order — " +
+			"all silently, because the original command succeeded. Keep NTP enabled in " +
+			"production; if you really need a frozen clock for reproducibility, isolate it " +
+			"to a namespace or CI container rather than the host.",
+		Check: checkZC1839,
+	})
+}
+
+var zc1839DisableServices = map[string]struct{}{
+	"systemd-timesyncd":         {},
+	"systemd-timesyncd.service": {},
+	"chronyd":                   {},
+	"chronyd.service":           {},
+	"chrony":                    {},
+	"chrony.service":            {},
+	"ntpd":                      {},
+	"ntpd.service":              {},
+	"ntp":                       {},
+	"ntp.service":               {},
+}
+
+func checkZC1839(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "timedatectl":
+		if len(cmd.Arguments) < 2 {
+			return nil
+		}
+		if cmd.Arguments[0].String() != "set-ntp" {
+			return nil
+		}
+		val := strings.ToLower(cmd.Arguments[1].String())
+		if val == "false" || val == "no" || val == "0" || val == "off" {
+			return zc1839Hit(cmd, "timedatectl set-ntp "+cmd.Arguments[1].String())
+		}
+	case "systemctl":
+		if len(cmd.Arguments) < 2 {
+			return nil
+		}
+		action := cmd.Arguments[0].String()
+		if action != "disable" && action != "mask" && action != "stop" {
+			return nil
+		}
+		for _, arg := range cmd.Arguments[1:] {
+			svc := strings.ToLower(arg.String())
+			if _, hit := zc1839DisableServices[svc]; hit {
+				return zc1839Hit(cmd, "systemctl "+action+" "+arg.String())
+			}
+		}
+	}
+	return nil
+}
+
+func zc1839Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1839",
+		Message: "`" + where + "` turns off network time sync — clock drift " +
+			"breaks TLS `notBefore`/`notAfter`, Kerberos, and TOTP. Leave NTP " +
+			"enabled; isolate frozen clocks to namespaces/CI.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 835 Katas = 0.8.35
-const Version = "0.8.35"
+// 836 Katas = 0.8.36
+const Version = "0.8.36"


### PR DESCRIPTION
ZC1839 — disabling NTP / time-sync

What: `timedatectl set-ntp false|no|0|off`, or `systemctl disable|mask|stop` of `systemd-timesyncd` / `chronyd` / `ntpd`.
Why: clock drift breaks TLS cert validity windows, Kerberos tickets, TOTP, and log ordering — silently after days.
Fix suggestion: keep NTP enabled in production; isolate frozen clocks to namespaces or CI containers.
Severity: Warning