### PR TITLE
feat: ZC1915 — detect `mdadm --zero-superblock`/`-S` RAID destruction

### DIFF
--- a/pkg/katas/katatests/zc1915_test.go
+++ b/pkg/katas/katatests/zc1915_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1915(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `mdadm --detail $MD` (read only)",
+			input:    `mdadm --detail $MD`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `mdadm --examine $DISK` (read only)",
+			input:    `mdadm --examine $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `mdadm --zero-superblock $DISK` (mangled)",
+			input: `mdadm --zero-superblock $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1915",
+					Message: "`mdadm --zero-superblock` drops RAID metadata or halts a live array — mounted root or /boot panics the host; a stale superblock scrambles data on next `--create`. Snapshot `mdadm --detail --export` first and keep behind a runbook.",
+					Line:    1,
+					Column:  9,
+				},
+			},
+		},
+		{
+			name:  "invalid — `mdadm -S $MD` (stop array)",
+			input: `mdadm -S $MD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1915",
+					Message: "`mdadm -S` drops RAID metadata or halts a live array — mounted root or /boot panics the host; a stale superblock scrambles data on next `--create`. Snapshot `mdadm --detail --export` first and keep behind a runbook.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1915")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1915.go
+++ b/pkg/katas/zc1915.go
@@ -1,0 +1,64 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1915",
+		Title:    "Error on `mdadm --zero-superblock` / `--stop` — drops RAID metadata or live array",
+		Severity: SeverityError,
+		Description: "`mdadm --zero-superblock $DEV` wipes the MD superblock from a member — the " +
+			"array forgets the device exists and a subsequent `--create` with the wrong layout " +
+			"permanently scrambles the data. `mdadm --stop $MD` (or `-S`) halts a live array " +
+			"from underneath whatever is mounted on it; if root or `/boot` lives there the host " +
+			"panics on the next fsync. Run `mdadm --examine` first, snapshot the superblock " +
+			"with `mdadm --detail --export`, and keep both calls behind a runbook rather than " +
+			"an automated script.",
+		Check: checkZC1915,
+	})
+}
+
+func checkZC1915(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `mdadm --zero-superblock $DEV` mangles the command
+	// name to `zero-superblock`.
+	switch ident.Value {
+	case "zero-superblock":
+		return zc1915Hit(cmd, "mdadm --zero-superblock")
+	case "mdadm":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			switch v {
+			case "--zero-superblock":
+				return zc1915Hit(cmd, "mdadm --zero-superblock")
+			case "-S", "--stop":
+				return zc1915Hit(cmd, "mdadm "+v)
+			case "--remove":
+				return zc1915Hit(cmd, "mdadm --remove")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1915Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1915",
+		Message: "`" + form + "` drops RAID metadata or halts a live array — mounted root " +
+			"or /boot panics the host; a stale superblock scrambles data on next `--create`. " +
+			"Snapshot `mdadm --detail --export` first and keep behind a runbook.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 911 Katas = 0.9.11
-const Version = "0.9.11"
+// 912 Katas = 0.9.12
+const Version = "0.9.12"


### PR DESCRIPTION
ZC1915 — Error on `mdadm --zero-superblock` / `-S`

What: `mdadm --zero-superblock` wipes MD metadata from a member; `mdadm -S` halts a live array.
Why: A subsequent `--create` with the wrong layout permanently scrambles data; stopping a mounted array panics the host if root/boot lives on it.
Fix suggestion: Snapshot `mdadm --detail --export` first, run `--examine` for sanity, and keep both calls behind a runbook.
Severity: Error