### PR TITLE
feat: ZC1949 — detect `rmmod -f` bypassing module refcount

### DIFF
--- a/pkg/katas/katatests/zc1949_test.go
+++ b/pkg/katas/katatests/zc1949_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1949(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `rmmod nft_chain_nat` (no force)",
+			input:    `rmmod nft_chain_nat`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `modprobe -r bluetooth`",
+			input:    `modprobe -r bluetooth`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `rmmod -f nvidia`",
+			input: `rmmod -f nvidia`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1949",
+					Message: "`rmmod -f` tears down a module even when its refcount is non-zero — in-use drivers dangle, kernel oopses on the next callback. Stop holders first (`lsof`/`umount`/`ip link down`), then `rmmod` without `-f`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `rmmod --force foo` (mangled)",
+			input: `rmmod --force foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1949",
+					Message: "`rmmod --force` tears down a module even when its refcount is non-zero — in-use drivers dangle, kernel oopses on the next callback. Stop holders first (`lsof`/`umount`/`ip link down`), then `rmmod` without `-f`.",
+					Line:    1,
+					Column:  9,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1949")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1949.go
+++ b/pkg/katas/zc1949.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1949",
+		Title:    "Error on `rmmod -f` / `rmmod --force` — bypasses refcount, can panic the kernel",
+		Severity: SeverityError,
+		Description: "`rmmod -f` asks the kernel to tear down a module even if its reference count " +
+			"is non-zero. Any live `open(\"/dev/…\")`, mounted filesystem, or in-flight network " +
+			"device driven by that module becomes a dangling pointer — the kernel oopses or " +
+			"outright panics as soon as the next callback fires. The feature is compiled out " +
+			"on most distros (`CONFIG_MODULE_FORCE_UNLOAD=n`), but when present it is strictly " +
+			"a break-glass recovery tool. Stop the holders first (`lsof /dev/FOO`, `umount`, " +
+			"`ip link set dev … down`), then use plain `rmmod` or `modprobe -r`.",
+		Check: checkZC1949,
+	})
+}
+
+func checkZC1949(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `rmmod --force MOD` mangles the command name to `force`.
+	if ident.Value == "force" {
+		return zc1949Hit(cmd, "rmmod --force")
+	}
+	if ident.Value != "rmmod" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-f" || v == "--force" {
+			return zc1949Hit(cmd, "rmmod "+v)
+		}
+	}
+	return nil
+}
+
+func zc1949Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1949",
+		Message: "`" + form + "` tears down a module even when its refcount is non-zero — " +
+			"in-use drivers dangle, kernel oopses on the next callback. Stop holders first " +
+			"(`lsof`/`umount`/`ip link down`), then `rmmod` without `-f`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 945 Katas = 0.9.45
-const Version = "0.9.45"
+// 946 Katas = 0.9.46
+const Version = "0.9.46"


### PR DESCRIPTION
ZC1949 — Error on `rmmod -f` / `rmmod --force`

What: Tears down a kernel module even when its reference count is non-zero.
Why: Live `open("/dev/…")`, mounted filesystems, or in-flight network drivers become dangling pointers — kernel oopses or panics on the next callback. Compiled out on most distros; strictly break-glass when present.
Fix suggestion: Stop holders first (`lsof /dev/FOO`, `umount`, `ip link set dev … down`), then plain `rmmod` or `modprobe -r`.
Severity: Error