### PR TITLE
feat: ZC1933 — detect `ipvsadm -C` wiping IPVS load-balancer table

### DIFF
--- a/pkg/katas/katatests/zc1933_test.go
+++ b/pkg/katas/katatests/zc1933_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1933(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ipvsadm -L -n` (list)",
+			input:    `ipvsadm -L -n`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ipvsadm --save` (backup)",
+			input:    `ipvsadm --save`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ipvsadm -C`",
+			input: `ipvsadm -C`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1933",
+					Message: "`ipvsadm -C` wipes every IPVS virtual service and real-server binding — load balancing stops, clients see 5xx. Save via `ipvsadm --save`, drain specific services with `-D`, reserve `--clear` for break-glass.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ipvsadm --clear now` (mangled)",
+			input: `ipvsadm --clear now`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1933",
+					Message: "`ipvsadm --clear` wipes every IPVS virtual service and real-server binding — load balancing stops, clients see 5xx. Save via `ipvsadm --save`, drain specific services with `-D`, reserve `--clear` for break-glass.",
+					Line:    1,
+					Column:  11,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1933")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1933.go
+++ b/pkg/katas/zc1933.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1933",
+		Title:    "Error on `ipvsadm -C` / `--clear` — wipes every IPVS virtual service, drops load balancer",
+		Severity: SeverityError,
+		Description: "`ipvsadm -C` (and the long form `--clear`) removes every virtual service, " +
+			"real server, and connection entry from the in-kernel IPVS table. Traffic that was " +
+			"being load-balanced to a backend farm now falls through to the host's local " +
+			"listen sockets (or drops), active keepalived/`ldirectord` states invert, and " +
+			"clients see 5xx until an operator replays the config. Save the current table first " +
+			"(`ipvsadm --save -n > /run/ipvs.bak`), drain specific services with `ipvsadm -D`, " +
+			"and keep `--clear` in break-glass-only runbooks.",
+		Check: checkZC1933,
+	})
+}
+
+func checkZC1933(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `ipvsadm --clear` mangles the command name to `clear`.
+	if ident.Value == "clear" {
+		return zc1933Hit(cmd, "ipvsadm --clear")
+	}
+	if ident.Value != "ipvsadm" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-C" || v == "--clear" {
+			return zc1933Hit(cmd, "ipvsadm "+v)
+		}
+	}
+	return nil
+}
+
+func zc1933Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1933",
+		Message: "`" + form + "` wipes every IPVS virtual service and real-server binding — " +
+			"load balancing stops, clients see 5xx. Save via `ipvsadm --save`, drain " +
+			"specific services with `-D`, reserve `--clear` for break-glass.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 929 Katas = 0.9.29
-const Version = "0.9.29"
+// 930 Katas = 0.9.30
+const Version = "0.9.30"


### PR DESCRIPTION
ZC1933 — Error on `ipvsadm -C` / `--clear`

What: Removes every virtual service, real server, and connection entry from the in-kernel IPVS table.
Why: Traffic that was being load-balanced to a backend farm falls through to local listeners (or drops); keepalived / ldirectord states invert; clients see 5xx until config is replayed.
Fix suggestion: Save first (`ipvsadm --save -n > /run/ipvs.bak`), drain specific services with `ipvsadm -D`, keep `--clear` in break-glass runbooks.
Severity: Error