### PR TITLE
feat: ZC1890 — error on `kadmin -w PASS` embedding Kerberos admin password in argv

### DIFF
--- a/pkg/katas/katatests/zc1890_test.go
+++ b/pkg/katas/katatests/zc1890_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1890(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `kadmin -p admin/admin -k -t /etc/krb5.keytab`",
+			input:    `kadmin -p admin/admin -k -t /etc/krb5.keytab`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `kinit admin/admin`",
+			input:    `kinit admin/admin`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `kadmin -p admin/admin -w hunter2`",
+			input: `kadmin -p admin/admin -w hunter2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1890",
+					Message: "`kadmin -w hunter2` embeds the Kerberos admin password in argv — visible to `ps`, `/proc`, shell history. Use `-k -t /etc/krb5.keytab` (keytab root-only) or pipe the password on stdin.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `kadmin.local -w hunter2 addprinc user`",
+			input: `kadmin.local -w hunter2 addprinc user`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1890",
+					Message: "`kadmin.local -w hunter2` embeds the Kerberos admin password in argv — visible to `ps`, `/proc`, shell history. Use `-k -t /etc/krb5.keytab` (keytab root-only) or pipe the password on stdin.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1890")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1890.go
+++ b/pkg/katas/zc1890.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1890",
+		Title:    "Error on `kadmin -w PASS` / `kinit` with password arg — Kerberos password in argv",
+		Severity: SeverityError,
+		Description: "`kadmin -w PASS` and `kadmin.local -w PASS` pass the Kerberos admin " +
+			"principal's password directly as an argv element. Every `ps`, `/proc/<pid>/" +
+			"cmdline`, history file, and CI-pipeline log therefore sees it in plaintext, " +
+			"which is catastrophic for an account that can edit the realm's KDC. Use " +
+			"`-k -t /etc/krb5.keytab` for non-interactive auth (keytab permissioned to " +
+			"root only), or pipe the password through stdin with the `-q` batch form so " +
+			"it never rides in argv.",
+		Check: checkZC1890,
+	})
+}
+
+func checkZC1890(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kadmin" && ident.Value != "kadmin.local" && ident.Value != "kpasswd" {
+		return nil
+	}
+	args := cmd.Arguments
+	for i := 0; i+1 < len(args); i++ {
+		if args[i].String() != "-w" {
+			continue
+		}
+		val := args[i+1].String()
+		if val == "" || val[0] == '-' {
+			continue
+		}
+		return []Violation{{
+			KataID: "ZC1890",
+			Message: "`" + ident.Value + " -w " + val + "` embeds the Kerberos " +
+				"admin password in argv — visible to `ps`, `/proc`, shell history. " +
+				"Use `-k -t /etc/krb5.keytab` (keytab root-only) or pipe the " +
+				"password on stdin.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityError,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 886 Katas = 0.8.86
-const Version = "0.8.86"
+// 887 Katas = 0.8.87
+const Version = "0.8.87"


### PR DESCRIPTION
ZC1890 — Kerberos password in argv

What: flags `kadmin`, `kadmin.local`, and `kpasswd` with `-w PASSWORD`.
Why: the admin principal's password lands in argv — visible to `ps`, `/proc/<pid>/cmdline`, shell history, and CI logs. An attacker who sees it can edit the realm.
Fix suggestion: use `-k -t /etc/krb5.keytab` (keytab root-only) or pipe the password through stdin with batch mode; never in argv.
Severity: Error