### PR TITLE
feat: ZC1898 — detect `gpg --export-secret-keys` private-key leak

### DIFF
--- a/pkg/katas/katatests/zc1898_test.go
+++ b/pkg/katas/katatests/zc1898_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1898(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gpg --export KEYID`",
+			input:    `gpg --export KEYID`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gpg --list-keys`",
+			input:    `gpg --list-keys`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gpg --export-secret-keys KEYID` (mangled name)",
+			input: `gpg --export-secret-keys KEYID`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1898",
+					Message: "`gpg --export-secret-keys` writes the private key to stdout — one CI-log or wrong-tty redirect leaks it. Back up interactively on an air-gapped host, or write to a `umask 077` path and re-encrypt.",
+					Line:    1,
+					Column:  7,
+				},
+			},
+		},
+		{
+			name:  "invalid — `gpg KEYID --export-secret-subkeys` (trailing)",
+			input: `gpg KEYID --export-secret-subkeys`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1898",
+					Message: "`gpg --export-secret-subkeys` writes the private key to stdout — one CI-log or wrong-tty redirect leaks it. Back up interactively on an air-gapped host, or write to a `umask 077` path and re-encrypt.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1898")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1898.go
+++ b/pkg/katas/zc1898.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1898",
+		Title:    "Error on `gpg --export-secret-keys` — private-key material leaks to stdout",
+		Severity: SeverityError,
+		Description: "`gpg --export-secret-keys KEYID` and `--export-secret-subkeys` write the " +
+			"ASCII-armoured private key to stdout. In a script, that stream usually lands " +
+			"in a file the operator plans to move off-box — and any misstep (wrong " +
+			"`cd`, script-wide stdout captured by CI, tee to a world-readable log, " +
+			"piped into a remote unencrypted channel) permanently leaks the key. Backup " +
+			"the key interactively on an air-gapped machine; if automation is required, " +
+			"write the output to a `umask 077`-protected path and immediately encrypt " +
+			"with a second symmetric passphrase.",
+		Check: checkZC1898,
+	})
+}
+
+func checkZC1898(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `gpg --export-secret-keys …` mangles the command name
+	// to `export-secret-keys` (or `-subkeys`).
+	switch ident.Value {
+	case "export-secret-keys", "export-secret-subkeys":
+		return zc1898Hit(cmd, "--"+ident.Value)
+	case "gpg", "gpg2":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "--export-secret-keys" || v == "--export-secret-subkeys" {
+				return zc1898Hit(cmd, v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1898Hit(cmd *ast.SimpleCommand, flag string) []Violation {
+	return []Violation{{
+		KataID: "ZC1898",
+		Message: "`gpg " + flag + "` writes the private key to stdout — one " +
+			"CI-log or wrong-tty redirect leaks it. Back up interactively on an " +
+			"air-gapped host, or write to a `umask 077` path and re-encrypt.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 894 Katas = 0.8.94
-const Version = "0.8.94"
+// 895 Katas = 0.8.95
+const Version = "0.8.95"


### PR DESCRIPTION
ZC1898 — Error on `gpg --export-secret-keys` — private-key material leaks to stdout

What: `gpg --export-secret-keys KEYID` / `--export-secret-subkeys` streams the ASCII-armoured private key to stdout.
Why: One CI log capture, wrong-tty redirect, or world-readable tee permanently exfiltrates the secret key.
Fix suggestion: Back up keys interactively on an air-gapped host, or write to a `umask 077` path and immediately re-encrypt.
Severity: Error