### PR TITLE
feat: ZC1950 — detect `tune2fs -O ^has_journal`/`-m 0` resilience strip

### DIFF
--- a/pkg/katas/katatests/zc1950_test.go
+++ b/pkg/katas/katatests/zc1950_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1950(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `tune2fs -l $DEV` (read only)",
+			input:    `tune2fs -l $DEV`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `tune2fs -m 1 $DEV` (tiny but non-zero reserve)",
+			input:    `tune2fs -m 1 $DEV`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `tune2fs -O ^has_journal $DEV`",
+			input: `tune2fs -O ^has_journal $DEV`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1950",
+					Message: "`tune2fs -O ^has_journal` strips the journal — crash recovery needs a full `fsck -y` and may truncate files. Keep the default.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `tune2fs -m 0 $DEV`",
+			input: `tune2fs -m 0 $DEV`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1950",
+					Message: "`tune2fs -m 0` zeroes the root reserve — a full fs leaves no headroom for `journald`/`apt`/root shells. Keep the default.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1950")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1950.go
+++ b/pkg/katas/zc1950.go
@@ -1,0 +1,74 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1950",
+		Title:    "Error on `tune2fs -O ^has_journal` / `-m 0` — removes journal or root reserve",
+		Severity: SeverityError,
+		Description: "`tune2fs -O ^has_journal $DEV` strips the ext3/4 journal from the " +
+			"filesystem. Crash recovery drops from \"replay the journal\" to \"scan the whole " +
+			"block device with `fsck -y`\", which frequently truncates partially-written files. " +
+			"`tune2fs -m 0 $DEV` takes the reserved-for-root space down to zero; when the " +
+			"filesystem fills up there is no headroom for `journald`, `apt`, or even a root " +
+			"shell to clean up — recovery needs rescue media. Keep the journal on and leave " +
+			"`-m` at the distro default (5% is overkill on large disks, but `-m 1` is still " +
+			"safe).",
+		Check: checkZC1950,
+	})
+}
+
+func checkZC1950(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "tune2fs" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-O" && i+1 < len(cmd.Arguments) {
+			spec := cmd.Arguments[i+1].String()
+			if zc1950StripsJournal(spec) {
+				return zc1950Hit(cmd, "-O "+spec, "strips the journal — crash recovery needs a full `fsck -y` and may truncate files")
+			}
+		}
+		if v == "-m" && i+1 < len(cmd.Arguments) {
+			if cmd.Arguments[i+1].String() == "0" {
+				return zc1950Hit(cmd, "-m 0", "zeroes the root reserve — a full fs leaves no headroom for `journald`/`apt`/root shells")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1950StripsJournal(spec string) bool {
+	for _, part := range strings.Split(spec, ",") {
+		part = strings.TrimSpace(part)
+		if part == "^has_journal" {
+			return true
+		}
+	}
+	return false
+}
+
+func zc1950Hit(cmd *ast.SimpleCommand, form, why string) []Violation {
+	return []Violation{{
+		KataID:  "ZC1950",
+		Message: "`tune2fs " + form + "` " + why + ". Keep the default.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 946 Katas = 0.9.46
-const Version = "0.9.46"
+// 947 Katas = 0.9.47
+const Version = "0.9.47"


### PR DESCRIPTION
ZC1950 — Error on `tune2fs -O ^has_journal` / `tune2fs -m 0`

What: Strips the ext3/4 journal or zeroes the root-reserved space.
Why: Crash recovery drops from journal-replay to full `fsck -y` (truncates partial files). Zero reserve leaves no headroom for `journald`/`apt`/root shells when the fs fills up — recovery via rescue media.
Fix suggestion: Keep the journal on. Leave `-m` at the distro default (5% is overkill on huge disks; `-m 1` is still safe).
Severity: Error