### PR TITLE
feat: ZC1989 — detect `setopt REMATCH_PCRE` flipping regex engine mid-script

### DIFF
--- a/pkg/katas/katatests/zc1989_test.go
+++ b/pkg/katas/katatests/zc1989_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1989(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt REMATCH_PCRE` (default)",
+			input:    `unsetopt REMATCH_PCRE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NO_REMATCH_PCRE`",
+			input:    `setopt NO_REMATCH_PCRE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt REMATCH_PCRE`",
+			input: `setopt REMATCH_PCRE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1989",
+					Message: "`setopt REMATCH_PCRE` swaps `[[ =~ ]]` from POSIX ERE to PCRE — `\\b`, `\\d`, lookahead, `(?i)` change meaning across every later match. Prefer `pcre_match` where PCRE is needed or scope with `LOCAL_OPTIONS`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_REMATCH_PCRE`",
+			input: `unsetopt NO_REMATCH_PCRE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1989",
+					Message: "`unsetopt NO_REMATCH_PCRE` swaps `[[ =~ ]]` from POSIX ERE to PCRE — `\\b`, `\\d`, lookahead, `(?i)` change meaning across every later match. Prefer `pcre_match` where PCRE is needed or scope with `LOCAL_OPTIONS`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1989")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1989.go
+++ b/pkg/katas/zc1989.go
@@ -1,0 +1,87 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1989",
+		Title:    "Warn on `setopt REMATCH_PCRE` — `[[ =~ ]]` regex flips from POSIX ERE to PCRE, changes semantics",
+		Severity: SeverityWarning,
+		Description: "By default Zsh's `[[ $str =~ pattern ]]` uses POSIX extended regex " +
+			"(ERE). `setopt REMATCH_PCRE` (after `zmodload zsh/pcre`) swaps the engine " +
+			"to PCRE for every later match. Patterns that pass through both engines " +
+			"change meaning subtly: `\\b` is a word boundary in PCRE but a literal `b` " +
+			"in ERE, `\\d`/`\\s`/`\\w` work in PCRE but not ERE, lookahead/lookbehind " +
+			"(`(?=…)`) parse in PCRE but error in ERE, and inline flags `(?i)` only " +
+			"exist in PCRE. Flipping the option globally silently rewrites the " +
+			"meaning of every existing regex — prefer an explicit `pcre_match`/`pcre_compile` " +
+			"call when PCRE is needed, or a `setopt LOCAL_OPTIONS REMATCH_PCRE` inside " +
+			"the single function that uses PCRE syntax.",
+		Check: checkZC1989,
+	})
+}
+
+func checkZC1989(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1989Canonical(arg.String())
+		switch v {
+		case "REMATCHPCRE":
+			if enabling {
+				return zc1989Hit(cmd, "setopt REMATCH_PCRE")
+			}
+		case "NOREMATCHPCRE":
+			if !enabling {
+				return zc1989Hit(cmd, "unsetopt NO_REMATCH_PCRE")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1989Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1989Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1989",
+		Message: "`" + form + "` swaps `[[ =~ ]]` from POSIX ERE to PCRE — `\\b`, " +
+			"`\\d`, lookahead, `(?i)` change meaning across every later match. " +
+			"Prefer `pcre_match` where PCRE is needed or scope with `LOCAL_OPTIONS`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 985 Katas = 0.9.85
-const Version = "0.9.85"
+// 986 Katas = 0.9.86
+const Version = "0.9.86"


### PR DESCRIPTION
ZC1989 — Warn on `setopt REMATCH_PCRE` — `[[ =~ ]]` regex flips from POSIX ERE to PCRE, changes semantics

What: Script flips `REMATCH_PCRE` on (`setopt REMATCH_PCRE` or `unsetopt NO_REMATCH_PCRE`).
Why: Default `[[ \$str =~ pat ]]` uses POSIX extended regex. With the option on (after `zmodload zsh/pcre`), every later match runs under PCRE. Patterns that pass through both engines change meaning: `\b` is a word boundary in PCRE but literal `b` in ERE; `\d`/`\s`/`\w` exist only in PCRE; lookahead/lookbehind parse in PCRE but error in ERE; inline flags like `(?i)` only exist in PCRE.
Fix suggestion: Use the explicit `pcre_compile` + `pcre_match` API when PCRE syntax is needed, or scope with `setopt LOCAL_OPTIONS REMATCH_PCRE` inside the single function that uses PCRE.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1989` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.86