### PR TITLE
feat: ZC1956 — detect `tailscale --auth-key=SECRET` in argv

### DIFF
--- a/pkg/katas/katatests/zc1956_test.go
+++ b/pkg/katas/katatests/zc1956_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1956(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `tailscale status`",
+			input:    `tailscale status`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `tailscale up --auth-key=file:/etc/ts.key` (file source)",
+			input:    `tailscale up --auth-key=file:/etc/ts.key`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `tailscale up host --auth-key=tskey-auth-abc123`",
+			input: `tailscale up host --auth-key=tskey-auth-abc123`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1956",
+					Message: "`tailscale --auth-key=tskey-auth-abc123` puts the pre-auth key in argv — visible in `ps`/`/proc`/history/crash dumps. Use `--auth-key=file:/etc/ts.key` (mode 0400) or `--authkey-env=TS_AUTHKEY`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `tailscale up host --authkey tskey-ZZZ`",
+			input: `tailscale up host --authkey tskey-ZZZ`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1956",
+					Message: "`tailscale --authkey tskey-ZZZ` puts the pre-auth key in argv — visible in `ps`/`/proc`/history/crash dumps. Use `--auth-key=file:/etc/ts.key` (mode 0400) or `--authkey-env=TS_AUTHKEY`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1956")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1956.go
+++ b/pkg/katas/zc1956.go
@@ -1,0 +1,79 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1956",
+		Title:    "Error on `tailscale up --auth-key=SECRET` — single-use join key visible in argv",
+		Severity: SeverityError,
+		Description: "`tailscale up --auth-key tskey-auth-…` (and the joined `--auth-key=…` form) " +
+			"passes the Tailscale pre-auth key as a command-line argument. Pre-auth keys grant " +
+			"full tailnet membership, and short-lived or not, the value ends up in `ps`, " +
+			"`/proc/PID/cmdline`, shell history, and any process dump taken before the join " +
+			"completes. Read the key from `TS_AUTHKEY` with `tailscale up --authkey-env=TS_AUTHKEY` " +
+			"(newer tailscaled), or from a file with `tailscale up --auth-key=file:/etc/ts.key` " +
+			"(mode `0400` owned by the provisioning user).",
+		Check: checkZC1956,
+	})
+}
+
+func checkZC1956(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "tailscale" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "--auth-key=") || strings.HasPrefix(v, "--authkey=") {
+			val := v[strings.IndexByte(v, '=')+1:]
+			if zc1956IsLiteralKey(val) {
+				return zc1956Hit(cmd, v)
+			}
+		}
+		if (v == "--auth-key" || v == "--authkey") && i+1 < len(cmd.Arguments) {
+			val := cmd.Arguments[i+1].String()
+			if zc1956IsLiteralKey(val) {
+				return zc1956Hit(cmd, v+" "+val)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1956IsLiteralKey(val string) bool {
+	if val == "" {
+		return false
+	}
+	if strings.HasPrefix(val, "file:") {
+		return false
+	}
+	if strings.HasPrefix(val, "$") {
+		return false
+	}
+	return true
+}
+
+func zc1956Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1956",
+		Message: "`tailscale " + form + "` puts the pre-auth key in argv — visible in " +
+			"`ps`/`/proc`/history/crash dumps. Use `--auth-key=file:/etc/ts.key` (mode 0400) " +
+			"or `--authkey-env=TS_AUTHKEY`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 952 Katas = 0.9.52
-const Version = "0.9.52"
+// 953 Katas = 0.9.53
+const Version = "0.9.53"


### PR DESCRIPTION
ZC1956 — Error on `tailscale up --auth-key=tskey-…` / `--authkey tskey-…`

What: Tailscale pre-auth key passed as a command-line argument.
Why: Grants full tailnet membership. Value ends up in `ps`, `/proc/PID/cmdline`, shell history, and process dumps taken before the join completes.
Fix suggestion: Use `--auth-key=file:/etc/ts.key` (mode `0400`) or `--authkey-env=TS_AUTHKEY` with an env-var source.
Severity: Error