### PR TITLE
feat: ZC1928 — detect `setopt SHARE_HISTORY` cross-session history leak

### DIFF
--- a/pkg/katas/katatests/zc1928_test.go
+++ b/pkg/katas/katatests/zc1928_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1928(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt SHARE_HISTORY` (explicit default)",
+			input:    `unsetopt SHARE_HISTORY`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt INC_APPEND_HISTORY` (safer alternative)",
+			input:    `setopt INC_APPEND_HISTORY`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt SHARE_HISTORY`",
+			input: `setopt SHARE_HISTORY`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1928",
+					Message: "`setopt SHARE_HISTORY` flushes every command into every sibling zsh session — secrets typed in one terminal surface in `fc -l` of every other. Prefer `setopt INC_APPEND_HISTORY` plus `HIST_IGNORE_SPACE` for safer isolation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_SHARE_HISTORY`",
+			input: `unsetopt NO_SHARE_HISTORY`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1928",
+					Message: "`unsetopt NO_SHARE_HISTORY` flushes every command into every sibling zsh session — secrets typed in one terminal surface in `fc -l` of every other. Prefer `setopt INC_APPEND_HISTORY` plus `HIST_IGNORE_SPACE` for safer isolation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1928")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1928.go
+++ b/pkg/katas/zc1928.go
@@ -1,0 +1,84 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1928",
+		Title:    "Warn on `setopt SHARE_HISTORY` — every session writes its history into every sibling session",
+		Severity: SeverityWarning,
+		Description: "`SHARE_HISTORY` flushes each command to `$HISTFILE` immediately and tells " +
+			"all other running zsh sessions to re-read the file. A secret typed in a one-off " +
+			"\"private\" terminal — `ssh user@host \"$PASS\"`, `aws sts ... --output text`, " +
+			"`git push https://user:token@…` — shows up in every other terminal's `fc -l` list " +
+			"seconds later. Prefer `setopt INC_APPEND_HISTORY` (append-only, per-session " +
+			"isolation) and `setopt HIST_IGNORE_SPACE` so a leading space keeps the line out " +
+			"of history altogether.",
+		Check: checkZC1928,
+	})
+}
+
+func checkZC1928(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1928Canonical(arg.String())
+		switch v {
+		case "SHAREHISTORY":
+			if enabling {
+				return zc1928Hit(cmd, "setopt SHARE_HISTORY")
+			}
+		case "NOSHAREHISTORY":
+			if !enabling {
+				return zc1928Hit(cmd, "unsetopt NO_SHARE_HISTORY")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1928Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1928Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1928",
+		Message: "`" + form + "` flushes every command into every sibling zsh session — " +
+			"secrets typed in one terminal surface in `fc -l` of every other. Prefer " +
+			"`setopt INC_APPEND_HISTORY` plus `HIST_IGNORE_SPACE` for safer isolation.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 924 Katas = 0.9.24
-const Version = "0.9.24"
+// 925 Katas = 0.9.25
+const Version = "0.9.25"


### PR DESCRIPTION
ZC1928 — Warn on `setopt SHARE_HISTORY`

What: Flushes each command to `$HISTFILE` immediately and tells every other zsh session to re-read it.
Why: A secret typed in a one-off 'private' terminal (`ssh user@host "$PASS"`, `git push https://user:token@…`) shows up in every other terminal's `fc -l` seconds later.
Fix suggestion: Prefer `setopt INC_APPEND_HISTORY` (per-session isolation) and `setopt HIST_IGNORE_SPACE` so a leading space keeps the line out of history.
Severity: Warning