### PR TITLE
feat: ZC1937 — detect `tmux kill-server`/`screen -X quit` session teardown

### DIFF
--- a/pkg/katas/katatests/zc1937_test.go
+++ b/pkg/katas/katatests/zc1937_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1937(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `tmux list-sessions`",
+			input:    `tmux list-sessions`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `tmux kill-window -t dev:1`",
+			input:    `tmux kill-window -t dev:1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `tmux kill-server`",
+			input: `tmux kill-server`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1937",
+					Message: "`tmux kill-server` tears down every detached process inside the session — builds, log tails, port-forwards get `SIGHUP`'d with no cleanup. Use `kill-window` for surgical removal or `systemd-run --scope` for workloads.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `screen -X quit`",
+			input: `screen -X quit`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1937",
+					Message: "`screen -X quit` tears down every detached process inside the session — builds, log tails, port-forwards get `SIGHUP`'d with no cleanup. Use `kill-window` for surgical removal or `systemd-run --scope` for workloads.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1937")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1937.go
+++ b/pkg/katas/zc1937.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1937",
+		Title:    "Warn on `tmux kill-server` / `tmux kill-session` — tears down every detached process inside",
+		Severity: SeverityWarning,
+		Description: "`tmux kill-server` terminates the whole tmux daemon, `tmux kill-session -t NAME` " +
+			"drops one named session, and `screen -X quit` does the screen equivalent. Anything " +
+			"the operator parked inside — a long-running build, a `tail -F` on production " +
+			"logs, a held `sudo` token, a port-forward — dies with the session, and the " +
+			"detached processes get `SIGHUP`'d with no cleanup. Use `tmux kill-window -t …` for " +
+			"surgical removal, send `SIGTERM` to the specific backend, or rely on `systemd-run " +
+			"--scope` for workloads that should survive terminal churn.",
+		Check: checkZC1937,
+	})
+}
+
+func checkZC1937(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	if ident.Value == "tmux" && len(cmd.Arguments) >= 1 {
+		sub := cmd.Arguments[0].String()
+		if sub == "kill-server" || sub == "kill-session" {
+			return zc1937Hit(cmd, "tmux "+sub)
+		}
+	}
+	if ident.Value == "screen" {
+		for i, arg := range cmd.Arguments {
+			if arg.String() == "-X" && i+1 < len(cmd.Arguments) &&
+				cmd.Arguments[i+1].String() == "quit" {
+				return zc1937Hit(cmd, "screen -X quit")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1937Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1937",
+		Message: "`" + form + "` tears down every detached process inside the session — " +
+			"builds, log tails, port-forwards get `SIGHUP`'d with no cleanup. Use " +
+			"`kill-window` for surgical removal or `systemd-run --scope` for workloads.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 933 Katas = 0.9.33
-const Version = "0.9.33"
+// 934 Katas = 0.9.34
+const Version = "0.9.34"


### PR DESCRIPTION
ZC1937 — Warn on `tmux kill-server` / `tmux kill-session` / `screen -X quit`

What: Terminates the whole multiplexer daemon or a named session.
Why: Builds, `tail -F` on production logs, held `sudo` tokens, port-forwards parked inside die with no cleanup — detached processes get `SIGHUP`'d.
Fix suggestion: Use `tmux kill-window -t …` for surgical removal, send `SIGTERM` to the specific backend, or use `systemd-run --scope` for workloads that should survive terminal churn.
Severity: Warning