### PR TITLE
feat: ZC1887 — warn on `setopt POSIX_TRAPS` flipping EXIT trap scope to shell-exit

### DIFF
--- a/pkg/katas/katatests/zc1887_test.go
+++ b/pkg/katas/katatests/zc1887_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1887(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt POSIX_TRAPS` (explicit default)",
+			input:    `unsetopt POSIX_TRAPS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt POSIX_TRAPS`",
+			input: `setopt POSIX_TRAPS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1887",
+					Message: "`setopt POSIX_TRAPS` flips `trap ... EXIT` inside functions from function-return to shell-exit scope — per-call cleanup leaks across the whole shell, TRAPZERR helpers stop firing. Keep the option off.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_POSIX_TRAPS`",
+			input: `unsetopt NO_POSIX_TRAPS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1887",
+					Message: "`unsetopt NO_POSIX_TRAPS` flips `trap ... EXIT` inside functions from function-return to shell-exit scope — per-call cleanup leaks across the whole shell, TRAPZERR helpers stop firing. Keep the option off.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1887")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1887.go
+++ b/pkg/katas/zc1887.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1887",
+		Title:    "Warn on `setopt POSIX_TRAPS` — EXIT/ZERR traps change scope and no longer fire on function return",
+		Severity: SeverityWarning,
+		Description: "`POSIX_TRAPS` is off by default in Zsh. With it off, `trap cleanup EXIT` " +
+			"inside a function fires when that function returns — the idiomatic Zsh way " +
+			"to scope cleanup to a scope. Turning the option on reverts to POSIX-sh " +
+			"semantics, where the EXIT trap only fires when the whole shell exits and " +
+			"is shared across the entire process. Scripts that installed a cleanup trap " +
+			"inside `do_work()` expecting it to run at each invocation now leak the " +
+			"first trap's handler into everything after, and helpers that counted on " +
+			"TRAPZERR / TRAPEXIT function-scoped behaviour silently skip. Keep the " +
+			"option off at script level; if a specific line really needs POSIX-scope, " +
+			"use `trap … EXIT` at top level and document it.",
+		Check: checkZC1887,
+	})
+}
+
+func checkZC1887(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			if zc1887IsPosixTraps(arg.String()) {
+				return zc1887Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOPOSIXTRAPS" {
+				return zc1887Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1887IsPosixTraps(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "POSIXTRAPS"
+}
+
+func zc1887Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1887",
+		Message: "`" + where + "` flips `trap ... EXIT` inside functions from " +
+			"function-return to shell-exit scope — per-call cleanup leaks across " +
+			"the whole shell, TRAPZERR helpers stop firing. Keep the option off.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 883 Katas = 0.8.83
-const Version = "0.8.83"
+// 884 Katas = 0.8.84
+const Version = "0.8.84"


### PR DESCRIPTION
ZC1887 — `setopt POSIX_TRAPS`

What: flags `setopt POSIX_TRAPS` / `unsetopt NO_POSIX_TRAPS`.
Why: flips `trap ... EXIT` inside functions from function-return scope to shell-exit scope — per-invocation cleanup leaks across the whole shell, and Zsh's TRAPEXIT/TRAPZERR function-scoped hooks stop firing.
Fix suggestion: keep the option off script-wide; install top-level `trap ... EXIT` explicitly when you really want shell-scope POSIX behaviour.
Severity: Warning