### PR TITLE
feat: ZC1925 — detect `unsetopt EQUALS` disabling Zsh path/tilde idioms

### DIFF
--- a/pkg/katas/katatests/zc1925_test.go
+++ b/pkg/katas/katatests/zc1925_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1925(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt EQUALS` (explicit default)",
+			input:    `setopt EQUALS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt EQUALS`",
+			input: `unsetopt EQUALS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1925",
+					Message: "`unsetopt EQUALS` turns off `=cmd` path expansion and tilde-after-colon — `=python`/`=ls` become literals and `PATH=~/bin:$PATH` stops tilde-expanding. Keep on; scope with `setopt LOCAL_OPTIONS; unsetopt EQUALS` inside a function.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_EQUALS`",
+			input: `setopt NO_EQUALS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1925",
+					Message: "`setopt NO_EQUALS` turns off `=cmd` path expansion and tilde-after-colon — `=python`/`=ls` become literals and `PATH=~/bin:$PATH` stops tilde-expanding. Keep on; scope with `setopt LOCAL_OPTIONS; unsetopt EQUALS` inside a function.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1925")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1925.go
+++ b/pkg/katas/zc1925.go
@@ -1,0 +1,84 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1925",
+		Title:    "Warn on `unsetopt EQUALS` — disables `=cmd` path expansion and tilde-after-colon",
+		Severity: SeverityWarning,
+		Description: "Zsh's `EQUALS` option (on by default) is what makes `=python`, `=ls`, and " +
+			"`=vim` expand to the absolute path of the command via `$PATH` lookup. It also " +
+			"drives the `PATH=~/bin:$PATH` tilde-after-colon expansion. `unsetopt EQUALS` " +
+			"turns both off: `=cmd` becomes a literal argument (breaking any idiom that " +
+			"relies on the short-path), and `PATH=~/bin:$PATH` stops expanding the tilde " +
+			"inside the colon-separated list. Keep the option on; if one function needs " +
+			"literal `=` arguments, scope via `setopt LOCAL_OPTIONS; unsetopt EQUALS` inside it.",
+		Check: checkZC1925,
+	})
+}
+
+func checkZC1925(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var disabling bool
+	switch ident.Value {
+	case "unsetopt":
+		disabling = true
+	case "setopt":
+		disabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1925Canonical(arg.String())
+		switch v {
+		case "EQUALS":
+			if disabling {
+				return zc1925Hit(cmd, "unsetopt EQUALS")
+			}
+		case "NOEQUALS":
+			if !disabling {
+				return zc1925Hit(cmd, "setopt NO_EQUALS")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1925Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1925Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1925",
+		Message: "`" + form + "` turns off `=cmd` path expansion and tilde-after-colon — " +
+			"`=python`/`=ls` become literals and `PATH=~/bin:$PATH` stops tilde-expanding. " +
+			"Keep on; scope with `setopt LOCAL_OPTIONS; unsetopt EQUALS` inside a function.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 921 Katas = 0.9.21
-const Version = "0.9.21"
+// 922 Katas = 0.9.22
+const Version = "0.9.22"


### PR DESCRIPTION
ZC1925 — Warn on `unsetopt EQUALS`

What: Zsh `EQUALS` option (on by default) drives `=cmd` → absolute path lookup and tilde-after-colon (`PATH=~/bin:$PATH`).
Why: Turning it off makes `=python`/`=ls` literals, and `PATH=~/bin:$PATH` stops expanding the tilde inside the colon-separated list.
Fix suggestion: Keep the option on. Scope via `setopt LOCAL_OPTIONS; unsetopt EQUALS` inside any function that needs literal `=` arguments.
Severity: Warning