### PR TITLE
feat: ZC1971 — detect `unsetopt GLOBAL_RCS` bypassing system Zsh rc files

### DIFF
--- a/pkg/katas/katatests/zc1971_test.go
+++ b/pkg/katas/katatests/zc1971_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1971(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt GLOBAL_RCS` (keeps default on)",
+			input:    `setopt GLOBAL_RCS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NO_GLOBAL_RCS` (restores default)",
+			input:    `unsetopt NO_GLOBAL_RCS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt GLOBAL_RCS`",
+			input: `unsetopt GLOBAL_RCS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1971",
+					Message: "`unsetopt GLOBAL_RCS` tells Zsh to skip `/etc/zprofile`, `/etc/zshrc`, `/etc/zlogin`, `/etc/zlogout` — corp `PATH`/audit/umask/proxy config silently dropped. Keep on; scope pristine setup with `emulate -LR zsh` or `env -i zsh -f`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_GLOBAL_RCS`",
+			input: `setopt NO_GLOBAL_RCS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1971",
+					Message: "`setopt NO_GLOBAL_RCS` tells Zsh to skip `/etc/zprofile`, `/etc/zshrc`, `/etc/zlogin`, `/etc/zlogout` — corp `PATH`/audit/umask/proxy config silently dropped. Keep on; scope pristine setup with `emulate -LR zsh` or `env -i zsh -f`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1971")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1971.go
+++ b/pkg/katas/zc1971.go
@@ -1,0 +1,88 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1971",
+		Title:    "Warn on `unsetopt GLOBAL_RCS` / `setopt NO_GLOBAL_RCS` — skips `/etc/zprofile`, `/etc/zshrc`, `/etc/zlogin`, `/etc/zlogout`",
+		Severity: SeverityWarning,
+		Description: "`GLOBAL_RCS` is on by default; only `/etc/zshenv` is sourced before it " +
+			"can be toggled. Flipping the option off (either `unsetopt GLOBAL_RCS` or " +
+			"`setopt NO_GLOBAL_RCS`) tells Zsh to skip `/etc/zprofile`, `/etc/zshrc`, " +
+			"`/etc/zlogin`, and `/etc/zlogout` — which is exactly where admins put " +
+			"corp-wide `PATH` hardening, audit hooks, umask, `HISTFILE` redirection, " +
+			"and proxy variables. A login-shell script that disables the option in " +
+			"`/etc/zshenv` neutralises every downstream system rc without a trace. " +
+			"Keep the option on; if a specific helper needs pristine setup use " +
+			"`emulate -LR zsh` inside a function or spawn `env -i zsh -f` scoped to " +
+			"that helper.",
+		Check: checkZC1971,
+	})
+}
+
+func checkZC1971(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1971Canonical(arg.String())
+		switch v {
+		case "GLOBALRCS":
+			if !enabling {
+				return zc1971Hit(cmd, "unsetopt GLOBAL_RCS")
+			}
+		case "NOGLOBALRCS":
+			if enabling {
+				return zc1971Hit(cmd, "setopt NO_GLOBAL_RCS")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1971Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1971Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1971",
+		Message: "`" + form + "` tells Zsh to skip `/etc/zprofile`, `/etc/zshrc`, " +
+			"`/etc/zlogin`, `/etc/zlogout` — corp `PATH`/audit/umask/proxy config " +
+			"silently dropped. Keep on; scope pristine setup with `emulate -LR zsh` " +
+			"or `env -i zsh -f`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 967 Katas = 0.9.67
-const Version = "0.9.67"
+// 968 Katas = 0.9.68
+const Version = "0.9.68"


### PR DESCRIPTION
ZC1971 — Warn on `unsetopt GLOBAL_RCS` / `setopt NO_GLOBAL_RCS` — skips `/etc/zprofile`, `/etc/zshrc`, `/etc/zlogin`, `/etc/zlogout`

What: Script flips `GLOBAL_RCS` off (either `unsetopt GLOBAL_RCS` or `setopt NO_GLOBAL_RCS`).
Why: `GLOBAL_RCS` is on by default and the system `/etc/zsh*` files are where admins park corp `PATH` hardening, audit hooks, umask, `HISTFILE` redirection, proxy vars. Disabling the option — typically from `/etc/zshenv`, the one file that runs before it can be toggled — neutralises every downstream system rc silently.
Fix suggestion: Keep the option on. For helpers that need a pristine shell, scope with `emulate -LR zsh` inside a function, or spawn `env -i zsh -f` for just that child.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1971` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.68