### PR TITLE
feat: ZC1873 — warn on `setopt ERR_RETURN` bailing functions on first non-zero exit

### DIFF
--- a/pkg/katas/katatests/zc1873_test.go
+++ b/pkg/katas/katatests/zc1873_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1873(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt ERR_RETURN` (explicit default)",
+			input:    `unsetopt ERR_RETURN`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt ERR_RETURN`",
+			input: `setopt ERR_RETURN`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1873",
+					Message: "`setopt ERR_RETURN` returns from every function on first non-zero exit — probing helpers (`test -f`, `grep -q`) bail before the fallback branch. Scope inside a `LOCAL_OPTIONS` function if needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_ERR_RETURN`",
+			input: `unsetopt NO_ERR_RETURN`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1873",
+					Message: "`unsetopt NO_ERR_RETURN` returns from every function on first non-zero exit — probing helpers (`test -f`, `grep -q`) bail before the fallback branch. Scope inside a `LOCAL_OPTIONS` function if needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1873")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1873.go
+++ b/pkg/katas/zc1873.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1873",
+		Title:    "Warn on `setopt ERR_RETURN` — functions silently bail out on the first non-zero exit",
+		Severity: SeverityWarning,
+		Description: "`ERR_RETURN` is the function-scoped cousin of `ERR_EXIT` and is off by " +
+			"default in Zsh. Turning it on script-wide makes every function `return` at " +
+			"the first command whose status is non-zero, which in practice means helpers " +
+			"that deliberately probe the environment (`test -f /some/file`, `grep -q " +
+			"PATTERN`, `id -u user`) will bail before they reach the branch that was meant " +
+			"to run when the probe failed. Callers see a success-or-nothing return and " +
+			"no stderr. Keep the option off at script level; inside one function that " +
+			"really wants fail-fast semantics, scope with `setopt LOCAL_OPTIONS; setopt " +
+			"ERR_RETURN` so the behaviour cannot leak to the rest of the shell.",
+		Check: checkZC1873,
+	})
+}
+
+func checkZC1873(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			if zc1873IsErrReturn(arg.String()) {
+				return zc1873Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOERRRETURN" {
+				return zc1873Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1873IsErrReturn(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "ERRRETURN"
+}
+
+func zc1873Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1873",
+		Message: "`" + where + "` returns from every function on first non-zero " +
+			"exit — probing helpers (`test -f`, `grep -q`) bail before the " +
+			"fallback branch. Scope inside a `LOCAL_OPTIONS` function if " +
+			"needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 869 Katas = 0.8.69
-const Version = "0.8.69"
+// 870 Katas = 0.8.70
+const Version = "0.8.70"


### PR DESCRIPTION
ZC1873 — `setopt ERR_RETURN`

What: flags `setopt ERR_RETURN` / `unsetopt NO_ERR_RETURN`.
Why: enabling it script-wide makes every function `return` on the first non-zero exit — probing helpers like `test -f`, `grep -q`, `id -u` bail before the fallback branch runs, with no stderr.
Fix suggestion: keep the option off script-wide; scope inside one function that truly wants fail-fast with `setopt LOCAL_OPTIONS; setopt ERR_RETURN`.
Severity: Warning