### PR TITLE
feat: ZC1892 — error on `install -m 4755|2755|6755` setting setuid/setgid bits

### DIFF
--- a/pkg/katas/katatests/zc1892_test.go
+++ b/pkg/katas/katatests/zc1892_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1892(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `install -m 0755 foo /usr/local/bin/foo`",
+			input:    `install -m 0755 foo /usr/local/bin/foo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `install -m 0644 foo.conf /etc/foo.conf`",
+			input:    `install -m 0644 foo.conf /etc/foo.conf`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `install -m 4755 foo /usr/local/bin/foo` (setuid)",
+			input: `install -m 4755 foo /usr/local/bin/foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1892",
+					Message: "`install -m 4755` sets setuid/setgid bits at install time — every execution becomes a privesc vector. Use `0755` and grant narrow caps with `setcap` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `install -m 2755 foo /usr/local/bin/foo` (setgid)",
+			input: `install -m 2755 foo /usr/local/bin/foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1892",
+					Message: "`install -m 2755` sets setuid/setgid bits at install time — every execution becomes a privesc vector. Use `0755` and grant narrow caps with `setcap` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1892")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1892.go
+++ b/pkg/katas/zc1892.go
@@ -1,0 +1,90 @@
+package katas
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1892",
+		Title:    "Error on `install -m 4755|6755|2755` — sets setuid/setgid bit at install time",
+		Severity: SeverityError,
+		Description: "`install -m <mode>` with the setuid (`4xxx`), setgid (`2xxx`), or combined " +
+			"(`6xxx`) octal prefix creates the target with those special bits set, which " +
+			"turns every execution into a privilege-elevation vector. An uninspected " +
+			"binary installed this way — especially from a build script or package " +
+			"post-install — becomes a persistent local-privesc primitive if the binary " +
+			"is writable, has command-injection, or links against attacker-influenced " +
+			"libraries. Drop the setuid/setgid bits from the mode (`install -m 0755`) and " +
+			"grant the narrow capability the program actually needs with `setcap " +
+			"cap_net_bind_service+ep`; audit the remaining setuid binaries with " +
+			"`find / -perm -4000`.",
+		Check: checkZC1892,
+	})
+}
+
+func checkZC1892(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "install" && ident.Value != "mkdir" {
+		return nil
+	}
+	args := cmd.Arguments
+	for i, arg := range args {
+		v := arg.String()
+		var mode string
+		switch {
+		case v == "-m" && i+1 < len(args):
+			mode = args[i+1].String()
+		case v == "--mode" && i+1 < len(args):
+			mode = args[i+1].String()
+		case strings.HasPrefix(v, "-m") && v != "-m":
+			mode = strings.TrimPrefix(v, "-m")
+		case strings.HasPrefix(v, "--mode="):
+			mode = strings.TrimPrefix(v, "--mode=")
+		default:
+			continue
+		}
+		if zc1892HasSetuidBits(mode) {
+			return []Violation{{
+				KataID: "ZC1892",
+				Message: "`" + ident.Value + " -m " + mode + "` sets setuid/setgid " +
+					"bits at install time — every execution becomes a privesc " +
+					"vector. Use `0755` and grant narrow caps with `setcap` instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1892HasSetuidBits(mode string) bool {
+	mode = strings.Trim(mode, "\"'")
+	if mode == "" {
+		return false
+	}
+	for _, r := range mode {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	var n int64
+	if strings.ContainsAny(mode, "89") {
+		n, _ = strconv.ParseInt(mode, 10, 32)
+	} else {
+		n, _ = strconv.ParseInt(mode, 8, 32)
+	}
+	// setuid (0o4000), setgid (0o2000)
+	return (n & 0o6000) != 0
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 888 Katas = 0.8.88
-const Version = "0.8.88"
+// 889 Katas = 0.8.89
+const Version = "0.8.89"


### PR DESCRIPTION
ZC1892 — setuid install mode

What: flags `install -m <mode>` / `mkdir -m <mode>` where `<mode>` has the setuid (0o4000) or setgid (0o2000) bit set.
Why: installs a setuid binary at build/install time — every future execution becomes a privilege-elevation vector.
Fix suggestion: use `0755` and grant the narrow capability with `setcap cap_xxx+ep`; audit with `find / -perm -4000`.
Severity: Error