### PR TITLE
feat: ZC1850 — warn on `ssh -o LogLevel=QUIET` silencing security diagnostics

### DIFF
--- a/pkg/katas/katatests/zc1850_test.go
+++ b/pkg/katas/katatests/zc1850_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1850(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ssh -o LogLevel=INFO host`",
+			input:    `ssh -o LogLevel=INFO host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ssh host` (default)",
+			input:    `ssh host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ssh -o LogLevel=QUIET host`",
+			input: `ssh -o LogLevel=QUIET host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1850",
+					Message: "`ssh -o LogLevel=QUIET` silences host-key, agent-forward, and canonical-hostname warnings — a MITM event produces no stderr. Keep the default level; capture stderr to a log if you need it clean.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ssh -oLogLevel=fatal host` (attached)",
+			input: `ssh -oLogLevel=fatal host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1850",
+					Message: "`ssh -o LogLevel=QUIET` silences host-key, agent-forward, and canonical-hostname warnings — a MITM event produces no stderr. Keep the default level; capture stderr to a log if you need it clean.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1850")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1850.go
+++ b/pkg/katas/zc1850.go
@@ -1,0 +1,78 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1850",
+		Title:    "Warn on `ssh -o LogLevel=QUIET` — silences security-relevant ssh diagnostics",
+		Severity: SeverityWarning,
+		Description: "`LogLevel=QUIET` (aliased to the `-q` short flag) suppresses every " +
+			"informational or warning message ssh would otherwise print: host-key " +
+			"changes, key-exchange downgrades, agent-forwarding permission denials, " +
+			"canonical-hostname rewrites. In a script, that means the output looks clean " +
+			"even when ssh is shouting about a MITM on the other end. Keep the default " +
+			"`INFO` level (or raise to `VERBOSE` during debugging), capture stderr to a " +
+			"log if the noise bothers you, and never pair `LogLevel=QUIET` with " +
+			"`StrictHostKeyChecking=no` in the same call — that combination actively " +
+			"hides known-bad-key events.",
+		Check: checkZC1850,
+	})
+}
+
+func checkZC1850(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ssh" && ident.Value != "scp" && ident.Value != "sftp" {
+		return nil
+	}
+	args := cmd.Arguments
+	for i, arg := range args {
+		v := arg.String()
+		var kv string
+		switch {
+		case v == "-o" && i+1 < len(args):
+			kv = args[i+1].String()
+		case strings.HasPrefix(v, "-o"):
+			kv = strings.TrimPrefix(v, "-o")
+		default:
+			continue
+		}
+		if zc1850IsLogLevelQuiet(kv) {
+			return []Violation{{
+				KataID: "ZC1850",
+				Message: "`" + ident.Value + " -o LogLevel=QUIET` silences host-key, " +
+					"agent-forward, and canonical-hostname warnings — a MITM " +
+					"event produces no stderr. Keep the default level; capture " +
+					"stderr to a log if you need it clean.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1850IsLogLevelQuiet(kv string) bool {
+	norm := strings.ToLower(strings.Trim(kv, "\"' \t"))
+	if !strings.HasPrefix(norm, "loglevel") {
+		return false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(norm, "loglevel"))
+	if !strings.HasPrefix(rest, "=") {
+		return false
+	}
+	val := strings.TrimSpace(strings.TrimPrefix(rest, "="))
+	return val == "quiet" || val == "fatal" || val == "error"
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 846 Katas = 0.8.46
-const Version = "0.8.46"
+// 847 Katas = 0.8.47
+const Version = "0.8.47"


### PR DESCRIPTION
ZC1850 — `ssh -o LogLevel=QUIET|fatal|error`

What: flags `ssh`/`scp`/`sftp` with `LogLevel` set to `QUIET`, `FATAL`, or `ERROR` in split or attached `-o` form.
Why: suppresses every informational/warning message from ssh — host-key changes, key-exchange downgrades, agent-forwarding denials, canonical-hostname rewrites — so MITM events leave no trace on stderr.
Fix suggestion: keep the default `INFO` level; capture stderr to a log if the noise is too much.
Severity: Warning