### PR TITLE
feat: ZC1879 — warn on `unsetopt BAD_PATTERN` silencing malformed glob errors

### DIFF
--- a/pkg/katas/katatests/zc1879_test.go
+++ b/pkg/katas/katatests/zc1879_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1879(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt BAD_PATTERN` (explicit default)",
+			input:    `setopt BAD_PATTERN`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt BAD_PATTERN`",
+			input: `unsetopt BAD_PATTERN`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1879",
+					Message: "`unsetopt BAD_PATTERN` silences `bad pattern` errors — `rm [abc` tries to remove a literal `[abc`, broken `case` arms stop firing. Keep the option on; quote one-off patterns or scope with `LOCAL_OPTIONS`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_BAD_PATTERN`",
+			input: `setopt NO_BAD_PATTERN`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1879",
+					Message: "`setopt NO_BAD_PATTERN` silences `bad pattern` errors — `rm [abc` tries to remove a literal `[abc`, broken `case` arms stop firing. Keep the option on; quote one-off patterns or scope with `LOCAL_OPTIONS`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1879")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1879.go
+++ b/pkg/katas/zc1879.go
@@ -1,0 +1,71 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1879",
+		Title:    "Warn on `unsetopt BAD_PATTERN` — malformed glob patterns silently pass through as literals",
+		Severity: SeverityWarning,
+		Description: "`BAD_PATTERN` is on in Zsh by default: a syntactically broken glob (unbalanced " +
+			"`[`, stray `^` outside extended-glob context, runaway `(alt|…`) produces a " +
+			"`zsh: bad pattern` error so the script knows the filename filter is wrong. " +
+			"Turning the option off reverts to POSIX behaviour — the pattern is handed to " +
+			"the command verbatim, and `rm [abc` silently tries to remove a file literally " +
+			"called `[abc`. Malformed patterns routed to `find -name` or passed to `case` " +
+			"blocks likewise stop firing. Keep the option on at script level; if one " +
+			"particular line really needs POSIX pass-through, quote the pattern or scope " +
+			"with `setopt LOCAL_OPTIONS; unsetopt BAD_PATTERN` inside a function.",
+		Check: checkZC1879,
+	})
+}
+
+func checkZC1879(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			if zc1879IsBadPattern(arg.String()) {
+				return zc1879Hit(cmd, "unsetopt "+arg.String())
+			}
+		}
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOBADPATTERN" {
+				return zc1879Hit(cmd, "setopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1879IsBadPattern(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "BADPATTERN"
+}
+
+func zc1879Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1879",
+		Message: "`" + where + "` silences `bad pattern` errors — `rm [abc` tries " +
+			"to remove a literal `[abc`, broken `case` arms stop firing. Keep " +
+			"the option on; quote one-off patterns or scope with `LOCAL_OPTIONS`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 875 Katas = 0.8.75
-const Version = "0.8.75"
+// 876 Katas = 0.8.76
+const Version = "0.8.76"


### PR DESCRIPTION
ZC1879 — `unsetopt BAD_PATTERN`

What: flags `unsetopt BAD_PATTERN` / `setopt NO_BAD_PATTERN`.
Why: malformed glob patterns (unbalanced `[`, runaway `(alt|…`) stop raising `bad pattern` and instead pass through as literals — `rm [abc` silently tries the file `[abc`, broken `case` arms stop matching.
Fix suggestion: keep the option on; quote one-off literal brackets or scope with `setopt LOCAL_OPTIONS; unsetopt BAD_PATTERN` inside a function.
Severity: Warning