### PR TITLE
feat: ZC1885 — warn on `setopt CSH_NULL_GLOB` hiding partial glob mismatches

### DIFF
--- a/pkg/katas/katatests/zc1885_test.go
+++ b/pkg/katas/katatests/zc1885_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1885(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt CSH_NULL_GLOB` (explicit default)",
+			input:    `unsetopt CSH_NULL_GLOB`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt CSH_NULL_GLOB`",
+			input: `setopt CSH_NULL_GLOB`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1885",
+					Message: "`setopt CSH_NULL_GLOB` silently discards unmatched globs in a list when any sibling matches — `rm *.lg *.bak` deletes the `.bak` files and hides the typo. Keep the option off; use `*(N)` per-glob.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_CSH_NULL_GLOB`",
+			input: `unsetopt NO_CSH_NULL_GLOB`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1885",
+					Message: "`unsetopt NO_CSH_NULL_GLOB` silently discards unmatched globs in a list when any sibling matches — `rm *.lg *.bak` deletes the `.bak` files and hides the typo. Keep the option off; use `*(N)` per-glob.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1885")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1885.go
+++ b/pkg/katas/zc1885.go
@@ -1,0 +1,71 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1885",
+		Title:    "Warn on `setopt CSH_NULL_GLOB` — unmatched globs drop instead of erroring when any sibling matches",
+		Severity: SeverityWarning,
+		Description: "`CSH_NULL_GLOB` (off by default) mimics csh's rule: in a list like " +
+			"`rm *.log *.bak *.tmp`, if at least one pattern produces matches the " +
+			"remaining unmatched patterns are silently discarded, and only if every " +
+			"pattern produces nothing does the shell raise `no match`. That is a " +
+			"partial-failure concealer — a genuine typo `rm *.lg *.bak` can still " +
+			"delete the `.bak` files while hiding the `.lg` mismatch, and maintenance " +
+			"loops that relied on `NOMATCH` to stop on typos pass right through. Keep " +
+			"the option off at script level; use `*(N)` per-glob when you want " +
+			"null-glob behaviour.",
+		Check: checkZC1885,
+	})
+}
+
+func checkZC1885(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			if zc1885IsCshNullGlob(arg.String()) {
+				return zc1885Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOCSHNULLGLOB" {
+				return zc1885Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1885IsCshNullGlob(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "CSHNULLGLOB"
+}
+
+func zc1885Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1885",
+		Message: "`" + where + "` silently discards unmatched globs in a list when " +
+			"any sibling matches — `rm *.lg *.bak` deletes the `.bak` files " +
+			"and hides the typo. Keep the option off; use `*(N)` per-glob.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 881 Katas = 0.8.81
-const Version = "0.8.81"
+// 882 Katas = 0.8.82
+const Version = "0.8.82"


### PR DESCRIPTION
ZC1885 — `setopt CSH_NULL_GLOB`

What: flags `setopt CSH_NULL_GLOB` / `unsetopt NO_CSH_NULL_GLOB`.
Why: applies csh-style null-glob to patterns in a list — `rm *.lg *.bak` deletes the `.bak` files and silently drops the `.lg` mismatch instead of erroring. Partial failures become invisible.
Fix suggestion: keep the option off; request null-glob per-pattern with the `*(N)` qualifier.
Severity: Warning