### PR TITLE
feat: ZC1980 — detect `udevadm trigger --action=remove` live-device detach

### DIFF
--- a/pkg/katas/katatests/zc1980_test.go
+++ b/pkg/katas/katatests/zc1980_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1980(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `udevadm control --reload`",
+			input:    `udevadm control --reload`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `udevadm trigger --action=change`",
+			input:    `udevadm trigger --action=change`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `udevadm trigger --action=remove`",
+			input: `udevadm trigger --action=remove`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1980",
+					Message: "`udevadm trigger --action=remove` replays `remove` uevents across `/sys` — SATA/NIC/GPU nodes detach on a live host. Reload rules with `udevadm control --reload`; scope with `--subsystem-match=`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `udevadm trigger -c remove`",
+			input: `udevadm trigger -c remove`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1980",
+					Message: "`udevadm trigger --action=remove` replays `remove` uevents across `/sys` — SATA/NIC/GPU nodes detach on a live host. Reload rules with `udevadm control --reload`; scope with `--subsystem-match=`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1980")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1980.go
+++ b/pkg/katas/zc1980.go
@@ -1,0 +1,73 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1980",
+		Title:    "Error on `udevadm trigger --action=remove` — replays `remove` uevents, detaches live devices",
+		Severity: SeverityError,
+		Description: "`udevadm trigger --action=remove` (also spelled `-c remove`) walks " +
+			"`/sys` and synthesises a `remove` uevent for every matching device. The " +
+			"kernel reacts as if every matched disk, NIC, GPU, or USB node was " +
+			"physically yanked — SATA controllers detach drives that back mounted " +
+			"filesystems, netdevs disappear mid-session, and `systemd-udevd` fires " +
+			"per-device cleanup rules it was never meant to run on a live host. The " +
+			"normal way to replay `add`/`change` events after a rules edit is " +
+			"`udevadm control --reload` followed by `udevadm trigger` with the default " +
+			"action (`change`); scope any `--action=remove` to a specific device " +
+			"subsystem with `--subsystem-match=` + `--attr-match=` and test on a " +
+			"non-production box first.",
+		Check: checkZC1980,
+	})
+}
+
+func checkZC1980(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "udevadm" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "trigger" {
+		return nil
+	}
+	for i, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if strings.HasPrefix(v, "--action=") {
+			if strings.TrimPrefix(v, "--action=") == "remove" {
+				return zc1980Hit(cmd)
+			}
+		}
+		if v == "-c" || v == "--action" {
+			if i+2 < len(cmd.Arguments) {
+				next := cmd.Arguments[i+2].String()
+				if next == "remove" {
+					return zc1980Hit(cmd)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func zc1980Hit(cmd *ast.SimpleCommand) []Violation {
+	return []Violation{{
+		KataID: "ZC1980",
+		Message: "`udevadm trigger --action=remove` replays `remove` uevents across " +
+			"`/sys` — SATA/NIC/GPU nodes detach on a live host. Reload rules " +
+			"with `udevadm control --reload`; scope with `--subsystem-match=`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 976 Katas = 0.9.76
-const Version = "0.9.76"
+// 977 Katas = 0.9.77
+const Version = "0.9.77"


### PR DESCRIPTION
ZC1980 — Error on `udevadm trigger --action=remove` — replays `remove` uevents, detaches live devices

What: Script calls `udevadm trigger --action=remove` (or `-c remove`).
Why: `udevadm trigger` walks `/sys` and synthesises the requested uevent for every matching device. With `--action=remove` the kernel reacts as if every matched disk, NIC, GPU, or USB node was physically yanked — SATA controllers detach drives backing mounted filesystems, netdevs disappear mid-session, and `systemd-udevd` fires per-device cleanup rules never meant for a live host.
Fix suggestion: To replay rules after a config edit, use `udevadm control --reload` then `udevadm trigger` with the default `change` action. Scope any genuine `--action=remove` with `--subsystem-match=` / `--attr-match=` and test on a non-production box first.
Severity: Error

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1980` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.77