### PR TITLE
feat: ZC1922 — detect `rpm --import http://` plaintext GPG key fetch

### DIFF
--- a/pkg/katas/katatests/zc1922_test.go
+++ b/pkg/katas/katatests/zc1922_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1922(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `rpm --import /tmp/key.asc` (local file)",
+			input:    `rpm --import /tmp/key.asc`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `rpm --import https://pinned.example/key.asc`",
+			input:    `rpm --import https://pinned.example/key.asc`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `rpm --import http://repo.example/key.asc`",
+			input: `rpm --import http://repo.example/key.asc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1922",
+					Message: "`rpm --import http://repo.example/key.asc` fetches a GPG key over plaintext — on-path attackers swap it, every future signed package installs. Use `https://` from a pinned origin, or `gpg --verify` against a known fingerprint.",
+					Line:    1,
+					Column:  7,
+				},
+			},
+		},
+		{
+			name:  "invalid — `rpmkeys --import ftp://repo.example/key.asc`",
+			input: `rpmkeys --import ftp://repo.example/key.asc`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1922",
+					Message: "`rpm --import ftp://repo.example/key.asc` fetches a GPG key over plaintext — on-path attackers swap it, every future signed package installs. Use `https://` from a pinned origin, or `gpg --verify` against a known fingerprint.",
+					Line:    1,
+					Column:  11,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1922")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1922.go
+++ b/pkg/katas/zc1922.go
@@ -1,0 +1,72 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1922",
+		Title:    "Error on `rpm --import http://…` / `rpmkeys --import ftp://…` — plaintext GPG key fetch",
+		Severity: SeverityError,
+		Description: "`rpm --import` (and `rpmkeys --import`) add the supplied ASCII-armoured " +
+			"key to the system RPM trust store. When the source is a plain `http://` / `ftp://` " +
+			"URL an on-path attacker swaps the key, and every subsequent package they sign " +
+			"installs cleanly. Serve keys over HTTPS from a TLS-authenticated origin, pin the " +
+			"key's SHA-256 before import, or stage an offline copy verified out of band " +
+			"(`gpg --verify` against a known-good fingerprint).",
+		Check: checkZC1922,
+	})
+}
+
+func checkZC1922(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `rpm --import URL` / `rpmkeys --import URL` both mangle
+	// the command name to `import`.
+	if ident.Value == "import" && len(cmd.Arguments) >= 1 {
+		url := cmd.Arguments[0].String()
+		if zc1922IsPlaintextURL(url) {
+			return zc1922Hit(cmd, url)
+		}
+		return nil
+	}
+	if ident.Value != "rpm" && ident.Value != "rpmkeys" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		if arg.String() == "--import" && i+1 < len(cmd.Arguments) {
+			url := cmd.Arguments[i+1].String()
+			if zc1922IsPlaintextURL(url) {
+				return zc1922Hit(cmd, url)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1922IsPlaintextURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "ftp://")
+}
+
+func zc1922Hit(cmd *ast.SimpleCommand, url string) []Violation {
+	return []Violation{{
+		KataID: "ZC1922",
+		Message: "`rpm --import " + url + "` fetches a GPG key over plaintext — on-path " +
+			"attackers swap it, every future signed package installs. Use `https://` from " +
+			"a pinned origin, or `gpg --verify` against a known fingerprint.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 918 Katas = 0.9.18
-const Version = "0.9.18"
+// 919 Katas = 0.9.19
+const Version = "0.9.19"


### PR DESCRIPTION
ZC1922 — Error on `rpm --import http://` / `rpmkeys --import ftp://`

What: Adds an ASCII-armoured GPG key to the system RPM trust store from a plaintext URL.
Why: An on-path attacker swaps the key, and every subsequent package they sign installs cleanly.
Fix suggestion: Serve keys over HTTPS from a TLS-authenticated origin, pin the SHA-256, or stage an offline copy verified with `gpg --verify` against a known fingerprint.
Severity: Error