### PR TITLE
feat: ZC1916 — detect `setopt NULL_GLOB` silencing every unmatched glob

### DIFF
--- a/pkg/katas/katatests/zc1916_test.go
+++ b/pkg/katas/katatests/zc1916_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1916(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt NULL_GLOB` (explicit default)",
+			input:    `unsetopt NULL_GLOB`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt EXTENDED_GLOB` (unrelated)",
+			input:    `setopt EXTENDED_GLOB`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt NULL_GLOB`",
+			input: `setopt NULL_GLOB`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1916",
+					Message: "`setopt NULL_GLOB` makes every later unmatched glob silently empty — `cp *.log /dest` mis-targets, `rm *.tmp` errors as argv-too-short. Use per-glob `*(N)`, or scope inside a function with `setopt LOCAL_OPTIONS NULL_GLOB`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_NULL_GLOB`",
+			input: `unsetopt NO_NULL_GLOB`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1916",
+					Message: "`unsetopt NO_NULL_GLOB` makes every later unmatched glob silently empty — `cp *.log /dest` mis-targets, `rm *.tmp` errors as argv-too-short. Use per-glob `*(N)`, or scope inside a function with `setopt LOCAL_OPTIONS NULL_GLOB`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1916")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1916.go
+++ b/pkg/katas/zc1916.go
@@ -1,0 +1,84 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1916",
+		Title:    "Warn on `setopt NULL_GLOB` — every unmatched glob silently expands to nothing",
+		Severity: SeverityWarning,
+		Description: "`setopt NULL_GLOB` removes the Zsh default behaviour of erroring out when a " +
+			"pattern matches nothing. Every later glob becomes silently empty instead — " +
+			"`cp *.log /dest` when no `.log` files exist turns into `cp /dest` (wrong target), " +
+			"`rm *.tmp` into `rm` (argv too short), and `for f in *.json` into a no-op. Reach " +
+			"for the per-glob `*(N)` qualifier when you want a single pattern to tolerate a " +
+			"zero match, or scope the switch with `setopt LOCAL_OPTIONS NULL_GLOB` inside the " +
+			"one function that needs it.",
+		Check: checkZC1916,
+	})
+}
+
+func checkZC1916(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1916Canonical(arg.String())
+		switch v {
+		case "NULLGLOB":
+			if enabling {
+				return zc1916Hit(cmd, "setopt NULL_GLOB")
+			}
+		case "NONULLGLOB":
+			if !enabling {
+				return zc1916Hit(cmd, "unsetopt NO_NULL_GLOB")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1916Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1916Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1916",
+		Message: "`" + form + "` makes every later unmatched glob silently empty — " +
+			"`cp *.log /dest` mis-targets, `rm *.tmp` errors as argv-too-short. Use per-glob " +
+			"`*(N)`, or scope inside a function with `setopt LOCAL_OPTIONS NULL_GLOB`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 912 Katas = 0.9.12
-const Version = "0.9.12"
+// 913 Katas = 0.9.13
+const Version = "0.9.13"


### PR DESCRIPTION
ZC1916 — Warn on `setopt NULL_GLOB`

What: `setopt NULL_GLOB` removes Zsh's default behaviour of erroring on unmatched globs; every later pattern silently expands to nothing.
Why: `cp *.log /dest` becomes `cp /dest` (wrong target), `rm *.tmp` becomes `rm` (argv too short), `for f in *.json` silently no-ops.
Fix suggestion: Use the per-glob `*(N)` qualifier when a single pattern can be empty. Or scope with `setopt LOCAL_OPTIONS NULL_GLOB` inside one function.
Severity: Warning