### PR TITLE
feat: ZC1951 — detect `ceph --yes-i-really-really-mean-it` safety bypass

### DIFF
--- a/pkg/katas/katatests/zc1951_test.go
+++ b/pkg/katas/katatests/zc1951_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1951(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ceph osd pool ls detail`",
+			input:    `ceph osd pool ls detail`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ceph -s` (health)",
+			input:    `ceph -s`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ceph osd pool delete rbd rbd --yes-i-really-really-mean-it now` (mangled)",
+			input: `ceph osd pool delete rbd rbd --yes-i-really-really-mean-it now`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1951",
+					Message: "`ceph … --yes-i-really-really-mean-it` automates the double-safety phrase — a typo or stale loop silently deletes production pools. Run deletions interactively, or spell the pool name in a runbook commit.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ceph config-key rm key --yes-i-really-mean-it now`",
+			input: `ceph config-key rm key --yes-i-really-mean-it now`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1951",
+					Message: "`ceph … --yes-i-really-really-mean-it` automates the double-safety phrase — a typo or stale loop silently deletes production pools. Run deletions interactively, or spell the pool name in a runbook commit.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1951")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1951.go
+++ b/pkg/katas/zc1951.go
@@ -1,0 +1,61 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1951",
+		Title:    "Error on `ceph osd pool delete … --yes-i-really-really-mean-it` — automates Ceph's double-safety phrase",
+		Severity: SeverityError,
+		Description: "Ceph intentionally requires both the pool name twice and the flag " +
+			"`--yes-i-really-really-mean-it` before it will delete a pool, so a typo during a " +
+			"live operation cannot drop production data. Baking the phrase into a script " +
+			"defeats the friction — a rebase of the wrong variable, a typo in the pool name, " +
+			"or a stale `for pool in $(…)` loop then silently deletes real pools. Remove the " +
+			"flag from scripts. Do the deletion interactively, or wrap it in a runbook that " +
+			"spells out the pool name in the commit message the operator acknowledges.",
+		Check: checkZC1951,
+	})
+}
+
+func checkZC1951(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `ceph osd pool delete … --yes-i-really-really-mean-it`
+	// mangles the command name to `yes-i-really-really-mean-it`.
+	if ident.Value == "yes-i-really-really-mean-it" ||
+		ident.Value == "yes-i-really-mean-it" {
+		return zc1951Hit(cmd)
+	}
+	if ident.Value != "ceph" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--yes-i-really-really-mean-it" || v == "--yes-i-really-mean-it" {
+			return zc1951Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1951Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1951",
+		Message: "`ceph … --yes-i-really-really-mean-it` automates the double-safety " +
+			"phrase — a typo or stale loop silently deletes production pools. Run " +
+			"deletions interactively, or spell the pool name in a runbook commit.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 947 Katas = 0.9.47
-const Version = "0.9.47"
+// 948 Katas = 0.9.48
+const Version = "0.9.48"


### PR DESCRIPTION
ZC1951 — Error on `ceph … --yes-i-really-really-mean-it` / `--yes-i-really-mean-it`

What: Bakes Ceph's intentional double-confirm phrase into a script.
Why: Ceph requires the phrase precisely so an operator-typo during a live op cannot drop production data. Automating it defeats the friction — stale `for pool in $(…)` loops, rebase mishaps, or wrong-variable expansions silently delete real pools.
Fix suggestion: Remove the flag from scripts. Do deletions interactively or wrap in a runbook that spells the pool name in a commit the operator acknowledges.
Severity: Error