### PR TITLE
feat: ZC1914 — detect `curl --doh-url`/`--dns-servers` resolver bypass

### DIFF
--- a/pkg/katas/katatests/zc1914_test.go
+++ b/pkg/katas/katatests/zc1914_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1914(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `curl https://api.example/resource`",
+			input:    `curl https://api.example/resource`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `curl --resolve api:443:10.0.0.1 https://api/`",
+			input:    `curl --resolve api:443:10.0.0.1 https://api/`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `curl https://api/ --doh-url=https://doh/dns-query`",
+			input: `curl https://api/ --doh-url=https://doh/dns-query`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1914",
+					Message: "`curl --doh-url` bypasses the host's resolver chain — `/etc/hosts`, `systemd-resolved`, split-horizon DNS — so the request lands at an IP the operator did not vet. Drop the flag or pair it with `--resolve` pinning.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `curl https://api/ --dns-servers=1.1.1.1`",
+			input: `curl https://api/ --dns-servers=1.1.1.1`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1914",
+					Message: "`curl --dns-servers` bypasses the host's resolver chain — `/etc/hosts`, `systemd-resolved`, split-horizon DNS — so the request lands at an IP the operator did not vet. Drop the flag or pair it with `--resolve` pinning.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1914")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1914.go
+++ b/pkg/katas/zc1914.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1914",
+		Title:    "Warn on `curl --doh-url …` / `--dns-servers …` — overrides system resolver per-request",
+		Severity: SeverityWarning,
+		Description: "`curl --doh-url https://doh.example/dns-query` routes the lookup through a " +
+			"caller-specified DNS-over-HTTPS endpoint; `curl --dns-servers 1.1.1.1,8.8.8.8` " +
+			"forces classic UDP to the listed servers. Both detour around the host's resolver " +
+			"chain — `/etc/hosts`, `systemd-resolved`, `nsswitch`, split-horizon DNS — so the " +
+			"request lands at an IP the operator did not vet. In production scripts that is " +
+			"usually a mis-debug line left in; drop the flag or gate it behind an explicit " +
+			"`--doh-insecure` + `--resolve` pinning audit so reviewers can see the intent.",
+		Check: checkZC1914,
+	})
+}
+
+func checkZC1914(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `curl --doh-url https://…` may mangle the name.
+	switch ident.Value {
+	case "doh-url":
+		return zc1914Hit(cmd, "--doh-url")
+	case "dns-servers":
+		return zc1914Hit(cmd, "--dns-servers")
+	case "curl":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			switch {
+			case v == "--doh-url", strings.HasPrefix(v, "--doh-url="):
+				return zc1914Hit(cmd, "--doh-url")
+			case v == "--dns-servers", strings.HasPrefix(v, "--dns-servers="):
+				return zc1914Hit(cmd, "--dns-servers")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1914Hit(cmd *ast.SimpleCommand, flag string) []Violation {
+	return []Violation{{
+		KataID: "ZC1914",
+		Message: "`curl " + flag + "` bypasses the host's resolver chain — `/etc/hosts`, " +
+			"`systemd-resolved`, split-horizon DNS — so the request lands at an IP the " +
+			"operator did not vet. Drop the flag or pair it with `--resolve` pinning.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 910 Katas = 0.9.10
-const Version = "0.9.10"
+// 911 Katas = 0.9.11
+const Version = "0.9.11"


### PR DESCRIPTION
ZC1914 — Warn on `curl --doh-url`/`--dns-servers`

What: `--doh-url` and `--dns-servers` make curl route lookups through a caller-specified DNS endpoint.
Why: The detour skips `/etc/hosts`, `systemd-resolved`, `nsswitch`, and split-horizon DNS — the request lands at an IP the operator did not vet.
Fix suggestion: Drop the flag, or pair it with explicit `--resolve` pinning + `--doh-insecure` audit.
Severity: Warning