### PR TITLE
feat: ZC1886 — error on `tee/cp/mv/install/dd` writing system shell-init files

### DIFF
--- a/pkg/katas/katatests/zc1886_test.go
+++ b/pkg/katas/katatests/zc1886_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1886(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `cp /tmp/app.tar /opt/app/`",
+			input:    `cp /tmp/app.tar /opt/app/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `tee /var/log/install.log`",
+			input:    `tee /var/log/install.log`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `tee /etc/profile`",
+			input: `tee /etc/profile`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1886",
+					Message: "`tee ... /etc/profile` writes a shell-init file sourced by every interactive shell — persistent foothold for the next root login. Stage a temp file, validate, and `install -m 644` atomically.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `cp new.sh /etc/profile.d/custom.sh`",
+			input: `cp new.sh /etc/profile.d/custom.sh`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1886",
+					Message: "`cp ... /etc/profile.d/custom.sh` writes a shell-init file sourced by every interactive shell — persistent foothold for the next root login. Stage a temp file, validate, and `install -m 644` atomically.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1886")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1886.go
+++ b/pkg/katas/zc1886.go
@@ -1,0 +1,81 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1886",
+		Title:    "Error on `tee/cp/mv/install/dd` writing system shell-init files — persistent privesc surface",
+		Severity: SeverityError,
+		Description: "`/etc/profile`, `/etc/bash.bashrc`, `/etc/zshrc`, `/etc/zsh/zshenv`, " +
+			"`/etc/environment`, and every drop-in under `/etc/profile.d/` are sourced " +
+			"by every interactive shell (and `/etc/zshenv` by every Zsh invocation). A " +
+			"script that `tee`s, `cp`s, `mv`s, or `dd`s arbitrary content into any of " +
+			"those paths becomes a persistent foothold — the next root login runs the " +
+			"injected code. These files belong to the packaging system; hand-edit " +
+			"carefully, stage a temp file, validate it with a dry-run login, and move " +
+			"it into place with an atomic `install -m 644`.",
+		Check: checkZC1886,
+	})
+}
+
+var zc1886SensitivePaths = []string{
+	"/etc/profile",
+	"/etc/bash.bashrc",
+	"/etc/bashrc",
+	"/etc/zshrc",
+	"/etc/zshenv",
+	"/etc/zsh/zshrc",
+	"/etc/zsh/zshenv",
+	"/etc/zsh/zprofile",
+	"/etc/zsh/zlogin",
+	"/etc/zprofile",
+	"/etc/zlogin",
+	"/etc/environment",
+}
+
+func checkZC1886(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "tee", "cp", "mv", "install", "dd":
+	default:
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if zc1886IsSensitivePath(v) {
+			return []Violation{{
+				KataID: "ZC1886",
+				Message: "`" + ident.Value + " ... " + v + "` writes a shell-init " +
+					"file sourced by every interactive shell — persistent " +
+					"foothold for the next root login. Stage a temp file, " +
+					"validate, and `install -m 644` atomically.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1886IsSensitivePath(v string) bool {
+	trimmed := strings.Trim(v, "\"'")
+	for _, p := range zc1886SensitivePaths {
+		if trimmed == p {
+			return true
+		}
+	}
+	return strings.HasPrefix(trimmed, "/etc/profile.d/")
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 882 Katas = 0.8.82
-const Version = "0.8.82"
+// 883 Katas = 0.8.83
+const Version = "0.8.83"


### PR DESCRIPTION
ZC1886 — persistent foothold via system shell-init write

What: flags `tee`/`cp`/`mv`/`install`/`dd` targeting `/etc/profile`, `/etc/bash.bashrc`, `/etc/zshrc`, `/etc/zsh/*`, `/etc/environment`, `/etc/profile.d/*`.
Why: these files are sourced by every interactive shell (and `/etc/zshenv` by every Zsh invocation) — arbitrary writes become persistent footholds that run on the next root login.
Fix suggestion: stage a temp file, validate in a dry-run login, and drop into place atomically with `install -m 644`.
Severity: Error