### PR TITLE
feat: ZC1867 — warn on `unsetopt GLOB` turning pattern expansion off script-wide

### DIFF
--- a/pkg/katas/katatests/zc1867_test.go
+++ b/pkg/katas/katatests/zc1867_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1867(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt GLOB` (explicit default)",
+			input:    `setopt GLOB`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt GLOB`",
+			input: `unsetopt GLOB`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1867",
+					Message: "`unsetopt GLOB` disables glob expansion — `rm *.log` chases the literal `*.log`, `for f in *.txt` loops once. Quote specific args or scope with `LOCAL_OPTIONS` inside a function.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_GLOB`",
+			input: `setopt NO_GLOB`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1867",
+					Message: "`setopt NO_GLOB` disables glob expansion — `rm *.log` chases the literal `*.log`, `for f in *.txt` loops once. Quote specific args or scope with `LOCAL_OPTIONS` inside a function.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1867")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1867.go
+++ b/pkg/katas/zc1867.go
@@ -1,0 +1,71 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1867",
+		Title:    "Warn on `unsetopt GLOB` — pattern expansion turned off, `rm *.log` tries the literal filename",
+		Severity: SeverityWarning,
+		Description: "`GLOB` is on by default in Zsh: `*`, `?`, `[...]`, and `**/` expand against " +
+			"the filesystem before the command runs. Turning the option off script-wide " +
+			"(via `unsetopt GLOB` or the equivalent `setopt NO_GLOB`, same as POSIX " +
+			"`set -f`) means every later pattern is handed to the command verbatim, so " +
+			"`rm *.log` tries to remove a file literally named `*.log`, `for f in *.txt` " +
+			"iterates over the single literal string, and expected-array-length checks " +
+			"always return 1. Keep the option on at the script level; if one specific " +
+			"line needs the pattern as a literal, quote the argument (`'*.log'`) or scope " +
+			"with `setopt LOCAL_OPTIONS; setopt NO_GLOB` inside a function.",
+		Check: checkZC1867,
+	})
+}
+
+func checkZC1867(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			if zc1867IsGlob(arg.String()) {
+				return zc1867Hit(cmd, "unsetopt "+arg.String())
+			}
+		}
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOGLOB" {
+				return zc1867Hit(cmd, "setopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1867IsGlob(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "GLOB"
+}
+
+func zc1867Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1867",
+		Message: "`" + where + "` disables glob expansion — `rm *.log` chases the " +
+			"literal `*.log`, `for f in *.txt` loops once. Quote specific args or " +
+			"scope with `LOCAL_OPTIONS` inside a function.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 863 Katas = 0.8.63
-const Version = "0.8.63"
+// 864 Katas = 0.8.64
+const Version = "0.8.64"


### PR DESCRIPTION
ZC1867 — `unsetopt GLOB`

What: flags `unsetopt GLOB` / `setopt NO_GLOB` (POSIX `set -f` equivalent).
Why: every subsequent pattern goes through verbatim — `rm *.log` tries to remove a file literally named `*.log`, `for f in *.txt` loops once over the pattern string, array-length checks always return 1.
Fix suggestion: keep the option on script-wide; quote specific args (`'*.log'`) or scope inside a function with `setopt LOCAL_OPTIONS; setopt NO_GLOB`.
Severity: Warning