### PR TITLE
feat: ZC1849 — warn on `setopt ALL_EXPORT` auto-exporting every assignment

### DIFF
--- a/pkg/katas/katatests/zc1849_test.go
+++ b/pkg/katas/katatests/zc1849_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1849(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt ALL_EXPORT` (explicit default)",
+			input:    `unsetopt ALL_EXPORT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt ALL_EXPORT`",
+			input: `setopt ALL_EXPORT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1849",
+					Message: "`setopt ALL_EXPORT` marks every later assignment for export — secrets like `password=...` leak into every child's env. Drop it; use explicit `export`, or scope inside a `LOCAL_OPTIONS` function.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_ALL_EXPORT`",
+			input: `unsetopt NO_ALL_EXPORT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1849",
+					Message: "`unsetopt NO_ALL_EXPORT` marks every later assignment for export — secrets like `password=...` leak into every child's env. Drop it; use explicit `export`, or scope inside a `LOCAL_OPTIONS` function.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1849")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1849.go
+++ b/pkg/katas/zc1849.go
@@ -1,0 +1,73 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1849",
+		Title:    "Warn on `setopt ALL_EXPORT` — every later `var=value` silently becomes `export var=value`",
+		Severity: SeverityWarning,
+		Description: "`ALL_EXPORT` (POSIX `set -a` equivalent, off by default) tells Zsh to mark " +
+			"every parameter assignment for export as soon as it is created, so " +
+			"`password=$(cat secret)` immediately rides into the environment of every " +
+			"child process the script spawns — the `ps e`, `/proc/<pid>/environ`, and " +
+			"journal of any later `| tee`, `| mail`, or `logger` call. Enabling it " +
+			"script-wide to avoid a few `export` keywords leaks credentials and private " +
+			"config by default. Drop the `setopt`, scope exports explicitly with " +
+			"`export VAR=value`, or wrap a narrow section in `setopt LOCAL_OPTIONS; setopt " +
+			"ALL_EXPORT` inside a function so the effect cannot leak past the closing " +
+			"brace.",
+		Check: checkZC1849,
+	})
+}
+
+func checkZC1849(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if zc1849IsAllExport(v) {
+				return zc1849Hit(cmd, "setopt "+v)
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOALLEXPORT" {
+				return zc1849Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1849IsAllExport(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "ALLEXPORT"
+}
+
+func zc1849Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1849",
+		Message: "`" + where + "` marks every later assignment for export — secrets " +
+			"like `password=...` leak into every child's env. Drop it; use " +
+			"explicit `export`, or scope inside a `LOCAL_OPTIONS` function.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 845 Katas = 0.8.45
-const Version = "0.8.45"
+// 846 Katas = 0.8.46
+const Version = "0.8.46"


### PR DESCRIPTION
ZC1849 — `setopt ALL_EXPORT`

What: flags `setopt ALL_EXPORT` / `unsetopt NO_ALL_EXPORT` (POSIX `set -a` equivalent).
Why: every later `var=value` becomes `export var=value` — secrets like `password=$(cat secret)` leak into every child's env, visible via `/proc/<pid>/environ` and any `ps e` later in the pipeline.
Fix suggestion: drop the `setopt`; use explicit `export VAR=value`, or scope inside `LOCAL_OPTIONS` function.
Severity: Warning