### PR TITLE
feat: ZC1924 — detect libguestfs host-side VM disk access

### DIFF
--- a/pkg/katas/katatests/zc1924_test.go
+++ b/pkg/katas/katatests/zc1924_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1924(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `virsh list --all` (read-only domain list)",
+			input:    `virsh list --all`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `virt-top -d 5` (live view)",
+			input:    `virt-top -d 5`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `virt-cat -d mydomain /etc/shadow`",
+			input: `virt-cat -d mydomain /etc/shadow`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1924",
+					Message: "`virt-cat` reads/writes the VM disk directly from the host — bypasses in-guest permissions, audit, and LUKS; a live VM risks corruption from double-mount. Snapshot first, work on the clone, prefer in-guest tooling.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `guestmount -d mydomain -i /mnt`",
+			input: `guestmount -d mydomain -i /mnt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1924",
+					Message: "`guestmount` reads/writes the VM disk directly from the host — bypasses in-guest permissions, audit, and LUKS; a live VM risks corruption from double-mount. Snapshot first, work on the clone, prefer in-guest tooling.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1924")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1924.go
+++ b/pkg/katas/zc1924.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+var zc1924Tools = map[string]bool{
+	"virt-cat":       true,
+	"virt-copy-out":  true,
+	"virt-tar-out":   true,
+	"virt-edit":      true,
+	"virt-copy-in":   true,
+	"virt-tar-in":    true,
+	"guestfish":      true,
+	"guestmount":     true,
+	"virt-customize": true,
+}
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1924",
+		Title:    "Warn on `virt-cat` / `virt-copy-out` / `guestfish` / `guestmount` — reads guest disk from host",
+		Severity: SeverityWarning,
+		Description: "libguestfs tools (`virt-cat`, `virt-copy-out`, `virt-tar-out`, `virt-edit`, " +
+			"`virt-customize`, `guestfish`, `guestmount`) open a VM's disk image directly from " +
+			"the hypervisor and read or mutate its contents without going through the guest " +
+			"OS. That bypasses every in-guest permission, audit, and LUKS keyslot the VM was " +
+			"using, and — if the VM is live — risks filesystem corruption because two writers " +
+			"are now mounted on the same image. Snapshot the disk first, work on the clone, " +
+			"and prefer in-guest `ssh`/`scp`/`ansible` for anything that does not need " +
+			"out-of-band recovery.",
+		Check: checkZC1924,
+	})
+}
+
+func checkZC1924(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if !zc1924Tools[ident.Value] {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1924",
+		Message: "`" + ident.Value + "` reads/writes the VM disk directly from the host — " +
+			"bypasses in-guest permissions, audit, and LUKS; a live VM risks corruption " +
+			"from double-mount. Snapshot first, work on the clone, prefer in-guest tooling.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 920 Katas = 0.9.20
-const Version = "0.9.20"
+// 921 Katas = 0.9.21
+const Version = "0.9.21"


### PR DESCRIPTION
ZC1924 — Warn on `virt-cat` / `virt-copy-out` / `virt-edit` / `guestfish` / `guestmount` / `virt-customize`

What: libguestfs tools open a VM's disk image from the hypervisor and read or mutate it without going through the guest OS.
Why: Bypasses in-guest permissions, audit, and LUKS keyslots. On a live VM, two writers mounted on the same image risk filesystem corruption.
Fix suggestion: Snapshot the disk first, work on the clone, and prefer in-guest `ssh`/`scp`/`ansible` for anything that does not need out-of-band recovery.
Severity: Warning