### PR TITLE
feat: ZC1907 — detect `sysctl fs.protected_*=0` /tmp-race safeguard removal

### DIFF
--- a/pkg/katas/katatests/zc1907_test.go
+++ b/pkg/katas/katatests/zc1907_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1907(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `sysctl -w fs.protected_symlinks=1` (re-enable)",
+			input:    `sysctl -w fs.protected_symlinks=1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `sysctl -w vm.swappiness=10` (unrelated)",
+			input:    `sysctl -w vm.swappiness=10`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `sysctl -w fs.protected_hardlinks=0`",
+			input: `sysctl -w fs.protected_hardlinks=0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1907",
+					Message: "`sysctl -w fs.protected_hardlinks=0` re-enables hardlink following — classic /tmp-race escalation vector. Keep the default; scope any exception in a dedicated namespace.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `sysctl -w fs.suid_dumpable=2`",
+			input: `sysctl -w fs.suid_dumpable=2`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1907",
+					Message: "`sysctl -w fs.suid_dumpable=2` re-enables SUID core-dump exposure (2 = root-readable) — classic /tmp-race escalation vector. Keep the default; scope any exception in a dedicated namespace.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1907")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1907.go
+++ b/pkg/katas/zc1907.go
@@ -1,0 +1,74 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+// zc1907Weak lists the fs.protected_* + fs.suid_dumpable values that roll back
+// kernel safeguards against /tmp-race / hardlink-escalation / FIFO-owner
+// symlink-attack patterns.
+var zc1907Weak = map[string]string{
+	"fs.protected_hardlinks=0": "hardlink following",
+	"fs.protected_symlinks=0":  "symlink following in world-writable dirs",
+	"fs.protected_fifos=0":     "FIFO open in world-writable dirs",
+	"fs.protected_regular=0":   "regular-file open in world-writable dirs",
+	"fs.suid_dumpable=1":       "SUID core-dump exposure (1 = group-only)",
+	"fs.suid_dumpable=2":       "SUID core-dump exposure (2 = root-readable)",
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1907",
+		Title:    "Warn on `sysctl -w fs.protected_*=0` / `fs.suid_dumpable=2` — disables /tmp-race safeguards",
+		Severity: SeverityWarning,
+		Description: "Linux ships `fs.protected_symlinks`, `fs.protected_hardlinks`, " +
+			"`fs.protected_fifos`, and `fs.protected_regular` enabled to stop classic " +
+			"`/tmp`-race escalation (dangling-symlink, hardlink-pivot, FIFO-open-owner). " +
+			"Setting any of them to `0`, or raising `fs.suid_dumpable` above `0`, hands " +
+			"unprivileged local users back the primitives. Keep the defaults; if a legacy " +
+			"tool genuinely needs them off, scope the change inside a namespace rather than " +
+			"flipping the host knob.",
+		Check: checkZC1907,
+	})
+}
+
+func checkZC1907(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "sysctl" {
+		return nil
+	}
+
+	var writing bool
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-w" || v == "--write" {
+			writing = true
+			continue
+		}
+		if strings.HasPrefix(v, "-") {
+			continue
+		}
+		pair := strings.ReplaceAll(v, " ", "")
+		if reason, ok := zc1907Weak[pair]; ok && writing {
+			return []Violation{{
+				KataID: "ZC1907",
+				Message: "`sysctl -w " + pair + "` re-enables " + reason + " — classic " +
+					"/tmp-race escalation vector. Keep the default; scope any exception in " +
+					"a dedicated namespace.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 903 Katas = 0.9.3
-const Version = "0.9.3"
+// 904 Katas = 0.9.4
+const Version = "0.9.4"


### PR DESCRIPTION
ZC1907 — Warn on `sysctl -w fs.protected_*=0` / `fs.suid_dumpable=2`

What: Disabling `fs.protected_symlinks`, `fs.protected_hardlinks`, `fs.protected_fifos`, `fs.protected_regular`, or raising `fs.suid_dumpable` above `0`.
Why: Restores classic /tmp-race escalation primitives (dangling-symlink, hardlink-pivot, FIFO-open-owner, SUID core dumps).
Fix suggestion: Keep the defaults on. If a legacy tool needs them off, scope the change inside a namespace.
Severity: Warning