### PR TITLE
feat: ZC1894 — error on `conntrack -F` wiping netfilter connection tracking

### DIFF
--- a/pkg/katas/katatests/zc1894_test.go
+++ b/pkg/katas/katatests/zc1894_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1894(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `conntrack -L` (list)",
+			input:    `conntrack -L`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `conntrack -D -s 10.0.0.5` (narrow delete)",
+			input:    `conntrack -D -s 10.0.0.5`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `conntrack -F`",
+			input: `conntrack -F`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1894",
+					Message: "`conntrack -F` wipes every tracked flow — stateful `ctstate ESTABLISHED` allowances drop, running SSH sessions lose their entry. Gate with `at now + N min` or narrow to one flow with `conntrack -D -s <ip>`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `conntrack --flush conntrack`",
+			input: `conntrack --flush conntrack`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1894",
+					Message: "`conntrack -F` wipes every tracked flow — stateful `ctstate ESTABLISHED` allowances drop, running SSH sessions lose their entry. Gate with `at now + N min` or narrow to one flow with `conntrack -D -s <ip>`.",
+					Line:    1,
+					Column:  13,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1894")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1894.go
+++ b/pkg/katas/zc1894.go
@@ -1,0 +1,62 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1894",
+		Title:    "Error on `conntrack -F` / `--flush` — every tracked connection (including SSH) is reset",
+		Severity: SeverityError,
+		Description: "`conntrack -F` (alias `--flush`) wipes the netfilter connection-tracking " +
+			"table. Every established TCP flow that depended on conntrack (every " +
+			"stateful-NAT connection, every `-m conntrack --ctstate RELATED,ESTABLISHED` " +
+			"allowance, every MASQUERADE session) loses its entry and the next packet is " +
+			"matched from scratch; most firewall rulesets drop it as \"new\" and the " +
+			"session dies. Over SSH, that means the shell running the very command drops. " +
+			"Stage the flush behind `at now + 5 minutes` so the session can re-enter the " +
+			"table via a preceding rule, or narrow the scope with `conntrack -D -s " +
+			"<client-IP>` for a specific hung flow.",
+		Check: checkZC1894,
+	})
+}
+
+func checkZC1894(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	// Parser caveat: `conntrack --flush <table>` mangles the command name to
+	// `flush`, with `<table>` promoted to arg[0].
+	if ident.Value == "flush" {
+		return zc1894Hit(cmd)
+	}
+	if ident.Value != "conntrack" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-F" || v == "--flush" {
+			return zc1894Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1894Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1894",
+		Message: "`conntrack -F` wipes every tracked flow — stateful " +
+			"`ctstate ESTABLISHED` allowances drop, running SSH sessions " +
+			"lose their entry. Gate with `at now + N min` or narrow to " +
+			"one flow with `conntrack -D -s <ip>`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 890 Katas = 0.8.90
-const Version = "0.8.90"
+// 891 Katas = 0.8.91
+const Version = "0.8.91"


### PR DESCRIPTION
ZC1894 — `conntrack -F`

What: flags `conntrack -F` / `conntrack --flush` (and mangled-name form from the parser).
Why: wipes the netfilter connection-tracking table — every stateful-NAT session, every `ctstate ESTABLISHED` allowance, and every running SSH session loses its entry and is dropped as a new packet.
Fix suggestion: gate behind `at now + N min` auto-recovery, or narrow with `conntrack -D -s <ip>` for a single stuck flow.
Severity: Error