### PR TITLE
feat: ZC1977 — detect `setopt CHASE_DOTS` breaking blue/green `current` symlinks

### DIFF
--- a/pkg/katas/katatests/zc1977_test.go
+++ b/pkg/katas/katatests/zc1977_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1977(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt CHASE_DOTS`",
+			input:    `unsetopt CHASE_DOTS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NO_CHASE_DOTS`",
+			input:    `setopt NO_CHASE_DOTS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt CHASE_DOTS`",
+			input: `setopt CHASE_DOTS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1977",
+					Message: "`setopt CHASE_DOTS` makes `cd ..` physically resolve before walking up — blue/green `current` symlinks stop working for `../foo` lookups. Keep off; use `cd -P` one-shot when physical resolution is needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_CHASE_DOTS`",
+			input: `unsetopt NO_CHASE_DOTS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1977",
+					Message: "`unsetopt NO_CHASE_DOTS` makes `cd ..` physically resolve before walking up — blue/green `current` symlinks stop working for `../foo` lookups. Keep off; use `cd -P` one-shot when physical resolution is needed.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1977")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1977.go
+++ b/pkg/katas/zc1977.go
@@ -1,0 +1,86 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1977",
+		Title:    "Warn on `setopt CHASE_DOTS` — `cd ..` physically resolves before walking up, breaking logical paths",
+		Severity: SeverityWarning,
+		Description: "Default Zsh keeps `..` logical: from `/app/current/lib` (where " +
+			"`/app/current` → `/app/releases/v5`), `cd ..` goes back to `/app/current`, " +
+			"matching the user's mental model and blue/green deployment symlinks. " +
+			"`setopt CHASE_DOTS` flips that — `..` first resolves the current directory " +
+			"to its physical inode, so the same `cd ..` lands in `/app/releases/v5` " +
+			"and the next `cd config` looks for `/app/releases/config` instead of " +
+			"`/app/config`. Scripts that rely on `${PWD}` staying logical or on " +
+			"`cd ../foo` matching the typed path break silently. Leave the option off; " +
+			"use `cd -P` one-shot when a specific call really needs physical resolution.",
+		Check: checkZC1977,
+	})
+}
+
+func checkZC1977(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1977Canonical(arg.String())
+		switch v {
+		case "CHASEDOTS":
+			if enabling {
+				return zc1977Hit(cmd, "setopt CHASE_DOTS")
+			}
+		case "NOCHASEDOTS":
+			if !enabling {
+				return zc1977Hit(cmd, "unsetopt NO_CHASE_DOTS")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1977Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1977Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1977",
+		Message: "`" + form + "` makes `cd ..` physically resolve before walking up — " +
+			"blue/green `current` symlinks stop working for `../foo` lookups. " +
+			"Keep off; use `cd -P` one-shot when physical resolution is needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 973 Katas = 0.9.73
-const Version = "0.9.73"
+// 974 Katas = 0.9.74
+const Version = "0.9.74"


### PR DESCRIPTION
ZC1977 — Warn on `setopt CHASE_DOTS` — `cd ..` physically resolves before walking up, breaking logical paths

What: Script flips `CHASE_DOTS` on (`setopt CHASE_DOTS` or `unsetopt NO_CHASE_DOTS`).
Why: Default behaviour keeps `..` logical: from `/app/current/lib` (where `/app/current` is a symlink), `cd ..` returns to `/app/current`. With the option on, `..` first resolves the current directory to its physical inode, so `cd ..` lands in the real release dir and `cd ../foo` looks for `foo` under that release — blue/green deployment symlinks break silently.
Fix suggestion: Leave the option off. Request one-shot physical resolution with `cd -P` when a specific call really needs it.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1977` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.74