### PR TITLE
feat: ZC1858 — error on `ssh -c 3des-cbc|arcfour|…` forcing weak tunnel cipher

### DIFF
--- a/pkg/katas/katatests/zc1858_test.go
+++ b/pkg/katas/katatests/zc1858_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1858(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ssh -c aes256-gcm@openssh.com host`",
+			input:    `ssh -c aes256-gcm@openssh.com host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ssh host` (default ciphers)",
+			input:    `ssh host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ssh -c 3des-cbc host`",
+			input: `ssh -c 3des-cbc host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1858",
+					Message: "`ssh ... 3des-cbc` forces a weak cipher with known plaintext-recovery / IV-reuse attacks. Leave cipher selection to OpenSSH defaults; if a legacy peer needs it, scope inside a `Host` block in `~/.ssh/config`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ssh -o Ciphers=arcfour,aes256-ctr host`",
+			input: `ssh -o Ciphers=arcfour,aes256-ctr host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1858",
+					Message: "`ssh ... arcfour` forces a weak cipher with known plaintext-recovery / IV-reuse attacks. Leave cipher selection to OpenSSH defaults; if a legacy peer needs it, scope inside a `Host` block in `~/.ssh/config`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1858")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1858.go
+++ b/pkg/katas/zc1858.go
@@ -1,0 +1,105 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1858",
+		Title:    "Error on `ssh -c 3des-cbc|arcfour|blowfish-cbc` — weak cipher forced on the tunnel",
+		Severity: SeverityError,
+		Description: "OpenSSH disables legacy ciphers by default; a script that explicitly forces " +
+			"one with `-c 3des-cbc`, `-c arcfour`, `-c blowfish-cbc`, or a matching entry " +
+			"in `-o Ciphers=...` downgrades the tunnel to an algorithm with known plaintext " +
+			"recovery, IV-reuse, or birthday-bound attacks. Typically this is done to reach " +
+			"an old appliance — but it drags every other session on the same invocation " +
+			"down with it. Leave cipher selection to OpenSSH's default; if a legacy device " +
+			"absolutely requires a weak cipher, isolate it in a `Host ...` block in " +
+			"`~/.ssh/config` with explicit `HostKeyAlgorithms` and keep the rest of the " +
+			"fleet on strong defaults.",
+		Check: checkZC1858,
+	})
+}
+
+var zc1858Weak = []string{
+	"3des-cbc",
+	"arcfour",
+	"arcfour128",
+	"arcfour256",
+	"blowfish-cbc",
+	"cast128-cbc",
+	"des-cbc",
+	"rijndael-cbc@lysator.liu.se",
+}
+
+func checkZC1858(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ssh" && ident.Value != "scp" && ident.Value != "sftp" {
+		return nil
+	}
+	args := cmd.Arguments
+	for i, arg := range args {
+		v := arg.String()
+		var candidate string
+		switch {
+		case v == "-c" && i+1 < len(args):
+			candidate = args[i+1].String()
+		case v == "-o" && i+1 < len(args):
+			candidate = zc1858ExtractCiphers(args[i+1].String())
+		case strings.HasPrefix(v, "-o"):
+			candidate = zc1858ExtractCiphers(strings.TrimPrefix(v, "-o"))
+		}
+		if candidate == "" {
+			continue
+		}
+		if weak := zc1858FirstWeakCipher(candidate); weak != "" {
+			return []Violation{{
+				KataID: "ZC1858",
+				Message: "`" + ident.Value + " ... " + weak + "` forces a weak cipher " +
+					"with known plaintext-recovery / IV-reuse attacks. Leave " +
+					"cipher selection to OpenSSH defaults; if a legacy peer needs " +
+					"it, scope inside a `Host` block in `~/.ssh/config`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1858ExtractCiphers(kv string) string {
+	kv = strings.TrimSpace(strings.Trim(kv, "\"'"))
+	lower := strings.ToLower(kv)
+	if !strings.HasPrefix(lower, "ciphers") {
+		return ""
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(lower, "ciphers"))
+	if !strings.HasPrefix(rest, "=") {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(rest, "="))
+}
+
+func zc1858FirstWeakCipher(list string) string {
+	lower := strings.ToLower(list)
+	for _, entry := range strings.Split(lower, ",") {
+		entry = strings.TrimSpace(strings.Trim(entry, "+^-"))
+		for _, weak := range zc1858Weak {
+			if entry == weak {
+				return entry
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 854 Katas = 0.8.54
-const Version = "0.8.54"
+// 855 Katas = 0.8.55
+const Version = "0.8.55"


### PR DESCRIPTION
ZC1858 — weak SSH ciphers

What: flags `ssh`/`scp`/`sftp` with `-c` or `-o Ciphers=` pointing at `3des-cbc`, `arcfour(128|256)?`, `blowfish-cbc`, `cast128-cbc`, `des-cbc`, or the `rijndael-cbc@lysator.liu.se` alias.
Why: all have known plaintext-recovery / IV-reuse / birthday-bound attacks. OpenSSH disables them by default; explicitly forcing downgrades the tunnel.
Fix suggestion: leave cipher selection to OpenSSH defaults; if a legacy peer truly needs a weak cipher, scope it inside a `Host …` block in `~/.ssh/config` and keep the rest of the fleet on defaults.
Severity: Error