### PR TITLE
feat: ZC1979 — detect `setopt HIST_FCNTL_LOCK` NFS lockd deadlock

### DIFF
--- a/pkg/katas/katatests/zc1979_test.go
+++ b/pkg/katas/katatests/zc1979_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1979(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt HIST_FCNTL_LOCK` (keeps default off)",
+			input:    `unsetopt HIST_FCNTL_LOCK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NO_HIST_FCNTL_LOCK`",
+			input:    `setopt NO_HIST_FCNTL_LOCK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt HIST_FCNTL_LOCK`",
+			input: `setopt HIST_FCNTL_LOCK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1979",
+					Message: "`setopt HIST_FCNTL_LOCK` routes `$HISTFILE` locking through POSIX `fcntl()` — on NFS home directories a hung `rpc.lockd` freezes every other shell at the next prompt. Keep off; enable only when `$HISTFILE` is on a local fs.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_HIST_FCNTL_LOCK`",
+			input: `unsetopt NO_HIST_FCNTL_LOCK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1979",
+					Message: "`unsetopt NO_HIST_FCNTL_LOCK` routes `$HISTFILE` locking through POSIX `fcntl()` — on NFS home directories a hung `rpc.lockd` freezes every other shell at the next prompt. Keep off; enable only when `$HISTFILE` is on a local fs.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1979")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1979.go
+++ b/pkg/katas/zc1979.go
@@ -1,0 +1,88 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1979",
+		Title:    "Warn on `setopt HIST_FCNTL_LOCK` — `fcntl()` lock on NFS `$HISTFILE` stalls or deadlocks",
+		Severity: SeverityWarning,
+		Description: "Off by default, Zsh serialises writes to `$HISTFILE` with its own " +
+			"lock-file dance next to the history. `setopt HIST_FCNTL_LOCK` switches to " +
+			"POSIX `fcntl()` advisory locking — which is the safer primitive on local " +
+			"filesystems, but on NFS homes the lock is proxied through `rpc.lockd` and " +
+			"a single hung client or rebooted NFS server leaves every other shell " +
+			"blocked the next time it tries to write history. The interactive shell " +
+			"appears frozen on prompt return, and scripts that source user rc files " +
+			"hang in `zshaddhistory`. Keep the option off on NFS homes; only turn it on " +
+			"when `$HISTFILE` lives on a local filesystem (ext4, xfs, btrfs, zfs local " +
+			"pool) that implements `fcntl()` without network round-trips.",
+		Check: checkZC1979,
+	})
+}
+
+func checkZC1979(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1979Canonical(arg.String())
+		switch v {
+		case "HISTFCNTLLOCK":
+			if enabling {
+				return zc1979Hit(cmd, "setopt HIST_FCNTL_LOCK")
+			}
+		case "NOHISTFCNTLLOCK":
+			if !enabling {
+				return zc1979Hit(cmd, "unsetopt NO_HIST_FCNTL_LOCK")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1979Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1979Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1979",
+		Message: "`" + form + "` routes `$HISTFILE` locking through POSIX `fcntl()` — " +
+			"on NFS home directories a hung `rpc.lockd` freezes every other shell " +
+			"at the next prompt. Keep off; enable only when `$HISTFILE` is on a " +
+			"local fs.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 975 Katas = 0.9.75
-const Version = "0.9.75"
+// 976 Katas = 0.9.76
+const Version = "0.9.76"


### PR DESCRIPTION
ZC1979 — Warn on `setopt HIST_FCNTL_LOCK` — `fcntl()` lock on NFS `\$HISTFILE` stalls or deadlocks

What: Script flips `HIST_FCNTL_LOCK` on (`setopt HIST_FCNTL_LOCK` or `unsetopt NO_HIST_FCNTL_LOCK`).
Why: Off by default, Zsh uses its own lock-file dance next to `\$HISTFILE`. With the option on, it switches to POSIX `fcntl()` advisory locking — safer locally, but on NFS homes the lock is proxied through `rpc.lockd`. A single hung client or rebooted NFS server leaves every other shell blocked the next time it writes history; interactive shells appear frozen, and scripts that source user rc files hang in `zshaddhistory`.
Fix suggestion: Keep off on NFS homes. Enable only when `\$HISTFILE` lives on a local fs (ext4/xfs/btrfs/zfs-local) that implements `fcntl()` without network round-trips.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1979` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.76