### PR TITLE
feat: ZC1948 — detect `ipmitool -P PASS` BMC password in argv

### DIFF
--- a/pkg/katas/katatests/zc1948_test.go
+++ b/pkg/katas/katatests/zc1948_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1948(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ipmitool -I lan -H bmc -U admin -f /etc/ipmi.pass chassis status`",
+			input:    `ipmitool -I lan -H bmc -U admin -f /etc/ipmi.pass chassis status`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ipmitool -E -H bmc chassis status` (env password)",
+			input:    `ipmitool -E -H bmc chassis status`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ipmitool -H bmc -U admin -P hunter2 chassis status`",
+			input: `ipmitool -H bmc -U admin -P hunter2 chassis status`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1948",
+					Message: "`ipmitool -P hunter2` leaks the BMC password into argv — visible in `ps`/`/proc`/crash dumps. Use `-f <password_file>` (mode 0400) or `IPMI_PASSWORD=… ipmitool -E`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ipmitool -Phunter2 -H bmc chassis power status` (joined)",
+			input: `ipmitool -Phunter2 -H bmc chassis power status`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1948",
+					Message: "`ipmitool -Phunter2` leaks the BMC password into argv — visible in `ps`/`/proc`/crash dumps. Use `-f <password_file>` (mode 0400) or `IPMI_PASSWORD=… ipmitool -E`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1948")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1948.go
+++ b/pkg/katas/zc1948.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1948",
+		Title:    "Error on `ipmitool -P PASS` / `-E` — BMC password visible in argv",
+		Severity: SeverityError,
+		Description: "`ipmitool -H <bmc> -U admin -P <password>` puts the BMC credential into " +
+			"`ps`, `/proc/PID/cmdline`, and every process-dump crash file. The BMC is a root-" +
+			"equivalent out-of-band controller (power, console, firmware update), so that " +
+			"password is one of the most sensitive tokens on the host. Use `-f <password_file>` " +
+			"(mode `0400`, owned by the automation user) or set `IPMI_PASSWORD` and pass `-E` — " +
+			"`ipmitool` reads the env var but never echoes it.",
+		Check: checkZC1948,
+	})
+}
+
+func checkZC1948(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ipmitool" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-P" && i+1 < len(cmd.Arguments) {
+			return zc1948Hit(cmd, "-P "+cmd.Arguments[i+1].String())
+		}
+		if strings.HasPrefix(v, "-P") && len(v) > 2 {
+			return zc1948Hit(cmd, v)
+		}
+	}
+	return nil
+}
+
+func zc1948Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1948",
+		Message: "`ipmitool " + form + "` leaks the BMC password into argv — visible in " +
+			"`ps`/`/proc`/crash dumps. Use `-f <password_file>` (mode 0400) or " +
+			"`IPMI_PASSWORD=… ipmitool -E`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 944 Katas = 0.9.44
-const Version = "0.9.44"
+// 945 Katas = 0.9.45
+const Version = "0.9.45"


### PR DESCRIPTION
ZC1948 — Error on `ipmitool -P PASS`

What: BMC credential passed as a command-line argument.
Why: Lands in `ps`, `/proc/PID/cmdline`, crash dumps. The BMC is a root-equivalent out-of-band controller (power, console, firmware update) — one of the most sensitive tokens on the host.
Fix suggestion: Use `-f <password_file>` (mode `0400`, owned by the automation user) or `IPMI_PASSWORD=… ipmitool -E`.
Severity: Error