### PR TITLE
feat: ZC1860 — warn on `hostnamectl set-hostname` leaving running services on old name

### DIFF
--- a/pkg/katas/katatests/zc1860_test.go
+++ b/pkg/katas/katatests/zc1860_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1860(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `hostnamectl status`",
+			input:    `hostnamectl status`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `hostname -f` (read-only query)",
+			input:    `hostname -f`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `hostnamectl set-hostname worker-42`",
+			input: `hostnamectl set-hostname worker-42`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1860",
+					Message: "`hostnamectl set-hostname worker-42` updates the kernel hostname live, but running services keep the old `gethostname()` — syslog tags, Prometheus labels, TLS SANs stay stale. Apply at provisioning or reboot.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `hostname worker-42`",
+			input: `hostname worker-42`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1860",
+					Message: "`hostname worker-42` updates the kernel hostname live, but running services keep the old `gethostname()` — syslog tags, Prometheus labels, TLS SANs stay stale. Apply at provisioning or reboot.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1860")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1860.go
+++ b/pkg/katas/zc1860.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1860",
+		Title:    "Warn on `hostnamectl set-hostname NEW` — caches and certs still reference the old name",
+		Severity: SeverityWarning,
+		Description: "`hostnamectl set-hostname NEW` (and the new-style `hostnamectl hostname NEW` " +
+			"and `hostname NEW`) updates `/etc/hostname` and `kernel.hostname` atomically, " +
+			"but every process that called `gethostname()` at startup keeps the old " +
+			"value until it restarts: syslog tags, Prometheus scrape labels, Docker " +
+			"daemons, and anything that populated a TLS `subjectAltName` with `$(hostname)` " +
+			"still speak as the previous host. Change the hostname interactively, then " +
+			"plan a restart window — in automation, prefer shipping the new hostname via " +
+			"cloud-init / Ignition so every service starts with it from boot.",
+		Check: checkZC1860,
+	})
+}
+
+func checkZC1860(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value == "hostnamectl" {
+		if len(cmd.Arguments) < 2 {
+			return nil
+		}
+		sub := cmd.Arguments[0].String()
+		if sub != "set-hostname" && sub != "hostname" {
+			return nil
+		}
+		return zc1860Hit(cmd, "hostnamectl "+sub+" "+cmd.Arguments[1].String())
+	}
+	if ident.Value == "hostname" {
+		if len(cmd.Arguments) != 1 {
+			return nil
+		}
+		v := cmd.Arguments[0].String()
+		// `hostname` with no args just prints; `hostname -f` is read-only.
+		if len(v) == 0 || v[0] == '-' {
+			return nil
+		}
+		return zc1860Hit(cmd, "hostname "+v)
+	}
+	return nil
+}
+
+func zc1860Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1860",
+		Message: "`" + where + "` updates the kernel hostname live, but running " +
+			"services keep the old `gethostname()` — syslog tags, Prometheus " +
+			"labels, TLS SANs stay stale. Apply at provisioning or reboot.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 856 Katas = 0.8.56
-const Version = "0.8.56"
+// 857 Katas = 0.8.57
+const Version = "0.8.57"


### PR DESCRIPTION
ZC1860 — live hostname change

What: flags `hostnamectl set-hostname NEW`, `hostnamectl hostname NEW`, and bare `hostname NEW`.
Why: kernel hostname updates live, but every service that already called `gethostname()` keeps the old value until restart — syslog tags, Prometheus labels, and TLS `subjectAltName` stay stale.
Fix suggestion: ship the new hostname via cloud-init / Ignition at provisioning, or plan a reboot window.
Severity: Warning