### PR TITLE
feat: ZC1923 — detect `setopt PRINT_EXIT_VALUE` stderr leak

### DIFF
--- a/pkg/katas/katatests/zc1923_test.go
+++ b/pkg/katas/katatests/zc1923_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1923(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt PRINT_EXIT_VALUE` (explicit default)",
+			input:    `unsetopt PRINT_EXIT_VALUE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt EXTENDED_HISTORY` (unrelated)",
+			input:    `setopt EXTENDED_HISTORY`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt PRINT_EXIT_VALUE`",
+			input: `setopt PRINT_EXIT_VALUE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1923",
+					Message: "`setopt PRINT_EXIT_VALUE` prints `zsh: exit N` on stderr for every non-zero exit — silent grep/test/curl probes suddenly leak status, and tools parsing stderr see interleaved shell chatter. Remove; use `|| printf …` per call.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_PRINT_EXIT_VALUE`",
+			input: `unsetopt NO_PRINT_EXIT_VALUE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1923",
+					Message: "`unsetopt NO_PRINT_EXIT_VALUE` prints `zsh: exit N` on stderr for every non-zero exit — silent grep/test/curl probes suddenly leak status, and tools parsing stderr see interleaved shell chatter. Remove; use `|| printf …` per call.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1923")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1923.go
+++ b/pkg/katas/zc1923.go
@@ -1,0 +1,85 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1923",
+		Title:    "Warn on `setopt PRINT_EXIT_VALUE` — every non-zero exit leaks a status line to stderr",
+		Severity: SeverityWarning,
+		Description: "`PRINT_EXIT_VALUE` makes Zsh emit `zsh: exit N` on stderr after every " +
+			"foreground command that returns a non-zero status. In a script the stream is " +
+			"typically captured by a supervisor or shipped to a log aggregator, and the " +
+			"extra line reveals which tool returned what — including grep / test / curl " +
+			"probes that were supposed to stay silent. Worse, tools that parse stderr for " +
+			"diagnostics (`git`, `ssh`, `rsync`) now see interleaved shell chatter. Remove " +
+			"the `setopt` call; if you actually want a per-command post-mortem, rely on " +
+			"`precmd`/`preexec` hooks or an explicit `|| printf …`.",
+		Check: checkZC1923,
+	})
+}
+
+func checkZC1923(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1923Canonical(arg.String())
+		switch v {
+		case "PRINTEXITVALUE":
+			if enabling {
+				return zc1923Hit(cmd, "setopt PRINT_EXIT_VALUE")
+			}
+		case "NOPRINTEXITVALUE":
+			if !enabling {
+				return zc1923Hit(cmd, "unsetopt NO_PRINT_EXIT_VALUE")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1923Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1923Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1923",
+		Message: "`" + form + "` prints `zsh: exit N` on stderr for every non-zero " +
+			"exit — silent grep/test/curl probes suddenly leak status, and tools parsing " +
+			"stderr see interleaved shell chatter. Remove; use `|| printf …` per call.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 919 Katas = 0.9.19
-const Version = "0.9.19"
+// 920 Katas = 0.9.20
+const Version = "0.9.20"


### PR DESCRIPTION
ZC1923 — Warn on `setopt PRINT_EXIT_VALUE`

What: Zsh emits `zsh: exit N` to stderr after every foreground command that returns non-zero.
Why: Silent grep/test/curl probes suddenly leak status to supervisors and log aggregators, and tools parsing stderr (`git`, `ssh`, `rsync`) see interleaved shell chatter.
Fix suggestion: Remove the call. Use `|| printf …` on specific commands, or a `precmd` hook for scoped post-mortems.
Severity: Warning