### PR TITLE
feat: ZC1932 — detect `unsetopt GLOBAL_EXPORT` function-local typeset -x

### DIFF
--- a/pkg/katas/katatests/zc1932_test.go
+++ b/pkg/katas/katatests/zc1932_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1932(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt GLOBAL_EXPORT` (explicit default)",
+			input:    `setopt GLOBAL_EXPORT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt GLOBAL_EXPORT`",
+			input: `unsetopt GLOBAL_EXPORT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1932",
+					Message: "`unsetopt GLOBAL_EXPORT` makes `typeset -x` exports function-local — helper functions that set `PATH`/`VIRTUAL_ENV`/`AWS_*` no longer propagate to callers. Keep it on; scope temporary exports in a subshell instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_GLOBAL_EXPORT`",
+			input: `setopt NO_GLOBAL_EXPORT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1932",
+					Message: "`setopt NO_GLOBAL_EXPORT` makes `typeset -x` exports function-local — helper functions that set `PATH`/`VIRTUAL_ENV`/`AWS_*` no longer propagate to callers. Keep it on; scope temporary exports in a subshell instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1932")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1932.go
+++ b/pkg/katas/zc1932.go
@@ -1,0 +1,85 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1932",
+		Title:    "Warn on `unsetopt GLOBAL_EXPORT` — `typeset -x` in a function stops leaking to outer scope",
+		Severity: SeverityWarning,
+		Description: "`GLOBAL_EXPORT` (on by default) makes `typeset -x VAR=val` inside a function " +
+			"not only export `VAR` but also promote it to the outer scope, so callers and " +
+			"subsequent functions see the same value. Turning it off changes the meaning of " +
+			"every such assignment across the script: exports become function-local and " +
+			"vanish the moment the function returns. Scripts that rely on a helper to set up " +
+			"`PATH`, `VIRTUAL_ENV`, or `AWS_*` variables suddenly run commands under the old " +
+			"environment. Keep the option on; if you want a temporary export, scope it with a " +
+			"subshell instead of a shell-wide flip.",
+		Check: checkZC1932,
+	})
+}
+
+func checkZC1932(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var disabling bool
+	switch ident.Value {
+	case "unsetopt":
+		disabling = true
+	case "setopt":
+		disabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1932Canonical(arg.String())
+		switch v {
+		case "GLOBALEXPORT":
+			if disabling {
+				return zc1932Hit(cmd, "unsetopt GLOBAL_EXPORT")
+			}
+		case "NOGLOBALEXPORT":
+			if !disabling {
+				return zc1932Hit(cmd, "setopt NO_GLOBAL_EXPORT")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1932Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1932Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1932",
+		Message: "`" + form + "` makes `typeset -x` exports function-local — helper " +
+			"functions that set `PATH`/`VIRTUAL_ENV`/`AWS_*` no longer propagate to callers. " +
+			"Keep it on; scope temporary exports in a subshell instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 928 Katas = 0.9.28
-const Version = "0.9.28"
+// 929 Katas = 0.9.29
+const Version = "0.9.29"


### PR DESCRIPTION
ZC1932 — Warn on `unsetopt GLOBAL_EXPORT`

What: Flips `typeset -x VAR=val` inside a function from "export AND promote to outer scope" to function-local.
Why: Helper functions that set `PATH`, `VIRTUAL_ENV`, `AWS_*` no longer propagate — subsequent commands run under the old environment.
Fix suggestion: Keep the option on. Scope temporary exports with a subshell rather than a shell-wide flip.
Severity: Warning