### PR TITLE
feat: ZC1957 — detect `lvchange -an`/`vgchange -an` live-volume deactivation

### DIFF
--- a/pkg/katas/katatests/zc1957_test.go
+++ b/pkg/katas/katatests/zc1957_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1957(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `lvchange -ay data/home` (activate)",
+			input:    `lvchange -ay data/home`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `vgchange -ay data`",
+			input:    `vgchange -ay data`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `lvchange -an data/home`",
+			input: `lvchange -an data/home`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1957",
+					Message: "`lvchange -an` deactivates the LV/VG — unflushed writes on a mounted fs may be lost, open fds see EIO. Umount and stop holders first, verify with `lsof`/`fuser`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `vgchange -an data`",
+			input: `vgchange -an data`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1957",
+					Message: "`vgchange -an` deactivates the LV/VG — unflushed writes on a mounted fs may be lost, open fds see EIO. Umount and stop holders first, verify with `lsof`/`fuser`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1957")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1957.go
+++ b/pkg/katas/zc1957.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1957",
+		Title:    "Warn on `lvchange -an` / `vgchange -an` — deactivates a live LV/VG, risks mounted-fs corruption",
+		Severity: SeverityWarning,
+		Description: "`lvchange -an VG/LV` (and `vgchange -an VG` for the whole group) deactivates " +
+			"a logical volume by removing its device-mapper entry. If the LV is mounted, " +
+			"writes that the kernel has buffered but not yet flushed may be lost, and any " +
+			"process holding an open fd on the filesystem gets EIO on the next syscall. " +
+			"`umount` the mount first, stop any service keeping files open, verify with " +
+			"`lsof` / `fuser`, and only then `lvchange -an`. For a scripted teardown, prefer " +
+			"`umount` + `lvremove` with a recovery snapshot in hand.",
+		Check: checkZC1957,
+	})
+}
+
+func checkZC1957(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "lvchange" && ident.Value != "vgchange" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "-an", "-aN":
+			return zc1957Hit(cmd, ident.Value+" -an")
+		case "--activate=n", "--activate=N":
+			return zc1957Hit(cmd, ident.Value+" "+v)
+		case "--activate":
+			if i+1 < len(cmd.Arguments) {
+				next := cmd.Arguments[i+1].String()
+				if next == "n" || next == "N" {
+					return zc1957Hit(cmd, ident.Value+" --activate n")
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func zc1957Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1957",
+		Message: "`" + form + "` deactivates the LV/VG — unflushed writes on a mounted " +
+			"fs may be lost, open fds see EIO. Umount and stop holders first, verify with " +
+			"`lsof`/`fuser`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 953 Katas = 0.9.53
-const Version = "0.9.53"
+// 954 Katas = 0.9.54
+const Version = "0.9.54"


### PR DESCRIPTION
ZC1957 — Warn on `lvchange -an VG/LV` / `vgchange -an VG`

What: Deactivates a logical volume (or entire VG) by removing its device-mapper entry.
Why: If mounted, kernel-buffered writes may be lost and processes with open fds get EIO on next syscall.
Fix suggestion: `umount` and stop holders first, verify with `lsof`/`fuser`, then `lvchange -an`. For teardown, prefer `umount` + `lvremove` with a recovery snapshot.
Severity: Warning