### PR TITLE
feat: ZC1983 — detect `setopt CSH_JUNKIE_QUOTES` breaking multi-line quoted strings

### DIFF
--- a/pkg/katas/katatests/zc1983_test.go
+++ b/pkg/katas/katatests/zc1983_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1983(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt CSH_JUNKIE_QUOTES`",
+			input:    `unsetopt CSH_JUNKIE_QUOTES`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NO_CSH_JUNKIE_QUOTES`",
+			input:    `setopt NO_CSH_JUNKIE_QUOTES`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt CSH_JUNKIE_QUOTES`",
+			input: `setopt CSH_JUNKIE_QUOTES`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1983",
+					Message: "`setopt CSH_JUNKIE_QUOTES` makes every later multi-line `\"…\"`/`'…'` an error — inlined SQL/JSON payloads and autoloaded helpers stop parsing. Scope csh-style strictness with `emulate -LR csh` in the one helper that needs it.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_CSH_JUNKIE_QUOTES`",
+			input: `unsetopt NO_CSH_JUNKIE_QUOTES`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1983",
+					Message: "`unsetopt NO_CSH_JUNKIE_QUOTES` makes every later multi-line `\"…\"`/`'…'` an error — inlined SQL/JSON payloads and autoloaded helpers stop parsing. Scope csh-style strictness with `emulate -LR csh` in the one helper that needs it.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1983")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1983.go
+++ b/pkg/katas/zc1983.go
@@ -1,0 +1,87 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1983",
+		Title:    "Warn on `setopt CSH_JUNKIE_QUOTES` — single/double-quoted strings that span lines become errors",
+		Severity: SeverityWarning,
+		Description: "With `CSH_JUNKIE_QUOTES` off (the default), Zsh lets `\"foo\\nbar\"` and " +
+			"`'line1\\nline2'` span physical lines. Setting the option on makes the " +
+			"parser emit an error on the first newline inside a quoted string — which " +
+			"breaks any existing multi-line SQL, JSON, or here-style payload that the " +
+			"script has been inlining up to this point. Functions that are autoloaded " +
+			"later or sourced from third-party helpers fail to parse, and the " +
+			"diagnostic points at the closing quote, not at the option toggle. Leave " +
+			"the option off; if csh-style strictness is genuinely required, scope " +
+			"with `emulate -LR csh` inside the single helper that needs it.",
+		Check: checkZC1983,
+	})
+}
+
+func checkZC1983(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1983Canonical(arg.String())
+		switch v {
+		case "CSHJUNKIEQUOTES":
+			if enabling {
+				return zc1983Hit(cmd, "setopt CSH_JUNKIE_QUOTES")
+			}
+		case "NOCSHJUNKIEQUOTES":
+			if !enabling {
+				return zc1983Hit(cmd, "unsetopt NO_CSH_JUNKIE_QUOTES")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1983Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1983Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1983",
+		Message: "`" + form + "` makes every later multi-line `\"…\"`/`'…'` an error — " +
+			"inlined SQL/JSON payloads and autoloaded helpers stop parsing. Scope " +
+			"csh-style strictness with `emulate -LR csh` in the one helper that " +
+			"needs it.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 979 Katas = 0.9.79
-const Version = "0.9.79"
+// 980 Katas = 0.9.80
+const Version = "0.9.80"


### PR DESCRIPTION
ZC1983 — Warn on `setopt CSH_JUNKIE_QUOTES` — single/double-quoted strings that span lines become errors

What: Script flips `CSH_JUNKIE_QUOTES` on (`setopt CSH_JUNKIE_QUOTES` or `unsetopt NO_CSH_JUNKIE_QUOTES`).
Why: With the option off (default) Zsh happily lets `"foo\nbar"` and `'line1\nline2'` span physical lines. Turning it on makes the parser emit an error on the first newline inside a quote, breaking inlined SQL/JSON/heredoc-style payloads and anything autoloaded afterward. The diagnostic points at the closing quote, not at the option toggle.
Fix suggestion: Leave the option off. If csh-style strictness is genuinely required for one helper, scope with `emulate -LR csh` inside that function.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1983` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.80