### PR TITLE
feat: ZC1963 — detect unpinned `npx`/`pnpm dlx`/`bunx` runners

### DIFF
--- a/pkg/katas/katatests/zc1963_test.go
+++ b/pkg/katas/katatests/zc1963_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1963(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `npx typescript@5.4.2 --init`",
+			input:    `npx typescript@5.4.2 --init`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `pnpm dlx @vercel/ncc@0.38.1 build`",
+			input:    `pnpm dlx @vercel/ncc@0.38.1 build`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `npx create-react-app demo`",
+			input: `npx create-react-app demo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1963",
+					Message: "`npx create-react-app` pulls the `latest` tag every run — a squatted or compromised package lands attacker code. Pin the version (`create-react-app@X.Y.Z`) or use a regular `npm install` + `./node_modules/.bin/`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `pnpm dlx prettier`",
+			input: `pnpm dlx prettier`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1963",
+					Message: "`pnpm dlx prettier` pulls the `latest` tag every run — a squatted or compromised package lands attacker code. Pin the version (`prettier@X.Y.Z`) or use a regular `npm install` + `./node_modules/.bin/`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1963")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1963.go
+++ b/pkg/katas/zc1963.go
@@ -1,0 +1,91 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1963",
+		Title:    "Warn on `npx pkg` / `pnpm dlx pkg` / `bunx pkg` without a version pin — runs latest registry code",
+		Severity: SeverityWarning,
+		Description: "`npx PKG`, `pnpm dlx PKG`, `bunx PKG`, and `bun x PKG` fetch the named " +
+			"package from the npm registry and execute its `bin` entry. Without a version " +
+			"pin (`pkg@1.2.3`), each run resolves to the registry's `latest` tag — a " +
+			"compromised maintainer, squatted name, or even a mistyped package is enough to " +
+			"land attacker code in the build. Pin the exact version (`npx pkg@1.2.3`), cache " +
+			"the binary under `./node_modules/.bin/` via a regular `npm install`, or verify " +
+			"the tarball signature before execution.",
+		Check: checkZC1963,
+	})
+}
+
+func checkZC1963(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var form string
+	var pkgs []ast.Expression
+	switch ident.Value {
+	case "npx":
+		form = "npx"
+		pkgs = cmd.Arguments
+	case "bunx":
+		form = "bunx"
+		pkgs = cmd.Arguments
+	case "pnpm", "bun":
+		if len(cmd.Arguments) < 2 {
+			return nil
+		}
+		sub := cmd.Arguments[0].String()
+		if ident.Value == "pnpm" && sub != "dlx" {
+			return nil
+		}
+		if ident.Value == "bun" && sub != "x" {
+			return nil
+		}
+		form = ident.Value + " " + sub
+		pkgs = cmd.Arguments[1:]
+	default:
+		return nil
+	}
+
+	for _, arg := range pkgs {
+		v := arg.String()
+		if strings.HasPrefix(v, "-") {
+			continue
+		}
+		if strings.Contains(v, "@") && !strings.HasPrefix(v, "@") {
+			// pkg@version — pinned.
+			return nil
+		}
+		if strings.HasPrefix(v, "@") {
+			// scoped name like @scope/pkg — check for second @ (version).
+			rest := v[1:]
+			if strings.Contains(rest, "@") {
+				return nil
+			}
+		}
+		if strings.HasPrefix(v, "$") {
+			return nil
+		}
+		return []Violation{{
+			KataID: "ZC1963",
+			Message: "`" + form + " " + v + "` pulls the `latest` tag every run — " +
+				"a squatted or compromised package lands attacker code. Pin the version " +
+				"(`" + v + "@X.Y.Z`) or use a regular `npm install` + `./node_modules/.bin/`.",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 959 Katas = 0.9.59
-const Version = "0.9.59"
+// 960 Katas = 0.9.60
+const Version = "0.9.60"


### PR DESCRIPTION
ZC1963 — Warn on `npx PKG` / `pnpm dlx PKG` / `bunx PKG` / `bun x PKG` without version pin

What: Fetches the named package from the npm registry and runs its `bin` entry using the `latest` tag.
Why: A compromised maintainer, squatted name, or mistyped package is enough to land attacker code in the build.
Fix suggestion: Pin the version (`pkg@1.2.3`), or `npm install` the package and invoke `./node_modules/.bin/…` with a lockfile. Verify tarball signature for high-value packages.
Severity: Warning