### PR TITLE
feat: ZC1912 — detect `dhclient -r`/`dhcpcd -k` dropping DHCP lease

### DIFF
--- a/pkg/katas/katatests/zc1912_test.go
+++ b/pkg/katas/katatests/zc1912_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1912(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `dhclient eth0` (renew)",
+			input:    `dhclient eth0`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `dhcpcd --rebind eth0`",
+			input:    `dhcpcd --rebind eth0`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `dhclient -r eth0`",
+			input: `dhclient -r eth0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1912",
+					Message: "`dhclient -r` drops the DHCP lease — SSH session cuts, VPC reachability stalls. Pair with a re-acquire (`dhclient -1`/`nmcli device reapply`), or schedule via `systemd-run --on-active=`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `dhcpcd -k eth0`",
+			input: `dhcpcd -k eth0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1912",
+					Message: "`dhcpcd -k` drops the DHCP lease — SSH session cuts, VPC reachability stalls. Pair with a re-acquire (`dhclient -1`/`nmcli device reapply`), or schedule via `systemd-run --on-active=`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1912")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1912.go
+++ b/pkg/katas/zc1912.go
@@ -1,0 +1,62 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1912",
+		Title:    "Warn on `dhclient -r` / `dhclient -x` / `dhcpcd -k` — drops the lease and breaks network",
+		Severity: SeverityWarning,
+		Description: "`dhclient -r` releases the current DHCP lease (sending a DHCPRELEASE), " +
+			"`dhclient -x` terminates the daemon without releasing, and `dhcpcd -k` does the " +
+			"equivalent for dhcpcd. On a remote host the very next thing that happens is the " +
+			"SSH session drops, and in a VPC any automation waiting for a reply never sees " +
+			"one. Stage the release together with a re-acquire (`dhclient -1 $iface` or " +
+			"`nmcli device reapply $iface`) or schedule it via `systemd-run --on-active=` " +
+			"so the operator is not cut off mid-session.",
+		Check: checkZC1912,
+	})
+}
+
+func checkZC1912(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "dhclient":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "-r" || v == "-x" || v == "--release" {
+				return zc1912Hit(cmd, "dhclient "+v)
+			}
+		}
+	case "dhcpcd":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "-k" || v == "--release" {
+				return zc1912Hit(cmd, "dhcpcd "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1912Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1912",
+		Message: "`" + form + "` drops the DHCP lease — SSH session cuts, VPC " +
+			"reachability stalls. Pair with a re-acquire (`dhclient -1`/`nmcli device " +
+			"reapply`), or schedule via `systemd-run --on-active=`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 908 Katas = 0.9.8
-const Version = "0.9.8"
+// 909 Katas = 0.9.9
+const Version = "0.9.9"


### PR DESCRIPTION
ZC1912 — Warn on `dhclient -r`/`-x` / `dhcpcd -k`

What: Releases or terminates the DHCP lease from inside a script.
Why: On a remote host the next thing that happens is the SSH session drops; VPC automation waiting on a reply never sees one.
Fix suggestion: Pair with a re-acquire (`dhclient -1` / `nmcli device reapply`), or schedule via `systemd-run --on-active=` so the operator is not cut off.
Severity: Warning