### PR TITLE
feat: ZC1941 — detect `restic --insecure-no-password` unencrypted repo

### DIFF
--- a/pkg/katas/katatests/zc1941_test.go
+++ b/pkg/katas/katatests/zc1941_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1941(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `restic init --password-file /etc/restic.pass`",
+			input:    `restic init --password-file /etc/restic.pass`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `restic snapshots`",
+			input:    `restic snapshots`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `restic init --insecure-no-password now`",
+			input: `restic init --insecure-no-password now`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1941",
+					Message: "`restic --insecure-no-password` creates an unencrypted repo — every operator with read access to the backend can reassemble the backed-up filesystem. Use `--password-file` / `--password-command` with a real passphrase.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `restic backup /data --insecure-no-password`",
+			input: `restic backup /data --insecure-no-password`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1941",
+					Message: "`restic --insecure-no-password` creates an unencrypted repo — every operator with read access to the backend can reassemble the backed-up filesystem. Use `--password-file` / `--password-command` with a real passphrase.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1941")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1941.go
+++ b/pkg/katas/zc1941.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1941",
+		Title:    "Error on `restic init --insecure-no-password` — creates an unencrypted backup repository",
+		Severity: SeverityError,
+		Description: "`restic init --insecure-no-password` creates a repo whose data chunks are " +
+			"reachable without a key. Every later `backup` and `restore` round-trips " +
+			"plaintext blocks to the storage backend, so any operator with read access to the " +
+			"bucket / NFS share / SFTP directory can assemble the backed-up filesystem — " +
+			"including shell history, SSH keys, and database dumps. Pass a real passphrase via " +
+			"`--password-file` (mode `0400`, readable only by the backup user) or " +
+			"`--password-command`, and never use the `--insecure-*` family outside a local " +
+			"test repo.",
+		Check: checkZC1941,
+	})
+}
+
+func checkZC1941(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `restic --insecure-no-password …` mangles the command
+	// name to `insecure-no-password`.
+	if ident.Value == "insecure-no-password" {
+		return zc1941Hit(cmd)
+	}
+	if ident.Value != "restic" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "--insecure-no-password" {
+			return zc1941Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1941Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1941",
+		Message: "`restic --insecure-no-password` creates an unencrypted repo — every " +
+			"operator with read access to the backend can reassemble the backed-up " +
+			"filesystem. Use `--password-file` / `--password-command` with a real passphrase.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 937 Katas = 0.9.37
-const Version = "0.9.37"
+// 938 Katas = 0.9.38
+const Version = "0.9.38"


### PR DESCRIPTION
ZC1941 — Error on `restic init --insecure-no-password`

What: Creates a restic repo whose data chunks are reachable without a key.
Why: Every `backup` / `restore` round-trips plaintext blocks — any operator with read access to the bucket / NFS share / SFTP directory can reassemble the backed-up filesystem (shell history, SSH keys, database dumps).
Fix suggestion: Pass a passphrase via `--password-file` (mode 0400, readable only by the backup user) or `--password-command`. Never use `--insecure-*` outside a local test repo.
Severity: Error