### PR TITLE
feat: ZC1840 — error on `openssl -k PASSWORD` legacy flag leaking secret in argv

### DIFF
--- a/pkg/katas/katatests/zc1840_test.go
+++ b/pkg/katas/katatests/zc1840_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1840(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `openssl enc -pass env:MYPASS`",
+			input:    `openssl enc -aes-256-cbc -pass env:MYPASS -in in.txt -out out.bin`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `openssl enc` without `-k`",
+			input:    `openssl enc -aes-256-cbc -in in.txt -out out.bin`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `openssl enc -k SECRET`",
+			input: `openssl enc -aes-256-cbc -k hunter2 -in in.txt -out out.bin`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1840",
+					Message: "`openssl -k hunter2` embeds the password in argv — visible to `ps`, `/proc/<pid>/cmdline`, and shell history. Use `-pass env:VAR`, `-pass file:PATH`, or `-pass fd:N`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1840")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1840.go
+++ b/pkg/katas/zc1840.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1840",
+		Title:    "Error on `openssl enc -k PASSWORD` — legacy flag embeds secret in argv",
+		Severity: SeverityError,
+		Description: "`openssl enc -k PASSWORD` (the pre-OpenSSL-3 short form of `-pass " +
+			"pass:PASSWORD`) takes the password directly as the next argv element — which " +
+			"makes it visible to every `ps` reader, every `/proc/<pid>/cmdline` consumer, " +
+			"shell history, and anything that logs command invocations. The same leak " +
+			"applies to `openssl rsa`, `openssl pkcs12`, and other subcommands that still " +
+			"accept the deprecated `-k` alias. Use `-pass env:VARNAME`, `-pass file:PATH`, " +
+			"or `-pass fd:N` (read from an open descriptor) so the secret never rides in " +
+			"the process argument vector.",
+		Check: checkZC1840,
+	})
+}
+
+func checkZC1840(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "openssl" {
+		return nil
+	}
+	args := cmd.Arguments
+	for i, arg := range args {
+		if arg.String() != "-k" {
+			continue
+		}
+		if i+1 >= len(args) {
+			continue
+		}
+		val := args[i+1].String()
+		// Ignore empty, flag-looking, or the `-k file:` / `-k env:` style
+		// that newer openssl binaries tolerate.
+		if val == "" || val[0] == '-' {
+			continue
+		}
+		return []Violation{{
+			KataID: "ZC1840",
+			Message: "`openssl -k " + val + "` embeds the password in argv — visible " +
+				"to `ps`, `/proc/<pid>/cmdline`, and shell history. Use " +
+				"`-pass env:VAR`, `-pass file:PATH`, or `-pass fd:N`.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityError,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 836 Katas = 0.8.36
-const Version = "0.8.36"
+// 837 Katas = 0.8.37
+const Version = "0.8.37"


### PR DESCRIPTION
ZC1840 — `openssl -k PASSWORD` legacy flag

What: detects the pre-OpenSSL-3 short-form `-k PASSWORD` on `openssl enc`/`rsa`/`pkcs12` subcommands.
Why: password rides in argv — visible to `ps`, `/proc/<pid>/cmdline`, shell history, audit logs.
Fix suggestion: use `-pass env:VARNAME`, `-pass file:PATH`, or `-pass fd:N` instead.
Severity: Error