### PR TITLE
feat: ZC1929 — detect `cpio -i` extraction without path safety

### DIFF
--- a/pkg/katas/katatests/zc1929_test.go
+++ b/pkg/katas/katatests/zc1929_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1929(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `cpio -o -H newc` (create, not extract)",
+			input:    `cpio -o -H newc`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `cpio -i --no-absolute-filenames`",
+			input:    `cpio -i --no-absolute-filenames`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `cpio -i -d`",
+			input: `cpio -i -d`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1929",
+					Message: "`cpio -i` extracts paths verbatim — absolute and `..` entries escape the target dir. Pass `--no-absolute-filenames` and stage into a scratch dir before `mv` into place.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `cpio -idmv` (clustered)",
+			input: `cpio -idmv`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1929",
+					Message: "`cpio -i` extracts paths verbatim — absolute and `..` entries escape the target dir. Pass `--no-absolute-filenames` and stage into a scratch dir before `mv` into place.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1929")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1929.go
+++ b/pkg/katas/zc1929.go
@@ -1,0 +1,66 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1929",
+		Title:    "Warn on `cpio -i` / `--extract` without `--no-absolute-filenames` — archive writes outside CWD",
+		Severity: SeverityWarning,
+		Description: "`cpio -i` (and `--extract`) is the default copy-in mode: it materialises " +
+			"every path stored in the archive verbatim. Paths starting with `/` land where the " +
+			"archive told them to, and relative paths containing `..` slip out of the " +
+			"extraction directory entirely — so a rogue initramfs or firmware bundle can drop " +
+			"files into `/etc/cron.d/`, `/usr/lib/systemd/system/`, or the operator's " +
+			"`~/.ssh/authorized_keys`. Always pass `--no-absolute-filenames` and extract into a " +
+			"fresh scratch directory reviewed before `mv`.",
+		Check: checkZC1929,
+	})
+}
+
+func checkZC1929(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "cpio" {
+		return nil
+	}
+
+	extract := false
+	safe := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "-i", "--extract":
+			extract = true
+		case "--no-absolute-filenames":
+			safe = true
+		}
+		if len(v) >= 2 && v[0] == '-' && v[1] != '-' {
+			for i := 1; i < len(v); i++ {
+				if v[i] == 'i' {
+					extract = true
+				}
+			}
+		}
+	}
+	if !extract || safe {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1929",
+		Message: "`cpio -i` extracts paths verbatim — absolute and `..` entries escape the " +
+			"target dir. Pass `--no-absolute-filenames` and stage into a scratch dir before " +
+			"`mv` into place.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 925 Katas = 0.9.25
-const Version = "0.9.25"
+// 926 Katas = 0.9.26
+const Version = "0.9.26"


### PR DESCRIPTION
ZC1929 — Warn on `cpio -i` / `--extract` without `--no-absolute-filenames`

What: Copy-in mode materialises every path verbatim — absolute paths land where the archive says, relative `..` paths escape the extraction dir.
Why: A rogue initramfs/firmware bundle drops files into `/etc/cron.d/`, `/usr/lib/systemd/system/`, or `~/.ssh/authorized_keys`.
Fix suggestion: Pass `--no-absolute-filenames` and extract into a fresh scratch dir reviewed before `mv` into place.
Severity: Warning