### PR TITLE
feat: ZC1991 — detect `setopt CSH_NULLCMD` breaking bare-redirect idioms

### DIFF
--- a/pkg/katas/katatests/zc1991_test.go
+++ b/pkg/katas/katatests/zc1991_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1991(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt CSH_NULLCMD` (default)",
+			input:    `unsetopt CSH_NULLCMD`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NO_CSH_NULLCMD`",
+			input:    `setopt NO_CSH_NULLCMD`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt CSH_NULLCMD`",
+			input: `setopt CSH_NULLCMD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1991",
+					Message: "`setopt CSH_NULLCMD` makes `> file` / `< file` (no command) a parse error — log truncation and bare-redirect idioms stop working. Write `: > file` explicitly for truncation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_CSH_NULLCMD`",
+			input: `unsetopt NO_CSH_NULLCMD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1991",
+					Message: "`unsetopt NO_CSH_NULLCMD` makes `> file` / `< file` (no command) a parse error — log truncation and bare-redirect idioms stop working. Write `: > file` explicitly for truncation.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1991")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1991.go
+++ b/pkg/katas/zc1991.go
@@ -1,0 +1,87 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1991",
+		Title:    "Warn on `setopt CSH_NULLCMD` — bare `> file` raises an error instead of running `$NULLCMD`",
+		Severity: SeverityWarning,
+		Description: "Default Zsh executes `$NULLCMD` (initially `cat`) when a line has " +
+			"redirections but no command, so `> file < input` copies input to file " +
+			"and `< file` pages through it with `$READNULLCMD` (initially `more`). " +
+			"`setopt CSH_NULLCMD` drops the Zsh convention and follows csh — any " +
+			"command line without an explicit command is a parse error, regardless of " +
+			"redirections. Scripts that rely on the bare-redirect idiom (log " +
+			"truncation via `> $LOG`, drop-in includes via `< file`, piped filters " +
+			"built from aliases) stop working with a confusing `parse error near '<'`. " +
+			"Keep the option off; write `: > file` (or `true > file`) explicitly when " +
+			"you mean to truncate.",
+		Check: checkZC1991,
+	})
+}
+
+func checkZC1991(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1991Canonical(arg.String())
+		switch v {
+		case "CSHNULLCMD":
+			if enabling {
+				return zc1991Hit(cmd, "setopt CSH_NULLCMD")
+			}
+		case "NOCSHNULLCMD":
+			if !enabling {
+				return zc1991Hit(cmd, "unsetopt NO_CSH_NULLCMD")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1991Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1991Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1991",
+		Message: "`" + form + "` makes `> file` / `< file` (no command) a parse error " +
+			"— log truncation and bare-redirect idioms stop working. Write `: > " +
+			"file` explicitly for truncation.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 987 Katas = 0.9.87
-const Version = "0.9.87"
+// 988 Katas = 0.9.88
+const Version = "0.9.88"


### PR DESCRIPTION
ZC1991 — Warn on `setopt CSH_NULLCMD` — bare `> file` raises an error instead of running `\$NULLCMD`

What: Script flips `CSH_NULLCMD` on (`setopt CSH_NULLCMD` or `unsetopt NO_CSH_NULLCMD`).
Why: Default Zsh executes `\$NULLCMD` (initially `cat`) when a line has redirections but no command, so `> file < input` is a valid copy and `< file` pages through it. With the option on, Zsh follows csh — any command line without an explicit command is a parse error regardless of redirections. Scripts relying on bare-redirect idioms (log truncation, drop-in includes) stop with a confusing `parse error near '<'`.
Fix suggestion: Keep the option off. Write `: > file` (or `true > file`) explicitly when the intent is to truncate a file.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1991` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.88