### PR TITLE
feat: ZC1881 — warn on `unsetopt MULTIBYTE` turning string ops into per-byte math

### DIFF
--- a/pkg/katas/katatests/zc1881_test.go
+++ b/pkg/katas/katatests/zc1881_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1881(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt MULTIBYTE` (explicit default)",
+			input:    `setopt MULTIBYTE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt MULTIBYTE`",
+			input: `unsetopt MULTIBYTE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1881",
+					Message: "`unsetopt MULTIBYTE` flips every string op to per-byte math — `${#str}` on an emoji returns 4, substrings slice mid-codepoint, `[[ =~ ]]` Unicode ranges break. Keep the option on; byte-count with `wc -c <<< $str` when truly needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_MULTIBYTE`",
+			input: `setopt NO_MULTIBYTE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1881",
+					Message: "`setopt NO_MULTIBYTE` flips every string op to per-byte math — `${#str}` on an emoji returns 4, substrings slice mid-codepoint, `[[ =~ ]]` Unicode ranges break. Keep the option on; byte-count with `wc -c <<< $str` when truly needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1881")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1881.go
+++ b/pkg/katas/zc1881.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1881",
+		Title:    "Warn on `unsetopt MULTIBYTE` — `${#str}`, substring, and `[[ =~ ]]` stop counting characters",
+		Severity: SeverityWarning,
+		Description: "`MULTIBYTE` is on in Zsh by default: `${#str}` returns character count, " +
+			"`${str:0:3}` extracts the first three characters, and `[[ $str =~ ... ]]` " +
+			"matches whole UTF-8 codepoints. Turning it off reverts every string " +
+			"operation to per-byte math, so an emoji that encodes to four bytes counts " +
+			"as four, a substring spanning a multi-byte character slices mid-codepoint " +
+			"and produces invalid UTF-8, and `[[ =~ ]]` regex ranges no longer cover " +
+			"Unicode blocks. Filenames containing non-ASCII, i18n log strings, and JSON " +
+			"snippets silently drift from their assumed layout. Keep the option on; if " +
+			"you truly need byte-level counting, use `${#${(%)str}}` or `wc -c <<< $str`.",
+		Check: checkZC1881,
+	})
+}
+
+func checkZC1881(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			if zc1881IsMultibyte(arg.String()) {
+				return zc1881Hit(cmd, "unsetopt "+arg.String())
+			}
+		}
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOMULTIBYTE" {
+				return zc1881Hit(cmd, "setopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1881IsMultibyte(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "MULTIBYTE"
+}
+
+func zc1881Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1881",
+		Message: "`" + where + "` flips every string op to per-byte math — `${#str}` " +
+			"on an emoji returns 4, substrings slice mid-codepoint, `[[ =~ ]]` " +
+			"Unicode ranges break. Keep the option on; byte-count with " +
+			"`wc -c <<< $str` when truly needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 877 Katas = 0.8.77
-const Version = "0.8.77"
+// 878 Katas = 0.8.78
+const Version = "0.8.78"


### PR DESCRIPTION
ZC1881 — `unsetopt MULTIBYTE`

What: flags `unsetopt MULTIBYTE` / `setopt NO_MULTIBYTE`.
Why: reverts every string operation to per-byte math — `${#emoji}` returns 4 instead of 1, substrings slice mid-codepoint, `[[ =~ ]]` Unicode ranges stop matching.
Fix suggestion: keep the option on script-wide; if you truly want byte counts, use `wc -c <<< $str` or `${#${(%)str}}`.
Severity: Warning