### PR TITLE
feat: ZC1955 — detect `rfkill block all` radio mass-down

### DIFF
--- a/pkg/katas/katatests/zc1955_test.go
+++ b/pkg/katas/katatests/zc1955_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1955(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `rfkill list`",
+			input:    `rfkill list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `rfkill unblock all`",
+			input:    `rfkill unblock all`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `rfkill block all`",
+			input: `rfkill block all`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1955",
+					Message: "`rfkill block all` hard-downs the radio(s) — host drops off the network in one call. Scope to the radio type that really needs it and schedule an `at now + N minutes` unblock for self-recovery.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `rfkill block wifi`",
+			input: `rfkill block wifi`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1955",
+					Message: "`rfkill block wifi` hard-downs the radio(s) — host drops off the network in one call. Scope to the radio type that really needs it and schedule an `at now + N minutes` unblock for self-recovery.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1955")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1955.go
+++ b/pkg/katas/zc1955.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1955",
+		Title:    "Warn on `rfkill block all` / `block wifi|bluetooth|wwan` — disables every radio, cuts wireless",
+		Severity: SeverityWarning,
+		Description: "`rfkill block all` toggles the soft-kill switch on every radio the kernel " +
+			"registered — WiFi, Bluetooth, WWAN, NFC, GPS, UWB — so the host drops off the " +
+			"network in one call. A follow-up `rfkill unblock all` takes seconds to a minute " +
+			"on some drivers and requires the operator to be physically present or have a " +
+			"cellular fallback. Scope the block to a specific type (e.g. `rfkill block " +
+			"bluetooth`) and schedule via `at now + 5 minutes ... rfkill unblock all` so the " +
+			"host recovers on its own.",
+		Check: checkZC1955,
+	})
+}
+
+func checkZC1955(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "rfkill" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "block" {
+		return nil
+	}
+	target := cmd.Arguments[1].String()
+	if target != "all" && target != "wifi" && target != "wlan" &&
+		target != "bluetooth" && target != "wwan" {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1955",
+		Message: "`rfkill block " + target + "` hard-downs the radio(s) — host drops " +
+			"off the network in one call. Scope to the radio type that really needs it " +
+			"and schedule an `at now + N minutes` unblock for self-recovery.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 951 Katas = 0.9.51
-const Version = "0.9.51"
+// 952 Katas = 0.9.52
+const Version = "0.9.52"


### PR DESCRIPTION
ZC1955 — Warn on `rfkill block all` / `block wifi|bluetooth|wwan`

What: Soft-kills every radio the kernel registered — WiFi, Bluetooth, WWAN, NFC, GPS, UWB — in one call.
Why: Host drops off the network. `unblock all` takes seconds-to-minutes on some drivers and requires the operator to be physically present or have cellular fallback.
Fix suggestion: Scope to a specific radio type. Schedule via `at now + N minutes … rfkill unblock all` so the host recovers on its own.
Severity: Warning