### PR TITLE
feat: ZC1985 — detect `setopt SH_FILE_EXPANSION` flipping Zsh expansion order

### DIFF
--- a/pkg/katas/katatests/zc1985_test.go
+++ b/pkg/katas/katatests/zc1985_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1985(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt SH_FILE_EXPANSION` (default)",
+			input:    `unsetopt SH_FILE_EXPANSION`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NO_SH_FILE_EXPANSION`",
+			input:    `setopt NO_SH_FILE_EXPANSION`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt SH_FILE_EXPANSION`",
+			input: `setopt SH_FILE_EXPANSION`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1985",
+					Message: "`setopt SH_FILE_EXPANSION` flips expansion order to POSIX — a `~` or `=cmd` sitting inside a `$VAR` value suddenly resolves, so a user-typed `~other/.cache` escapes into another home. Scope with `emulate -LR sh`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_SH_FILE_EXPANSION`",
+			input: `unsetopt NO_SH_FILE_EXPANSION`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1985",
+					Message: "`unsetopt NO_SH_FILE_EXPANSION` flips expansion order to POSIX — a `~` or `=cmd` sitting inside a `$VAR` value suddenly resolves, so a user-typed `~other/.cache` escapes into another home. Scope with `emulate -LR sh`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1985")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1985.go
+++ b/pkg/katas/zc1985.go
@@ -1,0 +1,87 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1985",
+		Title:    "Warn on `setopt SH_FILE_EXPANSION` — expansion order flips from Zsh-native to sh/bash, `~` leaks",
+		Severity: SeverityWarning,
+		Description: "Default Zsh runs parameter expansion first, then filename/`~` " +
+			"expansion — so a `VAR='~/cache'` keeps the tilde literal when you do " +
+			"`mkdir -p -- $VAR` because the `~` never leaves the value. `setopt " +
+			"SH_FILE_EXPANSION` (POSIX/sh ordering) flips the pass: filename expansion " +
+			"runs first on the raw text, then parameter expansion happens, so the " +
+			"same line suddenly makes the tilde resolve to `$HOME`, paths pointing at " +
+			"`~evil/.cache` resolve into another user's home, and `=cmd` spellings " +
+			"look up `$PATH` silently. Keep the option off; when a specific helper " +
+			"needs POSIX ordering use `emulate -LR sh` inside that function.",
+		Check: checkZC1985,
+	})
+}
+
+func checkZC1985(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1985Canonical(arg.String())
+		switch v {
+		case "SHFILEEXPANSION":
+			if enabling {
+				return zc1985Hit(cmd, "setopt SH_FILE_EXPANSION")
+			}
+		case "NOSHFILEEXPANSION":
+			if !enabling {
+				return zc1985Hit(cmd, "unsetopt NO_SH_FILE_EXPANSION")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1985Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1985Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1985",
+		Message: "`" + form + "` flips expansion order to POSIX — a `~` or `=cmd` " +
+			"sitting inside a `$VAR` value suddenly resolves, so a user-typed " +
+			"`~other/.cache` escapes into another home. Scope with `emulate -LR " +
+			"sh`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 981 Katas = 0.9.81
-const Version = "0.9.81"
+// 982 Katas = 0.9.82
+const Version = "0.9.82"


### PR DESCRIPTION
ZC1985 — Warn on `setopt SH_FILE_EXPANSION` — expansion order flips from Zsh-native to sh/bash, `~` leaks

What: Script flips `SH_FILE_EXPANSION` on (`setopt SH_FILE_EXPANSION` or `unsetopt NO_SH_FILE_EXPANSION`).
Why: Default Zsh runs parameter expansion first, then filename/`~` expansion — so a `VAR='~/cache'` keeps the tilde literal when later referenced. With the option on, the order flips to POSIX (filename first, parameter second): the same value suddenly resolves `~` to `\$HOME`, `~other` into another user's home, and `=cmd` looks up `\$PATH`.
Fix suggestion: Keep the option off. If POSIX ordering is genuinely needed for one helper, scope with `emulate -LR sh` inside the function.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1985` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.82