### PR TITLE
feat: ZC1853 — warn on `setopt MARK_DIRS` appending trailing `/` to dir globs

### DIFF
--- a/pkg/katas/katatests/zc1853_test.go
+++ b/pkg/katas/katatests/zc1853_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1853(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt MARK_DIRS` (explicit default)",
+			input:    `unsetopt MARK_DIRS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt MARK_DIRS`",
+			input: `setopt MARK_DIRS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1853",
+					Message: "`setopt MARK_DIRS` appends a trailing `/` to every glob-matched directory — `[[ -f \"$f\" ]]` and `rm -f *` start skipping, hash maps keyed on basenames double up. Keep the option off; use `*(/)` when you need dirs only.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_MARK_DIRS`",
+			input: `unsetopt NO_MARK_DIRS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1853",
+					Message: "`unsetopt NO_MARK_DIRS` appends a trailing `/` to every glob-matched directory — `[[ -f \"$f\" ]]` and `rm -f *` start skipping, hash maps keyed on basenames double up. Keep the option off; use `*(/)` when you need dirs only.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1853")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1853.go
+++ b/pkg/katas/zc1853.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1853",
+		Title:    "Warn on `setopt MARK_DIRS` — glob-matched directories gain a silent trailing `/`",
+		Severity: SeverityWarning,
+		Description: "With `MARK_DIRS` on, every filename produced by a glob that resolves to a " +
+			"directory picks up a trailing `/`. Inside a shell it looks harmless, but " +
+			"scripts that pass the glob result to other tools break in quiet ways: " +
+			"`[[ -f \"$f\" ]]` rejects `dir/` because it is not a regular file, `rm -f *` " +
+			"sees `dir/` and silently skips it (GNU rm refuses to remove directories " +
+			"without `-r`), and downstream hash maps indexed on basenames suddenly carry " +
+			"two keys for what the user thinks is one entry. Keep the option off at the " +
+			"script level and request the trailing slash per-glob with the `(/)` qualifier " +
+			"(`dirs=( *(/) )`) when you really need directories only.",
+		Check: checkZC1853,
+	})
+}
+
+func checkZC1853(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			if zc1853IsMarkDirs(arg.String()) {
+				return zc1853Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOMARKDIRS" {
+				return zc1853Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1853IsMarkDirs(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "MARKDIRS"
+}
+
+func zc1853Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1853",
+		Message: "`" + where + "` appends a trailing `/` to every glob-matched " +
+			"directory — `[[ -f \"$f\" ]]` and `rm -f *` start skipping, hash " +
+			"maps keyed on basenames double up. Keep the option off; use " +
+			"`*(/)` when you need dirs only.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 849 Katas = 0.8.49
-const Version = "0.8.49"
+// 850 Katas = 0.8.50
+const Version = "0.8.50"


### PR DESCRIPTION
ZC1853 — `setopt MARK_DIRS`

What: flags `setopt MARK_DIRS` / `unsetopt NO_MARK_DIRS`.
Why: every glob-matched directory gains a trailing `/` — `[[ -f "$f" ]]` rejects it, `rm -f *` silently skips, basename-indexed hash maps double-count.
Fix suggestion: keep the option off; request dirs-only per-glob with the `*(/)` qualifier.
Severity: Warning