### PR TITLE
feat: ZC1863 — warn on `unsetopt CASE_GLOB` flipping globs to case-insensitive

### DIFF
--- a/pkg/katas/katatests/zc1863_test.go
+++ b/pkg/katas/katatests/zc1863_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1863(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt CASE_GLOB` (explicit default)",
+			input:    `setopt CASE_GLOB`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt CASE_GLOB`",
+			input: `unsetopt CASE_GLOB`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1863",
+					Message: "`unsetopt CASE_GLOB` flips every later glob to case-insensitive — `rm *.log` sweeps `APP.LOG`, dispatchers keyed on case collisions. Keep the option on; use `(#i)pattern` per-glob when you need case-folding.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_CASE_GLOB`",
+			input: `setopt NO_CASE_GLOB`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1863",
+					Message: "`setopt NO_CASE_GLOB` flips every later glob to case-insensitive — `rm *.log` sweeps `APP.LOG`, dispatchers keyed on case collisions. Keep the option on; use `(#i)pattern` per-glob when you need case-folding.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1863")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1863.go
+++ b/pkg/katas/zc1863.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1863",
+		Title:    "Warn on `unsetopt CASE_GLOB` — globs silently go case-insensitive across the script",
+		Severity: SeverityWarning,
+		Description: "`CASE_GLOB` on is the Zsh default: `*.log` matches `app.log` but not " +
+			"`APP.LOG`, `[A-Z]*` is a real case-sensitive range, and `[[ $f == Foo* ]]` " +
+			"keeps the distinction between `Foo1` and `foo1`. Turning it off (or " +
+			"equivalently `setopt NO_CASE_GLOB`) silently re-evaluates every subsequent " +
+			"pattern case-insensitively — `rm *.log` now sweeps `APP.LOG` up, pattern " +
+			"dispatchers that used to distinguish `README` from `readme` stop doing so, " +
+			"and hash maps keyed on glob-built labels start colliding. Keep the option " +
+			"on at script level; request case-folding per-pattern with the Zsh qualifier " +
+			"`(#i)*.log`.",
+		Check: checkZC1863,
+	})
+}
+
+func checkZC1863(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			if zc1863IsCaseGlob(arg.String()) {
+				return zc1863Hit(cmd, "unsetopt "+arg.String())
+			}
+		}
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOCASEGLOB" {
+				return zc1863Hit(cmd, "setopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1863IsCaseGlob(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "CASEGLOB"
+}
+
+func zc1863Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1863",
+		Message: "`" + where + "` flips every later glob to case-insensitive — " +
+			"`rm *.log` sweeps `APP.LOG`, dispatchers keyed on case collisions. " +
+			"Keep the option on; use `(#i)pattern` per-glob when you need " +
+			"case-folding.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 859 Katas = 0.8.59
-const Version = "0.8.59"
+// 860 Katas = 0.8.60
+const Version = "0.8.60"


### PR DESCRIPTION
ZC1863 — `unsetopt CASE_GLOB`

What: flags `unsetopt CASE_GLOB` / `setopt NO_CASE_GLOB`.
Why: every later glob and `[[ == pat ]]` silently goes case-insensitive — `rm *.log` sweeps `APP.LOG`, case-distinguishing dispatchers (e.g. `README` vs `readme`) collide.
Fix suggestion: keep the option on script-wide; request case-folding per-pattern with Zsh's `(#i)pattern` qualifier.
Severity: Warning