### PR TITLE
feat: ZC1891 — error on `kubectl config view --raw` printing full kubeconfig with creds

### DIFF
--- a/pkg/katas/katatests/zc1891_test.go
+++ b/pkg/katas/katatests/zc1891_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1891(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `kubectl config view`",
+			input:    `kubectl config view`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `kubectl config view -o jsonpath='{.current-context}'`",
+			input:    `kubectl config view -o jsonpath='{.current-context}'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `kubectl config view --raw`",
+			input: `kubectl config view --raw`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1891",
+					Message: "`kubectl config view --raw` prints the full kubeconfig including client-certificate/key-data and bearer tokens — any script-captured stdout exfiltrates the creds. Emit the specific field with `-o jsonpath='…'`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `kubectl config view -R`",
+			input: `kubectl config view -R`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1891",
+					Message: "`kubectl config view --raw` prints the full kubeconfig including client-certificate/key-data and bearer tokens — any script-captured stdout exfiltrates the creds. Emit the specific field with `-o jsonpath='…'`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1891")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1891.go
+++ b/pkg/katas/zc1891.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1891",
+		Title:    "Error on `kubectl config view --raw` — prints the full kubeconfig with client keys",
+		Severity: SeverityError,
+		Description: "`kubectl config view` by default redacts secrets: `client-certificate-data`, " +
+			"`client-key-data`, `token`, and `password` fields are replaced with `REDACTED`. " +
+			"Adding `--raw` (or the synonym `-R`) undoes every redaction and prints the " +
+			"client's base64-encoded private key, bearer tokens, and any embedded user " +
+			"password to stdout. In a script where stdout lands in CI log storage, a " +
+			"`journalctl` ring buffer, or a Slack paste, the entire kubeconfig walks out. " +
+			"Emit only the specific field you need (e.g. `kubectl config view -o " +
+			"jsonpath='{.current-context}'`) or decrypt once into a temp file and `shred` it.",
+		Check: checkZC1891,
+	})
+}
+
+func checkZC1891(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "kubectl" {
+		return nil
+	}
+	args := cmd.Arguments
+	if len(args) < 2 {
+		return nil
+	}
+	if args[0].String() != "config" || args[1].String() != "view" {
+		return nil
+	}
+	for _, arg := range args[2:] {
+		v := arg.String()
+		if v == "--raw" || v == "-R" {
+			return []Violation{{
+				KataID: "ZC1891",
+				Message: "`kubectl config view --raw` prints the full kubeconfig " +
+					"including client-certificate/key-data and bearer tokens — " +
+					"any script-captured stdout exfiltrates the creds. Emit " +
+					"the specific field with `-o jsonpath='…'`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 887 Katas = 0.8.87
-const Version = "0.8.87"
+// 888 Katas = 0.8.88
+const Version = "0.8.88"


### PR DESCRIPTION
ZC1891 — `kubectl config view --raw`

What: flags `kubectl config view --raw` and the `-R` synonym.
Why: the default output redacts `client-certificate-data`, `client-key-data`, `token`, and `password` fields; `--raw` undoes that and prints the full kubeconfig — script-captured stdout ends up in CI logs, journalctl, or Slack pastes.
Fix suggestion: emit specific fields with `-o jsonpath='{…}'`, or pipe into `shred`-deletable temp files.
Severity: Error