### PR TITLE
feat: ZC1897 — warn on `setopt SH_GLOB` breaking Zsh-extended glob patterns

### DIFF
--- a/pkg/katas/katatests/zc1897_test.go
+++ b/pkg/katas/katatests/zc1897_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1897(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt SH_GLOB` (explicit default)",
+			input:    `unsetopt SH_GLOB`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt SH_GLOB`",
+			input: `setopt SH_GLOB`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1897",
+					Message: "`setopt SH_GLOB` disables Zsh-extended glob patterns — `*(N)` qualifiers, `<1-10>` ranges, and `(alt1|alt2)` alternation raise parse errors. Keep the option off; scope with `LOCAL_OPTIONS` if strict POSIX is needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_SH_GLOB`",
+			input: `unsetopt NO_SH_GLOB`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1897",
+					Message: "`unsetopt NO_SH_GLOB` disables Zsh-extended glob patterns — `*(N)` qualifiers, `<1-10>` ranges, and `(alt1|alt2)` alternation raise parse errors. Keep the option off; scope with `LOCAL_OPTIONS` if strict POSIX is needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1897")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1897.go
+++ b/pkg/katas/zc1897.go
@@ -1,0 +1,73 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1897",
+		Title:    "Warn on `setopt SH_GLOB` — Zsh-specific glob patterns (`*(N)`, `<1-10>`, alternation) stop parsing",
+		Severity: SeverityWarning,
+		Description: "`SH_GLOB` is off by default in Zsh. With it off, the shell recognises Zsh's " +
+			"extended patterns: `*(N)` null-glob qualifier, `<1-10>` numeric range globs, " +
+			"`(alt1|alt2)` in-glob alternation, and the whole `(#i)`/`(#c,m)` flag " +
+			"family. Turning the option on forces strict POSIX-sh parsing, so the parser " +
+			"re-interprets `(...)` as command grouping and the null-glob / range idioms " +
+			"raise parse errors. Every kata recommending `*(N)` (see ZC1830, ZC1893) " +
+			"silently breaks, and downstream helpers sourced after the setopt inherit the " +
+			"restricted pattern syntax. Keep the option off; scope inside a function " +
+			"with `setopt LOCAL_OPTIONS; setopt SH_GLOB` if a specific block genuinely " +
+			"needs POSIX patterns.",
+		Check: checkZC1897,
+	})
+}
+
+func checkZC1897(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "setopt":
+		for _, arg := range cmd.Arguments {
+			if zc1897IsShGlob(arg.String()) {
+				return zc1897Hit(cmd, "setopt "+arg.String())
+			}
+		}
+	case "unsetopt":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+			if norm == "NOSHGLOB" {
+				return zc1897Hit(cmd, "unsetopt "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1897IsShGlob(v string) bool {
+	norm := strings.ToUpper(strings.ReplaceAll(v, "_", ""))
+	return norm == "SHGLOB"
+}
+
+func zc1897Hit(cmd *ast.SimpleCommand, where string) []Violation {
+	return []Violation{{
+		KataID: "ZC1897",
+		Message: "`" + where + "` disables Zsh-extended glob patterns — `*(N)` " +
+			"qualifiers, `<1-10>` ranges, and `(alt1|alt2)` alternation raise " +
+			"parse errors. Keep the option off; scope with `LOCAL_OPTIONS` if " +
+			"strict POSIX is needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 893 Katas = 0.8.93
-const Version = "0.8.93"
+// 894 Katas = 0.8.94
+const Version = "0.8.94"


### PR DESCRIPTION
ZC1897 — `setopt SH_GLOB`

What: flags `setopt SH_GLOB` / `unsetopt NO_SH_GLOB`.
Why: forces strict POSIX glob parsing — `*(N)` null-glob qualifier, `<1-10>` numeric range globs, `(alt1|alt2)` alternation, and the `(#i)` flag family all stop parsing and raise errors.
Fix suggestion: keep the option off at script level; scope inside a function with `setopt LOCAL_OPTIONS; setopt SH_GLOB` if POSIX patterns are really needed.
Severity: Warning