### PR TITLE
feat: ZC1920 — detect `setopt VERBOSE` command-echo leak to stderr

### DIFF
--- a/pkg/katas/katatests/zc1920_test.go
+++ b/pkg/katas/katatests/zc1920_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1920(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt VERBOSE` (explicit default)",
+			input:    `unsetopt VERBOSE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt EXTENDED_HISTORY` (unrelated)",
+			input:    `setopt EXTENDED_HISTORY`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt VERBOSE`",
+			input: `setopt VERBOSE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1920",
+					Message: "`setopt VERBOSE` echoes every executed command to stderr — any line that mentions a password, token, or API key leaks with the trace. Remove and use `printf` / a logger, or scope via `setopt LOCAL_OPTIONS VERBOSE` in a helper.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_VERBOSE`",
+			input: `unsetopt NO_VERBOSE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1920",
+					Message: "`unsetopt NO_VERBOSE` echoes every executed command to stderr — any line that mentions a password, token, or API key leaks with the trace. Remove and use `printf` / a logger, or scope via `setopt LOCAL_OPTIONS VERBOSE` in a helper.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1920")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1920.go
+++ b/pkg/katas/zc1920.go
@@ -1,0 +1,85 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1920",
+		Title:    "Warn on `setopt VERBOSE` — every executed command is echoed to stderr",
+		Severity: SeverityWarning,
+		Description: "`setopt VERBOSE` is Zsh's name for the POSIX `set -v` flag: the shell prints " +
+			"each command line to stderr immediately after reading it. In a script that " +
+			"processes secrets the stderr stream then carries every command that mentions them, " +
+			"including `mysql -pSECRET`, `curl -u user:pass`, `export DB_PASS=…`. Unlike " +
+			"`set -x` (which already has dedicated detectors) the `VERBOSE` flag is easy to " +
+			"leave on by accident because the output looks like normal command echo. Remove " +
+			"the call and rely on `printf` / a proper logger; if a debug trace is required, " +
+			"scope it in a function with `setopt LOCAL_OPTIONS VERBOSE` then `unsetopt VERBOSE`.",
+		Check: checkZC1920,
+	})
+}
+
+func checkZC1920(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1920Canonical(arg.String())
+		switch v {
+		case "VERBOSE":
+			if enabling {
+				return zc1920Hit(cmd, "setopt VERBOSE")
+			}
+		case "NOVERBOSE":
+			if !enabling {
+				return zc1920Hit(cmd, "unsetopt NO_VERBOSE")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1920Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1920Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1920",
+		Message: "`" + form + "` echoes every executed command to stderr — any line that " +
+			"mentions a password, token, or API key leaks with the trace. Remove and use " +
+			"`printf` / a logger, or scope via `setopt LOCAL_OPTIONS VERBOSE` in a helper.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 916 Katas = 0.9.16
-const Version = "0.9.16"
+// 917 Katas = 0.9.17
+const Version = "0.9.17"


### PR DESCRIPTION
ZC1920 — Warn on `setopt VERBOSE`

What: Zsh name for the POSIX `set -v` flag — shell prints each command line to stderr as it reads.
Why: Scripts that touch secrets (`mysql -pSECRET`, `curl -u user:pass`, `export DB_PASS=…`) leak them to the trace stream.
Fix suggestion: Remove the call and use a logger. If a debug trace is required, scope via `setopt LOCAL_OPTIONS VERBOSE` in a helper.
Severity: Warning