### PR TITLE
feat: ZC1945 — detect `bpftrace -e`/`bpftool prog load` in-kernel eBPF

### DIFF
--- a/pkg/katas/katatests/zc1945_test.go
+++ b/pkg/katas/katatests/zc1945_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1945(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `bpftrace -l 'tracepoint:syscalls:*'` (list only)",
+			input:    `bpftrace -l tracepoint:syscalls:*`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `bpftool prog show`",
+			input:    `bpftool prog show`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `bpftrace -e 'tracepoint:syscalls:sys_enter_openat{printf(...)}'`",
+			input: `bpftrace -e 'tracepoint:syscalls:sys_enter_openat{printf(...)}'`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1945",
+					Message: "`bpftrace -e` loads an in-kernel eBPF program that can read arbitrary kernel/userland memory — every syscall arg, every TCP payload. Gate behind a runbook and prefer a short-lived `bpftrace -c CMD` over a pinned trace.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `bpftool prog load prog.o /sys/fs/bpf/spy`",
+			input: `bpftool prog load prog.o /sys/fs/bpf/spy`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1945",
+					Message: "`bpftool prog load` loads an in-kernel eBPF program that can read arbitrary kernel/userland memory — every syscall arg, every TCP payload. Gate behind a runbook and prefer a short-lived `bpftrace -c CMD` over a pinned trace.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1945")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1945.go
+++ b/pkg/katas/zc1945.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1945",
+		Title:    "Warn on `bpftrace -e` / `bpftool prog load` — loads in-kernel eBPF from a script",
+		Severity: SeverityWarning,
+		Description: "`bpftrace -e '…'` compiles an inline script into an eBPF program and attaches " +
+			"to kprobes, tracepoints, or uprobes; `bpftool prog load FILE pinned /sys/fs/bpf/…` " +
+			"installs a pre-built program. Both require `CAP_BPF`/`CAP_SYS_ADMIN` and can read " +
+			"arbitrary kernel/userland memory — every command a sibling process runs, every " +
+			"syscall argument, every TCP payload. Pin the loaded program to a directory the " +
+			"operator owns, gate invocation behind a runbook, and prefer a short-lived " +
+			"`bpftrace -c CMD` window over long-running traces left on the host.",
+		Check: checkZC1945,
+	})
+}
+
+func checkZC1945(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "bpftrace":
+		for _, arg := range cmd.Arguments {
+			if arg.String() == "-e" {
+				return zc1945Hit(cmd, "bpftrace -e")
+			}
+		}
+	case "bpftool":
+		if len(cmd.Arguments) >= 2 &&
+			cmd.Arguments[0].String() == "prog" &&
+			cmd.Arguments[1].String() == "load" {
+			return zc1945Hit(cmd, "bpftool prog load")
+		}
+	}
+	return nil
+}
+
+func zc1945Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1945",
+		Message: "`" + form + "` loads an in-kernel eBPF program that can read arbitrary " +
+			"kernel/userland memory — every syscall arg, every TCP payload. Gate behind a " +
+			"runbook and prefer a short-lived `bpftrace -c CMD` over a pinned trace.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 941 Katas = 0.9.41
-const Version = "0.9.41"
+// 942 Katas = 0.9.42
+const Version = "0.9.42"


### PR DESCRIPTION
ZC1945 — Warn on `bpftrace -e` / `bpftool prog load`

What: Compiles or installs an eBPF program that attaches to kprobes, tracepoints, or uprobes.
Why: Needs `CAP_BPF`/`CAP_SYS_ADMIN` and can read arbitrary kernel/userland memory — every syscall arg, every TCP payload, every command a sibling process runs.
Fix suggestion: Pin loaded programs to a directory the operator owns, gate invocation behind a runbook, prefer a short-lived `bpftrace -c CMD` window.
Severity: Warning