### PR TITLE
feat: ZC1895 — warn on `setopt NUMERIC_GLOB_SORT` reshuffling glob output order

### DIFF
--- a/pkg/katas/katatests/zc1895_test.go
+++ b/pkg/katas/katatests/zc1895_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1895(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt NUMERIC_GLOB_SORT` (explicit default)",
+			input:    `unsetopt NUMERIC_GLOB_SORT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt NUMERIC_GLOB_SORT`",
+			input: `setopt NUMERIC_GLOB_SORT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1895",
+					Message: "`setopt NUMERIC_GLOB_SORT` switches every later glob to numeric sort — log rotations sorted on numeric suffixes silently shuffle. Keep it off; use the per-glob `*(n)` qualifier when needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_NUMERIC_GLOB_SORT`",
+			input: `unsetopt NO_NUMERIC_GLOB_SORT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1895",
+					Message: "`unsetopt NO_NUMERIC_GLOB_SORT` switches every later glob to numeric sort — log rotations sorted on numeric suffixes silently shuffle. Keep it off; use the per-glob `*(n)` qualifier when needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1895")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1895.go
+++ b/pkg/katas/zc1895.go
@@ -1,0 +1,71 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1895",
+		Title:    "Warn on `setopt NUMERIC_GLOB_SORT` — glob output switches from lexicographic to numeric order",
+		Severity: SeverityWarning,
+		Description: "`NUMERIC_GLOB_SORT` is off by default: `ls *.log` returns filenames in the " +
+			"collation order the filesystem-iteration/sort step produces (lexicographic " +
+			"in the C locale, so `app-1.log`, `app-10.log`, `app-2.log`). Turning it on " +
+			"makes every subsequent glob and array expansion sort numeric runs " +
+			"numerically — the same glob now returns `app-1.log`, `app-2.log`, " +
+			"`app-10.log`. Scripts that tail the \"latest\" file by taking the last array " +
+			"element, pipelines that expect a specific stable order, and backup rotations " +
+			"built on `*[0-9].tar` silently shuffle. Keep the option off script-wide; " +
+			"request numeric sort per-glob with the `*(n)` qualifier when needed.",
+		Check: checkZC1895,
+	})
+}
+
+func checkZC1895(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			if zc1895IsNumericGlobSort(arg.String()) {
+				return zc1895Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NONUMERICGLOBSORT" {
+				return zc1895Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1895IsNumericGlobSort(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "NUMERICGLOBSORT"
+}
+
+func zc1895Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1895",
+		Message: "`" + where + "` switches every later glob to numeric sort — log " +
+			"rotations sorted on numeric suffixes silently shuffle. Keep it off; " +
+			"use the per-glob `*(n)` qualifier when needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 891 Katas = 0.8.91
-const Version = "0.8.91"
+// 892 Katas = 0.8.92
+const Version = "0.8.92"


### PR DESCRIPTION
ZC1895 — `setopt NUMERIC_GLOB_SORT`

What: flags `setopt NUMERIC_GLOB_SORT` / `unsetopt NO_NUMERIC_GLOB_SORT`.
Why: every subsequent glob and array expansion sorts numeric runs numerically instead of lexicographically — `app-1.log app-10.log app-2.log` becomes `app-1.log app-2.log app-10.log`, reshuffling log rotations and "latest-file" pipelines.
Fix suggestion: keep the option off script-wide; request numeric sort per-glob with the `*(n)` qualifier.
Severity: Warning