### PR TITLE
feat: ZC1962 — detect `kustomize build --load-restrictor=None`

### DIFF
--- a/pkg/katas/katatests/zc1962_test.go
+++ b/pkg/katas/katatests/zc1962_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1962(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `kustomize build overlays/prod`",
+			input:    `kustomize build overlays/prod`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `kustomize build . --load-restrictor=LoadRestrictionsRootOnly`",
+			input:    `kustomize build . --load-restrictor=LoadRestrictionsRootOnly`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `kustomize build . --load-restrictor=LoadRestrictionsNone`",
+			input: `kustomize build . --load-restrictor=LoadRestrictionsNone`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1962",
+					Message: "`kustomize build --load-restrictor=LoadRestrictionsNone` drops path-root restriction — untrusted overlays can reference `../../secrets/prod.env` and pull them into the render. Keep the default; vendor sibling files into the overlay.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1962")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1962.go
+++ b/pkg/katas/zc1962.go
@@ -1,0 +1,78 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1962",
+		Title:    "Warn on `kustomize build --load-restrictor=LoadRestrictionsNone` — path-traversal in overlays",
+		Severity: SeverityWarning,
+		Description: "Kustomize's default `LoadRestrictionsRootOnly` limits every base, patch, " +
+			"configMapGenerator, and secretGenerator to paths under the current kustomization " +
+			"root. `kustomize build … --load-restrictor=LoadRestrictionsNone` (also the legacy " +
+			"spelling `--load_restrictor none` / `--load-restrictor=LoadRestrictionsNone_WarnForAll`) " +
+			"drops that guard, so an overlay from an untrusted remote base can reference " +
+			"`../../secrets/prod.env` or absolute paths and pull them into the render. Keep " +
+			"the default; if a legitimate overlay needs a sibling file, vendor it in.",
+		Check: checkZC1962,
+	})
+}
+
+func checkZC1962(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kustomize" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "build" {
+		return nil
+	}
+
+	for i, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if strings.HasPrefix(v, "--load-restrictor=") ||
+			strings.HasPrefix(v, "--load_restrictor=") {
+			val := v[strings.IndexByte(v, '=')+1:]
+			if zc1962IsNoneVariant(val) {
+				return zc1962Hit(cmd, v)
+			}
+		}
+		if (v == "--load-restrictor" || v == "--load_restrictor") && i+2 <= len(cmd.Arguments)-1 {
+			val := cmd.Arguments[i+2].String()
+			if zc1962IsNoneVariant(val) {
+				return zc1962Hit(cmd, v+" "+val)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1962IsNoneVariant(val string) bool {
+	switch val {
+	case "none", "None", "LoadRestrictionsNone":
+		return true
+	}
+	return false
+}
+
+func zc1962Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1962",
+		Message: "`kustomize build " + form + "` drops path-root restriction — untrusted " +
+			"overlays can reference `../../secrets/prod.env` and pull them into the render. " +
+			"Keep the default; vendor sibling files into the overlay.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 958 Katas = 0.9.58
-const Version = "0.9.58"
+// 959 Katas = 0.9.59
+const Version = "0.9.59"


### PR DESCRIPTION
ZC1962 — Warn on `kustomize build … --load-restrictor=LoadRestrictionsNone` / `--load_restrictor none`

What: Drops kustomize's default path restriction so overlays can reference files outside the kustomization root.
Why: Untrusted remote bases or overlays can then load `../../secrets/prod.env`, absolute paths, or arbitrary host files — secrets leak into the render.
Fix suggestion: Keep the default `LoadRestrictionsRootOnly`. If an overlay legitimately needs a sibling file, vendor it into the overlay directory.
Severity: Warning