### PR TITLE
feat: ZC1856 — warn on `unset arr[N]` Bash-ism that leaves Zsh array intact

### DIFF
--- a/pkg/katas/katatests/zc1856_test.go
+++ b/pkg/katas/katatests/zc1856_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1856(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unset arr` (delete whole variable)",
+			input:    `unset arr`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unset FOO` (scalar)",
+			input:    `unset FOO`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unset arr[0]`",
+			input: `unset arr[0]`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1856",
+					Message: "`unset (arr[0])` is a Bash idiom — in Zsh it tries to unset a parameter literally named `(arr[0])` and leaves the array untouched. Use `arr[N]=()` or rebuild with `arr=(\"${(@)arr:#pattern}\")`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unset myarray[3]`",
+			input: `unset myarray[3]`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1856",
+					Message: "`unset (myarray[3])` is a Bash idiom — in Zsh it tries to unset a parameter literally named `(myarray[3])` and leaves the array untouched. Use `arr[N]=()` or rebuild with `arr=(\"${(@)arr:#pattern}\")`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1856")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1856.go
+++ b/pkg/katas/zc1856.go
@@ -1,0 +1,85 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1856",
+		Title:    "Warn on `unset arr[N]` — Zsh does not delete the array element, the array keeps its length",
+		Severity: SeverityWarning,
+		Description: "In Bash, `unset arr[N]` removes the N-th element of the array (leaving a " +
+			"sparse hole). In Zsh the same invocation passes the literal string `arr[N]` " +
+			"to the `unset` builtin, which looks for a parameter with that name — finds " +
+			"nothing — and returns success. The array is left untouched, `${#arr[@]}` " +
+			"does not budge, and every downstream `for x in \"${arr[@]}\"` keeps iterating " +
+			"the element the script thought it had removed. Use Zsh's native assignment " +
+			"form `arr[N]=()` to delete an index, or `arr=(\"${(@)arr:#pattern}\")` to " +
+			"filter by value.",
+		Check: checkZC1856,
+	})
+}
+
+func checkZC1856(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "unset" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if zc1856IsArraySubscript(v) {
+			return []Violation{{
+				KataID: "ZC1856",
+				Message: "`unset " + v + "` is a Bash idiom — in Zsh it tries to " +
+					"unset a parameter literally named `" + v + "` and leaves the " +
+					"array untouched. Use `arr[N]=()` or rebuild with " +
+					"`arr=(\"${(@)arr:#pattern}\")`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1856IsArraySubscript(v string) bool {
+	// Strip surrounding quotes and parser-applied `(...)` wrapping.
+	trimmed := strings.TrimSpace(v)
+	trimmed = strings.Trim(trimmed, "\"'")
+	if strings.HasPrefix(trimmed, "(") && strings.HasSuffix(trimmed, ")") && len(trimmed) >= 2 {
+		trimmed = trimmed[1 : len(trimmed)-1]
+	}
+	open := strings.Index(trimmed, "[")
+	close := strings.LastIndex(trimmed, "]")
+	if open <= 0 || close <= open+1 {
+		return false
+	}
+	// The name portion must look like a shell identifier.
+	return zc1856IsIdentifier(trimmed[:open])
+}
+
+func zc1856IsIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if i == 0 {
+			if !(r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')) {
+				return false
+			}
+			continue
+		}
+		if !(r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 852 Katas = 0.8.52
-const Version = "0.8.52"
+// 853 Katas = 0.8.53
+const Version = "0.8.53"


### PR DESCRIPTION
ZC1856 — `unset arr[N]` Bash-ism

What: flags `unset <identifier>[<subscript>]` on any command named `unset`.
Why: Bash removes the N-th element; Zsh tries to unset a parameter literally named `arr[N]`, finds none, returns success — the array is unchanged. Silent bug.
Fix suggestion: use `arr[N]=()` for index deletion, or rebuild with `arr=("${(@)arr:#pattern}")`.
Severity: Warning