### PR TITLE
feat: ZC1995 — detect `unsetopt BG_NICE` bg jobs stealing interactive priority

### DIFF
--- a/pkg/katas/katatests/zc1995_test.go
+++ b/pkg/katas/katatests/zc1995_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1995(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt BG_NICE` (keeps default on)",
+			input:    `setopt BG_NICE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NO_BG_NICE`",
+			input:    `unsetopt NO_BG_NICE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt BG_NICE`",
+			input: `unsetopt BG_NICE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1995",
+					Message: "`unsetopt BG_NICE` drops the `nice +5` that bg jobs get by default — a CPU-bound `cmd &` now competes with SSH/editor work. Wrap specific jobs with `nice -n 0` or a systemd `Nice=` unit instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_BG_NICE`",
+			input: `setopt NO_BG_NICE`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1995",
+					Message: "`setopt NO_BG_NICE` drops the `nice +5` that bg jobs get by default — a CPU-bound `cmd &` now competes with SSH/editor work. Wrap specific jobs with `nice -n 0` or a systemd `Nice=` unit instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1995")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1995.go
+++ b/pkg/katas/zc1995.go
@@ -1,0 +1,87 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1995",
+		Title:    "Warn on `unsetopt BGNICE` — background jobs run at full interactive priority, starve the foreground",
+		Severity: SeverityWarning,
+		Description: "Default Zsh applies `nice +5` to every backgrounded job so long-running " +
+			"work does not starve the interactive session. `unsetopt BGNICE` (or " +
+			"`setopt NO_BGNICE`) turns that off and bg jobs compete at the same " +
+			"priority as the foreground shell — SSH keystroke handling, editor " +
+			"redraws, and `cmd &` batch fan-out all feel laggy, and a single CPU-" +
+			"bound bg job can peg every core of a container it shares with a human " +
+			"operator. Keep the option on; when a background job legitimately needs " +
+			"full priority (audio pipeline, realtime simulator), wrap just that one " +
+			"with `nice -n 0 -- cmd &` or a systemd unit with `Nice=` instead of " +
+			"flipping globally.",
+		Check: checkZC1995,
+	})
+}
+
+func checkZC1995(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1995Canonical(arg.String())
+		switch v {
+		case "BGNICE":
+			if !enabling {
+				return zc1995Hit(cmd, "unsetopt BG_NICE")
+			}
+		case "NOBGNICE":
+			if enabling {
+				return zc1995Hit(cmd, "setopt NO_BG_NICE")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1995Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1995Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1995",
+		Message: "`" + form + "` drops the `nice +5` that bg jobs get by default — a " +
+			"CPU-bound `cmd &` now competes with SSH/editor work. Wrap specific " +
+			"jobs with `nice -n 0` or a systemd `Nice=` unit instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 991 Katas = 0.9.91
-const Version = "0.9.91"
+// 992 Katas = 0.9.92
+const Version = "0.9.92"


### PR DESCRIPTION
ZC1995 — Warn on `unsetopt BG_NICE` — background jobs run at full interactive priority, starve the foreground

What: Script flips `BG_NICE` off (`unsetopt BG_NICE` or `setopt NO_BG_NICE`).
Why: Default Zsh gives every `cmd &` bg job `nice +5`, so long-running work does not starve interactive input. With the option off, bg jobs compete at the same priority as the shell — SSH keystroke handling, editor redraws, and batch fan-out all feel laggy; a single CPU-bound bg job can peg every core of a container shared with a human operator.
Fix suggestion: Keep the option on. When a specific bg job legitimately needs full priority (audio pipeline, real-time simulator) wrap that one with `nice -n 0 -- cmd &` or a systemd unit with `Nice=` instead of flipping globally.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1995` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.92