### PR TITLE
feat: ZC1990 — detect `openssl passwd -crypt`/`-1`/`-apr1` broken hash formats

### DIFF
--- a/pkg/katas/katatests/zc1990_test.go
+++ b/pkg/katas/katatests/zc1990_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1990(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `openssl passwd -5 $PASS` (SHA-256-crypt)",
+			input:    `openssl passwd -5 $PASS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `openssl passwd -6 $PASS` (SHA-512-crypt)",
+			input:    `openssl passwd -6 $PASS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `openssl passwd -crypt $PASS`",
+			input: `openssl passwd -crypt $PASS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1990",
+					Message: "`openssl passwd -crypt` emits a broken hash format — DES/MD5 variants crack on a laptop. Use `-5` / `-6` or a KDF-based hasher (`mkpasswd -m yescrypt`, `htpasswd -B`, `argon2`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `openssl passwd -1 $PASS`",
+			input: `openssl passwd -1 $PASS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1990",
+					Message: "`openssl passwd -1` emits a broken hash format — DES/MD5 variants crack on a laptop. Use `-5` / `-6` or a KDF-based hasher (`mkpasswd -m yescrypt`, `htpasswd -B`, `argon2`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `openssl passwd -apr1 $PASS`",
+			input: `openssl passwd -apr1 $PASS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1990",
+					Message: "`openssl passwd -apr1` emits a broken hash format — DES/MD5 variants crack on a laptop. Use `-5` / `-6` or a KDF-based hasher (`mkpasswd -m yescrypt`, `htpasswd -B`, `argon2`).",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1990")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1990.go
+++ b/pkg/katas/zc1990.go
@@ -1,0 +1,57 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1990",
+		Title:    "Warn on `openssl passwd -crypt` / `-1` / `-apr1` — obsolete password hash formats",
+		Severity: SeverityWarning,
+		Description: "`openssl passwd -crypt` emits DES-crypt, 8-char truncated and crackable in " +
+			"seconds on modern hardware. `-1` is FreeBSD-style MD5, unsuitable for " +
+			"storage, long broken. `-apr1` is Apache's MD5-based variant with the same " +
+			"weakness. Any hash produced by these flags lands in `/etc/shadow`, an " +
+			"htpasswd file, or a database row where an attacker can offline-crack the " +
+			"whole batch with a single GPU. Use `-5` (SHA-256-crypt), `-6` (SHA-512-" +
+			"crypt), or prefer a dedicated KDF-based hasher — `mkpasswd -m yescrypt`, " +
+			"`htpasswd -B` (bcrypt), or `argon2` — so brute-force cost scales with " +
+			"hardware.",
+		Check: checkZC1990,
+	})
+}
+
+func checkZC1990(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "openssl" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "passwd" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		switch v {
+		case "-crypt", "-1", "-apr1":
+			return []Violation{{
+				KataID: "ZC1990",
+				Message: "`openssl passwd " + v + "` emits a broken hash format — " +
+					"DES/MD5 variants crack on a laptop. Use `-5` / `-6` or a " +
+					"KDF-based hasher (`mkpasswd -m yescrypt`, `htpasswd -B`, " +
+					"`argon2`).",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 986 Katas = 0.9.86
-const Version = "0.9.86"
+// 987 Katas = 0.9.87
+const Version = "0.9.87"


### PR DESCRIPTION
ZC1990 — Warn on `openssl passwd -crypt` / `-1` / `-apr1` — obsolete password hash formats

What: Script calls `openssl passwd` with `-crypt`, `-1`, or `-apr1`.
Why: `-crypt` emits DES-crypt (8-char truncated, seconds to crack on modern hardware). `-1` is FreeBSD-style MD5-crypt, long broken. `-apr1` is Apache's MD5 variant with the same weakness. Hashes land in `/etc/shadow`, htpasswd files, or database rows where an attacker offline-cracks the whole batch with a single GPU.
Fix suggestion: Use `-5` (SHA-256-crypt) or `-6` (SHA-512-crypt). Prefer a real KDF: `mkpasswd -m yescrypt`, `htpasswd -B` (bcrypt), `argon2`.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1990` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.87