### PR TITLE
feat: ZC1888 — warn on `aws iam create-access-key` minting long-lived static creds

### DIFF
--- a/pkg/katas/katatests/zc1888_test.go
+++ b/pkg/katas/katatests/zc1888_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1888(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `aws iam list-access-keys`",
+			input:    `aws iam list-access-keys`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `aws iam get-role --role-name foo`",
+			input:    `aws iam get-role --role-name foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `aws iam create-access-key --user-name ci-bot`",
+			input: `aws iam create-access-key --user-name ci-bot`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1888",
+					Message: "`aws iam create-access-key` mints a long-lived `AKIA.../secret` — prefer short-lived creds via instance profiles, IRSA, Lambda roles, or OIDC federation. If static keys are unavoidable, store in Secrets Manager and rotate.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1888")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1888.go
+++ b/pkg/katas/zc1888.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1888",
+		Title:    "Warn on `aws iam create-access-key` — mints long-lived static AWS credentials",
+		Severity: SeverityWarning,
+		Description: "`aws iam create-access-key` hands out a static `AKIA.../secret` pair that is " +
+			"valid forever until someone rotates it; whoever gets the pair speaks for " +
+			"the IAM user on every API call AWS accepts. Most modern deploys no longer " +
+			"need these: EC2 instance profiles, EKS/IRSA, Lambda roles, GitHub OIDC, " +
+			"and IAM Identity Center all hand out short-lived session credentials on " +
+			"demand. Prefer those; if a static key is genuinely required (legacy third-" +
+			"party tooling), store it in AWS Secrets Manager, scope the user to the " +
+			"narrowest policy possible, and rotate on a schedule with `aws iam update-" +
+			"access-key --status Inactive` / `delete-access-key`.",
+		Check: checkZC1888,
+	})
+}
+
+func checkZC1888(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "aws" {
+		return nil
+	}
+	args := cmd.Arguments
+	if len(args) < 2 {
+		return nil
+	}
+	if args[0].String() != "iam" || args[1].String() != "create-access-key" {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1888",
+		Message: "`aws iam create-access-key` mints a long-lived `AKIA.../secret` — " +
+			"prefer short-lived creds via instance profiles, IRSA, Lambda roles, " +
+			"or OIDC federation. If static keys are unavoidable, store in Secrets " +
+			"Manager and rotate.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 884 Katas = 0.8.84
-const Version = "0.8.84"
+// 885 Katas = 0.8.85
+const Version = "0.8.85"


### PR DESCRIPTION
ZC1888 — `aws iam create-access-key`

What: flags `aws iam create-access-key` invocations.
Why: hands out a static `AKIA.../secret` pair valid forever until someone rotates it — modern AWS deploys should use short-lived credentials (instance profiles, IRSA, Lambda roles, OIDC federation, IAM Identity Center).
Fix suggestion: switch the caller to a role-based short-lived credential flow; if a static key is truly required, store in Secrets Manager and rotate with `aws iam update-access-key`/`delete-access-key`.
Severity: Warning