### PR TITLE
feat: ZC1986 — detect `touch -d`/`-t`/`-r` timestamp rewrite

### DIFF
--- a/pkg/katas/katatests/zc1986_test.go
+++ b/pkg/katas/katatests/zc1986_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1986(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `touch $FILE` (current clock)",
+			input:    `touch $FILE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `touch -c $FILE` (no create, current clock)",
+			input:    `touch -c $FILE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `touch -d now $FILE`",
+			input: `touch -d now $FILE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1986",
+					Message: "`touch -d` writes a specific atime/mtime — also the classic \"age the dropped file\" antiforensics pattern. Derive from `$SOURCE_DATE_EPOCH` where the intent is deterministic.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `touch -t 202401011200 $FILE`",
+			input: `touch -t 202401011200 $FILE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1986",
+					Message: "`touch -t` writes a specific atime/mtime — also the classic \"age the dropped file\" antiforensics pattern. Derive from `$SOURCE_DATE_EPOCH` where the intent is deterministic.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `touch -r $REF $FILE`",
+			input: `touch -r $REF $FILE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1986",
+					Message: "`touch -r` writes a specific atime/mtime — also the classic \"age the dropped file\" antiforensics pattern. Derive from `$SOURCE_DATE_EPOCH` where the intent is deterministic.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1986")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1986.go
+++ b/pkg/katas/zc1986.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1986",
+		Title:    "Warn on `touch -d` / `-t` / `-r` — explicit timestamp write is a common antiforensics pattern",
+		Severity: SeverityWarning,
+		Description: "`touch -d \"2 years ago\" $F`, `touch -t YYYYMMDDhhmm $F`, and `touch -r " +
+			"$REF $F` all write the atime/mtime to a specific value rather than the " +
+			"current clock. Legitimate uses exist — re-stamping a mirror to match " +
+			"upstream, generating deterministic tarballs for reproducible-build " +
+			"pipelines, `rsync --archive` edge cases — but the pattern also matches the " +
+			"classic \"age the dropped file\" antiforensics trick where an attacker " +
+			"normalises a new binary to look as old as its neighbours so `find -mtime`- " +
+			"based triage misses it. Audit rules should flag these forms in production " +
+			"scripts; in reproducible-build contexts, keep the timestamp derived from " +
+			"`SOURCE_DATE_EPOCH` via `touch -d @$SOURCE_DATE_EPOCH` so operators can " +
+			"recognise the intent at a glance.",
+		Check: checkZC1986,
+	})
+}
+
+func checkZC1986(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "touch" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "-d", "-t", "-r":
+			return []Violation{{
+				KataID: "ZC1986",
+				Message: "`touch " + v + "` writes a specific atime/mtime — also the " +
+					"classic \"age the dropped file\" antiforensics pattern. Derive " +
+					"from `$SOURCE_DATE_EPOCH` where the intent is deterministic.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 982 Katas = 0.9.82
-const Version = "0.9.82"
+// 983 Katas = 0.9.83
+const Version = "0.9.83"


### PR DESCRIPTION
ZC1986 — Warn on `touch -d` / `-t` / `-r` — explicit timestamp write is a common antiforensics pattern

What: Script calls `touch -d`, `touch -t`, or `touch -r $REF` (the `--date`/`--time`/`--reference` forms).
Why: All three write a specific atime/mtime rather than the current clock. Legitimate cases exist (mirror re-stamp, reproducible build output), but the pattern also matches the classic "age the dropped file" antiforensics trick — normalise a new binary to match its neighbours so `find -mtime` triage skips it.
Fix suggestion: In reproducible-build contexts, derive from `\$SOURCE_DATE_EPOCH` (`touch -d @\$SOURCE_DATE_EPOCH`) so operators can recognise the intent. Audit rules should flag the forms in production scripts.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1986` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.83