### PR TITLE
feat: ZC1936 — detect `setopt POSIX_ALIASES` narrowing alias scope

### DIFF
--- a/pkg/katas/katatests/zc1936_test.go
+++ b/pkg/katas/katatests/zc1936_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1936(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt POSIX_ALIASES` (explicit default)",
+			input:    `unsetopt POSIX_ALIASES`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt EXTENDED_GLOB` (unrelated)",
+			input:    `setopt EXTENDED_GLOB`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt POSIX_ALIASES`",
+			input: `setopt POSIX_ALIASES`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1936",
+					Message: "`setopt POSIX_ALIASES` narrows alias expansion to plain identifiers — aliases on `if`/`for`/`function` silently stop firing and any library that hooked them breaks. Scope with `emulate -LR sh` instead of flipping globally.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_POSIX_ALIASES`",
+			input: `unsetopt NO_POSIX_ALIASES`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1936",
+					Message: "`unsetopt NO_POSIX_ALIASES` narrows alias expansion to plain identifiers — aliases on `if`/`for`/`function` silently stop firing and any library that hooked them breaks. Scope with `emulate -LR sh` instead of flipping globally.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1936")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1936.go
+++ b/pkg/katas/zc1936.go
@@ -1,0 +1,84 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1936",
+		Title:    "Warn on `setopt POSIX_ALIASES` — aliases on reserved words (`if`, `for`, …) stop expanding",
+		Severity: SeverityWarning,
+		Description: "Zsh by default lets `alias if='…'`, `alias function='…'`, etc. expand when " +
+			"the reserved word appears in command position — the feature that makes oh-my-zsh " +
+			"plugins able to hook `if` into their `preexec` chain. `setopt POSIX_ALIASES` " +
+			"narrows alias expansion to plain identifiers, so any library that aliased a " +
+			"reserved word silently stops being picked up. Keep the option off for " +
+			"interactive Zsh; if you need POSIX parity for a specific block, wrap it with " +
+			"`emulate -LR sh` instead of flipping the flag script-wide.",
+		Check: checkZC1936,
+	})
+}
+
+func checkZC1936(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1936Canonical(arg.String())
+		switch v {
+		case "POSIXALIASES":
+			if enabling {
+				return zc1936Hit(cmd, "setopt POSIX_ALIASES")
+			}
+		case "NOPOSIXALIASES":
+			if !enabling {
+				return zc1936Hit(cmd, "unsetopt NO_POSIX_ALIASES")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1936Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1936Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1936",
+		Message: "`" + form + "` narrows alias expansion to plain identifiers — aliases " +
+			"on `if`/`for`/`function` silently stop firing and any library that hooked " +
+			"them breaks. Scope with `emulate -LR sh` instead of flipping globally.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 932 Katas = 0.9.32
-const Version = "0.9.32"
+// 933 Katas = 0.9.33
+const Version = "0.9.33"


### PR DESCRIPTION
ZC1936 — Warn on `setopt POSIX_ALIASES`

What: Narrows alias expansion to plain identifiers — aliases on reserved words (`if`, `for`, `function`, `while`, `do`, `[`) stop firing.
Why: Libraries that hooked reserved words (oh-my-zsh-style plugin preexec wrappers) silently stop being picked up.
Fix suggestion: Keep the option off. Scope POSIX-specific blocks with `emulate -LR sh` instead of flipping globally.
Severity: Warning