### PR TITLE
feat: ZC1852 — error on `firewall-cmd --panic-on` dropping every packet

### DIFF
--- a/pkg/katas/katatests/zc1852_test.go
+++ b/pkg/katas/katatests/zc1852_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1852(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `firewall-cmd --panic-off foo`",
+			input:    `firewall-cmd --panic-off foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `firewall-cmd --reload`",
+			input:    `firewall-cmd --reload foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `firewall-cmd --panic-on >/dev/null` (mangled name)",
+			input: `firewall-cmd --panic-on foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1852",
+					Message: "`firewall-cmd --panic-on` drops every packet regardless of zone — an SSH-run call loses the session instantly. Use targeted zone rules; if you really need panic mode, gate behind `at now + N minutes … firewall-cmd --panic-off`.",
+					Line:    1,
+					Column:  16,
+				},
+			},
+		},
+		{
+			name:  "invalid — `firewall-cmd \"\" --panic-on` (trailing flag)",
+			input: `firewall-cmd "" --panic-on`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1852",
+					Message: "`firewall-cmd --panic-on` drops every packet regardless of zone — an SSH-run call loses the session instantly. Use targeted zone rules; if you really need panic mode, gate behind `at now + N minutes … firewall-cmd --panic-off`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1852")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1852.go
+++ b/pkg/katas/zc1852.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1852",
+		Title:    "Error on `firewall-cmd --panic-on` — firewalld drops every packet, kills the SSH session",
+		Severity: SeverityError,
+		Description: "`firewall-cmd --panic-on` puts firewalld into panic mode, which drops every " +
+			"inbound and outbound packet regardless of zone or rule. Running this over a " +
+			"remote SSH session is the textbook way to lock yourself out: the command " +
+			"returns success, the TCP ACK for that reply never arrives, and nobody can " +
+			"reach the host until someone visits the console to `--panic-off`. Stage " +
+			"panic-mode experiments on a machine you can power-cycle, gate the call behind " +
+			"`at now + 5 minutes` with an auto-disable, or use targeted zone rules instead " +
+			"of the blanket switch.",
+		Check: checkZC1852,
+	})
+}
+
+func checkZC1852(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `firewall-cmd --panic-on …` mangles the command name to
+	// `panic-on` when the flag is the first arg. Cover both shapes.
+	if ident.Value == "panic-on" {
+		return zc1852Hit(cmd)
+	}
+	if ident.Value != "firewall-cmd" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "--panic-on" {
+			return zc1852Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1852Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1852",
+		Message: "`firewall-cmd --panic-on` drops every packet regardless of zone — " +
+			"an SSH-run call loses the session instantly. Use targeted zone rules; " +
+			"if you really need panic mode, gate behind `at now + N minutes … " +
+			"firewall-cmd --panic-off`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 848 Katas = 0.8.48
-const Version = "0.8.48"
+// 849 Katas = 0.8.49
+const Version = "0.8.49"


### PR DESCRIPTION
ZC1852 — `firewall-cmd --panic-on`

What: flags `firewall-cmd --panic-on` in mangled-name and trailing-flag shapes.
Why: firewalld panic mode drops every inbound/outbound packet regardless of zone — running over remote SSH loses the session instantly.
Fix suggestion: use targeted zone rules; if you truly need panic, gate behind `at now + N minutes … firewall-cmd --panic-off` auto-recovery.
Severity: Error