### PR TITLE
feat: ZC1909 — detect `kexec -l/-e` bypassing bootloader Secure Boot

### DIFF
--- a/pkg/katas/katatests/zc1909_test.go
+++ b/pkg/katas/katatests/zc1909_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1909(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `kexec --help`",
+			input:    `kexec --help`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `kexec -h`",
+			input:    `kexec -h`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `kexec -l $KERN`",
+			input: `kexec -l $KERN`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1909",
+					Message: "`kexec -l` stages or jumps to a kernel without firmware / bootloader verification — Secure Boot never checks the signature. Gate behind `sudo` + audit and prefer `systemctl kexec` or a real reboot.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `kexec -e` (execute)",
+			input: `kexec -e`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1909",
+					Message: "`kexec -e` stages or jumps to a kernel without firmware / bootloader verification — Secure Boot never checks the signature. Gate behind `sudo` + audit and prefer `systemctl kexec` or a real reboot.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1909")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1909.go
+++ b/pkg/katas/zc1909.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1909",
+		Title:    "Warn on `kexec -l` / `-e` — jumps to an alternate kernel, bypasses bootloader and Secure Boot",
+		Severity: SeverityWarning,
+		Description: "`kexec -l /path/to/vmlinuz …` stages a second kernel image, and `kexec -e` " +
+			"(or `kexec -f`) then transfers control to it without going through the firmware, " +
+			"GRUB, or shim. On a Secure-Boot system the staged kernel is never verified against " +
+			"the enrolled MOK/PK — an attacker who lands a root exec can boot a hostile kernel " +
+			"while leaving /boot untouched. Reserve `kexec` for the live-patching / crash-dump " +
+			"workflow it was designed for, gate the call behind `sudo` + audit, and prefer " +
+			"`systemctl kexec` or a normal reboot when possible.",
+		Check: checkZC1909,
+	})
+}
+
+func checkZC1909(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value == "load" || ident.Value == "exec" || ident.Value == "unload" {
+		// Parser caveat: `kexec --load X` mangles to name=`load`.
+		return zc1909Hit(cmd, "kexec --"+ident.Value)
+	}
+	if ident.Value != "kexec" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "-l", "-e", "-f", "-p":
+			return zc1909Hit(cmd, "kexec "+v)
+		case "--load", "--exec", "--force", "--load-panic":
+			return zc1909Hit(cmd, "kexec "+v)
+		}
+	}
+	return nil
+}
+
+func zc1909Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1909",
+		Message: "`" + form + "` stages or jumps to a kernel without firmware / " +
+			"bootloader verification — Secure Boot never checks the signature. Gate behind " +
+			"`sudo` + audit and prefer `systemctl kexec` or a real reboot.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 905 Katas = 0.9.5
-const Version = "0.9.5"
+// 906 Katas = 0.9.6
+const Version = "0.9.6"


### PR DESCRIPTION
ZC1909 — Warn on `kexec -l` / `-e`

What: `kexec -l /path/vmlinuz` stages an alternate kernel; `kexec -e` transfers control to it.
Why: The staged kernel is never verified against enrolled MOK/PK — an attacker who lands root can boot a hostile kernel while leaving /boot untouched.
Fix suggestion: Reserve `kexec` for live-patching / crash-dump flows. Gate behind `sudo` + audit, prefer `systemctl kexec` or a real reboot.
Severity: Warning