### PR TITLE
feat: ZC1947 — detect `ip xfrm state/policy flush` IPsec teardown

### DIFF
--- a/pkg/katas/katatests/zc1947_test.go
+++ b/pkg/katas/katatests/zc1947_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1947(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ip xfrm state list`",
+			input:    `ip xfrm state list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ip xfrm policy show`",
+			input:    `ip xfrm policy show`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ip xfrm state flush`",
+			input: `ip xfrm state flush`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1947",
+					Message: "`ip xfrm state flush` tears down every IPsec SA/policy — VPN tunnels drop, kernel stops encrypting, plaintext may leak during renegotiation. Scope via `ip xfrm state deleteall src $A dst $B`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ip xfrm policy flush`",
+			input: `ip xfrm policy flush`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1947",
+					Message: "`ip xfrm policy flush` tears down every IPsec SA/policy — VPN tunnels drop, kernel stops encrypting, plaintext may leak during renegotiation. Scope via `ip xfrm policy deleteall src $A dst $B`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1947")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1947.go
+++ b/pkg/katas/zc1947.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1947",
+		Title:    "Error on `ip xfrm state flush` / `ip xfrm policy flush` — tears down every IPsec SA and policy",
+		Severity: SeverityError,
+		Description: "`ip xfrm state flush` removes every IPsec Security Association; " +
+			"`ip xfrm policy flush` removes every policy that would have driven them. " +
+			"Strongswan, libreswan, FRR, and WireGuard-over-xfrm all lose their tunnels " +
+			"instantly — site-to-site VPNs drop, kernel packet paths stop encrypting, and " +
+			"peers renegotiate from scratch (with traffic leaking in plaintext during the gap " +
+			"on misconfigured hosts). Use `ip xfrm state deleteall src $A dst $B` to scope " +
+			"the change to a single tunnel, and pair flushes with a maintenance window.",
+		Check: checkZC1947,
+	})
+}
+
+func checkZC1947(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ip" {
+		return nil
+	}
+	if len(cmd.Arguments) < 3 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "xfrm" {
+		return nil
+	}
+	tbl := cmd.Arguments[1].String()
+	if tbl != "state" && tbl != "policy" {
+		return nil
+	}
+	if cmd.Arguments[2].String() != "flush" {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1947",
+		Message: "`ip xfrm " + tbl + " flush` tears down every IPsec SA/policy — " +
+			"VPN tunnels drop, kernel stops encrypting, plaintext may leak during renegotiation. " +
+			"Scope via `ip xfrm " + tbl + " deleteall src $A dst $B`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 943 Katas = 0.9.43
-const Version = "0.9.43"
+// 944 Katas = 0.9.44
+const Version = "0.9.44"


### PR DESCRIPTION
ZC1947 — Error on `ip xfrm state flush` / `ip xfrm policy flush`

What: Removes every IPsec Security Association and every policy driving them.
Why: Strongswan/libreswan/FRR/WireGuard-over-xfrm tunnels drop instantly; kernel packet paths stop encrypting; peers renegotiate from scratch (plaintext may leak during the gap on misconfigured hosts).
Fix suggestion: Use `ip xfrm state deleteall src $A dst $B` to scope per-tunnel, pair flushes with a maintenance window.
Severity: Error