### PR TITLE
feat: ZC1876 — warn on `cargo publish --allow-dirty` shipping uncommitted tarball

### DIFF
--- a/pkg/katas/katatests/zc1876_test.go
+++ b/pkg/katas/katatests/zc1876_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1876(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `cargo publish`",
+			input:    `cargo publish`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `cargo publish --dry-run`",
+			input:    `cargo publish --dry-run`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `cargo publish --allow-dirty`",
+			input: `cargo publish --allow-dirty`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1876",
+					Message: "`cargo publish --allow-dirty` uploads a tarball snapshot of the dirty working tree — debug prints and local-only patches end up on crates.io for a version that cannot be replaced. Commit first; `--dry-run` to rehearse.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1876")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1876.go
+++ b/pkg/katas/zc1876.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1876",
+		Title:    "Warn on `cargo publish --allow-dirty` — publishes the crate with uncommitted local changes",
+		Severity: SeverityWarning,
+		Description: "`cargo publish` by default refuses to upload when the working tree is dirty, " +
+			"because the published tarball is a snapshot of whatever is on disk — not " +
+			"whatever is committed. `--allow-dirty` skips that check, so a `println!` " +
+			"dropped in for debugging, an uncommitted `Cargo.toml` dep bump, or a " +
+			"`patch.crates-io` override that only exists locally ends up on crates.io " +
+			"under the same version users see on GitHub. This is irreversible — once a " +
+			"version is uploaded it cannot be replaced, only yanked. Commit first and " +
+			"publish from a clean checkout; if you truly must publish from a dirty tree, " +
+			"scope the flag to a one-off manual call with a `--dry-run` rehearsal first.",
+		Check: checkZC1876,
+	})
+}
+
+func checkZC1876(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cargo" {
+		return nil
+	}
+	args := cmd.Arguments
+	if len(args) < 2 {
+		return nil
+	}
+	if args[0].String() != "publish" {
+		return nil
+	}
+	for _, arg := range args[1:] {
+		if arg.String() == "--allow-dirty" {
+			return []Violation{{
+				KataID: "ZC1876",
+				Message: "`cargo publish --allow-dirty` uploads a tarball snapshot of " +
+					"the dirty working tree — debug prints and local-only patches " +
+					"end up on crates.io for a version that cannot be replaced. " +
+					"Commit first; `--dry-run` to rehearse.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 872 Katas = 0.8.72
-const Version = "0.8.72"
+// 873 Katas = 0.8.73
+const Version = "0.8.73"


### PR DESCRIPTION
ZC1876 — `cargo publish --allow-dirty`

What: flags `cargo publish --allow-dirty`.
Why: skips the clean-tree check and uploads the current on-disk state — local debug prints, uncommitted `Cargo.toml` bumps, and `patch.crates-io` overrides ride into the published version, which cannot be replaced after upload.
Fix suggestion: commit first and publish from a clean checkout; rehearse with `--dry-run`.
Severity: Warning