### PR TITLE
feat: ZC1988 — detect `nsupdate -y` TSIG key in argv

### DIFF
--- a/pkg/katas/katatests/zc1988_test.go
+++ b/pkg/katas/katatests/zc1988_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1988(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `nsupdate -k $KEYFILE`",
+			input:    `nsupdate -k $KEYFILE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `nsupdate -v`",
+			input:    `nsupdate -v`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `nsupdate -y HMAC-SHA256:name:c2VjcmV0`",
+			input: `nsupdate -y HMAC-SHA256:name:c2VjcmV0`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1988",
+					Message: "`nsupdate -y …` puts the TSIG key in argv — `ps`, `/proc/*/cmdline`, and `$HISTFILE` all capture it. Use `nsupdate -k $KEYFILE` with a `0600` keyfile instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1988")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1988.go
+++ b/pkg/katas/zc1988.go
@@ -1,0 +1,50 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1988",
+		Title:    "Error on `nsupdate -y HMAC:NAME:SECRET` — TSIG key visible in argv and shell history",
+		Severity: SeverityError,
+		Description: "`nsupdate -y [alg:]name:base64secret` hands the TSIG shared secret " +
+			"directly on the command line, so `ps auxf`, `/proc/PID/cmdline`, and " +
+			"`$HISTFILE` all capture the key — and whoever owns the key can rewrite " +
+			"any zone that trusts it (DNS hijack, MX hijack, ACME domain-validation " +
+			"bypass). `nsupdate -k /etc/named/KEY` (or `-k $KEYFILE` with `0600` " +
+			"perms) reads the key from disk without exposing it. If the secret must " +
+			"come from a secret store, pipe it through `nsupdate -k /dev/stdin <<<\"$KEYFILE_CONTENTS\"` " +
+			"so the raw material never lands in argv.",
+		Check: checkZC1988,
+	})
+}
+
+func checkZC1988(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "nsupdate" {
+		return nil
+	}
+	for i, arg := range cmd.Arguments {
+		if arg.String() == "-y" && i+1 < len(cmd.Arguments) {
+			return []Violation{{
+				KataID: "ZC1988",
+				Message: "`nsupdate -y …` puts the TSIG key in argv — `ps`, " +
+					"`/proc/*/cmdline`, and `$HISTFILE` all capture it. Use " +
+					"`nsupdate -k $KEYFILE` with a `0600` keyfile instead.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 984 Katas = 0.9.84
-const Version = "0.9.84"
+// 985 Katas = 0.9.85
+const Version = "0.9.85"


### PR DESCRIPTION
ZC1988 — Error on `nsupdate -y HMAC:NAME:SECRET` — TSIG key visible in argv and shell history

What: Script calls `nsupdate -y [alg:]name:base64secret`.
Why: The shared secret is on the command line, so `ps auxf`, `/proc/*/cmdline`, and `\$HISTFILE` capture it. Whoever owns the key can rewrite any zone that trusts it — DNS hijack, MX hijack, ACME domain-validation bypass.
Fix suggestion: Use `nsupdate -k \$KEYFILE` with a `0600` keyfile. When the secret must come from a secret store, pipe via `nsupdate -k /dev/stdin <<<"\$KEYFILE_CONTENTS"` so the raw material never lands in argv.
Severity: Error

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1988` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.85