### PR TITLE
feat: ZC1919 — detect `ss -K`/`--kill` socket termination

### DIFF
--- a/pkg/katas/katatests/zc1919_test.go
+++ b/pkg/katas/katatests/zc1919_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1919(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ss -tunlp` (read-only socket list)",
+			input:    `ss -tunlp`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ss state established` (preview)",
+			input:    `ss state established`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ss -K state close-wait`",
+			input: `ss -K state close-wait`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1919",
+					Message: "`ss -K` terminates every socket the filter matches — broad filters (`state established`, `dport 22`) kill the running SSH session. Preview with the same filter minus `-K`, and pin to a specific dst/port/state tuple.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ss --kill state established`",
+			input: `ss --kill state established`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1919",
+					Message: "`ss -K` terminates every socket the filter matches — broad filters (`state established`, `dport 22`) kill the running SSH session. Preview with the same filter minus `-K`, and pin to a specific dst/port/state tuple.",
+					Line:    1,
+					Column:  6,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1919")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1919.go
+++ b/pkg/katas/zc1919.go
@@ -1,0 +1,80 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1919",
+		Title:    "Warn on `ss -K` / `ss --kill` — terminates every socket that matches the filter",
+		Severity: SeverityWarning,
+		Description: "`ss -K` issues `SOCK_DESTROY` to every socket matching the filter (requires " +
+			"`CAP_NET_ADMIN`). With a broad filter — `ss -K state established`, `ss -K dport 22` " +
+			"— the command happily terminates the SSH session that is running it, along with " +
+			"every backend keep-alive that happens to match. Spell the filter tightly " +
+			"(`ss -K dst 10.0.0.5 dport 5432 state close-wait`), test it first without `-K` " +
+			"to confirm only the target sockets appear, and wrap the call in a review step " +
+			"rather than a scheduled job.",
+		Check: checkZC1919,
+	})
+}
+
+func checkZC1919(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	// Parser caveat: `ss --kill <filter>` mangles the command name to `kill`.
+	if ident.Value == "kill" {
+		for _, arg := range cmd.Arguments {
+			if arg.String() == "state" || arg.String() == "dst" || arg.String() == "src" ||
+				arg.String() == "dport" || arg.String() == "sport" {
+				return zc1919Hit(cmd)
+			}
+		}
+	}
+	if ident.Value != "ss" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-K" || v == "--kill" {
+			return zc1919Hit(cmd)
+		}
+		if len(v) >= 2 && v[0] == '-' && v[1] != '-' {
+			for i := 1; i < len(v); i++ {
+				if v[i] == 'K' {
+					return []Violation{{
+						KataID: "ZC1919",
+						Message: "`ss -K` terminates every socket the filter matches — " +
+							"broad filters (`state established`, `dport 22`) kill the running SSH " +
+							"session. Preview with the same filter minus `-K`, and pin to a specific " +
+							"dst/port/state tuple.",
+						Line:   cmd.Token.Line,
+						Column: cmd.Token.Column,
+						Level:  SeverityWarning,
+					}}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func zc1919Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1919",
+		Message: "`ss -K` terminates every socket the filter matches — broad filters " +
+			"(`state established`, `dport 22`) kill the running SSH session. Preview " +
+			"with the same filter minus `-K`, and pin to a specific dst/port/state tuple.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 915 Katas = 0.9.15
-const Version = "0.9.15"
+// 916 Katas = 0.9.16
+const Version = "0.9.16"


### PR DESCRIPTION
ZC1919 — Warn on `ss -K` / `--kill`

What: Issues `SOCK_DESTROY` to every socket matching the filter.
Why: Broad filters (`state established`, `dport 22`) happily terminate the SSH session that is running the command, along with every backend keep-alive that matches.
Fix suggestion: Preview with the same filter minus `-K` first; pin to a specific `dst`/`dport`/`state` tuple; gate behind review, not automation.
Severity: Warning