### PR TITLE
feat: ZC1981 — detect `exec -a NAME` masking real binary from `ps`

### DIFF
--- a/pkg/katas/katatests/zc1981_test.go
+++ b/pkg/katas/katatests/zc1981_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1981(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `exec $BIN`",
+			input:    `exec $BIN`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `exec $BIN arg1 arg2`",
+			input:    `exec $BIN arg1 arg2`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `exec -a login $BIN`",
+			input: `exec -a login $BIN`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1981",
+					Message: "`exec -a NAME` sets `argv[0]` to `NAME` — `ps`/`top`/audit rules see the alias, not the real binary. Keep out of production scripts unless the alias is documented.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `exec -a $ALIAS $BIN`",
+			input: `exec -a $ALIAS $BIN`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1981",
+					Message: "`exec -a NAME` sets `argv[0]` to `NAME` — `ps`/`top`/audit rules see the alias, not the real binary. Keep out of production scripts unless the alias is documented.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1981")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1981.go
+++ b/pkg/katas/zc1981.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1981",
+		Title:    "Warn on `exec -a NAME cmd` — replaces `argv[0]`, hides the real binary from `ps`",
+		Severity: SeverityWarning,
+		Description: "`exec -a NAME $BIN` tells Zsh to set `argv[0]` of the `exec`'d process " +
+			"to `NAME` instead of the actual program path. `ps`, `top`, `proc`-based " +
+			"audit tools, and systemd's unit accounting all see `NAME` — the real " +
+			"binary on disk is only discoverable from `/proc/PID/exe`, which most " +
+			"monitoring does not read. The feature has legitimate uses (login shells " +
+			"spelling themselves `-zsh` so tty/shell detection works) but also makes a " +
+			"great disguise for a reverse shell or a cron-triggered helper. Keep " +
+			"`exec -a` out of production scripts unless the intent is documented; " +
+			"prefer running the binary at its real path so operators can match process " +
+			"name to on-disk file.",
+		Check: checkZC1981,
+	})
+}
+
+func checkZC1981(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "exec" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-a" {
+			return []Violation{{
+				KataID: "ZC1981",
+				Message: "`exec -a NAME` sets `argv[0]` to `NAME` — `ps`/`top`/audit " +
+					"rules see the alias, not the real binary. Keep out of production " +
+					"scripts unless the alias is documented.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 977 Katas = 0.9.77
-const Version = "0.9.77"
+// 978 Katas = 0.9.78
+const Version = "0.9.78"


### PR DESCRIPTION
ZC1981 — Warn on `exec -a NAME cmd` — replaces `argv[0]`, hides the real binary from `ps`

What: Script calls `exec -a NAME $BIN`.
Why: `-a` sets `argv[0]` on the `exec`'d process to `NAME` instead of the real program. `ps`, `top`, `/proc/*/cmdline`-based audit, and systemd unit accounting show `NAME` — the actual binary only surfaces via `/proc/PID/exe`, which most monitoring does not read. Legitimate use cases exist (login shells spelling themselves `-zsh`), but the feature is also a cheap disguise for reverse shells or cron-triggered helpers.
Fix suggestion: Run the binary at its real path so operators can match process name to the on-disk file. Only use `-a` where the alias is documented and expected.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1981` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.78