### PR TITLE
feat: ZC1882 — warn on bare `sudo -s` / `sudo su` / `sudo bash` in scripts

### DIFF
--- a/pkg/katas/katatests/zc1882_test.go
+++ b/pkg/katas/katatests/zc1882_test.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1882(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `sudo /usr/local/bin/setup.sh`",
+			input:    `sudo /usr/local/bin/setup.sh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `sudo -i /usr/local/bin/setup.sh`",
+			input:    `sudo -i /usr/local/bin/setup.sh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `sudo su -c \"cmd\"`",
+			input:    `sudo su -c "cmd"`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `sudo -s`",
+			input: `sudo -s`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1882",
+					Message: "`sudo -s` spawns an interactive root shell — in a script either hangs on stdin or drains the rest of the file into root's shell. Pass the command to sudo: `sudo /path/to/cmd arg …`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `sudo su -`",
+			input: `sudo su -`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1882",
+					Message: "`sudo su` spawns an interactive root shell — in a script either hangs on stdin or drains the rest of the file into root's shell. Pass the command to sudo: `sudo /path/to/cmd arg …`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `sudo bash`",
+			input: `sudo bash`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1882",
+					Message: "`sudo bash` spawns an interactive root shell — in a script either hangs on stdin or drains the rest of the file into root's shell. Pass the command to sudo: `sudo /path/to/cmd arg …`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1882")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1882.go
+++ b/pkg/katas/zc1882.go
@@ -1,0 +1,95 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1882",
+		Title:    "Warn on `sudo -s` / `sudo su` / `sudo bash` — spawns an interactive root shell from a script",
+		Severity: SeverityWarning,
+		Description: "`sudo -s`, `sudo -i`, `sudo su [-]`, and `sudo bash` (or `zsh`/`sh`/`ksh`) " +
+			"with no trailing command hand you an interactive root shell. That is fine " +
+			"at a prompt, but in a non-interactive script the shell either hangs " +
+			"waiting for stdin or drains stdin into root's shell as if those lines were " +
+			"the shell's commands — neither is what the script author meant. Pass the " +
+			"actual command to sudo (`sudo /usr/local/bin/provision.sh`) so the " +
+			"elevation is scoped and audit logs capture the real work.",
+		Check: checkZC1882,
+	})
+}
+
+func checkZC1882(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sudo" {
+		return nil
+	}
+	args := cmd.Arguments
+	if len(args) == 0 {
+		return nil
+	}
+
+	first := args[0].String()
+	rest := args[1:]
+
+	// sudo -s / sudo -i with no trailing positional command.
+	if (first == "-s" || first == "-i") && !zc1882HasPositional(rest) {
+		return zc1882Hit(cmd, "sudo "+first)
+	}
+
+	// sudo su, sudo su -, sudo su -l, sudo su --login (no -c).
+	if first == "su" {
+		if !zc1882HasArg(rest, "-c", "--command") {
+			return zc1882Hit(cmd, "sudo su")
+		}
+	}
+
+	// sudo bash / sudo zsh / sudo sh / sudo ksh without -c.
+	switch first {
+	case "bash", "zsh", "sh", "ksh", "dash", "ash":
+		if !zc1882HasArg(rest, "-c") {
+			return zc1882Hit(cmd, "sudo "+first)
+		}
+	}
+	return nil
+}
+
+func zc1882HasPositional(args []ast.Expression) bool {
+	for _, a := range args {
+		v := a.String()
+		if v == "" || v[0] == '-' {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func zc1882HasArg(args []ast.Expression, names ...string) bool {
+	for _, a := range args {
+		v := a.String()
+		for _, n := range names {
+			if v == n {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func zc1882Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1882",
+		Message: "`" + where + "` spawns an interactive root shell — in a script " +
+			"either hangs on stdin or drains the rest of the file into root's " +
+			"shell. Pass the command to sudo: `sudo /path/to/cmd arg …`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 878 Katas = 0.8.78
-const Version = "0.8.78"
+// 879 Katas = 0.8.79
+const Version = "0.8.79"


### PR DESCRIPTION
ZC1882 — interactive root shell via sudo

What: flags `sudo -s`, `sudo -i`, `sudo su[ -]`, and `sudo bash|zsh|sh|ksh|dash|ash` when no command/`-c` follows.
Why: in a non-interactive script the spawned root shell hangs on stdin or, worse, drains the script's remaining lines into the new shell — audit trails record "root shell opened" instead of the intended work.
Fix suggestion: pass the actual command to sudo — `sudo /usr/local/bin/setup.sh` — or scope with `sudo su -c "commands"`.
Severity: Warning