### PR TITLE
feat: ZC1954 — detect `setfattr -n security.*` raw xattr bypass

### DIFF
--- a/pkg/katas/katatests/zc1954_test.go
+++ b/pkg/katas/katatests/zc1954_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1954(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setfattr -n user.comment -v 'hello' /tmp/f`",
+			input:    `setfattr -n user.comment -v 'hello' /tmp/f`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `getfattr -d /tmp/f` (read-only sibling)",
+			input:    `getfattr -d /tmp/f`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setfattr -n security.capability -v $VAL /usr/local/bin/app`",
+			input: `setfattr -n security.capability -v $VAL /usr/local/bin/app`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1954",
+					Message: "`setfattr -n security.capability` writes the raw kernel xattr — bypasses `setcap`/`chcon`/`evmctl` validation and audit. Use the purpose-built tool.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setfattr -n security.selinux -v $CTX /etc/app`",
+			input: `setfattr -n security.selinux -v $CTX /etc/app`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1954",
+					Message: "`setfattr -n security.selinux` writes the raw kernel xattr — bypasses `setcap`/`chcon`/`evmctl` validation and audit. Use the purpose-built tool.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1954")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1954.go
+++ b/pkg/katas/zc1954.go
@@ -1,0 +1,82 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1954",
+		Title:    "Warn on `setfattr -n security.capability|security.selinux|security.ima` — bypasses `setcap`/`chcon`",
+		Severity: SeverityWarning,
+		Description: "`setfattr -n security.capability -v …` writes the raw file-capability xattr " +
+			"that the kernel consults when a binary `execve()`s, bypassing the `setcap` " +
+			"wrapper's validation and audit trail. Similarly, `security.selinux` replaces the " +
+			"SELinux label without going through `chcon` / `semanage`, and `security.ima` " +
+			"overwrites the IMA hash that integrity-measurement trusts. These attributes are " +
+			"the raw kernel knobs behind purpose-built tools; script usage is almost always " +
+			"wrong. Use `setcap`, `chcon`/`semanage fcontext`, and `evmctl` instead.",
+		Check: checkZC1954,
+	})
+}
+
+func checkZC1954(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "setfattr" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-n" && i+1 < len(cmd.Arguments) {
+			name := cmd.Arguments[i+1].String()
+			if zc1954SecurityAttr(name) {
+				return zc1954Hit(cmd, name)
+			}
+		}
+		if strings.HasPrefix(v, "-n") && len(v) > 2 {
+			if zc1954SecurityAttr(v[2:]) {
+				return zc1954Hit(cmd, v[2:])
+			}
+		}
+		if strings.HasPrefix(v, "--name=") {
+			if zc1954SecurityAttr(strings.TrimPrefix(v, "--name=")) {
+				return zc1954Hit(cmd, strings.TrimPrefix(v, "--name="))
+			}
+		}
+	}
+	return nil
+}
+
+func zc1954SecurityAttr(name string) bool {
+	switch {
+	case name == "security.capability",
+		name == "security.selinux",
+		name == "security.ima",
+		name == "security.evm":
+		return true
+	case strings.HasPrefix(name, "security.apparmor"):
+		return true
+	}
+	return false
+}
+
+func zc1954Hit(cmd *ast.SimpleCommand, attr string) []Violation {
+	return []Violation{{
+		KataID: "ZC1954",
+		Message: "`setfattr -n " + attr + "` writes the raw kernel xattr — bypasses " +
+			"`setcap`/`chcon`/`evmctl` validation and audit. Use the purpose-built tool.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 950 Katas = 0.9.50
-const Version = "0.9.50"
+// 951 Katas = 0.9.51
+const Version = "0.9.51"


### PR DESCRIPTION
ZC1954 — Warn on `setfattr -n security.capability|security.selinux|security.ima|security.evm|security.apparmor.*`

What: Writes the raw kernel security xattr directly.
Why: Bypasses purpose-built wrappers (`setcap`, `chcon`/`semanage fcontext`, `evmctl`) and the validation/audit they provide. Stealth privilege or label changes slip past normal review.
Fix suggestion: Use `setcap` for file capabilities, `chcon`/`semanage fcontext` for SELinux, `evmctl` for IMA/EVM.
Severity: Warning