### PR TITLE
feat: ZC1969 — detect `zsh -f`/`zsh -d` skipping startup-file hardening

### DIFF
--- a/pkg/katas/katatests/zc1969_test.go
+++ b/pkg/katas/katatests/zc1969_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1969(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `zsh -c ':'` (no -f/-d flag)",
+			input:    `zsh -c ':'`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `zsh $SCRIPT`",
+			input:    `zsh $SCRIPT`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `zsh -f $SCRIPT`",
+			input: `zsh -f $SCRIPT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1969",
+					Message: "`zsh -f` skips `/etc/zsh*` and `~/.zsh*` startup files — corp proxy/audit/`PATH` hardening silently dropped. For a pristine shell use `env -i zsh` with an explicit allow-list.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `zsh -d $SCRIPT`",
+			input: `zsh -d $SCRIPT`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1969",
+					Message: "`zsh -d` skips `/etc/zsh*` and `~/.zsh*` startup files — corp proxy/audit/`PATH` hardening silently dropped. For a pristine shell use `env -i zsh` with an explicit allow-list.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1969")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1969.go
+++ b/pkg/katas/zc1969.go
@@ -1,0 +1,56 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1969",
+		Title:    "Warn on `zsh -f` / `zsh -d` — skips `/etc/zsh*` and `~/.zsh*` startup files",
+		Severity: SeverityWarning,
+		Description: "`zsh -f` is the short form of `--no-rcs`, which skips every personal " +
+			"and system-wide startup file: `/etc/zshenv`, `/etc/zprofile`, `/etc/zshrc`, " +
+			"`/etc/zlogin`, `~/.zshenv`, `~/.zshrc`, `~/.zlogin`. `zsh -d` (`--no-" +
+			"globalrcs`) drops only the `/etc/zsh*` set but keeps per-user ones. Either " +
+			"form strips corp-mandated settings — proxy/hosts overrides, audit hooks, " +
+			"umask, `HISTFILE` redirection, `PATH` hardening — silently. Use it " +
+			"deliberately only for a pristine test harness or a minimal repro; never as " +
+			"the shebang of a production script. When isolation is required, prefer " +
+			"`env -i zsh` with an explicit allow-list of variables.",
+		Check: checkZC1969,
+	})
+}
+
+func checkZC1969(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "zsh" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-f" || v == "-d" {
+			return zc1969Hit(cmd, "zsh "+v)
+		}
+	}
+	return nil
+}
+
+func zc1969Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1969",
+		Message: "`" + form + "` skips `/etc/zsh*` and `~/.zsh*` startup files — " +
+			"corp proxy/audit/`PATH` hardening silently dropped. For a pristine " +
+			"shell use `env -i zsh` with an explicit allow-list.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 965 Katas = 0.9.65
-const Version = "0.9.65"
+// 966 Katas = 0.9.66
+const Version = "0.9.66"


### PR DESCRIPTION
ZC1969 — Warn on `zsh -f` / `zsh -d` — skips `/etc/zsh*` and `~/.zsh*` startup files

What: Script invokes `zsh -f` (`--no-rcs`) or `zsh -d` (`--no-globalrcs`).
Why: Either form strips corp-mandated settings that live in zsh startup files — proxy/hosts overrides, audit hooks, umask, `HISTFILE` redirection, `PATH` hardening — and the launched shell runs without them.
Fix suggestion: Use `-f`/`-d` only for a pristine test harness or a minimal repro. When isolation is required, prefer `env -i zsh` with an explicit allow-list of variables.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1969` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.66