### PR TITLE
feat: ZC1864 — error on `mount -o remount,exec|suid|dev` re-enabling hardened mount

### DIFF
--- a/pkg/katas/katatests/zc1864_test.go
+++ b/pkg/katas/katatests/zc1864_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1864(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `mount -o remount,noexec /tmp` (tightening)",
+			input:    `mount -o remount,noexec /tmp`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `mount -o remount,rw /` (unrelated)",
+			input:    `mount -o remount,rw /`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `mount -o remount,exec /tmp`",
+			input: `mount -o remount,exec /tmp`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1864",
+					Message: "`mount -o remount,exec` re-enables `exec` on a `noexec`/`nosuid`/`nodev`-hardened mount — dropped payloads suddenly execute. Pair with a `trap ... EXIT` that restores the original flags or skip the remount.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `mount -o remount,rw,suid /var`",
+			input: `mount -o remount,rw,suid /var`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1864",
+					Message: "`mount -o remount,rw,suid` re-enables `suid` on a `noexec`/`nosuid`/`nodev`-hardened mount — dropped payloads suddenly execute. Pair with a `trap ... EXIT` that restores the original flags or skip the remount.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1864")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1864.go
+++ b/pkg/katas/zc1864.go
@@ -1,0 +1,76 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1864",
+		Title:    "Error on `mount -o remount,exec` — re-enables exec on a previously `noexec` mount",
+		Severity: SeverityError,
+		Description: "Hardened systems mount `/tmp`, `/var/tmp`, `/dev/shm`, and `/home` with " +
+			"`noexec` so a dropper cannot chmod and launch a payload out of a world-writable " +
+			"directory. `mount -o remount,exec /tmp` (or the narrower `remount,suid`) " +
+			"removes that guardrail for the live kernel, and every shell that already had " +
+			"`cd /tmp` open picks it up immediately. Most legitimate uses come from install " +
+			"scripts that briefly relax `noexec`; those scripts should restore the flag in " +
+			"a `trap 'mount -o remount,noexec /tmp' EXIT`. Blanket `remount,exec` without a " +
+			"restore path leaves the system in a permanently weakened state until reboot.",
+		Check: checkZC1864,
+	})
+}
+
+func checkZC1864(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "mount" {
+		return nil
+	}
+	args := cmd.Arguments
+	for i, arg := range args {
+		v := arg.String()
+		var opts string
+		switch {
+		case v == "-o" && i+1 < len(args):
+			opts = args[i+1].String()
+		case strings.HasPrefix(v, "-o"):
+			opts = strings.TrimPrefix(v, "-o")
+		default:
+			continue
+		}
+		opts = strings.ToLower(strings.Trim(opts, "\"'"))
+		if !strings.Contains(opts, "remount") {
+			continue
+		}
+		if weak := zc1864FirstWeakenedFlag(opts); weak != "" {
+			return []Violation{{
+				KataID: "ZC1864",
+				Message: "`mount -o " + opts + "` re-enables `" + weak + "` on a " +
+					"`noexec`/`nosuid`/`nodev`-hardened mount — dropped payloads " +
+					"suddenly execute. Pair with a `trap ... EXIT` that restores " +
+					"the original flags or skip the remount.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1864FirstWeakenedFlag(opts string) string {
+	for _, entry := range strings.Split(opts, ",") {
+		entry = strings.TrimSpace(entry)
+		switch entry {
+		case "exec", "suid", "dev":
+			return entry
+		}
+	}
+	return ""
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 860 Katas = 0.8.60
-const Version = "0.8.60"
+// 861 Katas = 0.8.61
+const Version = "0.8.61"


### PR DESCRIPTION
ZC1864 — `mount -o remount,exec|suid|dev`

What: flags `mount -o remount,…` where the options include `exec`, `suid`, or `dev`.
Why: removes the `noexec`/`nosuid`/`nodev` guardrail on `/tmp`, `/var/tmp`, `/dev/shm`, or `/home` for the live kernel — dropped payloads suddenly execute, setuid binaries suddenly run.
Fix suggestion: pair the remount with a `trap 'mount -o remount,noexec …' EXIT` that restores flags, or skip the remount entirely.
Severity: Error