### PR TITLE
feat: ZC1844 — warn on `logger -p local*.…` facility that rsyslog often drops

### DIFF
--- a/pkg/katas/katatests/zc1844_test.go
+++ b/pkg/katas/katatests/zc1844_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1844(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `logger -p auth.notice` (audit)",
+			input:    `logger -p auth.notice -t scriptaudit "user added"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `logger message` (default)",
+			input:    `logger "hello"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `logger -p local0.info`",
+			input: `logger -p local0.info "audit: user added to wheel"`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1844",
+					Message: "`logger -p local0.info` writes to a `local*` facility — stock `rsyslog`/`journald` rarely collects these. Use `auth.notice`/`authpriv.info` for audit events, or `user.notice` + `-t TAG` for app logs.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `logger msg --priority=local7.notice` (trailing)",
+			input: `logger "site event" --priority=local7.notice`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1844",
+					Message: "`logger -p local7.notice` writes to a `local*` facility — stock `rsyslog`/`journald` rarely collects these. Use `auth.notice`/`authpriv.info` for audit events, or `user.notice` + `-t TAG` for app logs.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1844")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1844.go
+++ b/pkg/katas/zc1844.go
@@ -1,0 +1,79 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1844",
+		Title:    "Warn on `logger -p local0.info|local7.notice|…` — unreserved facility often uncollected",
+		Severity: SeverityWarning,
+		Description: "The eight `local0`–`local7` syslog facilities are reserved for site-specific " +
+			"use. Most distro `rsyslog` and `systemd-journald` defaults do not route them " +
+			"anywhere — they drop on the floor unless someone dropped a matching rule into " +
+			"`/etc/rsyslog.d/*.conf`. Scripts that call `logger -p local0.info 'audit: user " +
+			"added to wheel'` therefore log to nothing in the audit trail on a stock " +
+			"machine. For portable audit-style logging use the POSIX-reserved `auth.notice` " +
+			"or `authpriv.info` facility; for application events, pass `-t TAG` and use " +
+			"`user.notice` (the default) or a dedicated journald unit.",
+		Check: checkZC1844,
+	})
+}
+
+func checkZC1844(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "logger" {
+		return nil
+	}
+	args := cmd.Arguments
+	for i, arg := range args {
+		v := arg.String()
+		var facPrio string
+		switch {
+		case v == "-p" || v == "--priority":
+			if i+1 < len(args) {
+				facPrio = args[i+1].String()
+			}
+		case strings.HasPrefix(v, "-p"):
+			facPrio = strings.TrimPrefix(v, "-p")
+		case strings.HasPrefix(v, "--priority="):
+			facPrio = strings.TrimPrefix(v, "--priority=")
+		}
+		if facPrio == "" {
+			continue
+		}
+		facility := facPrio
+		if idx := strings.Index(facPrio, "."); idx >= 0 {
+			facility = facPrio[:idx]
+		}
+		facility = strings.ToLower(strings.Trim(facility, "\"'"))
+		if zc1844IsLocalFacility(facility) {
+			return []Violation{{
+				KataID: "ZC1844",
+				Message: "`logger -p " + facPrio + "` writes to a `local*` facility — " +
+					"stock `rsyslog`/`journald` rarely collects these. Use " +
+					"`auth.notice`/`authpriv.info` for audit events, or " +
+					"`user.notice` + `-t TAG` for app logs.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1844IsLocalFacility(f string) bool {
+	if len(f) != len("local0") || !strings.HasPrefix(f, "local") {
+		return false
+	}
+	c := f[len("local")]
+	return c >= '0' && c <= '7'
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 840 Katas = 0.8.40
-const Version = "0.8.40"
+// 841 Katas = 0.8.41
+const Version = "0.8.41"


### PR DESCRIPTION
ZC1844 — `logger -p local[0-7].*`

What: flags `logger -p local*.*` (short, long, and attached forms).
Why: `local0`-`local7` are site-reserved syslog facilities; stock `rsyslog`/`journald` usually doesn't collect them, so audit events go to nothing.
Fix suggestion: use `auth.notice`/`authpriv.info` for audit-style logging, or `user.notice` + `-t TAG` for app events.
Severity: Warning