### PR TITLE
feat: ZC1972 — detect `dmsetup remove_all`/`remove -f` tearing down live DM mappings

### DIFF
--- a/pkg/katas/katatests/zc1972_test.go
+++ b/pkg/katas/katatests/zc1972_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1972(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `dmsetup ls`",
+			input:    `dmsetup ls`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `dmsetup remove $NAME` (no force)",
+			input:    `dmsetup remove $NAME`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `dmsetup remove_all`",
+			input: `dmsetup remove_all`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1972",
+					Message: "`dmsetup remove_all` drops LVM/LUKS/multipath mappings while still in use — in-flight I/O returns `ENXIO`, metadata needs a reboot. `umount` + `vgchange -an` / `cryptsetup close` first, then `dmsetup remove`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `dmsetup remove -f $NAME`",
+			input: `dmsetup remove -f $NAME`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1972",
+					Message: "`dmsetup remove -f` drops LVM/LUKS/multipath mappings while still in use — in-flight I/O returns `ENXIO`, metadata needs a reboot. `umount` + `vgchange -an` / `cryptsetup close` first, then `dmsetup remove`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1972")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1972.go
+++ b/pkg/katas/zc1972.go
@@ -1,0 +1,65 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1972",
+		Title:    "Error on `dmsetup remove_all` / `dmsetup remove -f` — tears down live LVM/LUKS/multipath mappings",
+		Severity: SeverityError,
+		Description: "`dmsetup remove_all` iterates every device-mapper node on the host — " +
+			"LVM logical volumes, LUKS containers, multipath aggregates, `cryptsetup` " +
+			"mappings — and asks the kernel to drop each one. `dmsetup remove --force " +
+			"$NAME` targets a single mapping but still evicts it with in-flight I/O. " +
+			"When any of those devices is mounted or backing a running VM, new I/O to " +
+			"it returns `ENXIO`, `fsck` is no longer possible, and LVM metadata needs a " +
+			"cold reboot to reappear. Use `dmsetup remove $NAME` without `--force` " +
+			"after `umount`/`vgchange -an`/`cryptsetup close`, and never `remove_all` " +
+			"on a host you care about.",
+		Check: checkZC1972,
+	})
+}
+
+func checkZC1972(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "dmsetup" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	if sub == "remove_all" {
+		return zc1972Hit(cmd, "dmsetup remove_all")
+	}
+	if sub == "remove" {
+		for _, arg := range cmd.Arguments[1:] {
+			v := arg.String()
+			if v == "-f" || v == "--force" {
+				return zc1972Hit(cmd, "dmsetup remove -f")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1972Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1972",
+		Message: "`" + form + "` drops LVM/LUKS/multipath mappings while still in " +
+			"use — in-flight I/O returns `ENXIO`, metadata needs a reboot. `umount` " +
+			"+ `vgchange -an` / `cryptsetup close` first, then `dmsetup remove`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 968 Katas = 0.9.68
-const Version = "0.9.68"
+// 969 Katas = 0.9.69
+const Version = "0.9.69"


### PR DESCRIPTION
ZC1972 — Error on `dmsetup remove_all` / `dmsetup remove -f` — tears down live LVM/LUKS/multipath mappings

What: Script calls `dmsetup remove_all` or `dmsetup remove -f $NAME`.
Why: `remove_all` iterates every DM node on the host — LVM LVs, LUKS containers, multipath aggregates, `cryptsetup` mappings — and forces each out. `remove --force` does the same for a single mapping. When any of those devices is mounted or backing a VM, in-flight I/O returns `ENXIO`, `fsck` becomes impossible, and LVM metadata needs a cold reboot to reappear.
Fix suggestion: `umount` → `vgchange -an` → `cryptsetup close` in order, then `dmsetup remove $NAME` without force. Never `remove_all` on production.
Severity: Error

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1972` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.69