### PR TITLE
feat: ZC1917 — detect `iw dev $IF scan` active WiFi probe from scripts

### DIFF
--- a/pkg/katas/katatests/zc1917_test.go
+++ b/pkg/katas/katatests/zc1917_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1917(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `iw dev wlan0 link` (passive link info)",
+			input:    `iw dev wlan0 link`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `iwlist wlan0 channel`",
+			input:    `iwlist wlan0 channel`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `iw dev wlan0 scan`",
+			input: `iw dev wlan0 scan`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1917",
+					Message: "`iw dev <if> scan` runs an active probe-request sweep — interrupts the current association and broadcasts the host to every nearby AP. Use cached `iw dev $IF link` for passive queries.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `iwlist wlan0 scanning`",
+			input: `iwlist wlan0 scanning`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1917",
+					Message: "`iwlist <if> scan` runs an active probe-request sweep — interrupts the current association and broadcasts the host to every nearby AP. Use cached `iw dev $IF link` for passive queries.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1917")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1917.go
+++ b/pkg/katas/zc1917.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1917",
+		Title:    "Info on `iw dev $IF scan` / `iwlist $IF scan` — active WiFi scan from a script",
+		Severity: SeverityInfo,
+		Description: "`iw dev wlan0 scan` (and the older `iwlist wlan0 scan`) performs an active " +
+			"probe-request sweep across every supported channel. It requires `CAP_NET_ADMIN`, " +
+			"briefly interrupts the current association, and announces the host's presence to " +
+			"every nearby access point — logs on the other side will show one MAC asking " +
+			"about every SSID. Use the cached `iw dev $IF link` / `iwctl station $IF show` " +
+			"for passive lookups, and reserve `scan` for diagnostic sessions with console " +
+			"approval rather than background scripts.",
+		Check: checkZC1917,
+	})
+}
+
+func checkZC1917(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "iw":
+		if zc1917HasSubcmd(cmd, "scan") {
+			return zc1917Hit(cmd, "iw dev <if> scan")
+		}
+	case "iwlist":
+		if zc1917HasSubcmd(cmd, "scan") || zc1917HasSubcmd(cmd, "scanning") {
+			return zc1917Hit(cmd, "iwlist <if> scan")
+		}
+	}
+	return nil
+}
+
+func zc1917HasSubcmd(cmd *ast.SimpleCommand, sub string) bool {
+	for _, arg := range cmd.Arguments {
+		if arg.String() == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func zc1917Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1917",
+		Message: "`" + form + "` runs an active probe-request sweep — interrupts the " +
+			"current association and broadcasts the host to every nearby AP. Use cached " +
+			"`iw dev $IF link` for passive queries.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityInfo,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 913 Katas = 0.9.13
-const Version = "0.9.13"
+// 914 Katas = 0.9.14
+const Version = "0.9.14"


### PR DESCRIPTION
ZC1917 — Info on `iw dev scan` / `iwlist scanning`

What: Active WiFi probe-request sweep from a script, requires `CAP_NET_ADMIN`.
Why: Interrupts the current association, broadcasts the host's MAC to every nearby AP, and pollutes logs on the other side.
Fix suggestion: Use cached `iw dev $IF link` / `iwctl station $IF show` for passive lookups. Reserve `scan` for console-approved diagnostics.
Severity: Info