### PR TITLE
feat: ZC1943 — detect `systemd-nspawn -b` booting untrusted rootfs

### DIFF
--- a/pkg/katas/katatests/zc1943_test.go
+++ b/pkg/katas/katatests/zc1943_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1943(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `systemd-nspawn -D /srv/container /bin/sh` (not booting)",
+			input:    `systemd-nspawn -D /srv/container /bin/sh`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `machinectl start web`",
+			input:    `machinectl start web`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `systemd-nspawn -b -D /srv/container`",
+			input: `systemd-nspawn -b -D /srv/container`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1943",
+					Message: "`systemd-nspawn -b` runs the rootfs's `/sbin/init` with minimal isolation — init scripts execute first and can probe the host. Use `-U`, drop caps with `--capability=`, pair with `--private-network`, prefer `machinectl start`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `systemd-nspawn --boot -D $ROOT` (mangled)",
+			input: `systemd-nspawn --boot -D $ROOT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1943",
+					Message: "`systemd-nspawn --boot` runs the rootfs's `/sbin/init` with minimal isolation — init scripts execute first and can probe the host. Use `-U`, drop caps with `--capability=`, pair with `--private-network`, prefer `machinectl start`.",
+					Line:    1,
+					Column:  18,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1943")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1943.go
+++ b/pkg/katas/zc1943.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1943",
+		Title:    "Warn on `systemd-nspawn -b` / `--boot` — runs a full init inside a possibly untrusted rootfs",
+		Severity: SeverityWarning,
+		Description: "`systemd-nspawn -b -D $ROOT` (and `--boot -D $ROOT`) launches the rootfs's " +
+			"`/sbin/init` inside a minimally-isolated namespace — by default the container " +
+			"inherits `CAP_AUDIT_CONTROL`, `CAP_NET_ADMIN`, and read-write access to the " +
+			"host's `/dev` nodes that match the container's cgroup. If `$ROOT` is an " +
+			"operator-supplied tarball, any init script it ships runs first and can probe the " +
+			"host. Use `-U` for user-namespace isolation, drop capabilities with " +
+			"`--capability=`, pair with `--private-network`, and prefer `machinectl start` on " +
+			"a reviewed image instead of ad-hoc boots.",
+		Check: checkZC1943,
+	})
+}
+
+func checkZC1943(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `systemd-nspawn --boot` mangles the command name to
+	// `boot` (after the `systemd-nspawn--` subtract).
+	if ident.Value == "boot" {
+		return zc1943Hit(cmd, "systemd-nspawn --boot")
+	}
+	if ident.Value != "systemd-nspawn" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-b" || v == "--boot" {
+			return zc1943Hit(cmd, "systemd-nspawn "+v)
+		}
+	}
+	return nil
+}
+
+func zc1943Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1943",
+		Message: "`" + form + "` runs the rootfs's `/sbin/init` with minimal isolation — " +
+			"init scripts execute first and can probe the host. Use `-U`, drop caps with " +
+			"`--capability=`, pair with `--private-network`, prefer `machinectl start`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 939 Katas = 0.9.39
-const Version = "0.9.39"
+// 940 Katas = 0.9.40
+const Version = "0.9.40"


### PR DESCRIPTION
ZC1943 — Warn on `systemd-nspawn -b` / `--boot`

What: Launches the rootfs's `/sbin/init` inside a minimally-isolated namespace.
Why: Default caps inherit `CAP_AUDIT_CONTROL`, `CAP_NET_ADMIN`, r/w access to host `/dev` matching the cgroup. If `$ROOT` is operator-supplied, its init scripts run first and can probe the host.
Fix suggestion: Use `-U` for user-namespace isolation, drop caps with `--capability=`, pair with `--private-network`. Prefer `machinectl start` on a reviewed image.
Severity: Warning