### PR TITLE
feat: ZC1877 — warn on `unsetopt SHORT_LOOPS` breaking compact loop syntax

### DIFF
--- a/pkg/katas/katatests/zc1877_test.go
+++ b/pkg/katas/katatests/zc1877_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1877(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt SHORT_LOOPS` (explicit default)",
+			input:    `setopt SHORT_LOOPS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt SHORT_LOOPS`",
+			input: `unsetopt SHORT_LOOPS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1877",
+					Message: "`unsetopt SHORT_LOOPS` disables short-form loops — `for f in *.log; print $f` raises a parse error. Keep the option on; scope inside a function with `LOCAL_OPTIONS` if POSIX-strict parsing is really needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_SHORT_LOOPS`",
+			input: `setopt NO_SHORT_LOOPS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1877",
+					Message: "`setopt NO_SHORT_LOOPS` disables short-form loops — `for f in *.log; print $f` raises a parse error. Keep the option on; scope inside a function with `LOCAL_OPTIONS` if POSIX-strict parsing is really needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1877")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1877.go
+++ b/pkg/katas/zc1877.go
@@ -1,0 +1,71 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1877",
+		Title:    "Warn on `unsetopt SHORT_LOOPS` — short-form `for`/`while` bodies stop parsing",
+		Severity: SeverityWarning,
+		Description: "`SHORT_LOOPS` is on in Zsh by default: the compact forms `for x in *.log; " +
+			"print $x`, `while true; print .`, and `repeat 3 sleep 1` parse with an implicit " +
+			"single-command body. Turning the option off reverts to POSIX-shell parsing, " +
+			"which demands an explicit `do ... done` or `{ ... }` block. Every subsequent " +
+			"short-form loop raises a parse error (`parse error near '\\n'`), and the " +
+			"behaviour is global so even helper files sourced later fall over. Keep the " +
+			"option on; if you genuinely need POSIX-strict parsing, scope inside a function " +
+			"with `setopt LOCAL_OPTIONS; unsetopt SHORT_LOOPS`.",
+		Check: checkZC1877,
+	})
+}
+
+func checkZC1877(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			if zc1877IsShortLoops(arg.String()) {
+				return zc1877Hit(cmd, "unsetopt "+arg.String())
+			}
+		}
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOSHORTLOOPS" {
+				return zc1877Hit(cmd, "setopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1877IsShortLoops(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "SHORTLOOPS"
+}
+
+func zc1877Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1877",
+		Message: "`" + where + "` disables short-form loops — `for f in *.log; " +
+			"print $f` raises a parse error. Keep the option on; scope inside " +
+			"a function with `LOCAL_OPTIONS` if POSIX-strict parsing is " +
+			"really needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 873 Katas = 0.8.73
-const Version = "0.8.73"
+// 874 Katas = 0.8.74
+const Version = "0.8.74"


### PR DESCRIPTION
ZC1877 — `unsetopt SHORT_LOOPS`

What: flags `unsetopt SHORT_LOOPS` / `setopt NO_SHORT_LOOPS`.
Why: disables Zsh's default single-command `for`/`while`/`repeat` bodies — `for f in *.log; print $f` suddenly raises a parse error, and the flip is global so sourced helpers also break.
Fix suggestion: keep the option on script-wide; scope inside a function with `setopt LOCAL_OPTIONS; unsetopt SHORT_LOOPS` if POSIX-strict parsing is genuinely needed.
Severity: Warning