### PR TITLE
feat: ZC1893 — warn on `unsetopt BARE_GLOB_QUAL` breaking null-glob qualifier syntax

### DIFF
--- a/pkg/katas/katatests/zc1893_test.go
+++ b/pkg/katas/katatests/zc1893_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1893(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt BARE_GLOB_QUAL` (explicit default)",
+			input:    `setopt BARE_GLOB_QUAL`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt BARE_GLOB_QUAL`",
+			input: `unsetopt BARE_GLOB_QUAL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1893",
+					Message: "`unsetopt BARE_GLOB_QUAL` disables `*(qualifier)` syntax — `*(N)` stops being null-glob and becomes an alternation, so null-glob idioms silently break. Keep the option on; scope inside a `LOCAL_OPTIONS` function.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_BARE_GLOB_QUAL`",
+			input: `setopt NO_BARE_GLOB_QUAL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1893",
+					Message: "`setopt NO_BARE_GLOB_QUAL` disables `*(qualifier)` syntax — `*(N)` stops being null-glob and becomes an alternation, so null-glob idioms silently break. Keep the option on; scope inside a `LOCAL_OPTIONS` function.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1893")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1893.go
+++ b/pkg/katas/zc1893.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1893",
+		Title:    "Warn on `unsetopt BARE_GLOB_QUAL` — `*(N)` null-glob qualifier stops being special",
+		Severity: SeverityWarning,
+		Description: "`BARE_GLOB_QUAL` is on by default in Zsh — that is what makes the " +
+			"per-glob qualifier syntax (`*(N)` for null-glob, `*(.x)` for " +
+			"executable, `*(Om)` for sort-by-mtime) work. Turning it off reverts " +
+			"to ksh-style parsing where `(...)` inside a glob is a pattern " +
+			"alternation, so `*(N)` stops being a null-glob and turns into " +
+			"\"match zero-or-one N\" — a completely different pattern. Scripts that " +
+			"relied on `for f in *.log(N)` to cope with empty directories then " +
+			"silently iterate the literal string or fail under NOMATCH. Keep the " +
+			"option on; if you really want ksh-style qualifiers, use " +
+			"`setopt LOCAL_OPTIONS; unsetopt BARE_GLOB_QUAL` inside a function.",
+		Check: checkZC1893,
+	})
+}
+
+func checkZC1893(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			if zc1893IsBareGlobQual(arg.String()) {
+				return zc1893Hit(cmd, "unsetopt "+arg.String())
+			}
+		}
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOBAREGLOBQUAL" {
+				return zc1893Hit(cmd, "setopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1893IsBareGlobQual(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "BAREGLOBQUAL"
+}
+
+func zc1893Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1893",
+		Message: "`" + where + "` disables `*(qualifier)` syntax — `*(N)` stops being " +
+			"null-glob and becomes an alternation, so null-glob idioms silently " +
+			"break. Keep the option on; scope inside a `LOCAL_OPTIONS` function.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 889 Katas = 0.8.89
-const Version = "0.8.89"
+// 890 Katas = 0.8.90
+const Version = "0.8.90"


### PR DESCRIPTION
ZC1893 — `unsetopt BARE_GLOB_QUAL`

What: flags `unsetopt BARE_GLOB_QUAL` / `setopt NO_BARE_GLOB_QUAL`.
Why: disables Zsh's default per-glob qualifier syntax — `*(N)`, `*(.x)`, `*(Om)` stop being qualifiers and revert to ksh-style alternation, so null-glob idioms silently break.
Fix suggestion: keep the option on; scope inside a function with `setopt LOCAL_OPTIONS; unsetopt BARE_GLOB_QUAL` only if ksh-style parsing is genuinely needed.
Severity: Warning