### PR TITLE
feat: ZC1896 — error on `docker run -v /proc|/sys` bind-mounting host kernel ifaces

### DIFF
--- a/pkg/katas/katatests/zc1896_test.go
+++ b/pkg/katas/katatests/zc1896_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1896(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `docker run -v /etc/app:/app/etc ubuntu`",
+			input:    `docker run -v /etc/app:/app/etc ubuntu`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `docker run -v /home/user:/work ubuntu`",
+			input:    `docker run -v /home/user:/work ubuntu`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `docker run -v /proc:/host/proc:ro ubuntu`",
+			input: `docker run -v /proc:/host/proc:ro ubuntu`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1896",
+					Message: "`docker ... -v /proc:/host/proc:ro` bind-mounts host /proc into the container — every process's `environ`/`cmdline` and `/proc/1/ns/` breakout handles become readable. Use `--cap-add=SYS_PTRACE` or host-side monitoring instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `podman run --volume=/sys:/host/sys alpine`",
+			input: `podman run --volume=/sys:/host/sys alpine`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1896",
+					Message: "`podman ... -v /sys:/host/sys` bind-mounts host /sys into the container — every process's `environ`/`cmdline` and `/proc/1/ns/` breakout handles become readable. Use `--cap-add=SYS_PTRACE` or host-side monitoring instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1896")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1896.go
+++ b/pkg/katas/zc1896.go
@@ -1,0 +1,95 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1896",
+		Title:    "Error on `docker/podman run -v /proc:…|/sys:…` — bind-mounts host kernel interfaces into container",
+		Severity: SeverityError,
+		Description: "`docker run -v /proc:/host/proc` (or `-v /sys:…`) bind-mounts the host's " +
+			"procfs / sysfs hierarchy into the container's mount namespace. From inside, " +
+			"the container can read every host process's `environ` (secrets passed via " +
+			"env), every `cmdline`, every `/proc/1/ns/` to open namespace fds for a " +
+			"breakout, and `/sys/fs/cgroup` to modify resource limits that affect host " +
+			"services. `:ro` does not help — `/proc/<pid>/ns/...` handles remain usable. " +
+			"If the container genuinely needs process / kernel visibility, grant the " +
+			"narrowest capability instead (`--cap-add=SYS_PTRACE`) or run the monitoring " +
+			"agent on the host rather than inside an untrusted image.",
+		Check: checkZC1896,
+	})
+}
+
+func checkZC1896(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "docker" && ident.Value != "podman" {
+		return nil
+	}
+	args := cmd.Arguments
+	if len(args) == 0 || (args[0].String() != "run" && args[0].String() != "create") {
+		return nil
+	}
+	for i := 1; i < len(args); i++ {
+		v := args[i].String()
+		var mount string
+		switch {
+		case (v == "-v" || v == "--volume" || v == "--mount") && i+1 < len(args):
+			mount = args[i+1].String()
+		case strings.HasPrefix(v, "--volume=") || strings.HasPrefix(v, "--mount=") || strings.HasPrefix(v, "-v="):
+			mount = v[strings.Index(v, "=")+1:]
+		default:
+			continue
+		}
+		if src := zc1896HostKernelSource(mount); src != "" {
+			return []Violation{{
+				KataID: "ZC1896",
+				Message: "`" + ident.Value + " ... -v " + mount + "` bind-mounts host " +
+					src + " into the container — every process's `environ`/`cmdline` " +
+					"and `/proc/1/ns/` breakout handles become readable. Use " +
+					"`--cap-add=SYS_PTRACE` or host-side monitoring instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1896HostKernelSource(v string) string {
+	trimmed := strings.Trim(v, "\"'")
+	// Accept `source:target[:opts]` bind form and `source=/path,…` mount form.
+	source := trimmed
+	if idx := strings.Index(trimmed, ":"); idx > 0 {
+		source = trimmed[:idx]
+	}
+	// `--mount type=bind,source=/proc,…`
+	if strings.Contains(trimmed, "source=") {
+		for _, entry := range strings.Split(trimmed, ",") {
+			if strings.HasPrefix(entry, "source=") {
+				source = strings.TrimPrefix(entry, "source=")
+			} else if strings.HasPrefix(entry, "src=") {
+				source = strings.TrimPrefix(entry, "src=")
+			}
+		}
+	}
+	switch source {
+	case "/proc", "/sys":
+		return source
+	}
+	if strings.HasPrefix(source, "/proc/") || strings.HasPrefix(source, "/sys/") {
+		return source
+	}
+	return ""
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 892 Katas = 0.8.92
-const Version = "0.8.92"
+// 893 Katas = 0.8.93
+const Version = "0.8.93"


### PR DESCRIPTION
ZC1896 — host /proc, /sys bind-mount

What: flags `docker run`/`podman run` / `create` with `-v`, `--volume`, or `--mount` sourcing `/proc`, `/sys`, or any subpath of either.
Why: the container sees every host process's `environ`/`cmdline`, can open `/proc/1/ns/*` for a namespace breakout, and can rewrite cgroup limits — the `:ro` flag does not block ns-fd reuse.
Fix suggestion: use `--cap-add=SYS_PTRACE` or run the monitoring agent on the host rather than inside an untrusted image.
Severity: Error