### PR TITLE
feat: ZC1847 — warn on `setopt CHASE_LINKS` silently resolving `cd` symlinks

### DIFF
--- a/pkg/katas/katatests/zc1847_test.go
+++ b/pkg/katas/katatests/zc1847_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1847(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt CHASE_LINKS` (explicit default)",
+			input:    `unsetopt CHASE_LINKS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt CHASE_LINKS`",
+			input: `setopt CHASE_LINKS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1847",
+					Message: "`setopt CHASE_LINKS` makes every `cd` resolve symlinks to the physical inode — `cd releases/current` lands in the release dir, breaking `..` navigation. Keep it off; use `cd -P target` one-shot when needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_CHASE_LINKS`",
+			input: `unsetopt NO_CHASE_LINKS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1847",
+					Message: "`unsetopt NO_CHASE_LINKS` makes every `cd` resolve symlinks to the physical inode — `cd releases/current` lands in the release dir, breaking `..` navigation. Keep it off; use `cd -P target` one-shot when needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1847")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1847.go
+++ b/pkg/katas/zc1847.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1847",
+		Title:    "Warn on `setopt CHASE_LINKS` — every `cd` silently swaps symlink paths for the real inode",
+		Severity: SeverityWarning,
+		Description: "`CHASE_LINKS` off is the Zsh default: `cd releases/current` leaves `$PWD` " +
+			"as the logical path the user typed, and `cd ..` steps back up through the " +
+			"symlink to where they came from. Turning the option on globally makes every " +
+			"`cd` resolve the target to its physical inode — so `cd releases/current` lands " +
+			"in `/srv/app/releases/20260415-deadbeef`, and the next `cd ../config` looks " +
+			"for `/srv/app/releases/config` instead of the `/srv/app/config` that the user " +
+			"expected. Scripts that rely on blue/green-style `current` symlinks break " +
+			"silently. Keep the option off at the script level and request one-shot " +
+			"physical resolution with `cd -P target` when a specific call needs it.",
+		Check: checkZC1847,
+	})
+}
+
+func checkZC1847(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if zc1847IsChaseLinks(v) {
+				return zc1847Hit(cmd, "setopt "+v)
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOCHASELINKS" {
+				return zc1847Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1847IsChaseLinks(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "CHASELINKS"
+}
+
+func zc1847Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1847",
+		Message: "`" + where + "` makes every `cd` resolve symlinks to the physical " +
+			"inode — `cd releases/current` lands in the release dir, breaking `..` " +
+			"navigation. Keep it off; use `cd -P target` one-shot when needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 843 Katas = 0.8.43
-const Version = "0.8.43"
+// 844 Katas = 0.8.44
+const Version = "0.8.44"


### PR DESCRIPTION
ZC1847 — `setopt CHASE_LINKS`

What: flags `setopt CHASE_LINKS` / `unsetopt NO_CHASE_LINKS`.
Why: every subsequent `cd` resolves symlinks to the physical inode, breaking blue/green-style `current` symlink navigation and `..` traversal.
Fix suggestion: keep the option off; request per-call physical resolution with `cd -P target` when a specific line needs it.
Severity: Warning