### PR TITLE
feat: ZC1870 — warn on `setopt GLOB_ASSIGN` glob-expanding RHS of `var=`

### DIFF
--- a/pkg/katas/katatests/zc1870_test.go
+++ b/pkg/katas/katatests/zc1870_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1870(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt GLOB_ASSIGN` (explicit default)",
+			input:    `unsetopt GLOB_ASSIGN`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt GLOB_ASSIGN`",
+			input: `setopt GLOB_ASSIGN`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1870",
+					Message: "`setopt GLOB_ASSIGN` expands glob patterns on the RHS of `var=` — `logs=*.log` silently captures the first match, `cert=~/secrets/*` picks up attacker drops. Keep it off; use explicit `arr=( *.log )`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_GLOB_ASSIGN`",
+			input: `unsetopt NO_GLOB_ASSIGN`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1870",
+					Message: "`unsetopt NO_GLOB_ASSIGN` expands glob patterns on the RHS of `var=` — `logs=*.log` silently captures the first match, `cert=~/secrets/*` picks up attacker drops. Keep it off; use explicit `arr=( *.log )`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1870")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1870.go
+++ b/pkg/katas/zc1870.go
@@ -1,0 +1,71 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1870",
+		Title:    "Warn on `setopt GLOB_ASSIGN` — RHS of `var=pattern` silently glob-expands",
+		Severity: SeverityWarning,
+		Description: "`GLOB_ASSIGN` is off by default in Zsh: `logs=*.log` sets `$logs` to the " +
+			"literal string `*.log`, just like every other shell. Turning it on expands the " +
+			"right-hand side of unquoted assignments — `logs=*.log` silently becomes the " +
+			"first matching filename, `latest=backup-*` captures whatever sort-order the " +
+			"filesystem returns, and any empty-match case assigns an empty string. Scripts " +
+			"that port cleanly between Bash and Zsh suddenly diverge, and sensitive " +
+			"assignments like `cert=~/secrets/*` can grab attacker-dropped files. Keep the " +
+			"option off; use `set -A arr *.log` or explicit `arr=( *.log )` when you really " +
+			"want the expansion.",
+		Check: checkZC1870,
+	})
+}
+
+func checkZC1870(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			if zc1870IsGlobAssign(arg.String()) {
+				return zc1870Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOGLOBASSIGN" {
+				return zc1870Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1870IsGlobAssign(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "GLOBASSIGN"
+}
+
+func zc1870Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1870",
+		Message: "`" + where + "` expands glob patterns on the RHS of `var=` — " +
+			"`logs=*.log` silently captures the first match, `cert=~/secrets/*` " +
+			"picks up attacker drops. Keep it off; use explicit `arr=( *.log )`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 866 Katas = 0.8.66
-const Version = "0.8.66"
+// 867 Katas = 0.8.67
+const Version = "0.8.67"


### PR DESCRIPTION
ZC1870 — `setopt GLOB_ASSIGN`

What: flags `setopt GLOB_ASSIGN` / `unsetopt NO_GLOB_ASSIGN`.
Why: turns unquoted `var=*.log` and `cert=~/secrets/*` into filesystem globs — the script captures whatever matches first (or an empty string), and attacker-dropped files can slip into sensitive assignments.
Fix suggestion: keep the option off; use explicit `arr=( *.log )` when you really want glob expansion.
Severity: Warning