### PR TITLE
feat: ZC1899 — detect `mokutil --disable-validation` Secure Boot bypass

### DIFF
--- a/pkg/katas/katatests/zc1899_test.go
+++ b/pkg/katas/katatests/zc1899_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1899(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `mokutil --list-enrolled`",
+			input:    `mokutil --list-enrolled`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `mokutil --import /root/MOK.der`",
+			input:    `mokutil --import /root/MOK.der`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `mokutil --disable-validation now` (mangled name)",
+			input: `mokutil --disable-validation now`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1899",
+					Message: "`mokutil --disable-validation` stops the shim from validating kernel/modules against enrolled keys — Secure Boot becomes advisory. Leave validation on; enrol specific keys with `mokutil --import`.",
+					Line:    1,
+					Column:  11,
+				},
+			},
+		},
+		{
+			name:  "invalid — `mokutil -l --disable-validation` (trailing)",
+			input: `mokutil -l --disable-validation`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1899",
+					Message: "`mokutil --disable-validation` stops the shim from validating kernel/modules against enrolled keys — Secure Boot becomes advisory. Leave validation on; enrol specific keys with `mokutil --import`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1899")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1899.go
+++ b/pkg/katas/zc1899.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1899",
+		Title:    "Error on `mokutil --disable-validation` — turns UEFI Secure Boot off at the shim",
+		Severity: SeverityError,
+		Description: "`mokutil --disable-validation` queues a request for the shim to stop " +
+			"validating the kernel and modules against the enrolled MOK/PK certificates at " +
+			"next boot — Secure Boot silently becomes advisory. Any unsigned kernel or " +
+			"rootkit module then loads without prompt. Leave Secure Boot validation on; " +
+			"if you must load a custom module, enrol its key with `mokutil --import` and " +
+			"approve via the `MokManager` prompt at reboot.",
+		Check: checkZC1899,
+	})
+}
+
+func checkZC1899(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `mokutil --disable-validation` mangles the command
+	// name to `disable-validation`.
+	switch ident.Value {
+	case "disable-validation":
+		return zc1899Hit(cmd)
+	case "mokutil":
+		for _, arg := range cmd.Arguments {
+			if arg.String() == "--disable-validation" {
+				return zc1899Hit(cmd)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1899Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1899",
+		Message: "`mokutil --disable-validation` stops the shim from validating " +
+			"kernel/modules against enrolled keys — Secure Boot becomes advisory. " +
+			"Leave validation on; enrol specific keys with `mokutil --import`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 895 Katas = 0.8.95
-const Version = "0.8.95"
+// 896 Katas = 0.8.96
+const Version = "0.8.96"


### PR DESCRIPTION
ZC1899 — Error on `mokutil --disable-validation`

What: `mokutil --disable-validation` queues a shim request to stop validating kernel/modules against enrolled MOK/PK certificates.
Why: At next boot Secure Boot becomes advisory — unsigned kernels or rootkit modules load without prompt.
Fix suggestion: Leave validation on. If you need a custom module, enrol its key with `mokutil --import` and approve via `MokManager`.
Severity: Error