### PR TITLE
feat: ZC1862 — warn on `ssh-keygen -R HOST` scrubbing known-hosts silently

### DIFF
--- a/pkg/katas/katatests/zc1862_test.go
+++ b/pkg/katas/katatests/zc1862_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1862(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ssh-keygen -t ed25519 -f id_host`",
+			input:    `ssh-keygen -t ed25519 -f id_host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ssh-keygen -lf id_host.pub`",
+			input:    `ssh-keygen -lf id_host.pub`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ssh-keygen -R server.example`",
+			input: `ssh-keygen -R server.example`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1862",
+					Message: "`ssh-keygen -R server.example` deletes a known-hosts entry — the next `ssh` silently re-trusts whatever key the network returns. Fetch the new fingerprint out-of-band and verify before re-adding.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1862")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1862.go
+++ b/pkg/katas/zc1862.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1862",
+		Title:    "Warn on `ssh-keygen -R HOST` — deletes a known-hosts entry, next `ssh` re-trusts silently",
+		Severity: SeverityWarning,
+		Description: "`ssh-keygen -R HOST` scrubs the entry for `HOST` from `~/.ssh/known_hosts`. " +
+			"The legitimate trigger is a real key rotation (server reinstall, HSM " +
+			"replacement), but the flag is frequently dropped into automation to " +
+			"silence the REMOTE HOST IDENTIFICATION HAS CHANGED banner without ever " +
+			"confirming the new fingerprint. The very next `ssh` call then prompts " +
+			"once (or not at all under `StrictHostKeyChecking=no`) and blindly accepts " +
+			"whatever the network hands back — a MITM attacker who was waiting for a " +
+			"rebuild slips in without a trace. Fetch the new key out-of-band and " +
+			"`ssh-keyscan -t rsa,ed25519 HOST | ssh-keygen -lf -` before adding it, or " +
+			"pin fingerprints in a managed `known_hosts` file.",
+		Check: checkZC1862,
+	})
+}
+
+func checkZC1862(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "ssh-keygen" {
+		return nil
+	}
+	args := cmd.Arguments
+	for i, arg := range args {
+		v := arg.String()
+		if v != "-R" {
+			continue
+		}
+		if i+1 >= len(args) {
+			return nil
+		}
+		host := args[i+1].String()
+		return []Violation{{
+			KataID: "ZC1862",
+			Message: "`ssh-keygen -R " + host + "` deletes a known-hosts entry — the " +
+				"next `ssh` silently re-trusts whatever key the network returns. " +
+				"Fetch the new fingerprint out-of-band and verify before " +
+				"re-adding.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 858 Katas = 0.8.58
-const Version = "0.8.58"
+// 859 Katas = 0.8.59
+const Version = "0.8.59"


### PR DESCRIPTION
ZC1862 — `ssh-keygen -R HOST`

What: flags `ssh-keygen -R HOST` in automation.
Why: scrubs the known-hosts entry so the next `ssh` silently re-trusts whatever key the network returns — a MITM waiting for the rebuild window slips in without a prompt, especially paired with `StrictHostKeyChecking=no`.
Fix suggestion: fetch the new fingerprint out-of-band (`ssh-keyscan | ssh-keygen -lf -`), verify, then pin it in a managed `known_hosts`.
Severity: Warning