### PR TITLE
feat: ZC1964 — detect unpinned `uvx`/`uv tool run`/`pipx run` runners

### DIFF
--- a/pkg/katas/katatests/zc1964_test.go
+++ b/pkg/katas/katatests/zc1964_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1964(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `uvx ruff@0.5.7 check`",
+			input:    `uvx ruff@0.5.7 check`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `pipx run 'black==24.8.0' --version`",
+			input:    `pipx run 'black==24.8.0' --version`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `uvx ruff check`",
+			input: `uvx ruff check`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1964",
+					Message: "`uvx ruff` resolves to the PyPI `latest` release — a squatted name or compromised maintainer lands untested code. Pin `pkg==X.Y.Z` (or `pkg@X.Y.Z` for uv).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `pipx run black .`",
+			input: `pipx run black .`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1964",
+					Message: "`pipx run black` resolves to the PyPI `latest` release — a squatted name or compromised maintainer lands untested code. Pin `pkg==X.Y.Z` (or `pkg@X.Y.Z` for uv).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1964")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1964.go
+++ b/pkg/katas/zc1964.go
@@ -1,0 +1,90 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1964",
+		Title:    "Warn on `uvx pkg` / `uv tool run pkg` / `pipx run pkg` without a version pin — runs latest PyPI release",
+		Severity: SeverityWarning,
+		Description: "`uvx PKG`, `uv tool run PKG`, and `pipx run PKG` each resolve the package " +
+			"against PyPI and execute its entry point. Without a version constraint " +
+			"(`pkg==1.2.3` or `pkg@1.2.3` for uv), every run takes whatever the registry " +
+			"currently serves — a squatted typo (`reqeusts`, `djanggo`), a compromised " +
+			"maintainer release, or a sudden major-version bump lands untested code in the " +
+			"pipeline. Pin the version at the call site or use `uv tool install pkg==X.Y.Z` + " +
+			"`uv tool run pkg` so the lockfile is the source of truth.",
+		Check: checkZC1964,
+	})
+}
+
+func checkZC1964(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var form string
+	var pkgs []ast.Expression
+	switch ident.Value {
+	case "uvx":
+		form = "uvx"
+		pkgs = cmd.Arguments
+	case "uv":
+		if len(cmd.Arguments) < 3 {
+			return nil
+		}
+		if cmd.Arguments[0].String() != "tool" || cmd.Arguments[1].String() != "run" {
+			return nil
+		}
+		form = "uv tool run"
+		pkgs = cmd.Arguments[2:]
+	case "pipx":
+		if len(cmd.Arguments) < 2 {
+			return nil
+		}
+		if cmd.Arguments[0].String() != "run" {
+			return nil
+		}
+		form = "pipx run"
+		pkgs = cmd.Arguments[1:]
+	default:
+		return nil
+	}
+
+	for _, arg := range pkgs {
+		v := arg.String()
+		if strings.HasPrefix(v, "-") {
+			continue
+		}
+		if zc1964IsPinned(v) {
+			return nil
+		}
+		if strings.HasPrefix(v, "$") {
+			return nil
+		}
+		return []Violation{{
+			KataID: "ZC1964",
+			Message: "`" + form + " " + v + "` resolves to the PyPI `latest` release — " +
+				"a squatted name or compromised maintainer lands untested code. Pin " +
+				"`pkg==X.Y.Z` (or `pkg@X.Y.Z` for uv).",
+			Line:   cmd.Token.Line,
+			Column: cmd.Token.Column,
+			Level:  SeverityWarning,
+		}}
+	}
+	return nil
+}
+
+func zc1964IsPinned(v string) bool {
+	return strings.Contains(v, "==") || strings.Contains(v, "@") ||
+		strings.Contains(v, ">=") || strings.Contains(v, "~=")
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 960 Katas = 0.9.60
-const Version = "0.9.60"
+// 961 Katas = 0.9.61
+const Version = "0.9.61"


### PR DESCRIPTION
ZC1964 — Warn on `uvx PKG` / `uv tool run PKG` / `pipx run PKG` without version pin

What: Resolves the package against PyPI and executes its entry point; without `==X.Y.Z` or `@X.Y.Z` each run takes whatever the registry currently serves.
Why: Squatted typo names (`reqeusts`, `djanggo`), compromised maintainer releases, or sudden major bumps land untested code in the pipeline.
Fix suggestion: Pin `pkg==X.Y.Z` / `pkg@X.Y.Z` at the call site, or use `uv tool install pkg==X.Y.Z` once so the lockfile is authoritative.
Severity: Warning