### PR TITLE
feat: ZC1846 — warn on `certbot --force-renewal` burning ACME rate limits

### DIFF
--- a/pkg/katas/katatests/zc1846_test.go
+++ b/pkg/katas/katatests/zc1846_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1846(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `certbot renew` (default)",
+			input:    `certbot renew`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `certbot certificates`",
+			input:    `certbot certificates`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `certbot renew --force-renewal`",
+			input: `certbot renew --force-renewal`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1846",
+					Message: "`certbot renew --force-renewal` reissues regardless of expiry — in a cron it burns Let's Encrypt rate limits (50 certs per domain / 7 days). Drop the flag and let the 30-day gate work.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `certbot certonly --force-renewal -d example.com`",
+			input: `certbot certonly --force-renewal -d example.com`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1846",
+					Message: "`certbot certonly --force-renewal` reissues regardless of expiry — in a cron it burns Let's Encrypt rate limits (50 certs per domain / 7 days). Drop the flag and let the 30-day gate work.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1846")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1846.go
+++ b/pkg/katas/zc1846.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1846",
+		Title:    "Warn on `certbot … --force-renewal` — bypasses ACME rate-limit safety",
+		Severity: SeverityWarning,
+		Description: "`certbot renew --force-renewal` and `certbot certonly --force-renewal` reissue " +
+			"a certificate regardless of remaining validity. Placed in a daily cron, the " +
+			"same hostname burns through Let's Encrypt's per-domain rate limits (50 " +
+			"certificates per registered domain per 7 days, 5 duplicate certificates per " +
+			"domain per 7 days); once the limit trips, no cert for that host — fresh or " +
+			"renewal — can be issued until the rolling window expires, which often happens " +
+			"during an outage when you need it least. Drop `--force-renewal` and let " +
+			"certbot's default 30-days-before-expiry gate do its job, or if you really need " +
+			"a specific reissue, run it once manually.",
+		Check: checkZC1846,
+	})
+}
+
+func checkZC1846(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "certbot" {
+		return nil
+	}
+	args := cmd.Arguments
+	if len(args) < 2 {
+		return nil
+	}
+	sub := args[0].String()
+	if sub != "renew" && sub != "certonly" && sub != "run" {
+		return nil
+	}
+	for _, arg := range args[1:] {
+		if arg.String() == "--force-renewal" {
+			return []Violation{{
+				KataID: "ZC1846",
+				Message: "`certbot " + sub + " --force-renewal` reissues regardless of " +
+					"expiry — in a cron it burns Let's Encrypt rate limits (50 certs " +
+					"per domain / 7 days). Drop the flag and let the 30-day gate work.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 842 Katas = 0.8.42
-const Version = "0.8.42"
+// 843 Katas = 0.8.43
+const Version = "0.8.43"


### PR DESCRIPTION
ZC1846 — `certbot renew/certonly --force-renewal`

What: flags the `--force-renewal` flag on certbot's `renew`, `certonly`, and `run` subcommands.
Why: reissues a certificate regardless of remaining validity; in a cron it eats Let's Encrypt's 50-certs-per-domain / 7-day rate limit and blocks fresh issuance during outages.
Fix suggestion: drop the flag; let the default 30-day-before-expiry gate do its job, or run a one-off manual reissue when truly needed.
Severity: Warning