### PR TITLE
feat: ZC1900 — detect `curl --location-trusted` credential-forward on redirect

### DIFF
--- a/pkg/katas/katatests/zc1900_test.go
+++ b/pkg/katas/katatests/zc1900_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1900(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `curl -L https://api/resource`",
+			input:    `curl -L https://api/resource`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `curl -u user:pass https://api/resource` (no location)",
+			input:    `curl -u user:pass https://api/resource`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `curl --location-trusted https://api` (mangled)",
+			input: `curl --location-trusted https://api`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1900",
+					Message: "`curl --location-trusted` replays `Authorization`, cookies, and `-u user:pass` on every redirect — a 302 to attacker-controlled host leaks the token. Drop the flag; verify final hostname before sending secrets.",
+					Line:    1,
+					Column:  8,
+				},
+			},
+		},
+		{
+			name:  "invalid — `curl -u user:pass --location-trusted https://api` (trailing)",
+			input: `curl -u user:pass --location-trusted https://api`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1900",
+					Message: "`curl --location-trusted` replays `Authorization`, cookies, and `-u user:pass` on every redirect — a 302 to attacker-controlled host leaks the token. Drop the flag; verify final hostname before sending secrets.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1900")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1900.go
+++ b/pkg/katas/zc1900.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1900",
+		Title:    "Warn on `curl --location-trusted` — Authorization/cookies forwarded across redirects",
+		Severity: SeverityWarning,
+		Description: "`curl --location-trusted` (alias of `curl -L --location-trusted`) tells " +
+			"curl to replay the `Authorization` header, cookies, and `-u user:pass` credential " +
+			"on every redirect hop, even across hosts. A 302 to an attacker-controlled origin " +
+			"(or a compromised CDN edge) then receives the bearer token verbatim. Drop " +
+			"`--location-trusted`; if cross-origin auth is truly required, scope a short-lived " +
+			"token per destination and verify the final hostname before sending secrets.",
+		Check: checkZC1900,
+	})
+}
+
+func checkZC1900(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `curl --location-trusted …` mangles the command name
+	// to `location-trusted`.
+	switch ident.Value {
+	case "location-trusted":
+		return zc1900Hit(cmd)
+	case "curl":
+		for _, arg := range cmd.Arguments {
+			if arg.String() == "--location-trusted" {
+				return zc1900Hit(cmd)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1900Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1900",
+		Message: "`curl --location-trusted` replays `Authorization`, cookies, and " +
+			"`-u user:pass` on every redirect — a 302 to attacker-controlled host " +
+			"leaks the token. Drop the flag; verify final hostname before sending secrets.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 896 Katas = 0.8.96
-const Version = "0.8.96"
+// 897 Katas = 0.8.97
+const Version = "0.8.97"


### PR DESCRIPTION
ZC1900 — Warn on `curl --location-trusted`

What: `curl --location-trusted` replays `Authorization`, cookies, and `-u user:pass` on every redirect hop.
Why: A 302 to an attacker-controlled origin (or compromised CDN edge) receives the bearer token verbatim.
Fix suggestion: Drop the flag; scope a short-lived token per destination and verify the final hostname before sending secrets.
Severity: Warning