### PR TITLE
feat: ZC1994 — detect `lvreduce -f`/`-y` skipping shrink-confirm

### DIFF
--- a/pkg/katas/katatests/zc1994_test.go
+++ b/pkg/katas/katatests/zc1994_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1994(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `lvreduce -L 10G $LV` (interactive confirm)",
+			input:    `lvreduce -L 10G $LV`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `lvextend -L +10G $LV` (grow)",
+			input:    `lvextend -L +10G $LV`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `lvreduce -f -L 10G $LV`",
+			input: `lvreduce -f -L 10G $LV`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1994",
+					Message: "`lvreduce -f` skips the shrink-confirmation prompt — the filesystem above still believes the tail is allocated and the next mount sees corruption. Shrink fs first, or use `lvreduce --resizefs`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `lvreduce -y -L 10G $LV`",
+			input: `lvreduce -y -L 10G $LV`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1994",
+					Message: "`lvreduce -y` skips the shrink-confirmation prompt — the filesystem above still believes the tail is allocated and the next mount sees corruption. Shrink fs first, or use `lvreduce --resizefs`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1994")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1994.go
+++ b/pkg/katas/zc1994.go
@@ -1,0 +1,55 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1994",
+		Title:    "Error on `lvreduce -f` / `lvreduce -y` — shrinks the LV without checking the filesystem above",
+		Severity: SeverityError,
+		Description: "`lvreduce -L SIZE $LV` cuts the block device below an existing filesystem. " +
+			"The confirmation prompt exists precisely because ext4/xfs/btrfs do not " +
+			"shrink themselves — LVM happily lops off the tail even though the " +
+			"filesystem still believes those blocks are allocated. `-f` / `-y` / " +
+			"`--force` / `--yes` skip the prompt, and the next mount returns " +
+			"corruption or missing files. Shrink the filesystem first with " +
+			"`resize2fs $LV $NEWSIZE` (or `xfs_growfs` equivalent — xfs cannot shrink, " +
+			"so offline backup + recreate), verify `df` / `fsck`, then `lvreduce " +
+			"--resizefs` (which performs both steps atomically) instead of bypassing " +
+			"the prompt.",
+		Check: checkZC1994,
+	})
+}
+
+func checkZC1994(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "lvreduce" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch v {
+		case "-f", "-y", "--force", "--yes":
+			return []Violation{{
+				KataID: "ZC1994",
+				Message: "`lvreduce " + v + "` skips the shrink-confirmation prompt — " +
+					"the filesystem above still believes the tail is allocated and " +
+					"the next mount sees corruption. Shrink fs first, or use " +
+					"`lvreduce --resizefs`.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 990 Katas = 0.9.90
-const Version = "0.9.90"
+// 991 Katas = 0.9.91
+const Version = "0.9.91"


### PR DESCRIPTION
ZC1994 — Error on `lvreduce -f` / `lvreduce -y` — shrinks the LV without checking the filesystem above

What: Script calls `lvreduce` with `-f`/`-y`/`--force`/`--yes`.
Why: `lvreduce -L SIZE \$LV` cuts the block device under an existing filesystem. The interactive prompt exists precisely because ext4/xfs/btrfs do not shrink themselves — LVM lops off the tail even though the filesystem still believes those blocks are allocated, and the next mount returns corruption or missing files.
Fix suggestion: Shrink the filesystem first (`resize2fs \$LV \$NEWSIZE`; xfs can't shrink — offline backup + recreate), verify with `fsck`/`df`, then either confirm the prompt or use `lvreduce --resizefs` which sequences both steps atomically.
Severity: Error

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1994` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.91