### PR TITLE
feat: ZC1998 — detect `tpm2_clear`/`tpm2 clear` wiping TPM storage hierarchy

### DIFF
--- a/pkg/katas/katatests/zc1998_test.go
+++ b/pkg/katas/katatests/zc1998_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1998(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `tpm2 getcap algorithms`",
+			input:    `tpm2 getcap algorithms`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `tpm2_pcrread sha256:0,1,2`",
+			input:    `tpm2_pcrread sha256:0,1,2`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `tpm2_clear -c p`",
+			input: `tpm2_clear -c p`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1998",
+					Message: "`tpm2_clear` wipes the TPM storage hierarchy — every LUKS-TPM2 keyslot, `systemd-cryptenroll --tpm2-device` slot, and TPM-sealed TLS/sshd key is destroyed. No undo. Gate behind a recovery runbook.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `tpm2 clear -c p`",
+			input: `tpm2 clear -c p`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1998",
+					Message: "`tpm2 clear` wipes the TPM storage hierarchy — every LUKS-TPM2 keyslot, `systemd-cryptenroll --tpm2-device` slot, and TPM-sealed TLS/sshd key is destroyed. No undo. Gate behind a recovery runbook.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1998")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1998.go
+++ b/pkg/katas/zc1998.go
@@ -1,0 +1,54 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1998",
+		Title:    "Error on `tpm2_clear` / `tpm2 clear` — wipes TPM storage hierarchy, kills every sealed key",
+		Severity: SeverityError,
+		Description: "`tpm2_clear -c p` (or `tpm2 clear -c p`) invokes the TPM 2.0 `TPM2_Clear` " +
+			"command, which invalidates every object sealed against the storage " +
+			"hierarchy — LUKS-TPM2 keyslots, systemd-cryptenroll's `--tpm2-device` " +
+			"slot, sshd TPM-backed host keys, and SecureBoot measured-boot state. " +
+			"The machine can still boot but any disk that unlocked through the TPM " +
+			"now needs a recovery passphrase, and every TLS cert issued from a " +
+			"TPM-sealed CA loses its anchor. There is no undo. Run `tpm2_clear` only " +
+			"under a documented recovery runbook with the recovery material in hand; " +
+			"never put it in an automated scheduled script.",
+		Check: checkZC1998,
+	})
+}
+
+func checkZC1998(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value == "tpm2_clear" {
+		return zc1998Hit(cmd, "tpm2_clear")
+	}
+	if ident.Value == "tpm2" && len(cmd.Arguments) > 0 &&
+		cmd.Arguments[0].String() == "clear" {
+		return zc1998Hit(cmd, "tpm2 clear")
+	}
+	return nil
+}
+
+func zc1998Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1998",
+		Message: "`" + form + "` wipes the TPM storage hierarchy — every LUKS-TPM2 " +
+			"keyslot, `systemd-cryptenroll --tpm2-device` slot, and TPM-sealed " +
+			"TLS/sshd key is destroyed. No undo. Gate behind a recovery runbook.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 994 Katas = 0.9.94
-const Version = "0.9.94"
+// 995 Katas = 0.9.95
+const Version = "0.9.95"


### PR DESCRIPTION
ZC1998 — Error on `tpm2_clear` / `tpm2 clear` — wipes TPM storage hierarchy, kills every sealed key

What: Script calls `tpm2_clear` or `tpm2 clear` (the tpm2-tools `TPM2_Clear` wrapper).
Why: The command invalidates every object sealed against the storage hierarchy — LUKS-TPM2 keyslots, `systemd-cryptenroll --tpm2-device` slots, sshd TPM-backed host keys, SecureBoot measured-boot state. The machine can still boot, but any disk that unlocked through the TPM now needs a recovery passphrase, and every TLS cert issued from a TPM-sealed CA loses its anchor. No undo.
Fix suggestion: Run only under a documented recovery runbook with recovery material in hand. Never put it in an automated scheduled script.
Severity: Error

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1998` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.95