### PR TITLE
feat: ZC1959 — detect `trivy --skip-db-update` stale CVE DB

### DIFF
--- a/pkg/katas/katatests/zc1959_test.go
+++ b/pkg/katas/katatests/zc1959_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1959(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `trivy image alpine:3.20`",
+			input:    `trivy image alpine:3.20`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `trivy image --download-db-only`",
+			input:    `trivy image --download-db-only`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `trivy image alpine:3.20 --skip-db-update`",
+			input: `trivy image alpine:3.20 --skip-db-update`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1959",
+					Message: "`trivy --skip-db-update` scans against the cached DB — every CVE disclosed since last refresh is missed. Keep the default download, or run `trivy --download-db-only` once per day in a scheduled job.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `trivy image alpine:3.20 --skip-update`",
+			input: `trivy image alpine:3.20 --skip-update`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1959",
+					Message: "`trivy --skip-update` scans against the cached DB — every CVE disclosed since last refresh is missed. Keep the default download, or run `trivy --download-db-only` once per day in a scheduled job.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1959")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1959.go
+++ b/pkg/katas/zc1959.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1959",
+		Title:    "Warn on `trivy … --skip-db-update` / `--skip-update` — scans against a stale vulnerability DB",
+		Severity: SeverityWarning,
+		Description: "`trivy` embeds a vulnerability database that is rehydrated on every scan " +
+			"unless the operator passes `--skip-db-update` (or `--skip-update` on older " +
+			"releases). In CI the flag is tempting — each build then skips a 40 MB download — " +
+			"but the scan then misses every CVE disclosed since the cached DB was last " +
+			"refreshed. Keep the default download, or pre-populate the cache with " +
+			"`trivy image --download-db-only` once per day in a scheduled job, and only pass " +
+			"`--skip-db-update` inside the same job so every scan sees the fresh data.",
+		Check: checkZC1959,
+	})
+}
+
+func checkZC1959(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `trivy --skip-db-update image` mangles to name=`skip-db-update`.
+	if ident.Value == "skip-db-update" || ident.Value == "skip-update" {
+		return zc1959Hit(cmd, "trivy --"+ident.Value)
+	}
+	if ident.Value != "trivy" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--skip-db-update" || v == "--skip-update" {
+			return zc1959Hit(cmd, "trivy "+v)
+		}
+	}
+	return nil
+}
+
+func zc1959Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1959",
+		Message: "`" + form + "` scans against the cached DB — every CVE disclosed " +
+			"since last refresh is missed. Keep the default download, or run " +
+			"`trivy --download-db-only` once per day in a scheduled job.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 955 Katas = 0.9.55
-const Version = "0.9.55"
+// 956 Katas = 0.9.56
+const Version = "0.9.56"


### PR DESCRIPTION
ZC1959 — Warn on `trivy --skip-db-update` / `--skip-update`

What: Disables the per-scan refresh of trivy's vulnerability database.
Why: Each scan then misses every CVE disclosed since the cached DB was last refreshed — stale CI gate lets known vulns through.
Fix suggestion: Keep the default download. Pre-populate via scheduled `trivy --download-db-only`, and only skip inside that same job so every subsequent scan sees fresh data.
Severity: Warning