### PR TITLE
feat: ZC1999 — detect `setopt AUTO_NAMED_DIRS` auto-registering dir-valued scalars as `~name`

### DIFF
--- a/pkg/katas/katatests/zc1999_test.go
+++ b/pkg/katas/katatests/zc1999_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC1999(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `unsetopt AUTO_NAMED_DIRS` (default)",
+			input:    `unsetopt AUTO_NAMED_DIRS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `setopt NO_AUTO_NAMED_DIRS`",
+			input:    `setopt NO_AUTO_NAMED_DIRS`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `setopt AUTO_NAMED_DIRS`",
+			input: `setopt AUTO_NAMED_DIRS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1999",
+					Message: "`setopt AUTO_NAMED_DIRS` auto-registers every dir-valued scalar as `~name` — collisions with real usernames and stray `~$var` expansions. Register named dirs explicitly with `hash -d NAME=PATH`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `unsetopt NO_AUTO_NAMED_DIRS`",
+			input: `unsetopt NO_AUTO_NAMED_DIRS`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1999",
+					Message: "`unsetopt NO_AUTO_NAMED_DIRS` auto-registers every dir-valued scalar as `~name` — collisions with real usernames and stray `~$var` expansions. Register named dirs explicitly with `hash -d NAME=PATH`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC1999")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc1999.go
+++ b/pkg/katas/zc1999.go
@@ -1,0 +1,87 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC1999",
+		Title:    "Warn on `setopt AUTO_NAMED_DIRS` — every scalar holding a directory path becomes `~name`",
+		Severity: SeverityWarning,
+		Description: "Off by default, Zsh only treats `~USER` / explicit `hash -d` entries as " +
+			"named directories. `setopt AUTO_NAMED_DIRS` auto-registers any scalar " +
+			"whose value is an existing directory — so `release=/srv/app/releases` " +
+			"suddenly makes `~release/config` a valid path, and `ls ~release` lists " +
+			"`/srv/app/releases`. That silently collides with real usernames " +
+			"(`alice` in `/etc/passwd` vs. an `alice=$HOME/stage` scalar the script " +
+			"happens to set) and turns every unquoted `~$var` inside a heredoc or " +
+			"`cd` arg into a parameter that the prompt expander happily replaces " +
+			"with the wrong path. Keep the option off; when a script legitimately " +
+			"wants a named dir, register it explicitly with `hash -d NAME=PATH`.",
+		Check: checkZC1999,
+	})
+}
+
+func checkZC1999(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc1999Canonical(arg.String())
+		switch v {
+		case "AUTONAMEDDIRS":
+			if enabling {
+				return zc1999Hit(cmd, "setopt AUTO_NAMED_DIRS")
+			}
+		case "NOAUTONAMEDDIRS":
+			if !enabling {
+				return zc1999Hit(cmd, "unsetopt NO_AUTO_NAMED_DIRS")
+			}
+		}
+	}
+	return nil
+}
+
+func zc1999Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc1999Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC1999",
+		Message: "`" + form + "` auto-registers every dir-valued scalar as `~name` — " +
+			"collisions with real usernames and stray `~$var` expansions. " +
+			"Register named dirs explicitly with `hash -d NAME=PATH`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 995 Katas = 0.9.95
-const Version = "0.9.95"
+// 996 Katas = 0.9.96
+const Version = "0.9.96"


### PR DESCRIPTION
ZC1999 — Warn on `setopt AUTO_NAMED_DIRS` — every scalar holding a directory path becomes `~name`

What: Script flips `AUTO_NAMED_DIRS` on (`setopt AUTO_NAMED_DIRS` or `unsetopt NO_AUTO_NAMED_DIRS`).
Why: Off by default, Zsh only treats `~USER`/explicit `hash -d` entries as named directories. With the option on, any scalar whose value is an existing directory is auto-registered, so `release=/srv/app/releases` makes `~release/config` a valid path. That silently collides with real usernames (`alice` in `/etc/passwd` vs. an `alice=\$HOME/stage` scalar) and turns every unquoted `~\$var` inside a heredoc or `cd` arg into a prompt-expander replacement with the wrong path.
Fix suggestion: Keep the option off. When a script legitimately wants a named dir, register it explicitly with `hash -d NAME=PATH`.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC1999` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.96