### PR TITLE
feat: ZC1935 — detect `apt autoremove --purge` stripping deps + config

### DIFF
--- a/pkg/katas/katatests/zc1935_test.go
+++ b/pkg/katas/katatests/zc1935_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1935(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `apt autoremove --dry-run` (preview)",
+			input:    `apt autoremove --dry-run`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `apt autoremove` (no purge, config files kept)",
+			input:    `apt autoremove`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `apt autoremove --purge -y`",
+			input: `apt autoremove --purge -y`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1935",
+					Message: "`apt autoremove` strips packages the resolver thinks are unused plus their configs — uproots packages installed manually but never `apt-mark manual`-ed. Dry-run first, mark keepers, drop `--purge` in CI.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `zypper rm --clean-deps foo`",
+			input: `zypper rm --clean-deps foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1935",
+					Message: "`zypper autoremove` strips packages the resolver thinks are unused plus their configs — uproots packages installed manually but never `apt-mark manual`-ed. Dry-run first, mark keepers, drop `--purge` in CI.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1935")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1935.go
+++ b/pkg/katas/zc1935.go
@@ -1,0 +1,84 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1935",
+		Title:    "Warn on `apt autoremove --purge` / `dnf autoremove` — deletes auto-installed deps and their config",
+		Severity: SeverityWarning,
+		Description: "`apt autoremove --purge` (and `apt-get autoremove --purge`, `dnf autoremove`, " +
+			"`zypper rm --clean-deps`) remove every package the resolver thinks is no longer " +
+			"required, plus — with `--purge` — their `/etc` config and data dirs. In CI this " +
+			"quietly uproots packages someone else installed manually but never `apt-mark " +
+			"manual`-ed, and `--purge` makes the removal irreversible. Run a plain `apt " +
+			"autoremove --dry-run` in review, mark the keepers with `apt-mark manual`, and " +
+			"drop `--purge` from unattended jobs.",
+		Check: checkZC1935,
+	})
+}
+
+func checkZC1935(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var tool string
+	switch ident.Value {
+	case "apt", "apt-get":
+		tool = ident.Value
+	case "dnf", "yum":
+		tool = ident.Value
+	case "zypper":
+		tool = "zypper"
+	default:
+		return nil
+	}
+
+	hasAutoremove := false
+	hasPurge := false
+	hasCleanDeps := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "autoremove":
+			hasAutoremove = true
+		case "--purge", "--purge-unused":
+			hasPurge = true
+		case "--clean-deps":
+			hasCleanDeps = true
+		}
+		if v == "rm" && tool == "zypper" {
+			hasAutoremove = true
+		}
+	}
+	if !hasAutoremove {
+		return nil
+	}
+
+	// apt/apt-get autoremove --purge, or dnf/yum autoremove (always purges
+	// configs on RPM distros), or zypper rm --clean-deps.
+	if (tool == "apt" || tool == "apt-get") && !hasPurge {
+		return nil
+	}
+	if tool == "zypper" && !hasCleanDeps {
+		return nil
+	}
+
+	return []Violation{{
+		KataID: "ZC1935",
+		Message: "`" + tool + " autoremove` strips packages the resolver thinks are " +
+			"unused plus their configs — uproots packages installed manually but never " +
+			"`apt-mark manual`-ed. Dry-run first, mark keepers, drop `--purge` in CI.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 931 Katas = 0.9.31
-const Version = "0.9.31"
+// 932 Katas = 0.9.32
+const Version = "0.9.32"


### PR DESCRIPTION
ZC1935 — Warn on `apt autoremove --purge` / `zypper rm --clean-deps`

What: Removes every package the resolver thinks is no longer required, plus (with `--purge`) their `/etc` config and data dirs.
Why: In CI, quietly uproots packages someone installed manually but never `apt-mark manual`-ed. `--purge` makes the removal irreversible.
Fix suggestion: Run `apt autoremove --dry-run` in review, mark the keepers with `apt-mark manual`, drop `--purge` from unattended jobs.
Severity: Warning