### PR TITLE
feat: ZC1901 — detect `setopt POSIX_BUILTINS` Zsh-vs-POSIX scope flip

### DIFF
--- a/pkg/katas/katatests/zc1901_test.go
+++ b/pkg/katas/katatests/zc1901_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1901(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt POSIX_BUILTINS` (explicit default)",
+			input:    `unsetopt POSIX_BUILTINS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NOMATCH` (unrelated)",
+			input:    `setopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt POSIX_BUILTINS`",
+			input: `setopt POSIX_BUILTINS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1901",
+					Message: "`setopt POSIX_BUILTINS` switches Zsh to POSIX special-builtin rules — assignments before `export`/`readonly`/`eval` stop being local, silently leaking state. Scope any POSIX block with `emulate -LR sh` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_POSIX_BUILTINS`",
+			input: `unsetopt NO_POSIX_BUILTINS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1901",
+					Message: "`unsetopt NO_POSIX_BUILTINS` switches Zsh to POSIX special-builtin rules — assignments before `export`/`readonly`/`eval` stop being local, silently leaking state. Scope any POSIX block with `emulate -LR sh` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1901")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1901.go
+++ b/pkg/katas/zc1901.go
@@ -1,0 +1,83 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1901",
+		Title:    "Warn on `setopt POSIX_BUILTINS` — flips `command`/special-builtin semantics",
+		Severity: SeverityWarning,
+		Description: "`setopt POSIX_BUILTINS` switches Zsh to the POSIX rules for special " +
+			"builtins: assignments before `export`, `readonly`, `eval`, `.`, `trap`, `set`, " +
+			"etc. stay in the caller's scope, and `command builtin` can now resolve shell " +
+			"builtins. Mid-script Zsh code written against native semantics — where those " +
+			"assignments are local — silently leaks state. Leave the option off; scope any " +
+			"POSIX-specific block with `emulate -LR sh` instead of toggling globally.",
+		Check: checkZC1901,
+	})
+}
+
+func checkZC1901(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1901Canonical(arg.String())
+		switch v {
+		case "POSIXBUILTINS":
+			if enabling {
+				return zc1901Hit(cmd, "setopt POSIX_BUILTINS")
+			}
+		case "NOPOSIXBUILTINS":
+			if !enabling {
+				return zc1901Hit(cmd, "unsetopt NO_POSIX_BUILTINS")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1901Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1901Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1901",
+		Message: "`" + form + "` switches Zsh to POSIX special-builtin rules — " +
+			"assignments before `export`/`readonly`/`eval` stop being local, silently " +
+			"leaking state. Scope any POSIX block with `emulate -LR sh` instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 897 Katas = 0.8.97
-const Version = "0.8.97"
+// 898 Katas = 0.8.98
+const Version = "0.8.98"


### PR DESCRIPTION
ZC1901 — Warn on `setopt POSIX_BUILTINS`

What: `setopt POSIX_BUILTINS` switches Zsh to the POSIX rules for special builtins (`export`, `readonly`, `eval`, `.`, `trap`, `set`, etc.).
Why: Assignments before those builtins stop being local and silently leak into the caller's scope; `command builtin` can also now resolve shell builtins.
Fix suggestion: Leave the option off. Scope any POSIX-specific block with `emulate -LR sh` rather than toggling globally.
Severity: Warning