### PR TITLE
feat: ZC1946 — detect `unsetopt HUP` leaving background jobs past exit

### DIFF
--- a/pkg/katas/katatests/zc1946_test.go
+++ b/pkg/katas/katatests/zc1946_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1946(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt HUP` (explicit default)",
+			input:    `setopt HUP`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NOMATCH` (unrelated)",
+			input:    `unsetopt NOMATCH`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt HUP`",
+			input: `unsetopt HUP`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1946",
+					Message: "`unsetopt HUP` stops the shell from `SIGHUP`-ing background jobs on exit — long pipelines and spawned daemons outlive the session, orphans accumulate. Use `disown` or `systemd-run --scope` on specific commands instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_HUP`",
+			input: `setopt NO_HUP`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1946",
+					Message: "`setopt NO_HUP` stops the shell from `SIGHUP`-ing background jobs on exit — long pipelines and spawned daemons outlive the session, orphans accumulate. Use `disown` or `systemd-run --scope` on specific commands instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1946")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1946.go
+++ b/pkg/katas/zc1946.go
@@ -1,0 +1,84 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1946",
+		Title:    "Warn on `unsetopt HUP` — background jobs keep running after shell exit",
+		Severity: SeverityWarning,
+		Description: "Zsh's `HUP` option (on by default) sends `SIGHUP` to each running child job " +
+			"when the shell exits, letting them wind down cleanly. `unsetopt HUP` / " +
+			"`setopt NO_HUP` disables that, so long pipelines, `sleep` loops, and " +
+			"user-spawned daemons live on — `ps aux` accumulates orphaned workers across " +
+			"logouts and resource consumption creeps up. If a specific job really needs to " +
+			"outlive the shell, use `disown` or `systemd-run --scope` on that one invocation; " +
+			"leave `HUP` on globally.",
+		Check: checkZC1946,
+	})
+}
+
+func checkZC1946(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var disabling bool
+	switch ident.Value {
+	case "unsetopt":
+		disabling = true
+	case "setopt":
+		disabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1946Canonical(arg.String())
+		switch v {
+		case "HUP":
+			if disabling {
+				return zc1946Hit(cmd, "unsetopt HUP")
+			}
+		case "NOHUP":
+			if !disabling {
+				return zc1946Hit(cmd, "setopt NO_HUP")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1946Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1946Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1946",
+		Message: "`" + form + "` stops the shell from `SIGHUP`-ing background jobs on " +
+			"exit — long pipelines and spawned daemons outlive the session, orphans " +
+			"accumulate. Use `disown` or `systemd-run --scope` on specific commands instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 942 Katas = 0.9.42
-const Version = "0.9.42"
+// 943 Katas = 0.9.43
+const Version = "0.9.43"


### PR DESCRIPTION
ZC1946 — Warn on `unsetopt HUP`

What: Stops the shell from sending `SIGHUP` to running child jobs on exit (default ON in Zsh).
Why: Long pipelines, `sleep` loops, and spawned daemons outlive the session — `ps aux` accumulates orphans across logouts and resource use creeps up.
Fix suggestion: Keep `HUP` on globally. Use `disown` or `systemd-run --scope` on specific commands that need to outlive the shell.
Severity: Warning