### PR TITLE
feat: ZC1857 — error on `cloud-init clean` wiping boot state in automation

### DIFF
--- a/pkg/katas/katatests/zc1857_test.go
+++ b/pkg/katas/katatests/zc1857_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1857(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `cloud-init init` (boot-time init)",
+			input:    `cloud-init init`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `cloud-init status`",
+			input:    `cloud-init status`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `cloud-init clean`",
+			input: `cloud-init clean`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1857",
+					Message: "`cloud-init clean` wipes `/var/lib/cloud/` boot state — the next reboot re-runs the user-data and overwrites operator changes (SSH host keys, hostname, `/etc/fstab`). Run interactively only.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `cloud-init clean --logs --reboot`",
+			input: `cloud-init clean --logs --reboot`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1857",
+					Message: "`cloud-init clean` wipes `/var/lib/cloud/` boot state — the next reboot re-runs the user-data and overwrites operator changes (SSH host keys, hostname, `/etc/fstab`). Run interactively only.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1857")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1857.go
+++ b/pkg/katas/zc1857.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1857",
+		Title:    "Error on `cloud-init clean` — wipes boot state, next reboot re-provisions the host",
+		Severity: SeverityError,
+		Description: "`cloud-init clean` (and variants `--logs`, `--reboot`, `--machine-id`) " +
+			"removes every marker under `/var/lib/cloud/` and `/var/log/cloud-init*`, " +
+			"which tells cloud-init to re-run from scratch on the next boot. That run " +
+			"re-imports the image-builder's user-data: regenerates SSH host keys, resets " +
+			"the hostname, replaces `/etc/fstab` entries the operator may have edited, " +
+			"and (with `--reboot`) triggers the replay immediately. In a maintenance " +
+			"script this silently erases everything the operator configured after " +
+			"first-boot. Keep the command out of automation; if you truly need to " +
+			"re-seed an instance, snapshot state first and run the command interactively.",
+		Check: checkZC1857,
+	})
+}
+
+func checkZC1857(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cloud-init" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "clean" {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1857",
+		Message: "`cloud-init clean` wipes `/var/lib/cloud/` boot state — the next " +
+			"reboot re-runs the user-data and overwrites operator changes " +
+			"(SSH host keys, hostname, `/etc/fstab`). Run interactively only.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 853 Katas = 0.8.53
-const Version = "0.8.53"
+// 854 Katas = 0.8.54
+const Version = "0.8.54"


### PR DESCRIPTION
ZC1857 — `cloud-init clean`

What: flags `cloud-init clean` and its `--logs` / `--reboot` / `--machine-id` variants.
Why: removes `/var/lib/cloud/` markers — next reboot re-runs user-data and overwrites operator-made changes (SSH host keys, hostname, `/etc/fstab`).
Fix suggestion: keep the command out of automation; snapshot state first and invoke interactively if re-seeding is really needed.
Severity: Error