### PR TITLE
feat: ZC1952 — detect `zfs set sync=disabled` fsync no-op

### DIFF
--- a/pkg/katas/katatests/zc1952_test.go
+++ b/pkg/katas/katatests/zc1952_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1952(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `zfs set sync=standard tank/data`",
+			input:    `zfs set sync=standard tank/data`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `zfs get sync tank` (read only)",
+			input:    `zfs get sync tank`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `zfs set sync=disabled tank/pg`",
+			input: `zfs set sync=disabled tank/pg`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1952",
+					Message: "`zfs set sync=disabled` turns `fsync()` into a no-op — DBs (PostgreSQL/MariaDB/etcd) lose committed transactions on crash. Leave sync at `standard`; use a SLOG vdev if latency is the concern.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `zfs set sync=disabled $POOL`",
+			input: `zfs set sync=disabled $POOL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1952",
+					Message: "`zfs set sync=disabled` turns `fsync()` into a no-op — DBs (PostgreSQL/MariaDB/etcd) lose committed transactions on crash. Leave sync at `standard`; use a SLOG vdev if latency is the concern.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1952")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1952.go
+++ b/pkg/katas/zc1952.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1952",
+		Title:    "Error on `zfs set sync=disabled` — `fsync()` becomes a no-op, crash loses unflushed writes",
+		Severity: SeverityError,
+		Description: "`zfs set sync=disabled POOL/DATASET` turns `fsync()`, `O_SYNC`, and `O_DSYNC` " +
+			"into no-ops on that dataset. PostgreSQL, MariaDB, etcd, and every application that " +
+			"relies on fsync for durability will report success for writes that are still in the " +
+			"ARC, so a panic or power cut loses minutes of committed transactions. The flag is " +
+			"a benchmarking knob, not a production setting. Leave sync at `standard` and, if " +
+			"latency is the concern, add a `log` vdev (SLOG) or tune " +
+			"`zfs_txg_timeout` instead.",
+		Check: checkZC1952,
+	})
+}
+
+func checkZC1952(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "zfs" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 || cmd.Arguments[0].String() != "set" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if strings.HasPrefix(v, "sync=") {
+			val := strings.TrimPrefix(v, "sync=")
+			if val == "disabled" {
+				return []Violation{{
+					KataID: "ZC1952",
+					Message: "`zfs set sync=disabled` turns `fsync()` into a no-op — DBs " +
+						"(PostgreSQL/MariaDB/etcd) lose committed transactions on crash. Leave " +
+						"sync at `standard`; use a SLOG vdev if latency is the concern.",
+					Line:   cmd.Token.Line,
+					Column: cmd.Token.Column,
+					Level:  SeverityError,
+				}}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 948 Katas = 0.9.48
-const Version = "0.9.48"
+// 949 Katas = 0.9.49
+const Version = "0.9.49"


### PR DESCRIPTION
ZC1952 — Error on `zfs set sync=disabled POOL/DATASET`

What: Turns `fsync()`, `O_SYNC`, and `O_DSYNC` into no-ops on the dataset.
Why: PostgreSQL, MariaDB, etcd, and every fsync-relying app report success for writes still in ARC — panic or power cut loses minutes of committed transactions.
Fix suggestion: Leave sync at `standard`. If latency is the concern, add a `log` vdev (SLOG) or tune `zfs_txg_timeout`.
Severity: Error