### PR TITLE
feat: ZC1996 — detect `unshare -U`/`-r` unprivileged root-in-userns primitive

### DIFF
--- a/pkg/katas/katatests/zc1996_test.go
+++ b/pkg/katas/katatests/zc1996_test.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1996(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unshare -m $CMD` (mount namespace only)",
+			input:    `unshare -m $CMD`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `bwrap --unshare-all $CMD` (rootless runtime)",
+			input:    `bwrap --unshare-all $CMD`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unshare -Ur $CMD`",
+			input: `unshare -Ur $CMD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1996",
+					Message: "`unshare -Ur` opens a user namespace and maps the caller to uid 0 inside it — also the standard opening move for many kernel-LPE chains. Route legit rootless runtimes through `bwrap`/`podman --rootless` so the intent is clear.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unshare -U $CMD`",
+			input: `unshare -U $CMD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1996",
+					Message: "`unshare -U` opens a user namespace and maps the caller to uid 0 inside it — also the standard opening move for many kernel-LPE chains. Route legit rootless runtimes through `bwrap`/`podman --rootless` so the intent is clear.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unshare -Urm $CMD` (short bundle)",
+			input: `unshare -Urm $CMD`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1996",
+					Message: "`unshare -Urm` opens a user namespace and maps the caller to uid 0 inside it — also the standard opening move for many kernel-LPE chains. Route legit rootless runtimes through `bwrap`/`podman --rootless` so the intent is clear.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1996")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1996.go
+++ b/pkg/katas/zc1996.go
@@ -1,0 +1,70 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1996",
+		Title:    "Warn on `unshare -U` / `-r` — unprivileged user namespace maps caller to root inside the NS",
+		Severity: SeverityWarning,
+		Description: "`unshare -U` opens a new user namespace and `-r` / `--map-root-user` " +
+			"maps the caller's UID to `0` inside it. That's the foundation of rootless " +
+			"containers (bubblewrap, podman rootless, flatpak) and is legitimate in " +
+			"that context. It is also the standard opening move for a long list of " +
+			"LPE chains — once you are uid `0` in a user namespace you can create " +
+			"additional mount/net/cgroup namespaces, run `mount -t overlay` against " +
+			"attacker-controlled dirs, and probe kernel attack surface that is " +
+			"normally gated on `CAP_SYS_ADMIN`. Audit rules should flag the pattern " +
+			"in production scripts; if a rootless runtime really needs it, route " +
+			"through the runtime binary (`bwrap`, `podman --rootless`) so the invocation " +
+			"is recognisable.",
+		Check: checkZC1996,
+	})
+}
+
+func checkZC1996(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "unshare" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "-U" || v == "-r" || v == "-Ur" || v == "-rU" ||
+			v == "--user" || v == "--map-root-user" {
+			return zc1996Hit(cmd, "unshare "+v)
+		}
+		// Short-flag bundles like `-Urm`.
+		if strings.HasPrefix(v, "-") && !strings.HasPrefix(v, "--") &&
+			len(v) > 1 && !strings.Contains(v, "=") {
+			body := v[1:]
+			if strings.ContainsAny(body, "Ur") {
+				return zc1996Hit(cmd, "unshare "+v)
+			}
+		}
+	}
+	return nil
+}
+
+func zc1996Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1996",
+		Message: "`" + form + "` opens a user namespace and maps the caller to uid 0 " +
+			"inside it — also the standard opening move for many kernel-LPE " +
+			"chains. Route legit rootless runtimes through `bwrap`/`podman " +
+			"--rootless` so the intent is clear.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 992 Katas = 0.9.92
-const Version = "0.9.92"
+// 993 Katas = 0.9.93
+const Version = "0.9.93"


### PR DESCRIPTION
ZC1996 — Warn on `unshare -U` / `-r` — unprivileged user namespace maps caller to root inside the NS

What: Script calls `unshare` with `-U` / `-r` / `-Ur` / `--user` / `--map-root-user` (also short-flag bundles like `-Urm`).
Why: The pair opens a user namespace and maps the caller's UID to 0 inside it. Legitimate in rootless-container runtimes, but also the opening move for a long list of kernel-LPE chains — once uid 0 inside a userns, the caller can create additional mount/net/cgroup namespaces, overlay-mount attacker paths, and poke kernel attack surface that is normally gated on `CAP_SYS_ADMIN`.
Fix suggestion: Route legitimate rootless runtimes through `bwrap`, `podman --rootless`, `flatpak`, etc. so the invocation is recognisable to audit rules. Keep raw `unshare -U` out of production scripts unless explicitly documented.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1996` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.93