### PR TITLE
feat: ZC1872 — error on `badblocks -w` overwriting every disk sector

### DIFF
--- a/pkg/katas/katatests/zc1872_test.go
+++ b/pkg/katas/katatests/zc1872_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1872(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `badblocks -n $DISK`",
+			input:    `badblocks -n $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `badblocks $DISK` (read-only)",
+			input:    `badblocks $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `badblocks -w $DISK`",
+			input: `badblocks -w $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1872",
+					Message: "`badblocks -w` overwrites every sector of the target device — silent data wipe on a populated disk. Use `-n` (non-destructive) or gate destructive runs behind a confirmation and a fresh partition.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `badblocks -wsv $DISK` (combined)",
+			input: `badblocks -wsv $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1872",
+					Message: "`badblocks -w` overwrites every sector of the target device — silent data wipe on a populated disk. Use `-n` (non-destructive) or gate destructive runs behind a confirmation and a fresh partition.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1872")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1872.go
+++ b/pkg/katas/zc1872.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1872",
+		Title:    "Error on `badblocks -w` — destructive write-mode pattern test wipes the device",
+		Severity: SeverityError,
+		Description: "`badblocks -w` (alias `--write-mode`) runs the write-mode bad-block check, " +
+			"which overwrites every sector of the target device with a test pattern and " +
+			"reads it back. On a fresh drive about to be formatted that is exactly what " +
+			"you want; on an already-populated disk it is a silent data-wipe — the " +
+			"command returns success even as it bulldozes the filesystem. If only " +
+			"non-destructive checking is needed, use `badblocks -n` (read-test-restore) " +
+			"or `badblocks` without any mode flag (read-only). When a true destructive " +
+			"test is intended, gate the call behind a confirmation prompt and a freshly " +
+			"partitioned device.",
+		Check: checkZC1872,
+	})
+}
+
+func checkZC1872(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "badblocks" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-w" || v == "--write-mode" {
+			return zc1872Hit(cmd)
+		}
+		// Also catch combined short-option clusters like `-wsv`.
+		if len(v) > 1 && v[0] == '-' && v[1] != '-' && strings.ContainsRune(v[1:], 'w') {
+			return zc1872Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1872Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1872",
+		Message: "`badblocks -w` overwrites every sector of the target device — " +
+			"silent data wipe on a populated disk. Use `-n` (non-destructive) " +
+			"or gate destructive runs behind a confirmation and a fresh partition.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 868 Katas = 0.8.68
-const Version = "0.8.68"
+// 869 Katas = 0.8.69
+const Version = "0.8.69"


### PR DESCRIPTION
ZC1872 — `badblocks -w`

What: flags `badblocks -w` / `--write-mode` including combined short-option clusters like `-wsv`.
Why: write-mode bad-block test overwrites every sector with a pattern — a silent data wipe on a populated disk that still returns success.
Fix suggestion: use `badblocks -n` for non-destructive checking; gate destructive runs behind a confirmation prompt and a fresh partition.
Severity: Error