### PR TITLE
feat: ZC1868 — error on `gcloud config set auth/disable_ssl_validation true`

### DIFF
--- a/pkg/katas/katatests/zc1868_test.go
+++ b/pkg/katas/katatests/zc1868_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1868(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gcloud config set compute/zone us-central1-a`",
+			input:    `gcloud config set compute/zone us-central1-a`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gcloud config set auth/disable_ssl_validation false`",
+			input:    `gcloud config set auth/disable_ssl_validation false`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gcloud config set auth/disable_ssl_validation true`",
+			input: `gcloud config set auth/disable_ssl_validation true`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1868",
+					Message: "`gcloud config set auth/disable_ssl_validation true` turns off TLS for every later `gcloud` call — service-account tokens and deploys become interceptable. Unset it; pin custom CAs via `core/custom_ca_certs_file`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1868")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1868.go
+++ b/pkg/katas/zc1868.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1868",
+		Title:    "Error on `gcloud config set auth/disable_ssl_validation true` — disables TLS on every later gcloud call",
+		Severity: SeverityError,
+		Description: "`gcloud config set auth/disable_ssl_validation true` writes the flag into " +
+			"the active configuration file, so every subsequent `gcloud` invocation on " +
+			"that machine stops verifying the Google API certificate until someone " +
+			"reverses it. A MITM holding a self-signed cert can then intercept service " +
+			"account tokens, project-level credentials, and every deploy that runs under " +
+			"the same user. Remove the setting (`gcloud config unset " +
+			"auth/disable_ssl_validation`), and if a corporate proxy really needs a custom " +
+			"CA use `core/custom_ca_certs_file` to pin it rather than disabling the check.",
+		Check: checkZC1868,
+	})
+}
+
+func checkZC1868(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "gcloud" {
+		return nil
+	}
+	args := cmd.Arguments
+	if len(args) < 4 {
+		return nil
+	}
+	if args[0].String() != "config" || args[1].String() != "set" {
+		return nil
+	}
+	key := args[2].String()
+	val := strings.ToLower(args[3].String())
+	if key == "auth/disable_ssl_validation" && (val == "true" || val == "1" || val == "on") {
+		return []Violation{{
+			KataID: "ZC1868",
+			Message: "`gcloud config set auth/disable_ssl_validation " + args[3].String() +
+				"` turns off TLS for every later `gcloud` call — service-account " +
+				"tokens and deploys become interceptable. Unset it; pin custom " +
+				"CAs via `core/custom_ca_certs_file`.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityError,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 864 Katas = 0.8.64
-const Version = "0.8.64"
+// 865 Katas = 0.8.65
+const Version = "0.8.65"


### PR DESCRIPTION
ZC1868 — gcloud TLS off

What: flags `gcloud config set auth/disable_ssl_validation true|1|on`.
Why: persists the flag in the active gcloud config; every subsequent `gcloud` call skips Google-API cert verification — service-account tokens and deploy credentials become interceptable.
Fix suggestion: `gcloud config unset auth/disable_ssl_validation`; pin a custom CA via `core/custom_ca_certs_file` if a corporate proxy requires it.
Severity: Error