### PR TITLE
feat: ZC1843 — warn on container `--cgroup-parent` pointing at host-managed slice

### DIFF
--- a/pkg/katas/katatests/zc1843_test.go
+++ b/pkg/katas/katatests/zc1843_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1843(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `docker run ubuntu` (no cgroup-parent)",
+			input:    `docker run ubuntu`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `docker run --cgroup-parent=custom app` (non-host slice)",
+			input:    `docker run --cgroup-parent=custom app`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `docker run --cgroup-parent=/ ubuntu`",
+			input: `docker run --cgroup-parent=/ ubuntu`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1843",
+					Message: "`docker run --cgroup-parent=/` puts the container under a host-managed slice — the engine's memory/CPU caps no longer apply. Drop the flag or pass `--memory`/`--cpus`/`--pids-limit` directly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `podman run --cgroup-parent /system.slice alpine`",
+			input: `podman run --cgroup-parent /system.slice alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1843",
+					Message: "`podman run --cgroup-parent=/system.slice` puts the container under a host-managed slice — the engine's memory/CPU caps no longer apply. Drop the flag or pass `--memory`/`--cpus`/`--pids-limit` directly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1843")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1843.go
+++ b/pkg/katas/zc1843.go
@@ -1,0 +1,91 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1843",
+		Title:    "Warn on `docker/podman run --cgroup-parent=/system.slice|/init.scope|/` — container escapes engine limits",
+		Severity: SeverityWarning,
+		Description: "`--cgroup-parent=PATH` places the container under the given cgroup parent, " +
+			"which is normally `/docker` (or the engine's managed slice) and inherits the " +
+			"engine-wide memory/CPU/IO caps. Pointing the flag at `/`, `/system.slice`, or " +
+			"any host-managed slice puts the container side-by-side with systemd services — " +
+			"the engine's defaults no longer apply, and a runaway container can starve " +
+			"`sshd` or the kubelet for resources. Unless a specific orchestrator is " +
+			"supplying a managed cgroup path, drop the flag and let the engine choose; if " +
+			"you need custom limits, use `--memory` / `--cpus` / `--pids-limit` on the run " +
+			"itself.",
+		Check: checkZC1843,
+	})
+}
+
+func checkZC1843(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+	args := cmd.Arguments
+	if len(args) < 2 {
+		return nil
+	}
+	sub := args[0].String()
+	if sub != "run" && sub != "create" {
+		return nil
+	}
+
+	for i := 1; i < len(args); i++ {
+		v := args[i].String()
+		var parent string
+		switch {
+		case strings.HasPrefix(v, "--cgroup-parent="):
+			parent = strings.TrimPrefix(v, "--cgroup-parent=")
+		case v == "--cgroup-parent" && i+1 < len(args):
+			parent = args[i+1].String()
+		default:
+			continue
+		}
+		if zc1843IsHostSlice(parent) {
+			return []Violation{{
+				KataID: "ZC1843",
+				Message: "`" + ident.Value + " " + sub + " --cgroup-parent=" + parent +
+					"` puts the container under a host-managed slice — the engine's " +
+					"memory/CPU caps no longer apply. Drop the flag or pass " +
+					"`--memory`/`--cpus`/`--pids-limit` directly.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1843IsHostSlice(v string) bool {
+	if v == "" {
+		return false
+	}
+	trimmed := strings.Trim(v, "\"'")
+	switch trimmed {
+	case "/", "/system.slice", "/user.slice", "/init.scope", "/machine.slice":
+		return true
+	}
+	// Anything under /system.slice or /init.scope qualifies too.
+	for _, prefix := range []string{"/system.slice/", "/init.scope/", "/machine.slice/"} {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 839 Katas = 0.8.39
-const Version = "0.8.39"
+// 840 Katas = 0.8.40
+const Version = "0.8.40"


### PR DESCRIPTION
ZC1843 — `docker/podman run --cgroup-parent=/system.slice|/init.scope|/`

What: flags `--cgroup-parent` where the parent is the host root slice or systemd-managed slice.
Why: container sits side-by-side with host services, engine-wide memory/CPU caps no longer apply — runaway container can starve sshd or kubelet.
Fix suggestion: drop the flag; use per-run `--memory`/`--cpus`/`--pids-limit` instead.
Severity: Warning