### PR TITLE
feat: ZC1942 — detect `setopt CLOBBER_EMPTY` weakening NO_CLOBBER

### DIFF
--- a/pkg/katas/katatests/zc1942_test.go
+++ b/pkg/katas/katatests/zc1942_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1942(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt CLOBBER_EMPTY` (explicit default)",
+			input:    `unsetopt CLOBBER_EMPTY`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NO_CLOBBER` (unrelated)",
+			input:    `setopt NO_CLOBBER`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt CLOBBER_EMPTY`",
+			input: `setopt CLOBBER_EMPTY`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1942",
+					Message: "`setopt CLOBBER_EMPTY` lets `>file` overwrite zero-length files even under `NO_CLOBBER` — `touch`ed lock / sentinel files lose their safety net. Keep off; use explicit `>|file` to bypass `NO_CLOBBER` for a specific write.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_CLOBBER_EMPTY`",
+			input: `unsetopt NO_CLOBBER_EMPTY`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1942",
+					Message: "`unsetopt NO_CLOBBER_EMPTY` lets `>file` overwrite zero-length files even under `NO_CLOBBER` — `touch`ed lock / sentinel files lose their safety net. Keep off; use explicit `>|file` to bypass `NO_CLOBBER` for a specific write.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1942")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1942.go
+++ b/pkg/katas/zc1942.go
@@ -1,0 +1,83 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1942",
+		Title:    "Warn on `setopt CLOBBER_EMPTY` — `>file` still overwrites zero-length files under `NO_CLOBBER`",
+		Severity: SeverityWarning,
+		Description: "`setopt CLOBBER_EMPTY` relaxes `NO_CLOBBER`: a bare `>file` redirect still " +
+			"succeeds when the target is zero bytes. Scripts that rely on `setopt NO_CLOBBER` " +
+			"as a guard against accidental overwrite lose their safety net for every " +
+			"freshly-`touch`ed lock file, sentinel, or `install -D`-created placeholder — the " +
+			"next stray `>sentinel` quietly overwrites it. Keep the option off; use `>|file` " +
+			"explicitly when you do want to bypass the `NO_CLOBBER` guard for a specific write.",
+		Check: checkZC1942,
+	})
+}
+
+func checkZC1942(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1942Canonical(arg.String())
+		switch v {
+		case "CLOBBEREMPTY":
+			if enabling {
+				return zc1942Hit(cmd, "setopt CLOBBER_EMPTY")
+			}
+		case "NOCLOBBEREMPTY":
+			if !enabling {
+				return zc1942Hit(cmd, "unsetopt NO_CLOBBER_EMPTY")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1942Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1942Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1942",
+		Message: "`" + form + "` lets `>file` overwrite zero-length files even under " +
+			"`NO_CLOBBER` — `touch`ed lock / sentinel files lose their safety net. Keep " +
+			"off; use explicit `>|file` to bypass `NO_CLOBBER` for a specific write.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 938 Katas = 0.9.38
-const Version = "0.9.38"
+// 939 Katas = 0.9.39
+const Version = "0.9.39"


### PR DESCRIPTION
ZC1942 — Warn on `setopt CLOBBER_EMPTY`

What: Relaxes `NO_CLOBBER` so `>file` still overwrites zero-length targets.
Why: Scripts using `setopt NO_CLOBBER` as a safety net lose it for every freshly-`touch`ed lock file, sentinel, or `install -D`-created placeholder — next stray `>sentinel` silently overwrites.
Fix suggestion: Keep the option off. Use explicit `>|file` to bypass `NO_CLOBBER` for a specific write.
Severity: Warning