### PR TITLE
feat: ZC1992 — detect `pkexec` PolicyKit elevation from scripts

### DIFF
--- a/pkg/katas/katatests/zc1992_test.go
+++ b/pkg/katas/katatests/zc1992_test.go
@@ -1,0 +1,41 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1992(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `sudo $CMD` (targeted sudoers drop-in)",
+			input:    `sudo $CMD`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `pkexec $CMD arg`",
+			input: `pkexec $CMD arg`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1992",
+					Message: "`pkexec` elevates via PolicyKit — no agent to prompt in a script, poor CVE history (pwnkit), split audit trail. Use `sudo` with a targeted `sudoers.d` drop-in or a systemd unit with `User=`/`AmbientCapabilities=`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1992")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1992.go
+++ b/pkg/katas/zc1992.go
@@ -1,0 +1,51 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1992",
+		Title:    "Warn on `pkexec cmd` — PolicyKit privilege elevation is historically bug-prone and hard to audit from scripts",
+		Severity: SeverityWarning,
+		Description: "`pkexec` lifts a command to the UID configured in a PolicyKit `.policy` " +
+			"file — typically root — after consulting an authorisation agent. From a " +
+			"non-interactive script the agent has no way to prompt, so the call " +
+			"either depends on a pre-authorised `.policy` override or fails in a " +
+			"confusing manner. The binary also has a poor CVE track record (CVE-2021-" +
+			"4034 pwnkit, CVE-2017-16089, envvar handling bugs) and its audit trail is " +
+			"split across journald and `/var/log/auth.log`. Use `sudo` with a targeted " +
+			"`sudoers` drop-in for scripted privilege elevation, or run the script " +
+			"under a systemd unit with `User=` / `AmbientCapabilities=` when specific " +
+			"capabilities are needed.",
+		Check: checkZC1992,
+	})
+}
+
+func checkZC1992(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "pkexec" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1992",
+		Message: "`pkexec` elevates via PolicyKit — no agent to prompt in a script, " +
+			"poor CVE history (pwnkit), split audit trail. Use `sudo` with a " +
+			"targeted `sudoers.d` drop-in or a systemd unit with " +
+			"`User=`/`AmbientCapabilities=`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 988 Katas = 0.9.88
-const Version = "0.9.88"
+// 989 Katas = 0.9.89
+const Version = "0.9.89"


### PR DESCRIPTION
ZC1992 — Warn on `pkexec cmd` — PolicyKit privilege elevation is historically bug-prone and hard to audit from scripts

What: Script calls `pkexec CMD`.
Why: `pkexec` lifts a command to the UID configured in a PolicyKit `.policy` (typically root) after consulting an auth agent. A non-interactive script has no agent to prompt, so the call either depends on a pre-authorised `.policy` override or fails in a confusing way. The binary also has a poor CVE record (CVE-2021-4034 pwnkit, CVE-2017-16089) and its audit trail is split across journald and `/var/log/auth.log`.
Fix suggestion: Prefer `sudo` with a targeted `sudoers.d` drop-in for scripted elevation, or run the script under a systemd unit with `User=` / `AmbientCapabilities=` when specific capabilities are enough.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1992` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.89