### PR TITLE
feat: ZC1869 — warn on `setopt RC_EXPAND_PARAM` silently distributing array expansion

### DIFF
--- a/pkg/katas/katatests/zc1869_test.go
+++ b/pkg/katas/katatests/zc1869_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1869(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt RC_EXPAND_PARAM` (explicit default)",
+			input:    `unsetopt RC_EXPAND_PARAM`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt RC_EXPAND_PARAM`",
+			input: `setopt RC_EXPAND_PARAM`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1869",
+					Message: "`setopt RC_EXPAND_PARAM` distributes literal prefix/suffix across every array element — `cp src/${arr[@]}.bak dst` silently rewrites as `cp src/a.bak src/b.bak dst`. Keep it off; opt in per-use with `${^arr}`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_RC_EXPAND_PARAM`",
+			input: `unsetopt NO_RC_EXPAND_PARAM`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1869",
+					Message: "`unsetopt NO_RC_EXPAND_PARAM` distributes literal prefix/suffix across every array element — `cp src/${arr[@]}.bak dst` silently rewrites as `cp src/a.bak src/b.bak dst`. Keep it off; opt in per-use with `${^arr}`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1869")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1869.go
+++ b/pkg/katas/zc1869.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1869",
+		Title:    "Warn on `setopt RC_EXPAND_PARAM` — brace-adjacent array expansion silently distributes",
+		Severity: SeverityWarning,
+		Description: "`RC_EXPAND_PARAM` is off in Zsh by default: `echo x${arr[@]}y` concatenates " +
+			"once, producing `xay xby xcy` only if you wrote the template carefully. " +
+			"Turning it on changes the rule — every adjacent literal is distributed " +
+			"across each array element, so `cp src/${files[@]}.bak /tmp` suddenly " +
+			"rewrites as `cp src/a.bak src/b.bak src/c.bak /tmp`. That is exactly what " +
+			"you want when you want it, and a nasty surprise anywhere else because the " +
+			"same syntax keeps working silently. Leave the option off at script level; " +
+			"if one specific line needs distributive expansion, request it per-use with " +
+			"`${^arr}` (the `^` flag scopes the behaviour to that parameter only).",
+		Check: checkZC1869,
+	})
+}
+
+func checkZC1869(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			if zc1869IsRcExpandParam(arg.String()) {
+				return zc1869Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NORCEXPANDPARAM" {
+				return zc1869Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1869IsRcExpandParam(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "RCEXPANDPARAM"
+}
+
+func zc1869Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1869",
+		Message: "`" + where + "` distributes literal prefix/suffix across every " +
+			"array element — `cp src/${arr[@]}.bak dst` silently rewrites as " +
+			"`cp src/a.bak src/b.bak dst`. Keep it off; opt in per-use with " +
+			"`${^arr}`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 865 Katas = 0.8.65
-const Version = "0.8.65"
+// 866 Katas = 0.8.66
+const Version = "0.8.66"


### PR DESCRIPTION
ZC1869 — `setopt RC_EXPAND_PARAM`

What: flags `setopt RC_EXPAND_PARAM` / `unsetopt NO_RC_EXPAND_PARAM`.
Why: changes adjacent-literal semantics for array expansion — `cp src/${arr[@]}.bak dst` silently rewrites as `cp src/a.bak src/b.bak dst`, which is a nasty surprise outside the narrow intent.
Fix suggestion: keep the option off; request distributive expansion per-use with `${^arr}`.
Severity: Warning