### PR TITLE
feat: ZC1865 — warn on `unsetopt CASE_MATCH` flipping regex to case-insensitive

### DIFF
--- a/pkg/katas/katatests/zc1865_test.go
+++ b/pkg/katas/katatests/zc1865_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1865(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt CASE_MATCH` (explicit default)",
+			input:    `setopt CASE_MATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt CASE_MATCH`",
+			input: `unsetopt CASE_MATCH`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1865",
+					Message: "`unsetopt CASE_MATCH` flips every `[[ =~ ]]` / `[[ == pat ]]` to case-insensitive — `Admin` matches `ADMIN`, dispatchers collide. Keep it on; scope per-line with `(#i)pattern`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_CASE_MATCH`",
+			input: `setopt NO_CASE_MATCH`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1865",
+					Message: "`setopt NO_CASE_MATCH` flips every `[[ =~ ]]` / `[[ == pat ]]` to case-insensitive — `Admin` matches `ADMIN`, dispatchers collide. Keep it on; scope per-line with `(#i)pattern`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1865")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1865.go
+++ b/pkg/katas/zc1865.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1865",
+		Title:    "Warn on `unsetopt CASE_MATCH` — `[[ =~ ]]` and pattern tests quietly fold case",
+		Severity: SeverityWarning,
+		Description: "`CASE_MATCH` on is Zsh's default: `[[ $x =~ ^FOO ]]`, `[[ $x == Foo* ]]`, " +
+			"and the subst-in-conditional forms honour letter case exactly as written. " +
+			"Turning the option off flips every later test to case-insensitive — " +
+			"`[[ $user == Admin ]]` also matches `admin`/`ADMIN`, regex dispatchers stop " +
+			"distinguishing `README` from `readme`, and log-pattern filters over-collect. " +
+			"Keep the option on at script level; if one specific regex really needs " +
+			"case-folding, request it per-pattern with the Zsh `(#i)` flag " +
+			"(e.g. `[[ $x =~ (#i)foo ]]`).",
+		Check: checkZC1865,
+	})
+}
+
+func checkZC1865(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			if zc1865IsCaseMatch(arg.String()) {
+				return zc1865Hit(cmd, "unsetopt "+arg.String())
+			}
+		}
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOCASEMATCH" {
+				return zc1865Hit(cmd, "setopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1865IsCaseMatch(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "CASEMATCH"
+}
+
+func zc1865Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1865",
+		Message: "`" + where + "` flips every `[[ =~ ]]` / `[[ == pat ]]` to " +
+			"case-insensitive — `Admin` matches `ADMIN`, dispatchers collide. " +
+			"Keep it on; scope per-line with `(#i)pattern`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 861 Katas = 0.8.61
-const Version = "0.8.61"
+// 862 Katas = 0.8.62
+const Version = "0.8.62"


### PR DESCRIPTION
ZC1865 — `unsetopt CASE_MATCH`

What: flags `unsetopt CASE_MATCH` / `setopt NO_CASE_MATCH`.
Why: every later `[[ =~ ]]` and `[[ == pat ]]` goes case-insensitive — `Admin` matches `ADMIN`, regex dispatchers that distinguished case silently collapse.
Fix suggestion: keep the option on; scope case-folding per-pattern with `(#i)pattern`.
Severity: Warning