### PR TITLE
feat: ZC1970 — detect kernel partscan on untrusted disk image (`losetup -P`/`kpartx -a`/`partprobe`)

### DIFF
--- a/pkg/katas/katatests/zc1970_test.go
+++ b/pkg/katas/katatests/zc1970_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1970(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `losetup -r $LOOP $IMG` (readonly, no partscan)",
+			input:    `losetup -r $LOOP $IMG`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `sfdisk --dump $IMG` (offline parser)",
+			input:    `sfdisk --dump $IMG`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `losetup -P $LOOP $IMG`",
+			input: `losetup -P $LOOP $IMG`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1970",
+					Message: "`losetup -P` asks the kernel to parse the partition table of the image — attacker-controlled bytes have tripped kernel CVEs. Use `fdisk -l`/`sfdisk --dump` offline first, scan only known-good images.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `kpartx -av $IMG`",
+			input: `kpartx -av $IMG`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1970",
+					Message: "`kpartx -a` asks the kernel to parse the partition table of the image — attacker-controlled bytes have tripped kernel CVEs. Use `fdisk -l`/`sfdisk --dump` offline first, scan only known-good images.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `partprobe $LOOP`",
+			input: `partprobe $LOOP`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1970",
+					Message: "`partprobe` asks the kernel to parse the partition table of the image — attacker-controlled bytes have tripped kernel CVEs. Use `fdisk -l`/`sfdisk --dump` offline first, scan only known-good images.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1970")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1970.go
+++ b/pkg/katas/zc1970.go
@@ -1,0 +1,66 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1970",
+		Title:    "Warn on `losetup -P` / `kpartx -a` / `partprobe` on untrusted image — runs kernel partition parser",
+		Severity: SeverityWarning,
+		Description: "`losetup -P $LOOP $IMG`, `kpartx -av $IMG`, and `partprobe $LOOP` all " +
+			"tell the kernel to rescan a block device's partition table and emit `/dev/" +
+			"loopNpX` (or dm-N) entries. When the image comes from an untrusted source " +
+			"— a customer-supplied VM disk, a downloaded installer, a forensic capture — " +
+			"the scan runs MBR/GPT/LVM parsers over attacker-controlled bytes and has " +
+			"historically triggered kernel CVEs (fsconfig heap overflow, ext4 mount " +
+			"bugs). Do the inspection in a throwaway VM or an offline parser like " +
+			"`fdisk -l $IMG` / `sfdisk --dump $IMG` that reads without kernel scan, and " +
+			"only attach partitions with `losetup -P` after the layout is known-good.",
+		Check: checkZC1970,
+	})
+}
+
+func checkZC1970(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "losetup":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "-P" || v == "--partscan" ||
+				v == "-Pf" || v == "-fP" || v == "-rP" || v == "-Pr" {
+				return zc1970Hit(cmd, "losetup -P")
+			}
+		}
+	case "kpartx":
+		for _, arg := range cmd.Arguments {
+			v := arg.String()
+			if v == "-a" || v == "-av" || v == "-va" || v == "-as" || v == "-sa" {
+				return zc1970Hit(cmd, "kpartx -a")
+			}
+		}
+	case "partprobe":
+		return zc1970Hit(cmd, "partprobe")
+	}
+	return nil
+}
+
+func zc1970Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1970",
+		Message: "`" + form + "` asks the kernel to parse the partition table of the " +
+			"image — attacker-controlled bytes have tripped kernel CVEs. Use `fdisk " +
+			"-l`/`sfdisk --dump` offline first, scan only known-good images.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 966 Katas = 0.9.66
-const Version = "0.9.66"
+// 967 Katas = 0.9.67
+const Version = "0.9.67"


### PR DESCRIPTION
ZC1970 — Warn on `losetup -P` / `kpartx -a` / `partprobe` on untrusted image — runs kernel partition parser

What: Script calls `losetup -P`, `kpartx -a[v]`, or `partprobe` against a disk image.
Why: Each asks the kernel to rescan the partition table and publish `/dev/loopNpX`/`dm-N` nodes. The MBR/GPT/LVM parsers run over attacker-controlled bytes. Historically that path has tripped kernel CVEs (fsconfig heap overflow, ext4 mount bugs).
Fix suggestion: Inspect layouts offline with `fdisk -l $IMG`/`sfdisk --dump $IMG`, which never ask the kernel to scan. Only attach partitions with `losetup -P` once the image is known-good; isolate the attach in a throwaway VM for customer-supplied media.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1970` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.67