### PR TITLE
feat: ZC1883 — warn on `setopt PATH_SCRIPT` redirecting `source` via `$PATH`

### DIFF
--- a/pkg/katas/katatests/zc1883_test.go
+++ b/pkg/katas/katatests/zc1883_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1883(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt PATH_SCRIPT` (explicit default)",
+			input:    `unsetopt PATH_SCRIPT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt PATH_SCRIPT`",
+			input: `setopt PATH_SCRIPT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1883",
+					Message: "`setopt PATH_SCRIPT` lets `.`/`source` fall back to `$PATH` when a literal path misses — a dropper in `~/bin` or `./` runs inside the current shell with every exported secret. Keep the option off; always use explicit paths.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_PATH_SCRIPT`",
+			input: `unsetopt NO_PATH_SCRIPT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1883",
+					Message: "`unsetopt NO_PATH_SCRIPT` lets `.`/`source` fall back to `$PATH` when a literal path misses — a dropper in `~/bin` or `./` runs inside the current shell with every exported secret. Keep the option off; always use explicit paths.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1883")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1883.go
+++ b/pkg/katas/zc1883.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1883",
+		Title:    "Warn on `setopt PATH_SCRIPT` — `. ./script.sh` silently falls back to `$PATH` lookup",
+		Severity: SeverityWarning,
+		Description: "`PATH_SCRIPT` (off by default) lets the `.` builtin and `source` fall back to " +
+			"a `$PATH` walk when the literal path resolves to no file. With it on, " +
+			"`. helper.sh` looks for `helper.sh` in every `$path` entry — including " +
+			"user-owned directories like `~/bin` or `./` — and silently sources whichever " +
+			"matches first. An attacker who can drop `helper.sh` into any `$PATH` " +
+			"component runs their code inside the current shell's process, with every " +
+			"parent env var and exported secret available. Keep the option off; always " +
+			"source scripts with an explicit path (`./helper.sh`, `/opt/…/helper.sh`) so " +
+			"the source cannot be redirected.",
+		Check: checkZC1883,
+	})
+}
+
+func checkZC1883(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			if zc1883IsPathScript(arg.String()) {
+				return zc1883Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOPATHSCRIPT" {
+				return zc1883Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1883IsPathScript(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "PATHSCRIPT"
+}
+
+func zc1883Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1883",
+		Message: "`" + where + "` lets `.`/`source` fall back to `$PATH` when a " +
+			"literal path misses — a dropper in `~/bin` or `./` runs inside the " +
+			"current shell with every exported secret. Keep the option off; " +
+			"always use explicit paths.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 879 Katas = 0.8.79
-const Version = "0.8.79"
+// 880 Katas = 0.8.80
+const Version = "0.8.80"


### PR DESCRIPTION
ZC1883 — `setopt PATH_SCRIPT`

What: flags `setopt PATH_SCRIPT` / `unsetopt NO_PATH_SCRIPT`.
Why: lets `.` / `source` fall back to `$PATH` lookup when a literal path misses — a `helper.sh` dropped into `~/bin` or any user-writable `$PATH` entry runs inside the current shell with every exported secret.
Fix suggestion: keep the option off; always source with an explicit path (`./helper.sh`, absolute path).
Severity: Warning