### PR TITLE
feat: ZC1906 — detect `setopt POSIX_CD` altering CDPATH semantics

### DIFF
--- a/pkg/katas/katatests/zc1906_test.go
+++ b/pkg/katas/katatests/zc1906_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1906(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt POSIX_CD` (explicit default)",
+			input:    `unsetopt POSIX_CD`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt AUTO_PUSHD` (unrelated)",
+			input:    `setopt AUTO_PUSHD`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt POSIX_CD`",
+			input: `setopt POSIX_CD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1906",
+					Message: "`setopt POSIX_CD` changes when `cd`/`pushd` read `CDPATH` — scripts that relied on Zsh's default silently enter different directories. Keep it off; wrap POSIX-specific code with `emulate -LR sh`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_POSIX_CD`",
+			input: `unsetopt NO_POSIX_CD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1906",
+					Message: "`unsetopt NO_POSIX_CD` changes when `cd`/`pushd` read `CDPATH` — scripts that relied on Zsh's default silently enter different directories. Keep it off; wrap POSIX-specific code with `emulate -LR sh`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1906")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1906.go
+++ b/pkg/katas/zc1906.go
@@ -1,0 +1,84 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1906",
+		Title:    "Warn on `setopt POSIX_CD` — changes when `cd` / `pushd` consult `CDPATH`",
+		Severity: SeverityWarning,
+		Description: "`setopt POSIX_CD` makes `cd`, `chdir`, and `pushd` skip `CDPATH` for any " +
+			"argument that starts with `/`, `.`, or `..`. Zsh's default — consulting `CDPATH` " +
+			"for anything that does not start with `/` — was exactly what made `cd foo` resolve " +
+			"the \"project\" dir via `CDPATH` even when a local `./foo` existed. Flipping " +
+			"the option globally makes scripts that relied on the Zsh behaviour silently enter " +
+			"different directories. Keep the option off; if POSIX parity is needed, wrap a " +
+			"single function with `emulate -LR sh`.",
+		Check: checkZC1906,
+	})
+}
+
+func checkZC1906(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1906Canonical(arg.String())
+		switch v {
+		case "POSIXCD":
+			if enabling {
+				return zc1906Hit(cmd, "setopt POSIX_CD")
+			}
+		case "NOPOSIXCD":
+			if !enabling {
+				return zc1906Hit(cmd, "unsetopt NO_POSIX_CD")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1906Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1906Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1906",
+		Message: "`" + form + "` changes when `cd`/`pushd` read `CDPATH` — scripts that " +
+			"relied on Zsh's default silently enter different directories. Keep it off; " +
+			"wrap POSIX-specific code with `emulate -LR sh`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 902 Katas = 0.9.2
-const Version = "0.9.2"
+// 903 Katas = 0.9.3
+const Version = "0.9.3"


### PR DESCRIPTION
ZC1906 — Warn on `setopt POSIX_CD`

What: `setopt POSIX_CD` makes `cd`/`chdir`/`pushd` skip `CDPATH` when the argument starts with `/`, `.`, or `..`.
Why: Scripts that relied on Zsh's default (consult `CDPATH` unless the argument is absolute) silently enter different directories.
Fix suggestion: Keep the option off. Scope POSIX-specific code with `emulate -LR sh` instead of toggling globally.
Severity: Warning