### PR TITLE
feat: ZC1931 — detect `ip netns delete` namespace teardown

### DIFF
--- a/pkg/katas/katatests/zc1931_test.go
+++ b/pkg/katas/katatests/zc1931_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1931(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ip netns list`",
+			input:    `ip netns list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ip netns exec red ping host`",
+			input:    `ip netns exec red ping host`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ip netns delete red`",
+			input: `ip netns delete red`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1931",
+					Message: "`ip netns delete` tears down every interface, veth, tunnel, and WireGuard peer inside the namespace. Stop the workloads first and verify `ip -n $NS link` is empty before deleting.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ip netns del $NS`",
+			input: `ip netns del $NS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1931",
+					Message: "`ip netns del` tears down every interface, veth, tunnel, and WireGuard peer inside the namespace. Stop the workloads first and verify `ip -n $NS link` is empty before deleting.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1931")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1931.go
+++ b/pkg/katas/zc1931.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1931",
+		Title:    "Warn on `ip netns delete $NS` / `netns del` — drops the whole network namespace",
+		Severity: SeverityWarning,
+		Description: "`ip netns delete NAME` / `ip netns del NAME` unmounts the namespace and " +
+			"tears down every interface, veth pair, VXLAN, and WireGuard peer living inside. " +
+			"Processes still attached lose their network abruptly — container health checks " +
+			"fail, BGP sessions drop, and any other process using `ip netns exec NAME …` " +
+			"errors out with \"No such file or directory\". Stop the workloads first " +
+			"(`systemctl stop`, `pkill -SIGTERM -n $NS`), confirm `ip -n $NS link` is empty, " +
+			"then `delete` deliberately — or leave the namespace alone if it is managed by " +
+			"Docker/containerd/systemd-nspawn.",
+		Check: checkZC1931,
+	})
+}
+
+func checkZC1931(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ip" {
+		return nil
+	}
+	if len(cmd.Arguments) < 3 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "netns" {
+		return nil
+	}
+	sub := cmd.Arguments[1].String()
+	if sub != "delete" && sub != "del" {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1931",
+		Message: "`ip netns " + sub + "` tears down every interface, veth, tunnel, and " +
+			"WireGuard peer inside the namespace. Stop the workloads first and verify " +
+			"`ip -n $NS link` is empty before deleting.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 927 Katas = 0.9.27
-const Version = "0.9.27"
+// 928 Katas = 0.9.28
+const Version = "0.9.28"


### PR DESCRIPTION
ZC1931 — Warn on `ip netns delete $NS` / `ip netns del $NS`

What: Unmounts the namespace and tears down every interface, veth pair, VXLAN, and WireGuard peer living inside.
Why: Processes still attached lose network abruptly — container health checks fail, BGP sessions drop, `ip netns exec $NS` errors with 'No such file or directory'.
Fix suggestion: Stop the workloads first, verify `ip -n $NS link` is empty, then delete. Leave Docker/containerd/nspawn-managed namespaces alone.
Severity: Warning