### PR TITLE
feat: ZC1940 — detect `setopt POSIX_ARGZERO` freezing $0 in functions

### DIFF
--- a/pkg/katas/katatests/zc1940_test.go
+++ b/pkg/katas/katatests/zc1940_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1940(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt POSIX_ARGZERO` (explicit default)",
+			input:    `unsetopt POSIX_ARGZERO`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt FUNCTION_ARGZERO` (different option)",
+			input:    `setopt FUNCTION_ARGZERO`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt POSIX_ARGZERO`",
+			input: `setopt POSIX_ARGZERO`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1940",
+					Message: "`setopt POSIX_ARGZERO` freezes `$0` to the outer script name — loggers and `case $0` dispatch inside functions lose call-site context. Scope with `emulate -LR sh` instead of flipping globally.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_POSIX_ARGZERO`",
+			input: `unsetopt NO_POSIX_ARGZERO`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1940",
+					Message: "`unsetopt NO_POSIX_ARGZERO` freezes `$0` to the outer script name — loggers and `case $0` dispatch inside functions lose call-site context. Scope with `emulate -LR sh` instead of flipping globally.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1940")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1940.go
+++ b/pkg/katas/zc1940.go
@@ -1,0 +1,84 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1940",
+		Title:    "Warn on `setopt POSIX_ARGZERO` — `$0` no longer changes to the function name inside functions",
+		Severity: SeverityWarning,
+		Description: "Zsh's default behaviour (option off) assigns `$0` to the name of the " +
+			"currently-running function, so a helper like `log() { printf '%s\\n' \"$0: $*\"; }` " +
+			"prints `log: …`. `setopt POSIX_ARGZERO` keeps `$0` pointing at the outer script " +
+			"name (or the interpreter when sourced) — the logger instead prints the script " +
+			"path for every message and call-site context is lost. Every `case $0` dispatch " +
+			"inside an auto-loaded function also stops working. Leave the option off; if you " +
+			"need POSIX `$0`, scope it in a function with `emulate -LR sh`.",
+		Check: checkZC1940,
+	})
+}
+
+func checkZC1940(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1940Canonical(arg.String())
+		switch v {
+		case "POSIXARGZERO":
+			if enabling {
+				return zc1940Hit(cmd, "setopt POSIX_ARGZERO")
+			}
+		case "NOPOSIXARGZERO":
+			if !enabling {
+				return zc1940Hit(cmd, "unsetopt NO_POSIX_ARGZERO")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1940Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1940Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1940",
+		Message: "`" + form + "` freezes `$0` to the outer script name — loggers and " +
+			"`case $0` dispatch inside functions lose call-site context. Scope with " +
+			"`emulate -LR sh` instead of flipping globally.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 936 Katas = 0.9.36
-const Version = "0.9.36"
+// 937 Katas = 0.9.37
+const Version = "0.9.37"


### PR DESCRIPTION
ZC1940 — Warn on `setopt POSIX_ARGZERO`

What: `$0` no longer changes to the current function name; retains the outer script name (or interpreter when sourced).
Why: Loggers like `log() { printf '%s: %s\n' "$0" "$*"; }` print the script path for every call — call-site context lost. `case $0` dispatch inside auto-loaded functions breaks.
Fix suggestion: Leave off. If POSIX `$0` is required, scope with `emulate -LR sh` inside the function.
Severity: Warning