### PR TITLE
feat: ZC1993 — detect `setopt KSH_TYPESET` re-splitting typeset RHS

### DIFF
--- a/pkg/katas/katatests/zc1993_test.go
+++ b/pkg/katas/katatests/zc1993_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1993(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt KSH_TYPESET` (default)",
+			input:    `unsetopt KSH_TYPESET`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NO_KSH_TYPESET`",
+			input:    `setopt NO_KSH_TYPESET`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt KSH_TYPESET`",
+			input: `setopt KSH_TYPESET`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1993",
+					Message: "`setopt KSH_TYPESET` re-splits the RHS of every later `typeset`/`local` — `typeset path=$HOME/My Files` now treats `Files` as a second name. Scope with `emulate -LR ksh` inside the one helper that needs it.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_KSH_TYPESET`",
+			input: `unsetopt NO_KSH_TYPESET`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1993",
+					Message: "`unsetopt NO_KSH_TYPESET` re-splits the RHS of every later `typeset`/`local` — `typeset path=$HOME/My Files` now treats `Files` as a second name. Scope with `emulate -LR ksh` inside the one helper that needs it.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1993")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1993.go
+++ b/pkg/katas/zc1993.go
@@ -1,0 +1,87 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1993",
+		Title:    "Warn on `setopt KSH_TYPESET` — `typeset var=$val` starts word-splitting the RHS",
+		Severity: SeverityWarning,
+		Description: "Off by default, Zsh treats every `typeset`/`declare` assignment like a " +
+			"shell assignment: the whole RHS after `=` is one token, so `typeset " +
+			"msg=\"a b c\"` produces a single-element string. `setopt KSH_TYPESET` " +
+			"follows ksh instead — each word on the `typeset` line is its own " +
+			"assignment or name, and the shell re-splits the RHS on whitespace. " +
+			"Functions that used to accept `typeset path=$HOME/My Files` suddenly " +
+			"treat `Files` as a second variable name, and `local` (an alias for " +
+			"`typeset` inside functions) inherits the same change. Keep the option " +
+			"off; if ksh compatibility is genuinely needed, scope with `emulate -LR " +
+			"ksh` inside the helper that needs it.",
+		Check: checkZC1993,
+	})
+}
+
+func checkZC1993(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1993Canonical(arg.String())
+		switch v {
+		case "KSHTYPESET":
+			if enabling {
+				return zc1993Hit(cmd, "setopt KSH_TYPESET")
+			}
+		case "NOKSHTYPESET":
+			if !enabling {
+				return zc1993Hit(cmd, "unsetopt NO_KSH_TYPESET")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1993Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1993Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1993",
+		Message: "`" + form + "` re-splits the RHS of every later `typeset`/`local` — " +
+			"`typeset path=$HOME/My Files` now treats `Files` as a second name. " +
+			"Scope with `emulate -LR ksh` inside the one helper that needs it.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 989 Katas = 0.9.89
-const Version = "0.9.89"
+// 990 Katas = 0.9.90
+const Version = "0.9.90"


### PR DESCRIPTION
ZC1993 — Warn on `setopt KSH_TYPESET` — `typeset var=\$val` starts word-splitting the RHS

What: Script flips `KSH_TYPESET` on (`setopt KSH_TYPESET` or `unsetopt NO_KSH_TYPESET`).
Why: Off by default, Zsh treats each `typeset`/`local`/`declare` assignment as one token after `=`, so `typeset msg="a b c"` produces a single-element string. With the option on, Zsh follows ksh — words on the line are independent assignments, and the RHS re-splits on whitespace. Helpers that used to accept `typeset path=\$HOME/My Files` suddenly treat `Files` as a second variable.
Fix suggestion: Keep the option off. When ksh compatibility is genuinely required, scope with `emulate -LR ksh` inside the helper that needs it.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1993` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.90