### PR TITLE
feat: ZC1903 — detect `tee /etc/sudoers*` unvalidated sudoers write

### DIFF
--- a/pkg/katas/katatests/zc1903_test.go
+++ b/pkg/katas/katatests/zc1903_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1903(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `tee /var/log/app.log`",
+			input:    `tee /var/log/app.log`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `tee /etc/nginx/conf.d/site.conf`",
+			input:    `tee /etc/nginx/conf.d/site.conf`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `tee /etc/sudoers`",
+			input: `tee /etc/sudoers`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1903",
+					Message: "`tee /etc/sudoers` writes a sudoers rule without `visudo -c` validation — a syntax error locks every future `sudo` invocation. Write to a temp file, run `visudo -cf`, then `install -m 0440` into place.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `tee -a /etc/sudoers.d/app`",
+			input: `tee -a /etc/sudoers.d/app`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1903",
+					Message: "`tee /etc/sudoers.d/app` writes a sudoers rule without `visudo -c` validation — a syntax error locks every future `sudo` invocation. Write to a temp file, run `visudo -cf`, then `install -m 0440` into place.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1903")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1903.go
+++ b/pkg/katas/zc1903.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1903",
+		Title:    "Error on `tee /etc/sudoers*` — appends a rule that bypasses `visudo -c` validation",
+		Severity: SeverityError,
+		Description: "`tee /etc/sudoers` or `tee -a /etc/sudoers.d/<name>` is a common shortcut " +
+			"for adding a sudoers rule, but it skips the syntax check that `visudo -c` would " +
+			"perform. A malformed line (missing `ALL`, stray colon, unterminated `Cmnd_Alias`) " +
+			"makes sudo refuse every invocation — you lock yourself out of root recovery. " +
+			"Write the rule to a temporary file, run `visudo -cf /tmp/rule`, and only then " +
+			"`install -m 0440 /tmp/rule /etc/sudoers.d/<name>`.",
+		Check: checkZC1903,
+	})
+}
+
+func checkZC1903(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "tee" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "-") {
+			continue
+		}
+		if zc1903IsSudoersTarget(v) {
+			return []Violation{{
+				KataID: "ZC1903",
+				Message: "`tee " + v + "` writes a sudoers rule without `visudo -c` " +
+					"validation — a syntax error locks every future `sudo` invocation. " +
+					"Write to a temp file, run `visudo -cf`, then `install -m 0440` into place.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}
+
+func zc1903IsSudoersTarget(v string) bool {
+	return v == "/etc/sudoers" || strings.HasPrefix(v, "/etc/sudoers.d/")
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 899 Katas = 0.8.99
-const Version = "0.8.99"
+// 900 Katas = 0.9.0
+const Version = "0.9.0"


### PR DESCRIPTION
ZC1903 — Error on `tee /etc/sudoers*`

What: `tee /etc/sudoers` / `tee -a /etc/sudoers.d/<name>` writes a sudoers rule without running `visudo -c`.
Why: A malformed line makes sudo refuse every invocation — you lock yourself out of root recovery.
Fix suggestion: Write the rule to a temp file, run `visudo -cf /tmp/rule`, then `install -m 0440 /tmp/rule /etc/sudoers.d/<name>`.
Severity: Error