### PR TITLE
feat: ZC1854 — error on `yum-config-manager`/`dnf`/`zypper` adding plaintext HTTP repo

### DIFF
--- a/pkg/katas/katatests/zc1854_test.go
+++ b/pkg/katas/katatests/zc1854_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1854(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `yum-config-manager --add-repo https://…` (TLS)",
+			input:    `yum-config-manager --add-repo https://mirror.example/app.repo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `zypper addrepo https://…` (TLS)",
+			input:    `zypper addrepo https://mirror.example/app app`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `yum-config-manager --add-repo http://…` (mangled name)",
+			input: `yum-config-manager --add-repo http://mirror.example/app.repo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1854",
+					Message: "`yum-config-manager --add-repo http://mirror.example/app.repo` registers a plaintext repo — on-path attacker can substitute packages and strip GPG-check directives. Use `https://` and pin `gpgkey=file://` in the `.repo`.",
+					Line:    1,
+					Column:  22,
+				},
+			},
+		},
+		{
+			name:  "invalid — `dnf config-manager --add-repo http://…`",
+			input: `dnf config-manager --add-repo http://mirror.example/app.repo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1854",
+					Message: "`dnf config-manager --add-repo http://mirror.example/app.repo` registers a plaintext repo — on-path attacker can substitute packages and strip GPG-check directives. Use `https://` and pin `gpgkey=file://` in the `.repo`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `zypper addrepo http://…`",
+			input: `zypper addrepo http://mirror.example/app app`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1854",
+					Message: "`zypper addrepo http://mirror.example/app` registers a plaintext repo — on-path attacker can substitute packages and strip GPG-check directives. Use `https://` and pin `gpgkey=file://` in the `.repo`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1854")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1854.go
+++ b/pkg/katas/zc1854.go
@@ -1,0 +1,91 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1854",
+		Title:    "Error on `yum-config-manager --add-repo http://…` / `zypper addrepo http://…` — plaintext repo allows MITM",
+		Severity: SeverityError,
+		Description: "Adding a package repository over plain HTTP (`yum-config-manager " +
+			"--add-repo http://…`, `dnf config-manager --add-repo http://…`, `zypper " +
+			"addrepo http://…`) tells the package manager to fetch metadata and RPMs " +
+			"without TLS — any on-path attacker can substitute packages, and even GPG " +
+			"signature checks do not help because the attacker can simply strip the " +
+			"`repo_gpgcheck=1` line from the unsigned `.repo` file. Use the `https://` " +
+			"mirror (every major distro now publishes one), or pin to a local mirror over " +
+			"TLS and drop a `gpgkey=file:///etc/pki/...` entry in the same `.repo` so " +
+			"signatures cannot be disabled mid-install.",
+		Check: checkZC1854,
+	})
+}
+
+func checkZC1854(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "yum-config-manager":
+		for _, arg := range cmd.Arguments {
+			if zc1854IsHTTPURL(arg.String()) {
+				return zc1854Hit(cmd, "yum-config-manager --add-repo "+arg.String())
+			}
+		}
+	case "add-repo":
+		// Parser caveat: `yum-config-manager --add-repo URL` mangles the
+		// command name to `add-repo`.
+		for _, arg := range cmd.Arguments {
+			if zc1854IsHTTPURL(arg.String()) {
+				return zc1854Hit(cmd, "yum-config-manager --add-repo "+arg.String())
+			}
+		}
+	case "dnf":
+		if len(cmd.Arguments) >= 3 &&
+			cmd.Arguments[0].String() == "config-manager" &&
+			cmd.Arguments[1].String() == "--add-repo" {
+			for _, arg := range cmd.Arguments[2:] {
+				if zc1854IsHTTPURL(arg.String()) {
+					return zc1854Hit(cmd, "dnf config-manager --add-repo "+arg.String())
+				}
+			}
+		}
+	case "zypper":
+		if len(cmd.Arguments) >= 2 {
+			sub := cmd.Arguments[0].String()
+			if sub == "addrepo" || sub == "ar" {
+				for _, arg := range cmd.Arguments[1:] {
+					if zc1854IsHTTPURL(arg.String()) {
+						return zc1854Hit(cmd, "zypper addrepo "+arg.String())
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func zc1854IsHTTPURL(v string) bool {
+	return strings.HasPrefix(v, "http://")
+}
+
+func zc1854Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1854",
+		Message: "`" + where + "` registers a plaintext repo — on-path attacker can " +
+			"substitute packages and strip GPG-check directives. Use `https://` and " +
+			"pin `gpgkey=file://` in the `.repo`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 850 Katas = 0.8.50
-const Version = "0.8.50"
+// 851 Katas = 0.8.51
+const Version = "0.8.51"


### PR DESCRIPTION
ZC1854 — plaintext-HTTP package repos

What: flags `yum-config-manager --add-repo http://…`, `dnf config-manager --add-repo http://…`, and `zypper addrepo http://…`.
Why: metadata and RPMs fetched without TLS — on-path attacker substitutes packages and can strip `repo_gpgcheck=1` from the unsigned `.repo` before it lands.
Fix suggestion: use the `https://` mirror (every major distro publishes one); pin `gpgkey=file:///etc/pki/...` in the `.repo`.
Severity: Error