### PR TITLE
feat: ZC1944 — detect `setopt IGNORE_EOF` masking runaway subshells

### DIFF
--- a/pkg/katas/katatests/zc1944_test.go
+++ b/pkg/katas/katatests/zc1944_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1944(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt IGNORE_EOF` (explicit default)",
+			input:    `unsetopt IGNORE_EOF`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt EMACS` (unrelated)",
+			input:    `setopt EMACS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt IGNORE_EOF`",
+			input: `setopt IGNORE_EOF`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1944",
+					Message: "`setopt IGNORE_EOF` makes `Ctrl-D` stop terminating the shell — subshells, sudo holds, SSH tunnels linger after the parent left. Keep off; use `TMOUT=NN` for a timed stale-tty exit if needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_IGNORE_EOF`",
+			input: `unsetopt NO_IGNORE_EOF`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1944",
+					Message: "`unsetopt NO_IGNORE_EOF` makes `Ctrl-D` stop terminating the shell — subshells, sudo holds, SSH tunnels linger after the parent left. Keep off; use `TMOUT=NN` for a timed stale-tty exit if needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1944")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1944.go
+++ b/pkg/katas/zc1944.go
@@ -1,0 +1,84 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1944",
+		Title:    "Warn on `setopt IGNORE_EOF` — Ctrl-D no longer exits the shell, masking runaway pipelines",
+		Severity: SeverityWarning,
+		Description: "`IGNORE_EOF` tells the interactive shell to treat an end-of-file on stdin as " +
+			"if it were nothing, so `Ctrl-D` stops terminating a login. In an unattended `zsh " +
+			"-i -c` launch, or a sourced rc, this keeps a subshell alive that was supposed to " +
+			"wind down when the controlling terminal went away — sudo sessions, SSH tunnels, " +
+			"port-forwards, and build supervisors then linger long after the parent left. Keep " +
+			"the option off; if a stale-tty guard is truly wanted, set `TMOUT=NN` for a timed " +
+			"exit instead.",
+		Check: checkZC1944,
+	})
+}
+
+func checkZC1944(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1944Canonical(arg.String())
+		switch v {
+		case "IGNOREEOF":
+			if enabling {
+				return zc1944Hit(cmd, "setopt IGNORE_EOF")
+			}
+		case "NOIGNOREEOF":
+			if !enabling {
+				return zc1944Hit(cmd, "unsetopt NO_IGNORE_EOF")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1944Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1944Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1944",
+		Message: "`" + form + "` makes `Ctrl-D` stop terminating the shell — subshells, " +
+			"sudo holds, SSH tunnels linger after the parent left. Keep off; use " +
+			"`TMOUT=NN` for a timed stale-tty exit if needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 940 Katas = 0.9.40
-const Version = "0.9.40"
+// 941 Katas = 0.9.41
+const Version = "0.9.41"


### PR DESCRIPTION
ZC1944 — Warn on `setopt IGNORE_EOF`

What: Interactive shell treats EOF on stdin as nothing — `Ctrl-D` stops terminating a login.
Why: In unattended `zsh -i -c` launches or sourced rc files, subshells, sudo holds, SSH tunnels, port-forwards, and build supervisors linger long after the parent left.
Fix suggestion: Keep off. If a stale-tty guard is wanted, set `TMOUT=NN` for a timed exit.
Severity: Warning