### PR TITLE
feat: ZC1910 — detect `setopt GLOB_STAR_SHORT` bare-`**` recursion

### DIFF
--- a/pkg/katas/katatests/zc1910_test.go
+++ b/pkg/katas/katatests/zc1910_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1910(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt GLOB_STAR_SHORT` (explicit default)",
+			input:    `unsetopt GLOB_STAR_SHORT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt EXTENDED_GLOB` (unrelated)",
+			input:    `setopt EXTENDED_GLOB`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt GLOB_STAR_SHORT`",
+			input: `setopt GLOB_STAR_SHORT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1910",
+					Message: "`setopt GLOB_STAR_SHORT` turns bare `**` into `**/*` — `rm **` now wipes the tree. Keep the option off and spell `**/*` when recursion is actually wanted.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_GLOB_STAR_SHORT`",
+			input: `unsetopt NO_GLOB_STAR_SHORT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1910",
+					Message: "`unsetopt NO_GLOB_STAR_SHORT` turns bare `**` into `**/*` — `rm **` now wipes the tree. Keep the option off and spell `**/*` when recursion is actually wanted.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1910")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1910.go
+++ b/pkg/katas/zc1910.go
@@ -1,0 +1,82 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1910",
+		Title:    "Warn on `setopt GLOB_STAR_SHORT` — makes bare `**` recurse instead of matching literal",
+		Severity: SeverityWarning,
+		Description: "`GLOB_STAR_SHORT` teaches Zsh to expand bare `**` (not followed by `/`) as if " +
+			"it were `**/*` — suddenly `rm **` wipes every file under the current directory " +
+			"instead of erroring or matching the two-star literal. Scripts that pass `**` as a " +
+			"literal argument to `grep`, `sed`, or a logger call silently turn into deep " +
+			"directory recursions. Keep the option off; when you really need recursive globs, " +
+			"spell `**/*` explicitly so reviewers can see the intent.",
+		Check: checkZC1910,
+	})
+}
+
+func checkZC1910(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1910Canonical(arg.String())
+		switch v {
+		case "GLOBSTARSHORT":
+			if enabling {
+				return zc1910Hit(cmd, "setopt GLOB_STAR_SHORT")
+			}
+		case "NOGLOBSTARSHORT":
+			if !enabling {
+				return zc1910Hit(cmd, "unsetopt NO_GLOB_STAR_SHORT")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1910Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1910Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1910",
+		Message: "`" + form + "` turns bare `**` into `**/*` — `rm **` now wipes the tree. " +
+			"Keep the option off and spell `**/*` when recursion is actually wanted.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 906 Katas = 0.9.6
-const Version = "0.9.6"
+// 907 Katas = 0.9.7
+const Version = "0.9.7"


### PR DESCRIPTION
ZC1910 — Warn on `setopt GLOB_STAR_SHORT`

What: `GLOB_STAR_SHORT` expands bare `**` (not followed by `/`) as if it were `**/*`.
Why: `rm **` / `grep -l '**'` suddenly recurse into the whole tree. Literal `**` arguments silently become deep globs.
Fix suggestion: Keep the option off. Spell `**/*` explicitly when recursion is actually wanted.
Severity: Warning