### PR TITLE
feat: ZC1878 — warn on `kubectl apply --force-conflicts` stealing field ownership

### DIFF
--- a/pkg/katas/katatests/zc1878_test.go
+++ b/pkg/katas/katatests/zc1878_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1878(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `kubectl apply -f manifest.yaml`",
+			input:    `kubectl apply -f manifest.yaml`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `kubectl apply --server-side -f manifest.yaml`",
+			input:    `kubectl apply --server-side -f manifest.yaml`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `kubectl apply --server-side --force-conflicts -f manifest.yaml`",
+			input: `kubectl apply --server-side --force-conflicts -f manifest.yaml`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1878",
+					Message: "`kubectl apply --force-conflicts` grabs ownership of every conflicting field from other controllers (HPA, cert-manager, sidecar injectors). Resolve the conflict instead — drop the disputed fields or hand off via managed-field edit.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1878")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1878.go
+++ b/pkg/katas/zc1878.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1878",
+		Title:    "Warn on `kubectl apply --force-conflicts` — steals ownership of fields managed by other controllers",
+		Severity: SeverityWarning,
+		Description: "Server-side apply tracks every field of a resource by the applier that " +
+			"last set it (`metadata.managedFields`). When two appliers disagree, the " +
+			"default behaviour is to abort with `conflict` so you can reconcile " +
+			"deliberately. `kubectl apply --server-side --force-conflicts` overrides " +
+			"that: the current caller snatches ownership of every conflicting field — " +
+			"including fields set by operators, HPA, cert-manager, and webhook-injected " +
+			"sidecars — and those controllers will silently lose their reconcile " +
+			"pressure until their next write. Resolve the conflict instead: either " +
+			"drop the disputed fields from your manifest so the other owner can keep " +
+			"them, or coordinate a hand-off by first removing the managed-field entry " +
+			"(`kubectl apply --field-manager=... --subresource=...`).",
+		Check: checkZC1878,
+	})
+}
+
+func checkZC1878(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "kubectl" {
+		return nil
+	}
+	args := cmd.Arguments
+	if len(args) == 0 || args[0].String() != "apply" {
+		return nil
+	}
+	for _, arg := range args[1:] {
+		if arg.String() == "--force-conflicts" {
+			return []Violation{{
+				KataID: "ZC1878",
+				Message: "`kubectl apply --force-conflicts` grabs ownership of every " +
+					"conflicting field from other controllers (HPA, cert-manager, " +
+					"sidecar injectors). Resolve the conflict instead — drop the " +
+					"disputed fields or hand off via managed-field edit.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 874 Katas = 0.8.74
-const Version = "0.8.74"
+// 875 Katas = 0.8.75
+const Version = "0.8.75"


### PR DESCRIPTION
ZC1878 — `kubectl apply --force-conflicts`

What: flags `kubectl apply --force-conflicts` (typically paired with `--server-side`).
Why: grabs ownership of every conflicting field from other controllers — HPA replicas, cert-manager certs, sidecar-injector labels — which silently lose reconcile pressure until their next write.
Fix suggestion: resolve the conflict deliberately — drop the disputed fields from your manifest, or hand off via explicit `--field-manager` edit.
Severity: Warning