### PR TITLE
feat: ZC1975 — detect `unsetopt EXEC` turning the script into a silent no-op

### DIFF
--- a/pkg/katas/katatests/zc1975_test.go
+++ b/pkg/katas/katatests/zc1975_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1975(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt EXEC` (default on, keeps running)",
+			input:    `setopt EXEC`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NO_EXEC` (restores default)",
+			input:    `unsetopt NO_EXEC`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt EXEC`",
+			input: `unsetopt EXEC`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1975",
+					Message: "`unsetopt EXEC` stops running commands but keeps parsing — every later line becomes a silent no-op. For syntax checks run `zsh -n script.zsh` from outside the script.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_EXEC`",
+			input: `setopt NO_EXEC`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1975",
+					Message: "`setopt NO_EXEC` stops running commands but keeps parsing — every later line becomes a silent no-op. For syntax checks run `zsh -n script.zsh` from outside the script.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1975")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1975.go
+++ b/pkg/katas/zc1975.go
@@ -1,0 +1,86 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1975",
+		Title:    "Warn on `unsetopt EXEC` / `setopt NO_EXEC` — parser keeps scanning, commands stop running",
+		Severity: SeverityWarning,
+		Description: "`EXEC` is on by default; the shell both parses and runs each command. " +
+			"Turning it off (`unsetopt EXEC` or `setopt NO_EXEC`) tells Zsh to parse " +
+			"everything but silently skip the execution step — nothing fires, yet " +
+			"parameter assignments on the same line don't either, `$?` stays frozen, " +
+			"and functions that follow look defined but never run. That is the " +
+			"semantics behind `zsh -n script.zsh` for a pure syntax check; flipping " +
+			"the option in the middle of a production script converts every later " +
+			"line into a no-op without a visible error. Run syntax checks via `zsh " +
+			"-n` from the outside, never by flipping `EXEC` in-line.",
+		Check: checkZC1975,
+	})
+}
+
+func checkZC1975(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1975Canonical(arg.String())
+		switch v {
+		case "EXEC":
+			if !enabling {
+				return zc1975Hit(cmd, "unsetopt EXEC")
+			}
+		case "NOEXEC":
+			if enabling {
+				return zc1975Hit(cmd, "setopt NO_EXEC")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1975Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1975Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1975",
+		Message: "`" + form + "` stops running commands but keeps parsing — every " +
+			"later line becomes a silent no-op. For syntax checks run `zsh -n " +
+			"script.zsh` from outside the script.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 971 Katas = 0.9.71
-const Version = "0.9.71"
+// 972 Katas = 0.9.72
+const Version = "0.9.72"


### PR DESCRIPTION
ZC1975 — Warn on `unsetopt EXEC` / `setopt NO_EXEC` — parser keeps scanning, commands stop running

What: Script flips `EXEC` off (either `unsetopt EXEC` or `setopt NO_EXEC`).
Why: `EXEC` on = parse + run; off = parse only. Once disabled in-line, every later command is silently skipped, parameter assignments on the same line don't take effect, and `\$?` stays frozen. Same semantics as `zsh -n script.zsh`, except the script thinks it is running.
Fix suggestion: Run syntax checks from outside the script (`zsh -n script.zsh`). Never flip `EXEC` in the script body.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1975` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.72