### PR TITLE
feat: ZC1845 — warn on `setopt PATH_DIRS` rerouting slash-bearing commands via `$PATH`

### DIFF
--- a/pkg/katas/katatests/zc1845_test.go
+++ b/pkg/katas/katatests/zc1845_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1845(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt PATH_DIRS` (explicit default)",
+			input:    `unsetopt PATH_DIRS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt PATH_DIRS`",
+			input: `setopt PATH_DIRS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1845",
+					Message: "`setopt PATH_DIRS` lets `subdir/cmd` fall back to a `$PATH` lookup — a missing local binary silently runs a same-named subtree elsewhere on `$PATH`. Leave the option off; call locals as `./subdir/cmd`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_PATH_DIRS`",
+			input: `unsetopt NO_PATH_DIRS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1845",
+					Message: "`unsetopt NO_PATH_DIRS` lets `subdir/cmd` fall back to a `$PATH` lookup — a missing local binary silently runs a same-named subtree elsewhere on `$PATH`. Leave the option off; call locals as `./subdir/cmd`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1845")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1845.go
+++ b/pkg/katas/zc1845.go
@@ -1,0 +1,71 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1845",
+		Title:    "Warn on `setopt PATH_DIRS` — slash-bearing command names fall back to `$PATH` lookup",
+		Severity: SeverityWarning,
+		Description: "`PATH_DIRS` (off by default) changes how Zsh resolves a command that " +
+			"contains a `/`: instead of treating `./foo/bar` or `subdir/cmd` as a direct " +
+			"path, Zsh walks `$path` and retries `${path[i]}/subdir/cmd` until one is " +
+			"executable. The surface intent — run a local binary — is silently replaced by " +
+			"`/usr/local/bin/subdir/cmd` or any other same-shaped subtree that exists on " +
+			"`$PATH`. This gets even worse on shared build hosts where `$PATH` contains " +
+			"user-owned directories. Leave the option off and call local binaries with an " +
+			"explicit leading `./`, or hand the full absolute path to the shell.",
+		Check: checkZC1845,
+	})
+}
+
+func checkZC1845(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if zc1845IsPathDirs(v) {
+				return zc1845Hit(cmd, "setopt "+v)
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOPATHDIRS" {
+				return zc1845Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1845IsPathDirs(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "PATHDIRS"
+}
+
+func zc1845Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1845",
+		Message: "`" + where + "` lets `subdir/cmd` fall back to a `$PATH` lookup — " +
+			"a missing local binary silently runs a same-named subtree elsewhere on " +
+			"`$PATH`. Leave the option off; call locals as `./subdir/cmd`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 841 Katas = 0.8.41
-const Version = "0.8.41"
+// 842 Katas = 0.8.42
+const Version = "0.8.42"


### PR DESCRIPTION
ZC1845 — `setopt PATH_DIRS`

What: flags `setopt PATH_DIRS` / `unsetopt NO_PATH_DIRS`.
Why: a command containing `/` that is not directly executable is silently retried against every `$path` entry — `subdir/cmd` can run `/usr/local/bin/subdir/cmd` or a user-writable tree.
Fix suggestion: leave the option off; call locals as `./subdir/cmd` or use absolute paths.
Severity: Warning