### PR TITLE
feat: ZC1926 — detect `init 0/1/6` SysV runlevel changes in scripts

### DIFF
--- a/pkg/katas/katatests/zc1926_test.go
+++ b/pkg/katas/katatests/zc1926_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1926(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `init 3` (multi-user, legacy but non-destructive)",
+			input:    `init 3`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `systemctl reboot`",
+			input:    `systemctl reboot`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `init 0` (halt)",
+			input: `init 0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1926",
+					Message: "`init 0` changes runlevel — `0` halts, `6` reboots, `1`/`S` drops to single-user. Use `systemctl poweroff`/`reboot`/`rescue` or `shutdown -h +N` so reviewers can read the intent.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `telinit 6` (reboot)",
+			input: `telinit 6`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1926",
+					Message: "`telinit 6` changes runlevel — `0` halts, `6` reboots, `1`/`S` drops to single-user. Use `systemctl poweroff`/`reboot`/`rescue` or `shutdown -h +N` so reviewers can read the intent.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1926")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1926.go
+++ b/pkg/katas/zc1926.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1926",
+		Title:    "Warn on `telinit 0/1/6` / `init 0/1/6` — SysV runlevel change halts, reboots, or isolates the host",
+		Severity: SeverityWarning,
+		Description: "`init 0`, `init 6`, `init 1`, and their `telinit` aliases ask systemd (or " +
+			"SysV) to switch runlevel: `0` → `poweroff.target`, `6` → `reboot.target`, " +
+			"`1`/`S` → `rescue.target`. From a script the side effect is a remote SSH " +
+			"disconnect, an immediate service teardown for every other session on the host, " +
+			"and — in the `1`/`S` case — dropping to single-user mode without a console to " +
+			"recover. Use `systemctl poweroff`/`reboot`/`rescue` (which are clearer in " +
+			"reviews) or schedule via `shutdown -h +N` so the operator has a cancel window.",
+		Check: checkZC1926,
+	})
+}
+
+func checkZC1926(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "init" && ident.Value != "telinit" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	lvl := cmd.Arguments[0].String()
+	switch lvl {
+	case "0", "1", "6", "S", "s":
+		return []Violation{{
+			KataID: "ZC1926",
+			Message: "`" + ident.Value + " " + lvl + "` changes runlevel — `0` halts, `6` " +
+				"reboots, `1`/`S` drops to single-user. Use `systemctl poweroff`/`reboot`/" +
+				"`rescue` or `shutdown -h +N` so reviewers can read the intent.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 922 Katas = 0.9.22
-const Version = "0.9.22"
+// 923 Katas = 0.9.23
+const Version = "0.9.23"


### PR DESCRIPTION
ZC1926 — Warn on `init 0` / `init 1` / `init 6` / `telinit N`

What: SysV-style runlevel change — systemd maps `0` → `poweroff.target`, `6` → `reboot.target`, `1`/`S` → `rescue.target`.
Why: Remote SSH disconnects immediately, every other session on the host tears down, and `1`/`S` drops to single-user without a console to recover.
Fix suggestion: Use `systemctl poweroff`/`reboot`/`rescue` or `shutdown -h +N` — reviewers see the intent and operators have a cancel window.
Severity: Warning