### PR TITLE
feat: ZC1927 — detect `xfreerdp`/`rdesktop` RDP password in argv

### DIFF
--- a/pkg/katas/katatests/zc1916_test.go
+++ b/pkg/katas/katatests/zc1916_test.go
@@ -29,7 +29,7 @@ func TestZC1916(t *testing.T) {
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1916",
-					Message: "`setopt NULL_GLOB` makes every later unmatched glob silently empty — `cp *.log /dest` mis-targets, `rm *.tmp` errors as argv-too-short. Use per-glob `*(N)`, or scope inside a function with `setopt LOCAL_OPTIONS NULL_GLOB`.",
+					Message: "`setopt NULL_GLOB` makes every later unmatched glob silently empty — `cp *.log /dest` rewrites into `cp /dest`, `rm *.tmp` becomes argv-too-short. Use per-glob `*(N)`, or scope with `setopt LOCAL_OPTIONS NULL_GLOB` in a function.",
 					Line:    1,
 					Column:  1,
 				},
@@ -41,7 +41,7 @@ func TestZC1916(t *testing.T) {
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1916",
-					Message: "`unsetopt NO_NULL_GLOB` makes every later unmatched glob silently empty — `cp *.log /dest` mis-targets, `rm *.tmp` errors as argv-too-short. Use per-glob `*(N)`, or scope inside a function with `setopt LOCAL_OPTIONS NULL_GLOB`.",
+					Message: "`unsetopt NO_NULL_GLOB` makes every later unmatched glob silently empty — `cp *.log /dest` rewrites into `cp /dest`, `rm *.tmp` becomes argv-too-short. Use per-glob `*(N)`, or scope with `setopt LOCAL_OPTIONS NULL_GLOB` in a function.",
 					Line:    1,
 					Column:  1,
 				},

--- a/pkg/katas/katatests/zc1916_test.go
+++ b/pkg/katas/katatests/zc1916_test.go
@@ -29,7 +29,7 @@ func TestZC1916(t *testing.T) {
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1916",
-					Message: "`setopt NULL_GLOB` makes every later unmatched glob silently empty — `cp *.log /dest` rewrites into `cp /dest`, `rm *.tmp` becomes argv-too-short. Use per-glob `*(N)`, or scope with `setopt LOCAL_OPTIONS NULL_GLOB` in a function.",
+					Message: "`setopt NULL_GLOB` makes every later unmatched glob silently empty — `cp *.log /dest` rewrites to `cp /dest`, `rm *.tmp` becomes argv-too-short. Use per-glob `*(N)`, or `setopt LOCAL_OPTIONS NULL_GLOB` in a function.",
 					Line:    1,
 					Column:  1,
 				},
@@ -41,7 +41,7 @@ func TestZC1916(t *testing.T) {
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1916",
-					Message: "`unsetopt NO_NULL_GLOB` makes every later unmatched glob silently empty — `cp *.log /dest` rewrites into `cp /dest`, `rm *.tmp` becomes argv-too-short. Use per-glob `*(N)`, or scope with `setopt LOCAL_OPTIONS NULL_GLOB` in a function.",
+					Message: "`unsetopt NO_NULL_GLOB` makes every later unmatched glob silently empty — `cp *.log /dest` rewrites to `cp /dest`, `rm *.tmp` becomes argv-too-short. Use per-glob `*(N)`, or `setopt LOCAL_OPTIONS NULL_GLOB` in a function.",
 					Line:    1,
 					Column:  1,
 				},

--- a/pkg/katas/katatests/zc1927_test.go
+++ b/pkg/katas/katatests/zc1927_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1927(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `xfreerdp /u:alice /v:host.example` (no password)",
+			input:    `xfreerdp /u:alice /v:host.example`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `rdesktop -u alice host.example` (prompts)",
+			input:    `rdesktop -u alice host.example`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `xfreerdp /u:alice /p:$PASS /v:host`",
+			input: `xfreerdp /u:alice /p:$PASS /v:host`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1927",
+					Message: "`xfreerdp /p:$PASS` puts the RDP password in argv — visible in `ps`, `/proc`, and shell history. Pipe via `/from-stdin`, read from a protected `.rdp` file, or use NLA with a cached credential.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `rdesktop -u alice -p hunter2 host.example`",
+			input: `rdesktop -u alice -p hunter2 host.example`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1927",
+					Message: "`rdesktop -p hunter2` puts the RDP password in argv — visible in `ps`, `/proc`, and shell history. Pipe via `/from-stdin`, read from a protected `.rdp` file, or use NLA with a cached credential.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1927")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1914.go
+++ b/pkg/katas/zc1914.go
@@ -16,7 +16,7 @@ func init() {
 			"forces classic UDP to the listed servers. Both detour around the host's resolver " +
 			"chain — `/etc/hosts`, `systemd-resolved`, `nsswitch`, split-horizon DNS — so the " +
 			"request lands at an IP the operator did not vet. In production scripts that is " +
-			"usually a mis-debug line left in; drop the flag or gate it behind an explicit " +
+			"usually a stray debug line left in; drop the flag or gate it behind an explicit " +
 			"`--doh-insecure` + `--resolve` pinning audit so reviewers can see the intent.",
 		Check: checkZC1914,
 	})

--- a/pkg/katas/zc1916.go
+++ b/pkg/katas/zc1916.go
@@ -75,8 +75,8 @@ func zc1916Hit(cmd *ast.SimpleCommand, form string) []Violation {
 	return []Violation{{
 		KataID: "ZC1916",
 		Message: "`" + form + "` makes every later unmatched glob silently empty — " +
-			"`cp *.log /dest` rewrites into `cp /dest`, `rm *.tmp` becomes argv-too-short. " +
-			"Use per-glob `*(N)`, or scope with `setopt LOCAL_OPTIONS NULL_GLOB` in a function.",
+			"`cp *.log /dest` rewrites to `cp /dest`, `rm *.tmp` becomes argv-too-short. " +
+			"Use per-glob `*(N)`, or `setopt LOCAL_OPTIONS NULL_GLOB` in a function.",
 		Line:   cmd.Token.Line,
 		Column: cmd.Token.Column,
 		Level:  SeverityWarning,

--- a/pkg/katas/zc1916.go
+++ b/pkg/katas/zc1916.go
@@ -75,8 +75,8 @@ func zc1916Hit(cmd *ast.SimpleCommand, form string) []Violation {
 	return []Violation{{
 		KataID: "ZC1916",
 		Message: "`" + form + "` makes every later unmatched glob silently empty — " +
-			"`cp *.log /dest` mis-targets, `rm *.tmp` errors as argv-too-short. Use per-glob " +
-			"`*(N)`, or scope inside a function with `setopt LOCAL_OPTIONS NULL_GLOB`.",
+			"`cp *.log /dest` rewrites into `cp /dest`, `rm *.tmp` becomes argv-too-short. " +
+			"Use per-glob `*(N)`, or scope with `setopt LOCAL_OPTIONS NULL_GLOB` in a function.",
 		Line:   cmd.Token.Line,
 		Column: cmd.Token.Column,
 		Level:  SeverityWarning,

--- a/pkg/katas/zc1927.go
+++ b/pkg/katas/zc1927.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1927",
+		Title:    "Error on `xfreerdp /p:SECRET` / `rdesktop -p SECRET` — RDP password visible in argv",
+		Severity: SeverityError,
+		Description: "`xfreerdp /p:<password>` and `rdesktop -p <password>` (plus the `-p -` " +
+			"stdin form when followed by an argv password) put the Windows credential into " +
+			"`ps`, `/proc/PID/cmdline`, shell history, and every `ps aux` captured by " +
+			"monitoring. Use `xfreerdp /from-stdin` + a piped credential, " +
+			"`freerdp-shadow-cli /sec:nla` with a cached credential, or drop the password " +
+			"into a protected `.rdp` file passed via `/load-config-file`. Never inline the " +
+			"password on the command line.",
+		Check: checkZC1927,
+	})
+}
+
+func checkZC1927(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "xfreerdp", "xfreerdp3", "wlfreerdp":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if strings.HasPrefix(v, "/p:") && len(v) > 3 && v != "/p:-" {
+				return zc1927Hit(cmd, ident.Value+" "+v)
+			}
+		}
+	case "rdesktop":
+		for i, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "-p" && i+1 < len(cmd.Arguments) {
+				next := cmd.Arguments[i+1].String()
+				if next != "-" {
+					return zc1927Hit(cmd, "rdesktop -p "+next)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func zc1927Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1927",
+		Message: "`" + form + "` puts the RDP password in argv — visible in `ps`, " +
+			"`/proc`, and shell history. Pipe via `/from-stdin`, read from a protected " +
+			"`.rdp` file, or use NLA with a cached credential.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 923 Katas = 0.9.23
-const Version = "0.9.23"
+// 924 Katas = 0.9.24
+const Version = "0.9.24"


### PR DESCRIPTION
ZC1927 — Error on `xfreerdp /p:SECRET` / `rdesktop -p SECRET`

What: Windows RDP credential passed as a command-line argument to freerdp or rdesktop.
Why: Password lands in `ps`, `/proc/PID/cmdline`, shell history, and every `ps aux` captured by monitoring.
Fix suggestion: Use `xfreerdp /from-stdin` with a piped credential, NLA with a cached credential, or a protected `.rdp` config file.
Severity: Error