### PR TITLE
feat: ZC1930 — detect `unsetopt HASH_CMDS` per-call PATH walks

### DIFF
--- a/pkg/katas/katatests/zc1930_test.go
+++ b/pkg/katas/katatests/zc1930_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1930(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt HASH_CMDS` (explicit default)",
+			input:    `setopt HASH_CMDS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt HASH_CMDS`",
+			input: `unsetopt HASH_CMDS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1930",
+					Message: "`unsetopt HASH_CMDS` re-walks `$PATH` on every call — tens to hundreds of ms per command on slow filesystems. Keep it on; use `rehash` or `hash -r` to invalidate the cache after a targeted binary swap.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_HASH_CMDS`",
+			input: `setopt NO_HASH_CMDS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1930",
+					Message: "`setopt NO_HASH_CMDS` re-walks `$PATH` on every call — tens to hundreds of ms per command on slow filesystems. Keep it on; use `rehash` or `hash -r` to invalidate the cache after a targeted binary swap.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1930")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1930.go
+++ b/pkg/katas/zc1930.go
@@ -1,0 +1,84 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1930",
+		Title:    "Warn on `unsetopt HASH_CMDS` — every command invocation re-walks `$PATH`",
+		Severity: SeverityWarning,
+		Description: "`HASH_CMDS` (on by default) caches the resolved absolute path of every " +
+			"command after its first successful lookup. `unsetopt HASH_CMDS` disables the " +
+			"cache, so each invocation re-walks every `$PATH` entry and re-runs `stat()` on " +
+			"every candidate. On a slow filesystem (NFS home, encrypted volume, large `$PATH`) " +
+			"this adds tens to hundreds of milliseconds per command and can double the runtime " +
+			"of a long pipeline. Keep the option on; if you are changing a binary and want the " +
+			"cache invalidated, `rehash` (one-shot) or `hash -r` is the scoped fix.",
+		Check: checkZC1930,
+	})
+}
+
+func checkZC1930(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var disabling bool
+	switch ident.Value {
+	case "unsetopt":
+		disabling = true
+	case "setopt":
+		disabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1930Canonical(arg.String())
+		switch v {
+		case "HASHCMDS":
+			if disabling {
+				return zc1930Hit(cmd, "unsetopt HASH_CMDS")
+			}
+		case "NOHASHCMDS":
+			if !disabling {
+				return zc1930Hit(cmd, "setopt NO_HASH_CMDS")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1930Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1930Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1930",
+		Message: "`" + form + "` re-walks `$PATH` on every call — tens to hundreds of ms " +
+			"per command on slow filesystems. Keep it on; use `rehash` or `hash -r` to " +
+			"invalidate the cache after a targeted binary swap.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 926 Katas = 0.9.26
-const Version = "0.9.26"
+// 927 Katas = 0.9.27
+const Version = "0.9.27"


### PR DESCRIPTION
ZC1930 — Warn on `unsetopt HASH_CMDS`

What: Disables Zsh's default command-path cache. Every invocation re-walks `$PATH` and re-runs `stat()` on every candidate.
Why: On slow filesystems (NFS home, encrypted volume, long `$PATH`) adds tens to hundreds of ms per command; doubles long-pipeline runtime.
Fix suggestion: Keep the option on. Use `rehash` (one-shot) or `hash -r` to invalidate after a targeted binary swap.
Severity: Warning