### PR TITLE
feat: ZC1874 — warn on `sshuttle -r HOST 0/0` tunneling all traffic via jump host

### DIFF
--- a/pkg/katas/katatests/zc1874_test.go
+++ b/pkg/katas/katatests/zc1874_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1874(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `sshuttle -r user@host 10.0.0.0/8`",
+			input:    `sshuttle -r user@host 10.0.0.0/8`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `sshuttle -r user@host 192.168.1.0/24`",
+			input:    `sshuttle -r user@host 192.168.1.0/24`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `sshuttle -r user@host 0/0`",
+			input: `sshuttle -r user@host 0/0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1874",
+					Message: "`sshuttle ... 0/0` routes every outbound packet through the jump host — a compromise of `user@host` sees the whole fleet's traffic. Scope to the subnets you actually need.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `sshuttle -r user@host 0.0.0.0/0`",
+			input: `sshuttle -r user@host 0.0.0.0/0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1874",
+					Message: "`sshuttle ... 0.0.0.0/0` routes every outbound packet through the jump host — a compromise of `user@host` sees the whole fleet's traffic. Scope to the subnets you actually need.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1874")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1874.go
+++ b/pkg/katas/zc1874.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1874",
+		Title:    "Warn on `sshuttle -r HOST 0/0` — every outbound packet tunneled through the jump host",
+		Severity: SeverityWarning,
+		Description: "`sshuttle -r user@host 0/0` (or `0.0.0.0/0`, `::/0`) installs a VPN-like " +
+			"catch-all route: every TCP connection and DNS lookup on the local machine " +
+			"egresses through `user@host`, including traffic to corporate VPN endpoints, " +
+			"cloud APIs, and package mirrors that had been explicitly split-tunnel. If the " +
+			"jump host is compromised, misconfigured, or simply overloaded, every session " +
+			"on the workstation silently degrades or leaks to the wrong peer. Scope the " +
+			"subnet list to the networks you actually need (`10.0.0.0/8 172.16.0.0/12 " +
+			"192.168.0.0/16`), or prefer `ssh -D` with `--exclude` rules for a single " +
+			"browser profile.",
+		Check: checkZC1874,
+	})
+}
+
+func checkZC1874(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sshuttle" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if zc1874IsDefaultRoute(v) {
+			return []Violation{{
+				KataID: "ZC1874",
+				Message: "`sshuttle ... " + v + "` routes every outbound packet through " +
+					"the jump host — a compromise of `user@host` sees the whole " +
+					"fleet's traffic. Scope to the subnets you actually need.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1874IsDefaultRoute(v string) bool {
+	switch v {
+	case "0/0", "0.0.0.0/0", "::/0":
+		return true
+	}
+	return false
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 870 Katas = 0.8.70
-const Version = "0.8.70"
+// 871 Katas = 0.8.71
+const Version = "0.8.71"


### PR DESCRIPTION
ZC1874 — `sshuttle -r HOST 0/0`

What: flags `sshuttle -r user@host` with a catch-all CIDR (`0/0`, `0.0.0.0/0`, `::/0`).
Why: installs a VPN-wide route — every TCP session and DNS lookup egresses through the jump host; a compromise of `user@host` sees the whole workstation's traffic.
Fix suggestion: scope the subnet list to what you actually need (`10.0.0.0/8 172.16.0.0/12 192.168.0.0/16`); prefer `ssh -D` + browser-level rules for single-app tunneling.
Severity: Warning