### PR TITLE
feat: ZC1889 — error on `skopeo --src-tls-verify=false`/`--dest-tls-verify=false`

### DIFF
--- a/pkg/katas/katatests/zc1889_test.go
+++ b/pkg/katas/katatests/zc1889_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1889(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `skopeo copy docker://a docker://b`",
+			input:    `skopeo copy docker://a docker://b`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `skopeo copy --src-tls-verify=true docker://a docker://b`",
+			input:    `skopeo copy --src-tls-verify=true docker://a docker://b`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `skopeo copy --src-tls-verify=false docker://a docker://b`",
+			input: `skopeo copy --src-tls-verify=false docker://a docker://b`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1889",
+					Message: "`skopeo --src-tls-verify=false` disables TLS verification on image copy — on-path attacker can substitute a malicious manifest. Pin a private CA with `--src-cert-dir`/`--dest-cert-dir` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `skopeo copy --dest-tls-verify=false docker://a docker://b`",
+			input: `skopeo copy --dest-tls-verify=false docker://a docker://b`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1889",
+					Message: "`skopeo --dest-tls-verify=false` disables TLS verification on image copy — on-path attacker can substitute a malicious manifest. Pin a private CA with `--src-cert-dir`/`--dest-cert-dir` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1889")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1889.go
+++ b/pkg/katas/zc1889.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1889",
+		Title:    "Error on `skopeo copy --src-tls-verify=false` / `--dest-tls-verify=false` — MITM on image copy",
+		Severity: SeverityError,
+		Description: "`skopeo copy` is the glue for promoting container images between registries in " +
+			"CI, mirroring upstream images into internal caches, and rehydrating images " +
+			"to an air-gapped registry. `--src-tls-verify=false` and " +
+			"`--dest-tls-verify=false` drop certificate verification on the respective " +
+			"leg, which means any on-path attacker can substitute a malicious manifest or " +
+			"layer and the copy completes without a warning. Use `--src-cert-dir`/" +
+			"`--dest-cert-dir` to pin a private CA if you are mirroring to or from an " +
+			"internal registry with self-signed certs, or fix the upstream's cert.",
+		Check: checkZC1889,
+	})
+}
+
+func checkZC1889(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "skopeo" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		lower := strings.ToLower(v)
+		for _, prefix := range []string{"--src-tls-verify=", "--dest-tls-verify=", "--tls-verify="} {
+			if !strings.HasPrefix(lower, prefix) {
+				continue
+			}
+			val := strings.TrimPrefix(lower, prefix)
+			val = strings.Trim(val, "\"'")
+			if val == "false" || val == "0" || val == "no" || val == "off" {
+				return []Violation{{
+					KataID: "ZC1889",
+					Message: "`skopeo " + v + "` disables TLS verification on image " +
+						"copy — on-path attacker can substitute a malicious manifest. " +
+						"Pin a private CA with `--src-cert-dir`/`--dest-cert-dir` " +
+						"instead.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityError,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 885 Katas = 0.8.85
-const Version = "0.8.85"
+// 886 Katas = 0.8.86
+const Version = "0.8.86"


### PR DESCRIPTION
ZC1889 — skopeo TLS bypass

What: flags `skopeo copy/inspect/sync` invocations with `--src-tls-verify=false|0|no|off`, `--dest-tls-verify=…`, or bare `--tls-verify=…`.
Why: dropping cert verification on either end of an image copy/mirror lets an on-path attacker swap manifest or layer contents without a warning — classic supply-chain bypass.
Fix suggestion: pin a private CA via `--src-cert-dir` / `--dest-cert-dir`, or fix the upstream cert instead.
Severity: Error