### PR TITLE
feat: ZC1961 — detect `gcloud iam service-accounts keys create` static key

### DIFF
--- a/pkg/katas/katatests/zc1961_test.go
+++ b/pkg/katas/katatests/zc1961_test.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1961(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `gcloud iam service-accounts list`",
+			input:    `gcloud iam service-accounts list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `gcloud auth print-access-token` (short-lived)",
+			input:    `gcloud auth print-access-token`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `gcloud iam service-accounts keys create key.json --iam-account=$SA`",
+			input: `gcloud iam service-accounts keys create key.json --iam-account=$SA`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1961",
+					Message: "`gcloud iam service-accounts keys create` mints a long-lived JSON key — no auto-rotate, no refresh. Prefer Workload Identity Federation, `--impersonate-service-account`, or the attached service account.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:     "valid — `gcloud iam service-accounts keys list` (read only)",
+			input:    `gcloud iam service-accounts keys list`,
+			expected: []katas.Violation{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1961")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1961.go
+++ b/pkg/katas/zc1961.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1961",
+		Title:    "Warn on `gcloud iam service-accounts keys create` — mints a long-lived service-account JSON key",
+		Severity: SeverityWarning,
+		Description: "`gcloud iam service-accounts keys create key.json --iam-account=SA@PROJECT` " +
+			"exports an RSA key pair wrapped in a JSON file. Once written it is effectively a " +
+			"forever-valid bearer credential: no automatic rotation, no refresh, and a single " +
+			"\"leaked by a `cat key.json`\" is game-over. Prefer Workload Identity Federation " +
+			"(`gcloud iam workload-identity-pools …`), short-lived impersonation via " +
+			"`gcloud auth print-access-token --impersonate-service-account=SA`, or the " +
+			"key-less GCE/GKE attached service account. Reserve static JSON keys for provably " +
+			"off-platform callers.",
+		Check: checkZC1961,
+	})
+}
+
+func checkZC1961(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "gcloud" {
+		return nil
+	}
+	if len(cmd.Arguments) < 4 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "iam" ||
+		cmd.Arguments[1].String() != "service-accounts" ||
+		cmd.Arguments[2].String() != "keys" ||
+		cmd.Arguments[3].String() != "create" {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1961",
+		Message: "`gcloud iam service-accounts keys create` mints a long-lived JSON key — " +
+			"no auto-rotate, no refresh. Prefer Workload Identity Federation, " +
+			"`--impersonate-service-account`, or the attached service account.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 957 Katas = 0.9.57
-const Version = "0.9.57"
+// 958 Katas = 0.9.58
+const Version = "0.9.58"


### PR DESCRIPTION
ZC1961 — Warn on `gcloud iam service-accounts keys create key.json --iam-account=…`

What: Exports an RSA key pair as a JSON bearer credential.
Why: Forever-valid — no auto-rotation, no refresh. A single `cat key.json` leaks a full service-account identity with no revocation path short of manual key delete.
Fix suggestion: Use Workload Identity Federation, `--impersonate-service-account` for short-lived tokens, or the key-less GCE/GKE attached SA. Reserve JSON keys for provably off-platform callers.
Severity: Warning