### PR TITLE
feat: ZC1902 — detect `ln -s /dev/null <logfile>` audit/history silencing

### DIFF
--- a/pkg/katas/katatests/zc1902_test.go
+++ b/pkg/katas/katatests/zc1902_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1902(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ln -s /opt/app/current /opt/app/live` (app release symlink)",
+			input:    `ln -s /opt/app/current /opt/app/live`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ln -s /dev/null /tmp/scratch` (non-sensitive target)",
+			input:    `ln -s /dev/null /tmp/scratch`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ln -sf /dev/null /var/log/auth.log`",
+			input: `ln -sf /dev/null /var/log/auth.log`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1902",
+					Message: "`ln -s /dev/null /var/log/auth.log` redirects every write to the bit-bucket — audit / history entries vanish silently. If the log must stop, disable the writer or rotate with `logrotate`, never symlink to `/dev/null`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ln -s /dev/null $HOME/.bash_history`",
+			input: `ln -s /dev/null $HOME/.bash_history`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1902",
+					Message: "`ln -s /dev/null $HOME/.bash_history` redirects every write to the bit-bucket — audit / history entries vanish silently. If the log must stop, disable the writer or rotate with `logrotate`, never symlink to `/dev/null`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1902")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1902.go
+++ b/pkg/katas/zc1902.go
@@ -1,0 +1,102 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1902SensitiveTargets = []string{
+	"/var/log/",
+	"/var/log/audit/",
+	"/var/log/wtmp",
+	"/var/log/btmp",
+	"/var/log/lastlog",
+	"/var/log/secure",
+	"/var/log/auth.log",
+	"/var/log/syslog",
+	"/var/log/messages",
+	"/.bash_history",
+	"/.zsh_history",
+	"/.ash_history",
+	"/.python_history",
+	"/.mysql_history",
+	"/.psql_history",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1902",
+		Title:    "Error on `ln -s /dev/null <logfile>` — silently discards audit or history writes",
+		Severity: SeverityError,
+		Description: "A symlink from an audit or shell-history path to `/dev/null` turns every " +
+			"subsequent append into a no-op — `/var/log/auth.log`, `wtmp`, `~/.bash_history`, " +
+			"`~/.zsh_history` all stop recording. This is the textbook way to cover tracks on " +
+			"a compromised host and almost never appears in benign automation. If you really " +
+			"need to stop a log, disable the writer (rsyslog rule, `set +o history`) or rotate " +
+			"with `logrotate` — never redirect into `/dev/null`.",
+		Check: checkZC1902,
+	})
+}
+
+func checkZC1902(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ln" {
+		return nil
+	}
+
+	var symbolic bool
+	var source, target string
+	positional := 0
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "-") {
+			if strings.ContainsAny(v, "sS") {
+				symbolic = true
+			}
+			continue
+		}
+		switch positional {
+		case 0:
+			source = v
+		case 1:
+			target = v
+		}
+		positional++
+	}
+	if !symbolic || source != "/dev/null" {
+		return nil
+	}
+	if !zc1902IsSensitive(target) {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1902",
+		Message: "`ln -s /dev/null " + target + "` redirects every write to the " +
+			"bit-bucket — audit / history entries vanish silently. If the log must " +
+			"stop, disable the writer or rotate with `logrotate`, never symlink to `/dev/null`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}
+
+func zc1902IsSensitive(target string) bool {
+	if target == "" {
+		return false
+	}
+	for _, suffix := range zc1902SensitiveTargets {
+		if strings.HasSuffix(target, suffix) || strings.Contains(target, suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 898 Katas = 0.8.98
-const Version = "0.8.98"
+// 899 Katas = 0.8.99
+const Version = "0.8.99"


### PR DESCRIPTION
ZC1902 — Error on `ln -s /dev/null <logfile>`

What: A symlink from an audit or shell-history path to `/dev/null` turns every subsequent append into a no-op.
Why: `/var/log/auth.log`, `wtmp`, `~/.bash_history`, `~/.zsh_history` all stop recording — textbook way to cover tracks on a compromised host.
Fix suggestion: Disable the writer (rsyslog rule, `set +o history`) or rotate with `logrotate`. Never redirect an audit/history path into `/dev/null`.
Severity: Error