### PR TITLE
feat: ZC1939 — detect `reboot -f`/`halt -f`/`poweroff -f` force-shutdown

### DIFF
--- a/pkg/katas/katatests/zc1939_test.go
+++ b/pkg/katas/katatests/zc1939_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1939(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `systemctl reboot`",
+			input:    `systemctl reboot`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `shutdown -r +5`",
+			input:    `shutdown -r +5`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `reboot -f`",
+			input: `reboot -f`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1939",
+					Message: "`reboot -f` fires `reboot(2)` immediately — no `ExecStop=`, no filesystem sync, no clean unmount. Databases replay from last checkpoint. Use `systemctl reboot` / `shutdown -r +N`; reserve `-f` for wedged recovery.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `poweroff --force now` (mangled)",
+			input: `poweroff --force now`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1939",
+					Message: "`reboot/halt/poweroff --force` fires `reboot(2)` immediately — no `ExecStop=`, no filesystem sync, no clean unmount. Databases replay from last checkpoint. Use `systemctl reboot` / `shutdown -r +N`; reserve `-f` for wedged recovery.",
+					Line:    1,
+					Column:  12,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1939")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1939.go
+++ b/pkg/katas/zc1939.go
@@ -1,0 +1,67 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1939",
+		Title:    "Error on `reboot -f` / `halt -f` / `poweroff -f` — skips shutdown sequence, no graceful service stop",
+		Severity: SeverityError,
+		Description: "`reboot -f`, `halt -f`, and `poweroff -f` short-circuit the systemd " +
+			"shutdown graph — no `ExecStop=`, no `DefaultDependencies=`, no filesystem sync, " +
+			"no Before/After ordering. The kernel's `reboot(2)` fires immediately and every " +
+			"dirty buffer that was not yet flushed is lost. Journal writes stop mid-line, " +
+			"databases on the host replay from the last checkpoint, and anything that needed a " +
+			"clean unmount (LUKS, NFS, cephfs) logs a dirty state. Use plain `systemctl " +
+			"reboot` / `shutdown -r +N`, and reserve `-f` for recovery when the normal path is " +
+			"already wedged.",
+		Check: checkZC1939,
+	})
+}
+
+func checkZC1939(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	// Parser caveat: `<cmd> --force` mangles the command name to `force`.
+	if ident.Value == "force" {
+		return zc1939Hit(cmd, "reboot/halt/poweroff --force")
+	}
+	if ident.Value != "reboot" && ident.Value != "halt" && ident.Value != "poweroff" {
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-f" || v == "--force" {
+			return zc1939Hit(cmd, ident.Value+" "+v)
+		}
+		if len(v) >= 2 && v[0] == '-' && v[1] != '-' {
+			for i := 1; i < len(v); i++ {
+				if v[i] == 'f' {
+					return zc1939Hit(cmd, ident.Value+" -f")
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func zc1939Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1939",
+		Message: "`" + form + "` fires `reboot(2)` immediately — no `ExecStop=`, no " +
+			"filesystem sync, no clean unmount. Databases replay from last checkpoint. " +
+			"Use `systemctl reboot` / `shutdown -r +N`; reserve `-f` for wedged recovery.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 935 Katas = 0.9.35
-const Version = "0.9.35"
+// 936 Katas = 0.9.36
+const Version = "0.9.36"


### PR DESCRIPTION
ZC1939 — Error on `reboot -f` / `halt -f` / `poweroff -f`

What: Short-circuits the systemd shutdown graph — no `ExecStop=`, no filesystem sync, no clean unmount.
Why: `reboot(2)` fires immediately; dirty buffers lost, journal writes stop mid-line, databases replay from last checkpoint, LUKS/NFS/cephfs log a dirty state.
Fix suggestion: Use `systemctl reboot` / `shutdown -r +N`. Reserve `-f` for recovery when the normal path is already wedged.
Severity: Error