### PR TITLE
feat: ZC1965 — detect `systemd-cryptenroll --wipe-slot=all` LUKS keyslot wipe

### DIFF
--- a/pkg/katas/katatests/zc1965_test.go
+++ b/pkg/katas/katatests/zc1965_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1965(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `systemd-cryptenroll --wipe-slot=recovery $DEV`",
+			input:    `systemd-cryptenroll --wipe-slot=recovery $DEV`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `systemd-cryptenroll --tpm2-device=auto $DEV`",
+			input:    `systemd-cryptenroll --tpm2-device=auto $DEV`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `systemd-cryptenroll $DEV --wipe-slot=all`",
+			input: `systemd-cryptenroll $DEV --wipe-slot=all`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1965",
+					Message: "`systemd-cryptenroll --wipe-slot=all` wipes every LUKS key slot (passphrase/recovery/TPM2/FIDO2) in one call. Enrol the new slot first, wipe a specific index, back up the header with `cryptsetup luksHeaderBackup`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1965")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1965.go
+++ b/pkg/katas/zc1965.go
@@ -1,0 +1,66 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1965",
+		Title:    "Error on `systemd-cryptenroll --wipe-slot=all` — wipes every LUKS key slot",
+		Severity: SeverityError,
+		Description: "`systemd-cryptenroll --wipe-slot=all $DEV` removes every key slot on the " +
+			"LUKS volume — passphrase, recovery key, TPM2, FIDO2, PKCS#11 — in one call. " +
+			"`--wipe-slot=recovery` / `--wipe-slot=empty` are scoped; the `all` form is a " +
+			"one-shot brick with no confirmation. Either enrol the new slot first and then " +
+			"wipe the specific index you are retiring (`--wipe-slot=<n>`), or back up the " +
+			"header with `cryptsetup luksHeaderBackup` before the call so recovery is " +
+			"possible.",
+		Check: checkZC1965,
+	})
+}
+
+func checkZC1965(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `systemd-cryptenroll --wipe-slot=all $DEV` mangles the
+	// command name to `wipe-slot=all`.
+	if strings.HasPrefix(ident.Value, "wipe-slot=") {
+		if ident.Value == "wipe-slot=all" {
+			return zc1965Hit(cmd)
+		}
+	}
+	if ident.Value != "systemd-cryptenroll" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--wipe-slot=all" || v == "--wipe-slot" {
+			if v == "--wipe-slot=all" {
+				return zc1965Hit(cmd)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1965Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1965",
+		Message: "`systemd-cryptenroll --wipe-slot=all` wipes every LUKS key slot " +
+			"(passphrase/recovery/TPM2/FIDO2) in one call. Enrol the new slot first, " +
+			"wipe a specific index, back up the header with `cryptsetup luksHeaderBackup`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 961 Katas = 0.9.61
-const Version = "0.9.61"
+// 962 Katas = 0.9.62
+const Version = "0.9.62"


### PR DESCRIPTION
ZC1965 — Error on `systemd-cryptenroll --wipe-slot=all $DEV`

What: Removes every LUKS key slot — passphrase, recovery key, TPM2, FIDO2, PKCS#11 — in one call.
Why: No confirmation; one-shot brick. `--wipe-slot=recovery` / `--wipe-slot=empty` are scoped; `all` is not.
Fix suggestion: Enrol the new slot first, wipe the specific retired index (`--wipe-slot=<n>`). Back up the header with `cryptsetup luksHeaderBackup` before the call.
Severity: Error