### PR TITLE
feat: ZC1987 — detect `setopt BRACE_CCL` csh-style brace character class

### DIFF
--- a/pkg/katas/katatests/zc1987_test.go
+++ b/pkg/katas/katatests/zc1987_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1987(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt BRACE_CCL` (default)",
+			input:    `unsetopt BRACE_CCL`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NO_BRACE_CCL`",
+			input:    `setopt NO_BRACE_CCL`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt BRACE_CCL`",
+			input: `setopt BRACE_CCL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1987",
+					Message: "`setopt BRACE_CCL` promotes single-character braces to csh-style classes — `{a-z}` now expands to every letter, `{ABC}` to `A B C`, breaking regex/hex/CI-name literals. Use `{a..z}` when a real range is wanted.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_BRACE_CCL`",
+			input: `unsetopt NO_BRACE_CCL`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1987",
+					Message: "`unsetopt NO_BRACE_CCL` promotes single-character braces to csh-style classes — `{a-z}` now expands to every letter, `{ABC}` to `A B C`, breaking regex/hex/CI-name literals. Use `{a..z}` when a real range is wanted.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1987")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1987.go
+++ b/pkg/katas/zc1987.go
@@ -1,0 +1,86 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1987",
+		Title:    "Warn on `setopt BRACE_CCL` — `{a-z}` expands to each character instead of staying literal",
+		Severity: SeverityWarning,
+		Description: "`BRACE_CCL` is off by default: `echo {a-z}` stays literal `a-z` in Zsh, " +
+			"which is what most scripts that only want the numeric range form " +
+			"`{1..10}` actually expect. `setopt BRACE_CCL` promotes single-character " +
+			"ranges and enumerations inside braces to csh-style character-class " +
+			"expansion, so `echo {a-z}` suddenly prints every letter from `a` to `z` " +
+			"and `echo {ABC}` becomes `A B C`. Any later command line that embeds " +
+			"single-character ranges — regex fragments, hex masks, CI job names with " +
+			"stage suffixes — expands unexpectedly. Leave the option off; use `{a..z}` " +
+			"when a real range is wanted and quote literals that contain `{…}`.",
+		Check: checkZC1987,
+	})
+}
+
+func checkZC1987(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1987Canonical(arg.String())
+		switch v {
+		case "BRACECCL":
+			if enabling {
+				return zc1987Hit(cmd, "setopt BRACE_CCL")
+			}
+		case "NOBRACECCL":
+			if !enabling {
+				return zc1987Hit(cmd, "unsetopt NO_BRACE_CCL")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1987Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1987Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1987",
+		Message: "`" + form + "` promotes single-character braces to csh-style classes " +
+			"— `{a-z}` now expands to every letter, `{ABC}` to `A B C`, breaking " +
+			"regex/hex/CI-name literals. Use `{a..z}` when a real range is wanted.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 983 Katas = 0.9.83
-const Version = "0.9.83"
+// 984 Katas = 0.9.84
+const Version = "0.9.84"


### PR DESCRIPTION
ZC1987 — Warn on `setopt BRACE_CCL` — `{a-z}` expands to each character instead of staying literal

What: Script flips `BRACE_CCL` on (`setopt BRACE_CCL` or `unsetopt NO_BRACE_CCL`).
Why: Default Zsh leaves `{a-z}` literal; only the numeric range `{1..10}` expands. Turning the option on promotes single-character ranges and enumerations to csh-style classes, so `{a-z}` becomes every letter and `{ABC}` becomes `A B C`. Regex fragments, hex masks, and CI job names that embed single-character ranges expand unexpectedly.
Fix suggestion: Leave the option off. When a real range is wanted, use the unambiguous `{a..z}` form and quote literals that contain `{…}`.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1987` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.84