### PR TITLE
feat: ZC1976 — detect `exportfs -au`/`-u` unexport that ESTALEs live NFS mounts

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,9 @@ linters:
     - misspell
 
 linters-settings:
+  misspell:
+    ignore-words:
+      - exportfs
   lll:
     line-length: 250
   funlen:

--- a/pkg/katas/katatests/zc1976_test.go
+++ b/pkg/katas/katatests/zc1976_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1976(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `exportfs -ra` (re-sync)",
+			input:    `exportfs -ra`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `exportfs -f` (flush cache after edit)",
+			input:    `exportfs -f`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `exportfs -au`",
+			input: `exportfs -au`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1976",
+					Message: "`exportfs -au` unexports live NFS shares — mounted clients see `ESTALE` on every open fd. Use `exportfs -f` after editing `/etc/exports`; reserve `-u`/`-au` for coordinated shutdowns.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `exportfs -u $HOST:$PATH`",
+			input: `exportfs -u $HOST:$PATH`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1976",
+					Message: "`exportfs -u` unexports live NFS shares — mounted clients see `ESTALE` on every open fd. Use `exportfs -f` after editing `/etc/exports`; reserve `-u`/`-au` for coordinated shutdowns.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1976")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1976.go
+++ b/pkg/katas/zc1976.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1976",
+		Title:    "Error on `exportfs -au` / `exportfs -u` — unexports live NFS shares, clients get `ESTALE`",
+		Severity: SeverityError,
+		Description: "`exportfs -au` unexports every NFS share on the server; `exportfs -u " +
+			"HOST:/PATH` removes a single share. Any client that currently has the " +
+			"export mounted is not notified — the next read/write returns `ESTALE`, " +
+			"the mount looks live but every open fd fails, and the only recovery is a " +
+			"client-side `umount -l` + remount. `exportfs -f` (flush) is almost always " +
+			"what you actually want after an `/etc/exports` edit; keep `-u`/`-au` for " +
+			"planned shutdowns with a coordinated client `umount` first.",
+		Check: checkZC1976,
+	})
+}
+
+func checkZC1976(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "exportfs" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-au" || v == "-ua" || v == "-u" {
+			return zc1976Hit(cmd, "exportfs "+v)
+		}
+	}
+	return nil
+}
+
+func zc1976Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1976",
+		Message: "`" + form + "` unexports live NFS shares — mounted clients see " +
+			"`ESTALE` on every open fd. Use `exportfs -f` after editing " +
+			"`/etc/exports`; reserve `-u`/`-au` for coordinated shutdowns.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 972 Katas = 0.9.72
-const Version = "0.9.72"
+// 973 Katas = 0.9.73
+const Version = "0.9.73"


### PR DESCRIPTION
ZC1976 — Error on `exportfs -au` / `exportfs -u` — unexports live NFS shares, clients get `ESTALE`

What: Script calls `exportfs -au` (unexport all) or `exportfs -u HOST:/PATH` (unexport one).
Why: Clients that already have the export mounted are not notified. The next read/write returns `ESTALE`, every open fd fails, and recovery requires a client-side `umount -l` + remount.
Fix suggestion: After editing `/etc/exports`, use `exportfs -f` (flush cache) — that's almost always what's actually wanted. Reserve `-u`/`-au` for a planned shutdown with a coordinated client `umount` first.
Severity: Error

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1976` passes
- [x] `golangci-lint run ./...` clean (added `exportfs` to misspell ignore-words)
- [x] `scripts/update-version.sh` → 0.9.73