### PR TITLE
feat: ZC1884 — error on credentials in `curl/wget` URL query string

### DIFF
--- a/pkg/katas/katatests/zc1884_test.go
+++ b/pkg/katas/katatests/zc1884_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1884(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `curl https://api.example/public`",
+			input:    `curl https://api.example/public`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `curl -H \"Authorization: Bearer $T\" https://api.example/private`",
+			input:    `curl -H "Authorization: Bearer $T" https://api.example/private`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `curl https://api/thing?apikey=abc`",
+			input: `curl https://api.example/thing?apikey=abc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1884",
+					Message: "`curl https://api.example/thing?apikey=abc` carries `apikey...` in the URL query — logged by every proxy, CDN, and server access log along the path. Move credentials to `-H \"Authorization: Bearer \"$TOKEN\"` or a POST body.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `curl -X POST https://api.example/auth?token=xyz`",
+			input: `curl -X POST https://api.example/auth?token=xyz`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1884",
+					Message: "`curl https://api.example/auth?token=xyz` carries `token...` in the URL query — logged by every proxy, CDN, and server access log along the path. Move credentials to `-H \"Authorization: Bearer \"$TOKEN\"` or a POST body.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1884")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1884.go
+++ b/pkg/katas/zc1884.go
@@ -1,0 +1,92 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1884",
+		Title:    "Error on `curl/wget https://...?apikey=...` — credential in URL query string",
+		Severity: SeverityError,
+		Description: "Anything passed as an HTTP query parameter is logged by every intermediary: " +
+			"the server's access log, the transparent proxy, the CDN request-id trail, " +
+			"browser referrer headers, and any client-side observability tooling. A URL " +
+			"like `https://api.example/widgets?apikey=SECRET&token=xyz` therefore " +
+			"tattoos the credential into logs that live forever and are often shared " +
+			"with downstream teams. Move the secret into an HTTP header " +
+			"(`curl -H \"Authorization: Bearer $TOKEN\"`), a POST body with " +
+			"`--data-urlencode` + TLS, or an `-u user:` basic-auth combo — never the " +
+			"query string.",
+		Check: checkZC1884,
+	})
+}
+
+var zc1884SecretKeys = []string{
+	"apikey=",
+	"api_key=",
+	"api-key=",
+	"token=",
+	"access_token=",
+	"id_token=",
+	"auth_token=",
+	"access-token=",
+	"password=",
+	"passwd=",
+	"secret=",
+	"client_secret=",
+	"sig=",
+	"signature=",
+}
+
+func checkZC1884(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "curl" && ident.Value != "wget" && ident.Value != "http" && ident.Value != "httpie" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if match := zc1884FirstSecretKey(v); match != "" {
+			return []Violation{{
+				KataID: "ZC1884",
+				Message: "`" + ident.Value + " " + v + "` carries `" + match +
+					"...` in the URL query — logged by every proxy, CDN, and " +
+					"server access log along the path. Move credentials to " +
+					"`-H \"Authorization: Bearer \"$TOKEN\"` or a POST body.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1884FirstSecretKey(v string) string {
+	lower := strings.ToLower(strings.Trim(v, "\"'"))
+	// Only flag when this looks like a URL; drop anything without `://` or `?`.
+	if !strings.Contains(lower, "://") || !strings.Contains(lower, "?") {
+		return ""
+	}
+	// Scan after the `?` boundary.
+	idx := strings.Index(lower, "?")
+	if idx < 0 {
+		return ""
+	}
+	query := lower[idx:]
+	for _, key := range zc1884SecretKeys {
+		if strings.Contains(query, key) {
+			return strings.TrimSuffix(key, "=")
+		}
+	}
+	return ""
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 880 Katas = 0.8.80
-const Version = "0.8.80"
+// 881 Katas = 0.8.81
+const Version = "0.8.81"


### PR DESCRIPTION
ZC1884 — credential in URL query

What: flags `curl`/`wget`/`http(ie)` when a URL contains common secret-bearing query keys (`apikey=`, `token=`, `access_token=`, `password=`, `secret=`, `signature=`, `client_secret=` and variants).
Why: query strings are logged by every proxy, CDN, and server access log along the path — credentials tattooed there live forever and leak to downstream teams.
Fix suggestion: move secrets to an HTTP header (`-H "Authorization: Bearer $TOKEN"`), POST body with `--data-urlencode`, or `-u user:` basic auth.
Severity: Error