### PR TITLE
feat: ZC2000 — detect `kubectl taint nodes ...:NoExecute` mass pod eviction

### DIFF
--- a/pkg/katas/katatests/zc2000_test.go
+++ b/pkg/katas/katatests/zc2000_test.go
@@ -1,0 +1,46 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC2000(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `kubectl taint nodes $NODE key=value:NoSchedule` (gentle)",
+			input:    `kubectl taint nodes $NODE key=value:NoSchedule`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `kubectl drain $NODE`",
+			input:    `kubectl drain $NODE`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `kubectl taint nodes $NODE key=value:NoExecute`",
+			input: `kubectl taint nodes $NODE key=value:NoExecute`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC2000",
+					Message: "`kubectl taint nodes … :NoExecute` evicts every non-tolerating pod immediately — a typo on `--all` nodes empties the cluster. Prefer `kubectl drain $NODE` or a `:NoSchedule` taint for gentle drain.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC2000")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc2000.go
+++ b/pkg/katas/zc2000.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC2000",
+		Title:    "Error on `kubectl taint nodes $NODE key=value:NoExecute` — evicts every non-tolerating pod off the node",
+		Severity: SeverityError,
+		Description: "A `NoExecute` taint kicks every existing pod off the node unless the pod " +
+			"spec explicitly tolerates it. Draining one node during a rolling upgrade " +
+			"is one thing; a script that types the taint wrong (mis-keying the " +
+			"toleration value, applying to `--all` nodes, or iterating a node list " +
+			"without a pause) can empty a whole cluster in seconds and trigger " +
+			"cascade reschedules that overwhelm the scheduler. Prefer `kubectl drain " +
+			"$NODE` (which respects PodDisruptionBudget and runs PreStop hooks) or a " +
+			"`NoSchedule` taint for gentle drain; reserve `NoExecute` for genuine " +
+			"incident response with a runbook and a safety countdown.",
+		Check: checkZC2000,
+	})
+}
+
+func checkZC2000(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "kubectl" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 || cmd.Arguments[0].String() != "taint" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if strings.Contains(v, ":NoExecute") {
+			return []Violation{{
+				KataID: "ZC2000",
+				Message: "`kubectl taint nodes … :NoExecute` evicts every non-tolerating " +
+					"pod immediately — a typo on `--all` nodes empties the cluster. " +
+					"Prefer `kubectl drain $NODE` or a `:NoSchedule` taint for " +
+					"gentle drain.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
+		}
+	}
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 996 Katas = 0.9.96
-const Version = "0.9.96"
+// 997 Katas = 0.9.97
+const Version = "0.9.97"


### PR DESCRIPTION
ZC2000 — Error on `kubectl taint nodes \$NODE key=value:NoExecute` — evicts every non-tolerating pod off the node

What: Script calls `kubectl taint nodes ...` with an effect of `:NoExecute`.
Why: `NoExecute` kicks every existing pod off the node unless the pod spec explicitly tolerates it. A single mistyped command on `--all` nodes empties the cluster in seconds and triggers cascade reschedules that overwhelm the scheduler.
Fix suggestion: Prefer `kubectl drain \$NODE` (which respects PodDisruptionBudget and runs PreStop hooks) or a `:NoSchedule` taint for gentle drain. Reserve `:NoExecute` for genuine incident response with a runbook and a safety countdown.
Severity: Error

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC2000` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.97