### PR TITLE
feat: ZC1842 — warn on `setopt CDABLE_VARS` silently rewriting `cd` via variable

### DIFF
--- a/pkg/katas/katatests/zc1842_test.go
+++ b/pkg/katas/katatests/zc1842_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1842(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt CDABLE_VARS` (explicit default)",
+			input:    `unsetopt CDABLE_VARS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt CDABLE_VARS`",
+			input: `setopt CDABLE_VARS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1842",
+					Message: "`setopt CDABLE_VARS` turns a failed `cd NAME` into `cd $NAME` — a typo silently lands in whatever directory the matching variable points to. Keep this in `~/.zshrc`; in scripts use `cd \"$dir\" || exit`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_CDABLE_VARS`",
+			input: `unsetopt NO_CDABLE_VARS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1842",
+					Message: "`unsetopt NO_CDABLE_VARS` turns a failed `cd NAME` into `cd $NAME` — a typo silently lands in whatever directory the matching variable points to. Keep this in `~/.zshrc`; in scripts use `cd \"$dir\" || exit`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1842")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1842.go
+++ b/pkg/katas/zc1842.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1842",
+		Title:    "Warn on `setopt CDABLE_VARS` — `cd NAME` silently falls back to `cd $NAME`",
+		Severity: SeverityWarning,
+		Description: "With `CDABLE_VARS` on, any `cd NAME` whose `NAME` does not exist as a " +
+			"directory is retried as `cd ${NAME}` — if a parameter of the same name is set, " +
+			"the working directory silently jumps to wherever the variable points. A typo " +
+			"like `cd cinfig` (intent: `config`) suddenly lands inside `${cinfig}` when one " +
+			"exists, and every later relative path in the script is computed from the wrong " +
+			"root. Keep this option inside `~/.zshrc` where it is an interactive shortcut; " +
+			"in scripts, always `cd \"$dir\"` explicitly and pair with `|| exit` so a missed " +
+			"directory fails loudly instead of rewriting `$PWD`.",
+		Check: checkZC1842,
+	})
+}
+
+func checkZC1842(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			if zc1842IsCdableVars(arg.String()) {
+				return zc1842Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOCDABLEVARS" {
+				return zc1842Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1842IsCdableVars(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "CDABLEVARS"
+}
+
+func zc1842Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1842",
+		Message: "`" + where + "` turns a failed `cd NAME` into `cd $NAME` — a typo " +
+			"silently lands in whatever directory the matching variable points to. " +
+			"Keep this in `~/.zshrc`; in scripts use `cd \"$dir\" || exit`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 838 Katas = 0.8.38
-const Version = "0.8.38"
+// 839 Katas = 0.8.39
+const Version = "0.8.39"


### PR DESCRIPTION
ZC1842 — `setopt CDABLE_VARS`

What: flags `setopt CDABLE_VARS` / `unsetopt NO_CDABLE_VARS`.
Why: a failed `cd NAME` is retried as `cd $NAME` — a typo that shares a variable name silently jumps to the variable's path; every later relative path runs from the wrong root.
Fix suggestion: keep the option in `~/.zshrc` (interactive shortcut); in scripts use `cd "$dir" || exit`.
Severity: Warning