### PR TITLE
feat: ZC1978 — detect `ftp`/`tftp` plaintext file transfer

### DIFF
--- a/pkg/katas/katatests/zc1978_test.go
+++ b/pkg/katas/katatests/zc1978_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1978(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `sftp $HOST`",
+			input:    `sftp $HOST`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `curl -u user: https://$HOST/file`",
+			input:    `curl -u user: https://$HOST/file`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ftp $HOST`",
+			input: `ftp $HOST`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1978",
+					Message: "`ftp` transfers in plaintext — creds and payload visible on the wire. Use `sftp`/`scp`/`rsync -e ssh` or a signed-payload `curl` over HTTPS instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `tftp $HOST`",
+			input: `tftp $HOST`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1978",
+					Message: "`tftp` transfers in plaintext — creds and payload visible on the wire. Use `sftp`/`scp`/`rsync -e ssh` or a signed-payload `curl` over HTTPS instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1978")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1978.go
+++ b/pkg/katas/zc1978.go
@@ -1,0 +1,49 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1978",
+		Title:    "Warn on `ftp` / `tftp` — cleartext transfer, credentials and payload exposed on the wire",
+		Severity: SeverityWarning,
+		Description: "`ftp HOST` negotiates USER/PASS and moves the payload over plaintext TCP " +
+			"(port 21) — every credential and byte is visible to anything between the " +
+			"caller and the server. `tftp` has no auth at all and runs over UDP/69, so " +
+			"any packet capture recovers the full transfer. Both are also routinely " +
+			"mishandled by NAT/firewall gear because of their dual-channel design. " +
+			"Replace with `curl -u USER: https://…` / `sftp` / `scp` / `rsync -e ssh` " +
+			"for authenticated transfers, and with a signed-payload pull over HTTPS for " +
+			"PXE-style provisioning that used to rely on `tftp`.",
+		Check: checkZC1978,
+	})
+}
+
+func checkZC1978(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ftp" && ident.Value != "tftp" {
+		return nil
+	}
+	// Require at least one arg so bare `ftp` at a prompt isn't flagged.
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1978",
+		Message: "`" + ident.Value + "` transfers in plaintext — creds and payload " +
+			"visible on the wire. Use `sftp`/`scp`/`rsync -e ssh` or a signed-" +
+			"payload `curl` over HTTPS instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 974 Katas = 0.9.74
-const Version = "0.9.74"
+// 975 Katas = 0.9.75
+const Version = "0.9.75"


### PR DESCRIPTION
ZC1978 — Warn on `ftp` / `tftp` — cleartext transfer, credentials and payload exposed on the wire

What: Script calls `ftp HOST…` or `tftp HOST…`.
Why: `ftp` negotiates `USER`/`PASS` and moves payloads in plaintext TCP/21; anything between caller and server sees both. `tftp` has no auth at all and runs in the clear over UDP/69. Dual-channel design also trips modern NAT/firewall gear.
Fix suggestion: Use `sftp` / `scp` / `rsync -e ssh` for authenticated transfers. For PXE-style provisioning that historically used `tftp`, fetch a signed payload over HTTPS with `curl`.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1978` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.75