### PR TITLE
feat: ZC1982 — detect `ipcrm -a` wiping every SysV IPC object

### DIFF
--- a/pkg/katas/katatests/zc1982_test.go
+++ b/pkg/katas/katatests/zc1982_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1982(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `ipcs -a` (list)",
+			input:    `ipcs -a`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `ipcrm -m $SHMID` (scoped)",
+			input:    `ipcrm -m $SHMID`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `ipcrm -a`",
+			input: `ipcrm -a`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1982",
+					Message: "`ipcrm -a` deletes every SysV shm/sem/mqueue object — Postgres/Oracle/shm-based services lose their backing store mid-transaction. Scope with `-m`/`-s`/`-q` on the specific ID after checking `ipcs -a`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1982")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1982.go
+++ b/pkg/katas/zc1982.go
@@ -1,0 +1,52 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1982",
+		Title:    "Error on `ipcrm -a` — removes every SysV IPC object, breaks Postgres/Oracle/shm apps",
+		Severity: SeverityError,
+		Description: "`ipcrm -a` deletes every System V shared-memory segment, semaphore set, " +
+			"and message queue owned by the caller (or, as root, every object on the " +
+			"host). Long-running services that rely on SysV IPC — PostgreSQL's shared " +
+			"buffers, Oracle's SGA, the `sysv` session store in several RDBMS test " +
+			"suites, shm-based mutexes in batch pipelines — lose their backing store " +
+			"mid-transaction and either SIGSEGV or return `EINVAL` on the next access. " +
+			"Scope the removal: `ipcrm -m ID`/`-s ID`/`-q ID` against the specific " +
+			"identifier reported by `ipcs -a`, after confirming no running process " +
+			"attached to it.",
+		Check: checkZC1982,
+	})
+}
+
+func checkZC1982(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "ipcrm" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-a" {
+			return []Violation{{
+				KataID: "ZC1982",
+				Message: "`ipcrm -a` deletes every SysV shm/sem/mqueue object — " +
+					"Postgres/Oracle/shm-based services lose their backing store " +
+					"mid-transaction. Scope with `-m`/`-s`/`-q` on the specific ID " +
+					"after checking `ipcs -a`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 978 Katas = 0.9.78
-const Version = "0.9.78"
+// 979 Katas = 0.9.79
+const Version = "0.9.79"


### PR DESCRIPTION
ZC1982 — Error on `ipcrm -a` — removes every SysV IPC object, breaks Postgres/Oracle/shm apps

What: Script calls `ipcrm -a`.
Why: Deletes every SysV shared-memory segment, semaphore set, and message queue owned by the caller (or, as root, every object on the host). Services that rely on SysV IPC — PostgreSQL shared buffers, Oracle SGA, shm-based mutexes — lose their backing store mid-transaction and either SIGSEGV or return `EINVAL` on the next access.
Fix suggestion: Scope the removal with `ipcrm -m ID`/`-s ID`/`-q ID` against the specific identifier reported by `ipcs -a`, after confirming no running process has it attached.
Severity: Error

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1982` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.79