### PR TITLE
feat: ZC1968 — detect `dnf/yum versionlock add` RPM pin blocking CVE updates

### DIFF
--- a/pkg/katas/katatests/zc1968_test.go
+++ b/pkg/katas/katatests/zc1968_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1968(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `dnf versionlock list`",
+			input:    `dnf versionlock list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `dnf update --exclude=kernel`",
+			input:    `dnf update --exclude=kernel`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `dnf versionlock add kernel`",
+			input: `dnf versionlock add kernel`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1968",
+					Message: "`dnf versionlock add` pins the rpm — blocks future CVE fixes for glibc/openssl/kernel. Prefer `--exclude` on a single transaction and schedule a `versionlock delete` review.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `yum versionlock add openssl`",
+			input: `yum versionlock add openssl`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1968",
+					Message: "`yum versionlock add` pins the rpm — blocks future CVE fixes for glibc/openssl/kernel. Prefer `--exclude` on a single transaction and schedule a `versionlock delete` review.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1968")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1968.go
+++ b/pkg/katas/zc1968.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1968",
+		Title:    "Warn on `dnf versionlock add` / `yum versionlock add` — pins RPM, blocks CVE updates",
+		Severity: SeverityWarning,
+		Description: "`dnf versionlock add pkg` (and the legacy `yum versionlock add pkg`) " +
+			"write an entry to `/etc/dnf/plugins/versionlock.list` that excludes the " +
+			"package from future `dnf update` / `dnf upgrade` runs. Mirrors `apt-mark " +
+			"hold` on Debian (ZC1550): the lock survives reboots and unattended-upgrades " +
+			"never sees the newer rpm, so kernel, openssl, or glibc CVEs pile up unseen. " +
+			"Document the exact reason in the commit, pair the lock with a scheduled " +
+			"`dnf versionlock delete` date, and prefer excluding the problematic " +
+			"transaction via `--exclude` or a one-shot `dnf update --setopt=exclude=pkg` " +
+			"rather than a persistent pin.",
+		Check: checkZC1968,
+	})
+}
+
+func checkZC1968(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "dnf" && ident.Value != "yum" && ident.Value != "microdnf" {
+		return nil
+	}
+	if len(cmd.Arguments) < 3 {
+		return nil
+	}
+	if cmd.Arguments[0].String() != "versionlock" {
+		return nil
+	}
+	sub := cmd.Arguments[1].String()
+	if sub != "add" && sub != "exclude" {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1968",
+		Message: "`" + ident.Value + " versionlock " + sub + "` pins the rpm — blocks " +
+			"future CVE fixes for glibc/openssl/kernel. Prefer `--exclude` on a single " +
+			"transaction and schedule a `versionlock delete` review.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 964 Katas = 0.9.64
-const Version = "0.9.64"
+// 965 Katas = 0.9.65
+const Version = "0.9.65"


### PR DESCRIPTION
ZC1968 — Warn on `dnf versionlock add` / `yum versionlock add` — pins RPM, blocks CVE updates

What: Script calls `dnf versionlock add pkg` / `yum versionlock add pkg` / `microdnf versionlock add pkg` (or the `exclude` subform).
Why: Writes a persistent entry to `/etc/dnf/plugins/versionlock.list` that hides the package from future `dnf update`. Unattended-upgrades never sees the new rpm — kernel/openssl/glibc CVEs accumulate silently. RPM-side parallel of ZC1550 (`apt-mark hold`).
Fix suggestion: Prefer a one-shot `--exclude` on the single transaction (`dnf update --exclude=pkg`), document the reason, schedule a `dnf versionlock delete` review.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1968` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.65