### PR TITLE
feat: ZC1859 — warn on `unsetopt MULTIOS` dropping Zsh multi-redirection

### DIFF
--- a/pkg/katas/katatests/zc1859_test.go
+++ b/pkg/katas/katatests/zc1859_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1859(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt MULTIOS` (explicit default)",
+			input:    `setopt MULTIOS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt MULTIOS`",
+			input: `unsetopt MULTIOS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1859",
+					Message: "`unsetopt MULTIOS` reverts to POSIX single-output redirection — `cmd >a >b` silently drops `a`, log collectors stop receiving new lines. Keep the option on; scope inside a `LOCAL_OPTIONS` function if one line really needs POSIX.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_MULTIOS`",
+			input: `setopt NO_MULTIOS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1859",
+					Message: "`setopt NO_MULTIOS` reverts to POSIX single-output redirection — `cmd >a >b` silently drops `a`, log collectors stop receiving new lines. Keep the option on; scope inside a `LOCAL_OPTIONS` function if one line really needs POSIX.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1859")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1859.go
+++ b/pkg/katas/zc1859.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1859",
+		Title:    "Warn on `unsetopt MULTIOS` — `cmd >a >b` silently keeps only the last redirection",
+		Severity: SeverityWarning,
+		Description: "`MULTIOS` is on by default in Zsh: `cmd >out.log >>archive.log` sends stdout " +
+			"to both files via an implicit `tee`, and `cmd <a <b` concatenates the two " +
+			"inputs in order. Disabling it reverts to POSIX-sh semantics — Zsh opens each " +
+			"earlier redirection, closes it immediately, and only the last one in the " +
+			"direction wins. Any script that was written for Zsh suddenly starts dropping " +
+			"the `archive.log` tail, and log collectors that opened `archive.log` keep " +
+			"the fd but never receive new lines. Keep the option on at the script level; " +
+			"if one specific line really needs POSIX behaviour, wrap it in a function with " +
+			"`setopt LOCAL_OPTIONS; unsetopt MULTIOS`.",
+		Check: checkZC1859,
+	})
+}
+
+func checkZC1859(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			if zc1859IsMultios(arg.String()) {
+				return zc1859Hit(cmd, "unsetopt "+arg.String())
+			}
+		}
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOMULTIOS" {
+				return zc1859Hit(cmd, "setopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1859IsMultios(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "MULTIOS"
+}
+
+func zc1859Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1859",
+		Message: "`" + where + "` reverts to POSIX single-output redirection — " +
+			"`cmd >a >b` silently drops `a`, log collectors stop receiving new " +
+			"lines. Keep the option on; scope inside a `LOCAL_OPTIONS` function " +
+			"if one line really needs POSIX.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 855 Katas = 0.8.55
-const Version = "0.8.55"
+// 856 Katas = 0.8.56
+const Version = "0.8.56"


### PR DESCRIPTION
ZC1859 — `unsetopt MULTIOS`

What: flags `unsetopt MULTIOS` / `setopt NO_MULTIOS`.
Why: disables Zsh's default multi-output redirection; `cmd >a >b` silently keeps only the last file, log collectors tailing the earlier file stop receiving new lines.
Fix suggestion: keep the option on script-wide; if one line genuinely needs POSIX single-output semantics, wrap it in a function with `setopt LOCAL_OPTIONS; unsetopt MULTIOS`.
Severity: Warning