### PR TITLE
feat: ZC1875 — warn on `setopt RC_QUOTES` flipping single-quote escape semantics

### DIFF
--- a/pkg/katas/katatests/zc1875_test.go
+++ b/pkg/katas/katatests/zc1875_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1875(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt RC_QUOTES` (explicit default)",
+			input:    `unsetopt RC_QUOTES`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt RC_QUOTES`",
+			input: `setopt RC_QUOTES`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1875",
+					Message: "`setopt RC_QUOTES` reinterprets `''` inside single quotes as a literal apostrophe — `'it''s'` flips from `its` to `it's`, breaking tokens and SQL. Use double quotes or `\\'` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_RC_QUOTES`",
+			input: `unsetopt NO_RC_QUOTES`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1875",
+					Message: "`unsetopt NO_RC_QUOTES` reinterprets `''` inside single quotes as a literal apostrophe — `'it''s'` flips from `its` to `it's`, breaking tokens and SQL. Use double quotes or `\\'` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1875")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1875.go
+++ b/pkg/katas/zc1875.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1875",
+		Title:    "Warn on `setopt RC_QUOTES` — `''` inside single quotes flips from empty-concat to literal apostrophe",
+		Severity: SeverityWarning,
+		Description: "`RC_QUOTES` is off by default in Zsh: inside a single-quoted string `'it''s'` " +
+			"parses as two adjacent single-quoted regions with an empty middle, producing " +
+			"the literal `its`. Turning the option on reinterprets the doubled apostrophe " +
+			"as one escaped quote, so `'it''s'` suddenly becomes `it's`. That is a " +
+			"source-level change to every already-written string literal in the file — " +
+			"password strings, SQL fragments, display text — so log lines, stored tokens, " +
+			"and API payloads silently diverge. Keep the option off; write a literal " +
+			"apostrophe with `\\'` outside the quotes or with double-quoted wrapping.",
+		Check: checkZC1875,
+	})
+}
+
+func checkZC1875(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			if zc1875IsRCQuotes(arg.String()) {
+				return zc1875Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NORCQUOTES" {
+				return zc1875Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1875IsRCQuotes(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "RCQUOTES"
+}
+
+func zc1875Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1875",
+		Message: "`" + where + "` reinterprets `''` inside single quotes as a " +
+			"literal apostrophe — `'it''s'` flips from `its` to `it's`, " +
+			"breaking tokens and SQL. Use double quotes or `\\'` instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 871 Katas = 0.8.71
-const Version = "0.8.71"
+// 872 Katas = 0.8.72
+const Version = "0.8.72"


### PR DESCRIPTION
ZC1875 — `setopt RC_QUOTES`

What: flags `setopt RC_QUOTES` / `unsetopt NO_RC_QUOTES`.
Why: reinterprets `''` inside single-quoted strings as a literal apostrophe — `'it''s'` flips from `its` (empty-concat) to `it's`, breaking tokens, SQL fragments, and log strings across the file.
Fix suggestion: keep the option off; use double quotes or `\'` when you need a literal apostrophe.
Severity: Warning