### PR TITLE
feat: ZC1997 — detect `setopt HIST_NO_FUNCTIONS` hiding function defs from history

### DIFF
--- a/pkg/katas/katatests/zc1997_test.go
+++ b/pkg/katas/katatests/zc1997_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1997(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt HIST_NO_FUNCTIONS` (default)",
+			input:    `unsetopt HIST_NO_FUNCTIONS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NO_HIST_NO_FUNCTIONS`",
+			input:    `setopt NO_HIST_NO_FUNCTIONS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt HIST_NO_FUNCTIONS`",
+			input: `setopt HIST_NO_FUNCTIONS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1997",
+					Message: "`setopt HIST_NO_FUNCTIONS` drops function-definition commands from `$HISTFILE` — forensic trail loses the definition while the call that used it still shows. Scope hiding via `zshaddhistory` hook instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_HIST_NO_FUNCTIONS`",
+			input: `unsetopt NO_HIST_NO_FUNCTIONS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1997",
+					Message: "`unsetopt NO_HIST_NO_FUNCTIONS` drops function-definition commands from `$HISTFILE` — forensic trail loses the definition while the call that used it still shows. Scope hiding via `zshaddhistory` hook instead.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1997")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1997.go
+++ b/pkg/katas/zc1997.go
@@ -1,0 +1,87 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1997",
+		Title:    "Warn on `setopt HIST_NO_FUNCTIONS` — function definitions skipped from `$HISTFILE`, breaks forensic trail",
+		Severity: SeverityWarning,
+		Description: "Default Zsh writes every command you type, including function " +
+			"definitions, to `$HISTFILE`. `setopt HIST_NO_FUNCTIONS` suppresses " +
+			"storage of commands that define a function. On a multi-admin box or a " +
+			"shared root account this breaks the forensic trail — the function the " +
+			"attacker just defined (or that an operator typed before running the " +
+			"destructive bit) vanishes from history while the invocation that used " +
+			"it still shows, leaving responders with a command that references a " +
+			"name that no longer exists on disk or in any log. Keep the option off " +
+			"and scope any hiding needs with the Zsh hook `zshaddhistory { return " +
+			"1 }` inside a function where the secret actually lives.",
+		Check: checkZC1997,
+	})
+}
+
+func checkZC1997(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1997Canonical(arg.String())
+		switch v {
+		case "HISTNOFUNCTIONS":
+			if enabling {
+				return zc1997Hit(cmd, "setopt HIST_NO_FUNCTIONS")
+			}
+		case "NOHISTNOFUNCTIONS":
+			if !enabling {
+				return zc1997Hit(cmd, "unsetopt NO_HIST_NO_FUNCTIONS")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1997Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1997Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1997",
+		Message: "`" + form + "` drops function-definition commands from `$HISTFILE` " +
+			"— forensic trail loses the definition while the call that used it " +
+			"still shows. Scope hiding via `zshaddhistory` hook instead.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 993 Katas = 0.9.93
-const Version = "0.9.93"
+// 994 Katas = 0.9.94
+const Version = "0.9.94"


### PR DESCRIPTION
ZC1997 — Warn on `setopt HIST_NO_FUNCTIONS` — function definitions skipped from `\$HISTFILE`, breaks forensic trail

What: Script flips `HIST_NO_FUNCTIONS` on (`setopt HIST_NO_FUNCTIONS` or `unsetopt NO_HIST_NO_FUNCTIONS`).
Why: Default Zsh records every typed command in `\$HISTFILE`, including function definitions. With the option on, function-definition commands are suppressed from history. On a multi-admin or shared-root box the forensic trail breaks — the definition vanishes while the invocation that used it still shows, leaving responders with a name that no longer resolves to anything on disk or in any log.
Fix suggestion: Keep the option off. Scope any hiding needs with a `zshaddhistory { return 1 }` hook inside the specific function that touches the secret.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1997` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.94