### PR TITLE
feat: ZC1880 — warn on `kubectl annotate|label --overwrite` rewriting controller signals

### DIFF
--- a/pkg/katas/katatests/zc1880_test.go
+++ b/pkg/katas/katatests/zc1880_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1880(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `kubectl annotate pod/foo key=val`",
+			input:    `kubectl annotate pod/foo key=val`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `kubectl label pod/foo role=app`",
+			input:    `kubectl label pod/foo role=app`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `kubectl annotate pod/foo --overwrite key=val`",
+			input: `kubectl annotate pod/foo --overwrite key=val`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1880",
+					Message: "`kubectl annotate --overwrite` silently replaces an existing controller signal — cert-manager, external-dns, HPA watchers reconcile on the new value. Inspect first; drop `--overwrite` so conflicts error.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `kubectl label node/bar --overwrite role=worker`",
+			input: `kubectl label node/bar --overwrite role=worker`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1880",
+					Message: "`kubectl label --overwrite` silently replaces an existing controller signal — cert-manager, external-dns, HPA watchers reconcile on the new value. Inspect first; drop `--overwrite` so conflicts error.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1880")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1880.go
+++ b/pkg/katas/zc1880.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1880",
+		Title:    "Warn on `kubectl annotate|label --overwrite` — silently rewrites controller signals",
+		Severity: SeverityWarning,
+		Description: "Kubernetes annotations and labels are not plain metadata — they are the " +
+			"protocol by which cert-manager, external-dns, ingress-nginx, the " +
+			"HorizontalPodAutoscaler, and most Helm-managed controllers decide what to " +
+			"do with a resource. `kubectl annotate --overwrite` and `kubectl label " +
+			"--overwrite` suppress the conflict check and replace whatever value was " +
+			"there, so the script silently rewrites `kubectl.kubernetes.io/last-applied-" +
+			"configuration`, `cert-manager.io/cluster-issuer`, or " +
+			"`prometheus.io/scrape`, triggering reissue / reconfiguration or breaking " +
+			"the next apply. Inspect the existing annotation with `kubectl get -o " +
+			"jsonpath='{.metadata.annotations}'` first, and drop `--overwrite` so a " +
+			"conflict surfaces as an error.",
+		Check: checkZC1880,
+	})
+}
+
+func checkZC1880(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "kubectl" {
+		return nil
+	}
+	args := cmd.Arguments
+	if len(args) == 0 {
+		return nil
+	}
+	sub := args[0].String()
+	if sub != "annotate" && sub != "label" {
+		return nil
+	}
+	for _, arg := range args[1:] {
+		if arg.String() == "--overwrite" {
+			return []Violation{{
+				KataID: "ZC1880",
+				Message: "`kubectl " + sub + " --overwrite` silently replaces an " +
+					"existing controller signal — cert-manager, external-dns, " +
+					"HPA watchers reconcile on the new value. Inspect first; " +
+					"drop `--overwrite` so conflicts error.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 876 Katas = 0.8.76
-const Version = "0.8.76"
+// 877 Katas = 0.8.77
+const Version = "0.8.77"


### PR DESCRIPTION
ZC1880 — `kubectl annotate|label --overwrite`

What: flags `kubectl annotate --overwrite` and `kubectl label --overwrite`.
Why: annotations and labels are controller protocol — overwriting silently retriggers cert-manager reissue, external-dns record churn, HPA reconcile, or breaks Helm's `last-applied-configuration` tracking.
Fix suggestion: inspect the existing value (`kubectl get -o jsonpath='{.metadata.annotations}'`), drop `--overwrite`, and let conflicts surface as errors so you reconcile deliberately.
Severity: Warning