### PR TITLE
feat: ZC1973 — detect `setopt POSIX_IDENTIFIERS` breaking Unicode parameter names

### DIFF
--- a/pkg/katas/katatests/zc1973_test.go
+++ b/pkg/katas/katatests/zc1973_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1973(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt POSIX_IDENTIFIERS` (restores default)",
+			input:    `unsetopt POSIX_IDENTIFIERS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NO_POSIX_IDENTIFIERS` (restores default)",
+			input:    `setopt NO_POSIX_IDENTIFIERS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt POSIX_IDENTIFIERS`",
+			input: `setopt POSIX_IDENTIFIERS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1973",
+					Message: "`setopt POSIX_IDENTIFIERS` restricts parameter names to ASCII; later `${café}`/`${π}` fail to parse and i18n-named libs stop loading. Scope with `emulate -LR sh` inside the helper instead of flipping globally.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_POSIX_IDENTIFIERS`",
+			input: `unsetopt NO_POSIX_IDENTIFIERS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1973",
+					Message: "`unsetopt NO_POSIX_IDENTIFIERS` restricts parameter names to ASCII; later `${café}`/`${π}` fail to parse and i18n-named libs stop loading. Scope with `emulate -LR sh` inside the helper instead of flipping globally.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1973")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1973.go
+++ b/pkg/katas/zc1973.go
@@ -1,0 +1,86 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1973",
+		Title:    "Warn on `setopt POSIX_IDENTIFIERS` — restricts parameter names to ASCII, breaks Unicode `$var`",
+		Severity: SeverityWarning,
+		Description: "Zsh accepts Unicode parameter names by default: `$café`, `$π`, `$данные` " +
+			"all parse. `setopt POSIX_IDENTIFIERS` tightens that to the POSIX subset — " +
+			"ASCII letters, digits, underscore, not starting with a digit. Once the " +
+			"option is on, every later `${café}` or `café=1` is a parse error, and " +
+			"scripts/libraries that expose i18n-named vars stop loading. If you need " +
+			"POSIX identifiers for a specific helper, scope it inside a function with " +
+			"`emulate -LR sh`; leave the global option off so the rest of the shell " +
+			"keeps the Zsh behaviour the user expects.",
+		Check: checkZC1973,
+	})
+}
+
+func checkZC1973(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1973Canonical(arg.String())
+		switch v {
+		case "POSIXIDENTIFIERS":
+			if enabling {
+				return zc1973Hit(cmd, "setopt POSIX_IDENTIFIERS")
+			}
+		case "NOPOSIXIDENTIFIERS":
+			if !enabling {
+				return zc1973Hit(cmd, "unsetopt NO_POSIX_IDENTIFIERS")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1973Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1973Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1973",
+		Message: "`" + form + "` restricts parameter names to ASCII; later " +
+			"`${café}`/`${π}` fail to parse and i18n-named libs stop loading. " +
+			"Scope with `emulate -LR sh` inside the helper instead of flipping " +
+			"globally.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 969 Katas = 0.9.69
-const Version = "0.9.69"
+// 970 Katas = 0.9.70
+const Version = "0.9.70"


### PR DESCRIPTION
ZC1973 — Warn on `setopt POSIX_IDENTIFIERS` — restricts parameter names to ASCII, breaks Unicode `\$var`

What: Script flips `POSIX_IDENTIFIERS` on (either `setopt POSIX_IDENTIFIERS` or `unsetopt NO_POSIX_IDENTIFIERS`).
Why: Default Zsh accepts Unicode parameter names (`\$café`, `\$π`, `\$данные`). With the option on, the parser rejects anything outside POSIX (ASCII alnum + `_`, not digit-leading), so i18n-named vars in libraries stop loading and later assignments fail.
Fix suggestion: Leave the option off globally. When POSIX identifiers are genuinely needed for a helper, scope with `emulate -LR sh` inside that function rather than flipping the global setting.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1973` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.70