### PR TITLE
feat: ZC1967 — detect `setopt PROMPT_SUBST` prompt-substitution footgun

### DIFF
--- a/pkg/katas/katatests/zc1967_test.go
+++ b/pkg/katas/katatests/zc1967_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1967(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt PROMPT_SUBST`",
+			input:    `unsetopt PROMPT_SUBST`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NO_PROMPT_SUBST`",
+			input:    `setopt NO_PROMPT_SUBST`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt PROMPT_SUBST`",
+			input: `setopt PROMPT_SUBST`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1967",
+					Message: "`setopt PROMPT_SUBST` re-runs command substitution on every prompt redraw — a branch/host/dir value with `$(…)` executes each render. Prefer `%n`/`%d`/`%~`/`vcs_info`, or scope via `LOCAL_OPTIONS`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_PROMPT_SUBST`",
+			input: `unsetopt NO_PROMPT_SUBST`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1967",
+					Message: "`unsetopt NO_PROMPT_SUBST` re-runs command substitution on every prompt redraw — a branch/host/dir value with `$(…)` executes each render. Prefer `%n`/`%d`/`%~`/`vcs_info`, or scope via `LOCAL_OPTIONS`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1967")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1967.go
+++ b/pkg/katas/zc1967.go
@@ -1,0 +1,86 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1967",
+		Title:    "Warn on `setopt PROMPT_SUBST` — expansions inside `$PROMPT` evaluate command substitution every redraw",
+		Severity: SeverityWarning,
+		Description: "`setopt PROMPT_SUBST` turns on parameter, command, and arithmetic " +
+			"substitution inside `$PS1`/`$PROMPT`/`$RPROMPT`. Any value that lands in the " +
+			"prompt from an untrusted source — a git branch name, a checkout path, a " +
+			"hostname in `/etc/hostname`, an env var set by a spawned tool — is reparsed " +
+			"as shell code on every redraw, so a branch like `$(id>/tmp/p)` runs each time " +
+			"the cursor returns. Prefer Zsh prompt escapes (`%n`, `%d`, `%~`, `%m`, " +
+			"`vcs_info`) which already sanitise their inputs, or scope with `setopt " +
+			"LOCAL_OPTIONS PROMPT_SUBST` inside the prompt-building function instead of " +
+			"flipping the option globally.",
+		Check: checkZC1967,
+	})
+}
+
+func checkZC1967(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1967Canonical(arg.String())
+		switch v {
+		case "PROMPTSUBST":
+			if enabling {
+				return zc1967Hit(cmd, "setopt PROMPT_SUBST")
+			}
+		case "NOPROMPTSUBST":
+			if !enabling {
+				return zc1967Hit(cmd, "unsetopt NO_PROMPT_SUBST")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1967Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1967Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1967",
+		Message: "`" + form + "` re-runs command substitution on every prompt " +
+			"redraw — a branch/host/dir value with `$(…)` executes each render. Prefer " +
+			"`%n`/`%d`/`%~`/`vcs_info`, or scope via `LOCAL_OPTIONS`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 963 Katas = 0.9.63
-const Version = "0.9.63"
+// 964 Katas = 0.9.64
+const Version = "0.9.64"


### PR DESCRIPTION
ZC1967 — Warn on `setopt PROMPT_SUBST` — expansions inside `$PROMPT` evaluate command substitution every redraw

What: Script flips `setopt PROMPT_SUBST` (or `unsetopt NO_PROMPT_SUBST`) globally.
Why: With the option on, parameter/command/arith expansion runs on every prompt redraw against values from untrusted sources — git branch, directory name, hostname, env var set by a spawned tool. A branch called `$(id>/tmp/p)` executes on each render.
Fix suggestion: Use Zsh prompt escapes (`%n`/`%d`/`%~`/`%m`/`vcs_info`) which sanitise their inputs, or scope with `setopt LOCAL_OPTIONS PROMPT_SUBST` inside the prompt-building function.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1967` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.64