### PR TITLE
feat: ZC1960 — detect cloud-plane RCE: `az vm run-command` / `aws ssm send-command`

### DIFF
--- a/pkg/katas/katatests/zc1960_test.go
+++ b/pkg/katas/katatests/zc1960_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1960(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `az vm list`",
+			input:    `az vm list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `aws ssm describe-instance-information`",
+			input:    `aws ssm describe-instance-information`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `az vm run-command invoke -g rg -n vm --command-id RunShellScript --scripts $CMD`",
+			input: `az vm run-command invoke -g rg -n vm --command-id RunShellScript --scripts $CMD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1960",
+					Message: "`az vm run-command invoke` runs arbitrary shell on the VM via the cloud control plane — operator-composed command strings become IAM-driven RCE. Pin to a reviewed asset, template-escape input, require MFA.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `aws ssm send-command --document-name AWS-RunShellScript --parameters commands=$CMD`",
+			input: `aws ssm send-command --document-name AWS-RunShellScript --parameters commands=$CMD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1960",
+					Message: "`aws ssm send-command` runs arbitrary shell on the VM via the cloud control plane — operator-composed command strings become IAM-driven RCE. Pin to a reviewed asset, template-escape input, require MFA.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1960")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1960.go
+++ b/pkg/katas/zc1960.go
@@ -1,0 +1,74 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1960",
+		Title:    "Warn on `az vm run-command invoke` / `aws ssm send-command` — arbitrary commands on remote VM",
+		Severity: SeverityWarning,
+		Description: "`az vm run-command invoke --command-id RunShellScript --scripts \"$CMD\"` " +
+			"(and the AWS equivalent `aws ssm send-command --document-name AWS-RunShellScript " +
+			"--parameters \"commands=['$CMD']\"`) runs arbitrary shell on the target instance " +
+			"via the cloud control plane. The identity making the call is whatever role the " +
+			"script's credentials carry; if `$CMD` is composed from any operator or attacker " +
+			"input, the result is remote code execution through IAM. Gate the call behind " +
+			"a shell-escape-safe templater, pin the document version / script to a reviewed " +
+			"asset in blob / S3, and require MFA on the invoking role.",
+		Check: checkZC1960,
+	})
+}
+
+func checkZC1960(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	switch ident.Value {
+	case "az":
+		// Look for `az vm run-command invoke` subcommand sequence.
+		if len(cmd.Arguments) >= 3 &&
+			cmd.Arguments[0].String() == "vm" &&
+			cmd.Arguments[1].String() == "run-command" &&
+			(cmd.Arguments[2].String() == "invoke" || cmd.Arguments[2].String() == "create") {
+			return zc1960Hit(cmd, "az vm run-command "+cmd.Arguments[2].String())
+		}
+	case "aws":
+		if len(cmd.Arguments) >= 2 &&
+			cmd.Arguments[0].String() == "ssm" &&
+			cmd.Arguments[1].String() == "send-command" {
+			return zc1960Hit(cmd, "aws ssm send-command")
+		}
+	case "gcloud":
+		if len(cmd.Arguments) >= 2 &&
+			cmd.Arguments[0].String() == "compute" &&
+			cmd.Arguments[1].String() == "ssh" {
+			for _, arg := range cmd.Arguments[2:] {
+				v := arg.String()
+				if v == "--command" || len(v) > 10 && v[:10] == "--command=" {
+					return zc1960Hit(cmd, "gcloud compute ssh --command")
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func zc1960Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1960",
+		Message: "`" + form + "` runs arbitrary shell on the VM via the cloud control " +
+			"plane — operator-composed command strings become IAM-driven RCE. Pin to a " +
+			"reviewed asset, template-escape input, require MFA.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 956 Katas = 0.9.56
-const Version = "0.9.56"
+// 957 Katas = 0.9.57
+const Version = "0.9.57"


### PR DESCRIPTION
ZC1960 — Warn on `az vm run-command invoke` / `aws ssm send-command` / `gcloud compute ssh --command`

What: Runs arbitrary shell on a remote VM via the cloud control plane's IAM credentials.
Why: The identity making the call is whatever role the script carries; if the command string is composed from operator/attacker input, the result is RCE on the target instance through IAM.
Fix suggestion: Pin the document/script to a reviewed asset in blob/S3, template-escape any injected parameters, and require MFA on the invoking role.
Severity: Warning