### PR TITLE
feat: ZC1913 — detect `setopt ALIAS_FUNC_DEF` function/alias shadowing

### DIFF
--- a/pkg/katas/katatests/zc1913_test.go
+++ b/pkg/katas/katatests/zc1913_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1913(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt ALIAS_FUNC_DEF` (explicit default)",
+			input:    `unsetopt ALIAS_FUNC_DEF`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt AUTO_CD` (unrelated)",
+			input:    `setopt AUTO_CD`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt ALIAS_FUNC_DEF`",
+			input: `setopt ALIAS_FUNC_DEF`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1913",
+					Message: "`setopt ALIAS_FUNC_DEF` lets a function silently shadow an alias — one sourced rc file replaces your function with the alias, no error surfaces. Keep it off; quote the name if the override is intentional.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_ALIAS_FUNC_DEF`",
+			input: `unsetopt NO_ALIAS_FUNC_DEF`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1913",
+					Message: "`unsetopt NO_ALIAS_FUNC_DEF` lets a function silently shadow an alias — one sourced rc file replaces your function with the alias, no error surfaces. Keep it off; quote the name if the override is intentional.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1913")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1913.go
+++ b/pkg/katas/zc1913.go
@@ -1,0 +1,84 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1913",
+		Title:    "Warn on `setopt ALIAS_FUNC_DEF` — re-enables defining functions with aliased names",
+		Severity: SeverityWarning,
+		Description: "Zsh's default refuses the syntax `ls () { … }` when `ls` is aliased — " +
+			"because the alias expands at definition time and the function the author meant " +
+			"to write never actually exists. `setopt ALIAS_FUNC_DEF` disables that guardrail: " +
+			"the alias is suppressed during definition, and the function silently shadows the " +
+			"alias afterwards. The combination is almost always a bug — one alias in a sourced " +
+			"rc file quietly replaces the function. Keep the option off and write " +
+			"`function \\ls () { … }` (quoted) if you really need to override an aliased name.",
+		Check: checkZC1913,
+	})
+}
+
+func checkZC1913(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1913Canonical(arg.String())
+		switch v {
+		case "ALIASFUNCDEF":
+			if enabling {
+				return zc1913Hit(cmd, "setopt ALIAS_FUNC_DEF")
+			}
+		case "NOALIASFUNCDEF":
+			if !enabling {
+				return zc1913Hit(cmd, "unsetopt NO_ALIAS_FUNC_DEF")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1913Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1913Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1913",
+		Message: "`" + form + "` lets a function silently shadow an alias — one sourced " +
+			"rc file replaces your function with the alias, no error surfaces. Keep it " +
+			"off; quote the name if the override is intentional.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 909 Katas = 0.9.9
-const Version = "0.9.9"
+// 910 Katas = 0.9.10
+const Version = "0.9.10"


### PR DESCRIPTION
ZC1913 — Warn on `setopt ALIAS_FUNC_DEF`

What: `setopt ALIAS_FUNC_DEF` disables the default guardrail that refuses `name () { … }` when `name` is aliased.
Why: The alias is suppressed at definition time, and the function silently shadows the alias afterwards — one sourced rc file replaces the function with the alias.
Fix suggestion: Keep the option off. If the override is intentional, quote the name.
Severity: Warning