### PR TITLE
feat: ZC1984 — detect `sgdisk -Z`/`-o` wiping the GPT partition table

### DIFF
--- a/pkg/katas/katatests/zc1984_test.go
+++ b/pkg/katas/katatests/zc1984_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1984(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `sgdisk -p $DISK` (print)",
+			input:    `sgdisk -p $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `sgdisk --backup=/root/disk.gpt $DISK`",
+			input:    `sgdisk --backup=/root/disk.gpt $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `sgdisk -Z $DISK`",
+			input: `sgdisk -Z $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1984",
+					Message: "`sgdisk -Z` erases the GPT on the target device — a wrong `$DISK` detaches every partition/LVM/LUKS header and bricks boot. `lsblk`/`blkid` preflight, `--backup` the old table, and test with `-t`/`--pretend` first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `sgdisk -o $DISK`",
+			input: `sgdisk -o $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1984",
+					Message: "`sgdisk -o` erases the GPT on the target device — a wrong `$DISK` detaches every partition/LVM/LUKS header and bricks boot. `lsblk`/`blkid` preflight, `--backup` the old table, and test with `-t`/`--pretend` first.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `sgdisk --zap-all $DISK` (parser-mangled form)",
+			input: `sgdisk --zap-all $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1984",
+					Message: "`sgdisk --zap-all` erases the GPT on the target device — a wrong `$DISK` detaches every partition/LVM/LUKS header and bricks boot. `lsblk`/`blkid` preflight, `--backup` the old table, and test with `-t`/`--pretend` first.",
+					Line:    1,
+					Column:  10,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1984")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1984.go
+++ b/pkg/katas/zc1984.go
@@ -1,0 +1,66 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1984",
+		Title:    "Error on `sgdisk -Z` / `sgdisk -o` — erases the GPT partition table on the target disk",
+		Severity: SeverityError,
+		Description: "`sgdisk -Z $DISK` (`--zap-all`) wipes the primary GPT, the protective " +
+			"MBR, and the backup GPT at the end of the device. `sgdisk -o $DISK` " +
+			"(`--clear`) replaces the existing partition table with a fresh empty GPT. " +
+			"Either command detaches every partition, LVM PV, LUKS container, and " +
+			"filesystem header on the device — when the target variable resolves to a " +
+			"wrong path (tab completion, `$DISK` defaulted to `/dev/sda`), the host " +
+			"becomes unbootable. Require an `lsblk $DISK` + `blkid $DISK` preflight in " +
+			"the script, route the action through `--pretend` (`-t`) first, and keep a " +
+			"`sgdisk --backup=/root/$DISK.gpt $DISK` image before any zap.",
+		Check: checkZC1984,
+	})
+}
+
+func checkZC1984(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	// Parser caveat: `sgdisk --zap-all $DISK` mangles command name to
+	// `zap-all` and leaves the `--` as a postfix on a prior expression.
+	if ident.Value == "zap-all" {
+		return zc1984Hit(cmd, "sgdisk --zap-all")
+	}
+	if ident.Value != "sgdisk" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "-Z":
+			return zc1984Hit(cmd, "sgdisk -Z")
+		case "-o":
+			return zc1984Hit(cmd, "sgdisk -o")
+		}
+	}
+	return nil
+}
+
+func zc1984Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1984",
+		Message: "`" + form + "` erases the GPT on the target device — a wrong " +
+			"`$DISK` detaches every partition/LVM/LUKS header and bricks boot. " +
+			"`lsblk`/`blkid` preflight, `--backup` the old table, and test with " +
+			"`-t`/`--pretend` first.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 980 Katas = 0.9.80
-const Version = "0.9.80"
+// 981 Katas = 0.9.81
+const Version = "0.9.81"


### PR DESCRIPTION
ZC1984 — Error on `sgdisk -Z` / `sgdisk -o` — erases the GPT partition table on the target disk

What: Script calls `sgdisk -Z $DISK` (`--zap-all`) or `sgdisk -o $DISK` (`--clear`).
Why: `-Z` wipes the primary GPT, the protective MBR, and the backup GPT at the end of the device. `-o` replaces the existing partition table with a fresh empty GPT. Either command detaches every partition, LVM PV, LUKS container, and filesystem header. A tab-completed or defaulted `\$DISK` on the wrong device bricks the boot.
Fix suggestion: Require an `lsblk \$DISK` + `blkid \$DISK` preflight. Route the action through `-t`/`--pretend` first. Keep a `sgdisk --backup=/root/\$DISK.gpt \$DISK` image before any zap.
Severity: Error

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1984` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.81