### PR TITLE
feat: ZC1851 — warn on `unsetopt FUNCTION_ARGZERO` hiding function $0

### DIFF
--- a/pkg/katas/katatests/zc1851_test.go
+++ b/pkg/katas/katatests/zc1851_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1851(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt FUNCTION_ARGZERO` (explicit default)",
+			input:    `setopt FUNCTION_ARGZERO`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt FUNCTION_ARGZERO`",
+			input: `unsetopt FUNCTION_ARGZERO`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1851",
+					Message: "`unsetopt FUNCTION_ARGZERO` makes `$0` inside functions point at the outer script — breaks `log \"$0: ...\"` helpers and `case $0` dispatchers. Keep the option on; reach the script name explicitly via `$ZSH_ARGZERO` when needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_FUNCTION_ARGZERO`",
+			input: `setopt NO_FUNCTION_ARGZERO`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1851",
+					Message: "`setopt NO_FUNCTION_ARGZERO` makes `$0` inside functions point at the outer script — breaks `log \"$0: ...\"` helpers and `case $0` dispatchers. Keep the option on; reach the script name explicitly via `$ZSH_ARGZERO` when needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1851")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1851.go
+++ b/pkg/katas/zc1851.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1851",
+		Title:    "Warn on `unsetopt FUNCTION_ARGZERO` — `$0` inside a function stops reporting the function name",
+		Severity: SeverityWarning,
+		Description: "`FUNCTION_ARGZERO` is Zsh's default: inside a function or `source`d file, " +
+			"`$0` holds the function/file name, which is what every `log_error \"$0: ...\"` " +
+			"helper, every self-reflecting `$funcfiletrace` fallback, and every `case $0` " +
+			"dispatcher expects. Turning it off reverts to POSIX-sh behaviour where `$0` " +
+			"always points at the outer script — so `my_func() { echo \"${0}: bad input\" }` " +
+			"silently starts logging `myscript.sh: bad input` for every function, which " +
+			"makes stack-trace logs unreadable and breaks dispatchers that branch on `$0`. " +
+			"Keep the option on at the script level and, if one specific helper needs the " +
+			"POSIX name, reach it explicitly with `$ZSH_ARGZERO` or `$ZSH_SCRIPT`.",
+		Check: checkZC1851,
+	})
+}
+
+func checkZC1851(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			if zc1851IsFunctionArgzero(arg.String()) {
+				return zc1851Hit(cmd, "unsetopt "+arg.String())
+			}
+		}
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOFUNCTIONARGZERO" {
+				return zc1851Hit(cmd, "setopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1851IsFunctionArgzero(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "FUNCTIONARGZERO"
+}
+
+func zc1851Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1851",
+		Message: "`" + where + "` makes `$0` inside functions point at the outer " +
+			"script — breaks `log \"$0: ...\"` helpers and `case $0` dispatchers. " +
+			"Keep the option on; reach the script name explicitly via " +
+			"`$ZSH_ARGZERO` when needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 847 Katas = 0.8.47
-const Version = "0.8.47"
+// 848 Katas = 0.8.48
+const Version = "0.8.48"


### PR DESCRIPTION
ZC1851 — `unsetopt FUNCTION_ARGZERO`

What: flags `unsetopt FUNCTION_ARGZERO` / `setopt NO_FUNCTION_ARGZERO`.
Why: reverts Zsh to POSIX-sh `$0` behaviour — `$0` inside a function points at the outer script, so `log "$0: bad input"` helpers and `case $0` dispatchers silently break.
Fix suggestion: keep the option on; if one helper needs the outer script name, use `$ZSH_ARGZERO` / `$ZSH_SCRIPT` explicitly.
Severity: Warning