### PR TITLE
feat: ZC1911 — detect `umount -l` lazy-unmount ghost fds

### DIFF
--- a/pkg/katas/katatests/zc1911_test.go
+++ b/pkg/katas/katatests/zc1911_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1911(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `umount /mnt/scratch`",
+			input:    `umount /mnt/scratch`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `umount -f /mnt/stuck` (force, not lazy)",
+			input:    `umount -f /mnt/stuck`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `umount -l /mnt/scratch`",
+			input: `umount -l /mnt/scratch`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1911",
+					Message: "`umount -l` detaches the mount but leaves any open fd pointing at a ghost filesystem — writers keep writing, re-mounts stack invisibly. Stop the fd holder first (`lsof`/`fuser`), then do a normal `umount`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `umount --lazy /mnt/scratch`",
+			input: `umount --lazy /mnt/scratch`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1911",
+					Message: "`umount --lazy` detaches the mount but leaves any open fd pointing at a ghost filesystem — writers keep writing, re-mounts stack invisibly. Stop the fd holder first (`lsof`/`fuser`), then do a normal `umount`.",
+					Line:    1,
+					Column:  10,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1911")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1911.go
+++ b/pkg/katas/zc1911.go
@@ -1,0 +1,69 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1911",
+		Title:    "Warn on `umount -l` / `--lazy` — detach now, leaves open fds pointing at a ghost mount",
+		Severity: SeverityWarning,
+		Description: "`umount -l` (lazy unmount) detaches the filesystem from the directory tree " +
+			"immediately but defers the real cleanup until every open file descriptor on it is " +
+			"closed. Any process still holding an fd keeps reading/writing into a mount that " +
+			"`mount | grep` no longer lists — cron jobs drop logs into a phantom directory, a " +
+			"re-mount of the same path stacks invisibly, and `lsof`/`fuser` often miss the " +
+			"stale handles. Find and stop the holder (`lsof`/`fuser`/`systemd-cgls`) first, " +
+			"then do a normal `umount`; reserve `-l` for break-glass recovery, not scripts.",
+		Check: checkZC1911,
+	})
+}
+
+func checkZC1911(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	// Parser caveat: `umount --lazy MOUNT` mangles the command name to `lazy`.
+	if ident.Value == "lazy" {
+		return zc1911Hit(cmd, "--lazy")
+	}
+	if ident.Value != "umount" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-l" || v == "--lazy" {
+			return zc1911Hit(cmd, v)
+		}
+		if strings.HasPrefix(v, "-") && !strings.HasPrefix(v, "--") {
+			// Clustered short flags, e.g. `-fl` / `-lf`.
+			for i := 1; i < len(v); i++ {
+				if v[i] == 'l' {
+					return zc1911Hit(cmd, "-l")
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func zc1911Hit(cmd *ast.SimpleCommand, flag string) []Violation {
+	return []Violation{{
+		KataID: "ZC1911",
+		Message: "`umount " + flag + "` detaches the mount but leaves any open fd pointing at " +
+			"a ghost filesystem — writers keep writing, re-mounts stack invisibly. Stop the " +
+			"fd holder first (`lsof`/`fuser`), then do a normal `umount`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 907 Katas = 0.9.7
-const Version = "0.9.7"
+// 908 Katas = 0.9.8
+const Version = "0.9.8"


### PR DESCRIPTION
ZC1911 — Warn on `umount -l` / `--lazy`

What: Lazy unmount detaches the filesystem from the tree now, defers real cleanup until every open fd closes.
Why: Writers keep writing into a phantom mount, re-mounts stack invisibly, and `lsof`/`fuser` often miss the stale handles.
Fix suggestion: Stop the fd holder first (`lsof`/`fuser`/`systemd-cgls`), then do a normal `umount`. Reserve `-l` for break-glass.
Severity: Warning