### PR TITLE
feat: ZC1953 — detect `mount --make-shared` propagation escape vector

### DIFF
--- a/pkg/katas/katatests/zc1953_test.go
+++ b/pkg/katas/katatests/zc1953_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1953(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `mount --make-private /sys`",
+			input:    `mount --make-private /sys`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `mount -t tmpfs tmpfs /run`",
+			input:    `mount -t tmpfs tmpfs /run`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `mount --make-shared /data`",
+			input: `mount --make-shared /data`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1953",
+					Message: "`mount --make-shared` puts the mount in a shared-subtree group — later bind-mounts propagate to every peer, including containers. Classic escape stepping stone. Use `--make-private` on sensitive paths.",
+					Line:    1,
+					Column:  9,
+				},
+			},
+		},
+		{
+			name:  "invalid — `mount /srv --make-rshared`",
+			input: `mount /srv --make-rshared`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1953",
+					Message: "`mount --make-rshared` puts the mount in a shared-subtree group — later bind-mounts propagate to every peer, including containers. Classic escape stepping stone. Use `--make-private` on sensitive paths.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1953")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1953.go
+++ b/pkg/katas/zc1953.go
@@ -1,0 +1,60 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1953",
+		Title:    "Warn on `mount --make-shared` / `--make-rshared` — flips propagation, container-escape vector",
+		Severity: SeverityWarning,
+		Description: "`mount --make-shared /path` (and the recursive `--make-rshared`) turns the " +
+			"mount point into a peer in a shared-subtree group. Any later bind-mount that " +
+			"lands inside it propagates to every other peer, including containers and other " +
+			"namespaces. Combined with `CAP_SYS_ADMIN` inside a pod, that is one of the " +
+			"classic container-escape stepping stones — a hostile workload can mount into the " +
+			"host's `/` via the propagation group. Use `--make-private` on sensitive paths and " +
+			"mount containers with `--mount-propagation=private` / `slave` unless the app " +
+			"genuinely requires `shared`.",
+		Check: checkZC1953,
+	})
+}
+
+func checkZC1953(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `mount --make-shared PATH` mangles the command name to
+	// `make-shared` (or `make-rshared`).
+	switch ident.Value {
+	case "make-shared", "make-rshared":
+		return zc1953Hit(cmd, "mount --"+ident.Value)
+	case "mount":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "--make-shared" || v == "--make-rshared" {
+				return zc1953Hit(cmd, "mount "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1953Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1953",
+		Message: "`" + form + "` puts the mount in a shared-subtree group — later " +
+			"bind-mounts propagate to every peer, including containers. Classic escape " +
+			"stepping stone. Use `--make-private` on sensitive paths.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 949 Katas = 0.9.49
-const Version = "0.9.49"
+// 950 Katas = 0.9.50
+const Version = "0.9.50"


### PR DESCRIPTION
ZC1953 — Warn on `mount --make-shared` / `mount --make-rshared`

What: Turns the mount point into a peer in a shared-subtree group.
Why: Later bind-mounts propagate to every peer, including containers and other namespaces. Combined with `CAP_SYS_ADMIN` in a pod, this is a classic container-escape stepping stone.
Fix suggestion: Use `--make-private` on sensitive paths; mount containers with `--mount-propagation=private`/`slave` unless the app needs `shared`.
Severity: Warning