### PR TITLE
feat: ZC1966 — detect `zpool import -f`/`export -f` forced pool op

### DIFF
--- a/pkg/katas/katatests/zc1966_test.go
+++ b/pkg/katas/katatests/zc1966_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1966(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `zpool import $POOL` (no force)",
+			input:    `zpool import $POOL`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `zpool export $POOL`",
+			input:    `zpool export $POOL`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `zpool import -f $POOL`",
+			input: `zpool import -f $POOL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1966",
+					Message: "`zpool import -f` bypasses hostid/txg safety — forced import of a pool already online elsewhere (SAN/HA) corrupts it; forced export drops in-flight txgs. `zfs unmount -a` first, then plain `zpool export`/`import`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `zpool export -f $POOL`",
+			input: `zpool export -f $POOL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1966",
+					Message: "`zpool export -f` bypasses hostid/txg safety — forced import of a pool already online elsewhere (SAN/HA) corrupts it; forced export drops in-flight txgs. `zfs unmount -a` first, then plain `zpool export`/`import`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1966")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1966.go
+++ b/pkg/katas/zc1966.go
@@ -1,0 +1,59 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1966",
+		Title:    "Error on `zpool import -f` / `zpool export -f` — forced ZFS pool op bypasses hostid/txg checks",
+		Severity: SeverityError,
+		Description: "`zpool import -f $POOL` force-imports a pool even when the on-disk " +
+			"hostid differs — i.e. the pool is already imported on another host " +
+			"(multipath/SAN, shared JBOD, HA cluster). The second import writes to the " +
+			"same vdevs and silently corrupts the pool. `zpool export -f` skips the " +
+			"graceful-flush path and detaches vdevs with in-flight txgs, which can lose " +
+			"the tail of the ZIL. Export without `-f` after `zfs unmount -a`; import " +
+			"without `-f` after verifying `zpool import` (no target) reports the pool " +
+			"as `ONLINE` and the hostid matches.",
+		Check: checkZC1966,
+	})
+}
+
+func checkZC1966(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "zpool" || len(cmd.Arguments) < 2 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	if sub != "import" && sub != "export" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "-f" || v == "--force" {
+			return zc1966Hit(cmd, "zpool "+sub+" -f")
+		}
+	}
+	return nil
+}
+
+func zc1966Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1966",
+		Message: "`" + form + "` bypasses hostid/txg safety — forced import of a pool " +
+			"already online elsewhere (SAN/HA) corrupts it; forced export drops in-flight " +
+			"txgs. `zfs unmount -a` first, then plain `zpool export`/`import`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 962 Katas = 0.9.62
-const Version = "0.9.62"
+// 963 Katas = 0.9.63
+const Version = "0.9.63"


### PR DESCRIPTION
ZC1966 — Error on `zpool import -f` / `zpool export -f` — forced ZFS pool op bypasses hostid/txg checks

What: `zpool import -f $POOL` or `zpool export -f $POOL` forcing past safety checks.
Why: `-f` on import bypasses the hostid guard — on SAN/multipath/HA a pool already imported elsewhere gets a second writer and silently corrupts. `-f` on export skips graceful txg flush and can drop the tail of the ZIL.
Fix suggestion: `zfs unmount -a` then plain `zpool export`/`import`; verify with `zpool import` (no target) first.
Severity: Error