### PR TITLE
feat: ZC1921 — detect `systemctl kill -s KILL` skipping ExecStop cleanup

### DIFF
--- a/pkg/katas/katatests/zc1921_test.go
+++ b/pkg/katas/katatests/zc1921_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1921(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `systemctl stop myapp`",
+			input:    `systemctl stop myapp`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `systemctl kill -s HUP myapp` (graceful reload)",
+			input:    `systemctl kill -s HUP myapp`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `systemctl kill -s KILL myapp`",
+			input: `systemctl kill -s KILL myapp`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1921",
+					Message: "`systemctl kill -s KILL` bypasses `ExecStop=` and `TimeoutStopSec=` — lockfiles, sockets, and shm segments survive and the next restart often fails with \"address already in use\". Use `systemctl stop` or `restart` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `systemctl kill myapp --signal=SIGKILL`",
+			input: `systemctl kill myapp --signal=SIGKILL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1921",
+					Message: "`systemctl kill --signal=SIGKILL` bypasses `ExecStop=` and `TimeoutStopSec=` — lockfiles, sockets, and shm segments survive and the next restart often fails with \"address already in use\". Use `systemctl stop` or `restart` instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1921")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1921.go
+++ b/pkg/katas/zc1921.go
@@ -1,0 +1,76 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1921",
+		Title:    "Warn on `systemctl kill -s KILL` / `--signal=SIGKILL` — skips `ExecStop=`, leaks resources",
+		Severity: SeverityWarning,
+		Description: "`systemctl kill UNIT -s KILL` (and `--signal=9` / `SIGKILL`) bypasses the " +
+			"unit's `ExecStop=` sequence and the `TimeoutStopSec=` budget. Any lockfile, " +
+			"socket, or shared-memory segment the service was supposed to unlink survives; the " +
+			"next restart often fails with \"address already in use\" or a corrupt journal. " +
+			"Default to `systemctl stop UNIT` (or `restart`) and let the stop sequence run. " +
+			"Reserve `-s KILL` for a last-resort recovery path with a runbook attached.",
+		Check: checkZC1921,
+	})
+}
+
+func checkZC1921(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "systemctl" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "kill" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if strings.HasPrefix(v, "--signal=") {
+			if zc1921IsHardSignal(strings.TrimPrefix(v, "--signal=")) {
+				return zc1921Hit(cmd, v)
+			}
+		}
+		if v == "-s" && i+2 < len(cmd.Arguments) {
+			sig := cmd.Arguments[i+2].String()
+			if zc1921IsHardSignal(sig) {
+				return zc1921Hit(cmd, "-s "+sig)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1921IsHardSignal(sig string) bool {
+	switch strings.ToUpper(sig) {
+	case "KILL", "SIGKILL", "9":
+		return true
+	}
+	return false
+}
+
+func zc1921Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1921",
+		Message: "`systemctl kill " + form + "` bypasses `ExecStop=` and " +
+			"`TimeoutStopSec=` — lockfiles, sockets, and shm segments survive and the next " +
+			"restart often fails with \"address already in use\". Use `systemctl stop` or " +
+			"`restart` instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 917 Katas = 0.9.17
-const Version = "0.9.17"
+// 918 Katas = 0.9.18
+const Version = "0.9.18"


### PR DESCRIPTION
ZC1921 — Warn on `systemctl kill -s KILL` / `--signal=SIGKILL`

What: Sends SIGKILL to a unit via systemctl, bypassing its `ExecStop=` sequence and `TimeoutStopSec=` budget.
Why: Lockfiles, sockets, and shm segments the service was supposed to unlink survive — next restart often fails with 'address already in use' or a corrupt journal.
Fix suggestion: Default to `systemctl stop` (or `restart`) and let ExecStop run. Reserve `-s KILL` for last-resort recovery with a runbook.
Severity: Warning