### PR TITLE
feat: ZC1974 — detect `ipset flush`/`ipset destroy` wiping firewall-referenced sets

### DIFF
--- a/pkg/katas/katatests/zc1974_test.go
+++ b/pkg/katas/katatests/zc1974_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1974(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ipset list`",
+			input:    `ipset list`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ipset destroy blocklist` (targeted name)",
+			input:    `ipset destroy blocklist`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ipset flush`",
+			input: `ipset flush`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1974",
+					Message: "`ipset flush` drops named IP sets wholesale — iptables/nft rules that reference them fall through to the default policy (block-list empty, allow-list gone). Target by name; reload atomically via `ipset restore -! < snapshot`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `ipset destroy` (no arg, wipes every set)",
+			input: `ipset destroy`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1974",
+					Message: "`ipset destroy` drops named IP sets wholesale — iptables/nft rules that reference them fall through to the default policy (block-list empty, allow-list gone). Target by name; reload atomically via `ipset restore -! < snapshot`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1974")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1974.go
+++ b/pkg/katas/zc1974.go
@@ -1,0 +1,63 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1974",
+		Title:    "Error on `ipset flush` / `ipset destroy` — nukes named sets referenced by iptables/nft rules",
+		Severity: SeverityError,
+		Description: "`ipset flush` empties every entry from a named IP set; `ipset destroy` " +
+			"(no args) removes every set on the host. iptables/nft rules of the form " +
+			"`-m set --match-set $NAME src` then reference a set that is either empty " +
+			"or gone, so block-lists disappear instantly and allow-lists stop " +
+			"whitelisting — the ruleset falls through to its default policy. Target a " +
+			"specific set by name (`ipset destroy $NAME` after confirming no rule " +
+			"references it), or add new entries with `ipset add` instead of rebuilding " +
+			"from scratch. Reload atomically with `ipset restore -! < snapshot` if a " +
+			"full replace is genuinely needed.",
+		Check: checkZC1974,
+	})
+}
+
+func checkZC1974(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ipset" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	switch sub {
+	case "flush", "-F":
+		return zc1974Hit(cmd, "ipset flush")
+	case "destroy", "-X":
+		if len(cmd.Arguments) == 1 {
+			return zc1974Hit(cmd, "ipset destroy")
+		}
+	}
+	return nil
+}
+
+func zc1974Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1974",
+		Message: "`" + form + "` drops named IP sets wholesale — iptables/nft rules " +
+			"that reference them fall through to the default policy (block-list " +
+			"empty, allow-list gone). Target by name; reload atomically via " +
+			"`ipset restore -! < snapshot`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 970 Katas = 0.9.70
-const Version = "0.9.70"
+// 971 Katas = 0.9.71
+const Version = "0.9.71"


### PR DESCRIPTION
ZC1974 — Error on `ipset flush` / `ipset destroy` — nukes named sets referenced by iptables/nft rules

What: Script calls `ipset flush` (empties every entry from a named set) or `ipset destroy` with no args (removes every set).
Why: iptables/nft rules of the form `-m set --match-set $NAME src` then point at an empty or missing set. Block-lists stop blocking; allow-lists stop whitelisting. The policy silently falls through to the default (ACCEPT/DROP) and the firewall's intent is gone.
Fix suggestion: Target by name (`ipset destroy $NAME` after confirming no rule references it), or reload atomically with `ipset restore -! < snapshot` when a full replace is genuinely needed.
Severity: Error

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1974` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.71