### PR TITLE
feat: ZC1938 — detect `setopt POSIX_JOBS` job-table scope flip

### DIFF
--- a/pkg/katas/katatests/zc1938_test.go
+++ b/pkg/katas/katatests/zc1938_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1938(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt POSIX_JOBS` (explicit default)",
+			input:    `unsetopt POSIX_JOBS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt MONITOR` (unrelated)",
+			input:    `setopt MONITOR`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt POSIX_JOBS`",
+			input: `setopt POSIX_JOBS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1938",
+					Message: "`setopt POSIX_JOBS` scopes `%n` / `fg` / `bg` / `disown` per subshell — parent jobs become invisible inside `(…)`. Leave off; scope POSIX job semantics with `emulate -LR sh` inside a function.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_POSIX_JOBS`",
+			input: `unsetopt NO_POSIX_JOBS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1938",
+					Message: "`unsetopt NO_POSIX_JOBS` scopes `%n` / `fg` / `bg` / `disown` per subshell — parent jobs become invisible inside `(…)`. Leave off; scope POSIX job semantics with `emulate -LR sh` inside a function.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1938")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1938.go
+++ b/pkg/katas/zc1938.go
@@ -1,0 +1,84 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1938",
+		Title:    "Warn on `setopt POSIX_JOBS` — flips job-control semantics and `%n` scope",
+		Severity: SeverityWarning,
+		Description: "`POSIX_JOBS` makes Zsh's job-control spec follow POSIX: `%1` / `%n` refer " +
+			"only to jobs of the current shell (forked subshells get their own job table), " +
+			"`fg`/`bg` no longer accept a job ID from an outer shell, and `disown` on a " +
+			"subshell's job is a no-op. Scripts that launched a background job in the parent " +
+			"and then `wait %1`-ed from a `( subshell )` suddenly fail with \"no such job\". " +
+			"Leave the option off in Zsh; if POSIX job semantics are required, scope them via " +
+			"`emulate -LR sh` inside the single function that needs them.",
+		Check: checkZC1938,
+	})
+}
+
+func checkZC1938(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1938Canonical(arg.String())
+		switch v {
+		case "POSIXJOBS":
+			if enabling {
+				return zc1938Hit(cmd, "setopt POSIX_JOBS")
+			}
+		case "NOPOSIXJOBS":
+			if !enabling {
+				return zc1938Hit(cmd, "unsetopt NO_POSIX_JOBS")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1938Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1938Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1938",
+		Message: "`" + form + "` scopes `%n` / `fg` / `bg` / `disown` per subshell — parent " +
+			"jobs become invisible inside `(…)`. Leave off; scope POSIX job semantics with " +
+			"`emulate -LR sh` inside a function.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 934 Katas = 0.9.34
-const Version = "0.9.34"
+// 935 Katas = 0.9.35
+const Version = "0.9.35"


### PR DESCRIPTION
ZC1938 — Warn on `setopt POSIX_JOBS`

What: Makes job control POSIX-compliant — `%1` / `%n` refer only to jobs of the current shell, forked subshells get their own job table.
Why: Scripts that launched a background job in the parent and then `wait %1` from inside a subshell fail with 'no such job'. `fg`/`bg`/`disown` scope-differently too.
Fix suggestion: Leave off in Zsh. If POSIX job semantics are required, scope with `emulate -LR sh` inside one function.
Severity: Warning