### PR TITLE
feat: ZC1861 — warn on `setopt OCTAL_ZEROES` reinterpreting leading-zero integers

### DIFF
--- a/pkg/katas/katatests/zc1861_test.go
+++ b/pkg/katas/katatests/zc1861_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1861(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt OCTAL_ZEROES` (explicit default)",
+			input:    `unsetopt OCTAL_ZEROES`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt OCTAL_ZEROES`",
+			input: `setopt OCTAL_ZEROES`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1861",
+					Message: "`setopt OCTAL_ZEROES` reinterprets leading-zero integers as octal — `(( n = 0100 ))` assigns 64 instead of 100, breaking timestamp, phone-prefix, and mode parsing. Keep the option off; use `8#100` when you want explicit octal.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_OCTAL_ZEROES`",
+			input: `unsetopt NO_OCTAL_ZEROES`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1861",
+					Message: "`unsetopt NO_OCTAL_ZEROES` reinterprets leading-zero integers as octal — `(( n = 0100 ))` assigns 64 instead of 100, breaking timestamp, phone-prefix, and mode parsing. Keep the option off; use `8#100` when you want explicit octal.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1861")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1861.go
+++ b/pkg/katas/zc1861.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1861",
+		Title:    "Warn on `setopt OCTAL_ZEROES` — leading-zero integers silently reinterpret as octal",
+		Severity: SeverityWarning,
+		Description: "`OCTAL_ZEROES` is off in Zsh by default: arithmetic treats `0100` as the " +
+			"decimal integer one hundred, matching what every other scripting language " +
+			"does. Setting it on reverts to POSIX-shell semantics where the leading `0` " +
+			"flags the literal as octal — `(( n = 0100 ))` assigns 64, not 100. Scripts " +
+			"that read timestamps padded to `00:59`, CSVs of phone-number prefixes " +
+			"(`0049`), or file modes formatted as `0700` silently return the wrong " +
+			"integer. Keep the option off at script level; if you really want C-style " +
+			"octal literals, stay explicit with `(( n = 8#100 ))` or `$(( 8#$val ))` " +
+			"so the intent is obvious.",
+		Check: checkZC1861,
+	})
+}
+
+func checkZC1861(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			if zc1861IsOctalZeroes(arg.String()) {
+				return zc1861Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOOCTALZEROES" {
+				return zc1861Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1861IsOctalZeroes(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "OCTALZEROES"
+}
+
+func zc1861Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1861",
+		Message: "`" + where + "` reinterprets leading-zero integers as octal — " +
+			"`(( n = 0100 ))` assigns 64 instead of 100, breaking timestamp, " +
+			"phone-prefix, and mode parsing. Keep the option off; use `8#100` " +
+			"when you want explicit octal.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 857 Katas = 0.8.57
-const Version = "0.8.57"
+// 858 Katas = 0.8.58
+const Version = "0.8.58"


### PR DESCRIPTION
ZC1861 — `setopt OCTAL_ZEROES`

What: flags `setopt OCTAL_ZEROES` / `unsetopt NO_OCTAL_ZEROES`.
Why: reverts arithmetic to POSIX-sh octal semantics — `(( n = 0100 ))` assigns 64 instead of 100, so timestamp, phone-prefix, and file-mode parsing silently lies.
Fix suggestion: keep the option off; use explicit `8#100` or `$(( 8#$val ))` when you really want octal.
Severity: Warning