### PR TITLE
feat: ZC1841 — error on `curl --proxy-insecure` disabling proxy-leg TLS

### DIFF
--- a/pkg/katas/katatests/zc1841_test.go
+++ b/pkg/katas/katatests/zc1841_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1841(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `curl --proxy-cacert /etc/ssl/proxy.pem https://api`",
+			input:    `curl --proxy-cacert /etc/ssl/proxy.pem https://api`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `curl https://api` (no proxy flags)",
+			input:    `curl https://api`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `curl --proxy-insecure https://api` (flag first)",
+			input: `curl --proxy-insecure https://api`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1841",
+					Message: "`curl --proxy-insecure` skips TLS verification on the proxy hop — an on-path attacker can present any cert and decrypt the tunnel (including `Authorization:` headers). Install the proxy CA and use `--proxy-cacert PATH`.",
+					Line:    1,
+					Column:  8,
+				},
+			},
+		},
+		{
+			name:  "invalid — `curl https://api --proxy-insecure` (flag trailing)",
+			input: `curl https://api --proxy-insecure`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1841",
+					Message: "`curl --proxy-insecure` skips TLS verification on the proxy hop — an on-path attacker can present any cert and decrypt the tunnel (including `Authorization:` headers). Install the proxy CA and use `--proxy-cacert PATH`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1841")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1841.go
+++ b/pkg/katas/zc1841.go
@@ -1,0 +1,62 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1841",
+		Title:    "Error on `curl --proxy-insecure` — TLS verification disabled on the proxy hop",
+		Severity: SeverityError,
+		Description: "`curl --proxy-insecure` (alias of `-k` but scoped to the proxy leg, " +
+			"introduced alongside `--proxy-cacert` in curl 7.52) tells curl to accept any " +
+			"certificate presented by the HTTPS proxy that sits between the script and the " +
+			"origin server. The origin TLS handshake is still validated, which makes the " +
+			"issue easy to miss in review, but any box that can intercept traffic to the " +
+			"proxy — a captive portal, a rogue WPAD auto-discovery, an attacker on the same " +
+			"VLAN — can present its own cert and read or rewrite the tunnel contents, " +
+			"including any `Authorization:` header attached to the request. Install the " +
+			"proxy's CA bundle and point `--proxy-cacert` / `CURL_CA_BUNDLE` at it instead.",
+		Check: checkZC1841,
+	})
+}
+
+func checkZC1841(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `curl --proxy-insecure …` mangles the command name to
+	// `proxy-insecure` when the flag is the first arg. Cover both shapes.
+	if ident.Value == "proxy-insecure" {
+		return zc1841Hit(cmd)
+	}
+	if ident.Value != "curl" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "--proxy-insecure" {
+			return zc1841Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1841Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1841",
+		Message: "`curl --proxy-insecure` skips TLS verification on the proxy hop — " +
+			"an on-path attacker can present any cert and decrypt the tunnel " +
+			"(including `Authorization:` headers). Install the proxy CA and use " +
+			"`--proxy-cacert PATH`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 837 Katas = 0.8.37
-const Version = "0.8.37"
+// 838 Katas = 0.8.38
+const Version = "0.8.38"


### PR DESCRIPTION
ZC1841 — `curl --proxy-insecure`

What: detects `curl --proxy-insecure` in both flag-first and flag-trailing positions.
Why: disables TLS verification on the HTTPS-proxy hop — on-path attacker can decrypt the tunnel (including `Authorization:` headers).
Fix suggestion: install the proxy CA and use `--proxy-cacert PATH` / `CURL_CA_BUNDLE`.
Severity: Error