### PR TITLE
feat: ZC1958 — detect `helm upgrade --force` delete+create strategy

### DIFF
--- a/pkg/katas/katatests/zc1958_test.go
+++ b/pkg/katas/katatests/zc1958_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1958(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `helm upgrade myapp bitnami/nginx`",
+			input:    `helm upgrade myapp bitnami/nginx`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `helm upgrade myapp ./chart --atomic --wait`",
+			input:    `helm upgrade myapp ./chart --atomic --wait`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `helm upgrade myapp ./chart --force`",
+			input: `helm upgrade myapp ./chart --force`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1958",
+					Message: "`helm upgrade --force` is delete+create — pods die, PodDisruptionBudget is bypassed, Services reset their `clusterIP`. Use plain `helm upgrade` (three-way merge) or `--atomic`/`--wait` for a supervised roll.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `helm3 upgrade --install myapp ./chart --force`",
+			input: `helm3 upgrade --install myapp ./chart --force`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1958",
+					Message: "`helm upgrade --force` is delete+create — pods die, PodDisruptionBudget is bypassed, Services reset their `clusterIP`. Use plain `helm upgrade` (three-way merge) or `--atomic`/`--wait` for a supervised roll.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1958")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1958.go
+++ b/pkg/katas/zc1958.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1958",
+		Title:    "Warn on `helm upgrade --force` — delete-and-recreate resources, drops running pods",
+		Severity: SeverityWarning,
+		Description: "`helm upgrade RELEASE CHART --force` flips the upgrade strategy from " +
+			"three-way-merge to `delete + create` for every resource Helm owns. Deployments " +
+			"become new objects, Services lose their `clusterIP` for a beat, and any " +
+			"`PodDisruptionBudget` is bypassed because the resource is deleted, not rolled " +
+			"out. Use plain `helm upgrade` (three-way merge) or `--atomic` / `--wait` for a " +
+			"supervised roll. Reserve `--force` for recovery after a failed upgrade with a " +
+			"stuck resource, not routine deploys.",
+		Check: checkZC1958,
+	})
+}
+
+func checkZC1958(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "helm" && ident.Value != "helm3" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 || cmd.Arguments[0].String() != "upgrade" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments[1:] {
+		if arg.String() == "--force" {
+			return zc1958Hit(cmd)
+		}
+	}
+	return nil
+}
+
+func zc1958Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1958",
+		Message: "`helm upgrade --force` is delete+create — pods die, PodDisruptionBudget " +
+			"is bypassed, Services reset their `clusterIP`. Use plain `helm upgrade` " +
+			"(three-way merge) or `--atomic`/`--wait` for a supervised roll.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 954 Katas = 0.9.54
-const Version = "0.9.54"
+// 955 Katas = 0.9.55
+const Version = "0.9.55"


### PR DESCRIPTION
ZC1958 — Warn on `helm upgrade --force`

What: Flips the upgrade strategy from three-way merge to delete+create for every resource Helm owns.
Why: Deployments become new objects, Services lose `clusterIP` for a beat, `PodDisruptionBudget` is bypassed because the resource is deleted not rolled out.
Fix suggestion: Use plain `helm upgrade` (three-way merge) or `--atomic`/`--wait` for supervised rolls. Reserve `--force` for recovery after a failed upgrade with a stuck resource.
Severity: Warning