### PR TITLE
feat: ZC2001 — detect `unsetopt EVAL_LINENO` collapsing eval'd line numbers

### DIFF
--- a/pkg/katas/katatests/zc2001_test.go
+++ b/pkg/katas/katatests/zc2001_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC2001(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `setopt EVAL_LINENO` (default on)",
+			input:    `setopt EVAL_LINENO`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `unsetopt NO_EVAL_LINENO`",
+			input:    `unsetopt NO_EVAL_LINENO`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `unsetopt EVAL_LINENO`",
+			input: `unsetopt EVAL_LINENO`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC2001",
+					Message: "`unsetopt EVAL_LINENO` reverts `$LINENO` inside `eval` to the outer line — errors in generated configs collapse to a single source line and stack frames past `eval` vanish. Keep on; scope via `emulate -LR sh`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `setopt NO_EVAL_LINENO`",
+			input: `setopt NO_EVAL_LINENO`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC2001",
+					Message: "`setopt NO_EVAL_LINENO` reverts `$LINENO` inside `eval` to the outer line — errors in generated configs collapse to a single source line and stack frames past `eval` vanish. Keep on; scope via `emulate -LR sh`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC2001")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc2001.go
+++ b/pkg/katas/zc2001.go
@@ -1,0 +1,86 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC2001",
+		Title:    "Warn on `unsetopt EVAL_LINENO` — `$LINENO` inside `eval` stops tracking source, stack traces go blank",
+		Severity: SeverityWarning,
+		Description: "On by default, Zsh's `EVAL_LINENO` keeps `$LINENO`, `$funcfiletrace`, and " +
+			"`$funcstack` pointing at the line inside the `eval`ed string where the " +
+			"error actually happened. Turning the option off (`unsetopt EVAL_LINENO` " +
+			"or `setopt NO_EVAL_LINENO`) reverts to pre-Zsh-4.3 behaviour: `$LINENO` " +
+			"collapses to the line that launched the `eval`, so every runtime error " +
+			"inside a generated config, a lazy-loaded function, or a `compile`d string " +
+			"reports the same line number and the stack trace loses every frame past " +
+			"the eval. Keep the option on; if strict POSIX-matching line numbers are " +
+			"needed inside one helper, scope with `emulate -LR sh` in that function.",
+		Check: checkZC2001,
+	})
+}
+
+func checkZC2001(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	var enabling bool
+	switch ident.Value {
+	case "setopt":
+		enabling = true
+	case "unsetopt":
+		enabling = false
+	default:
+		return nil
+	}
+
+	for _, arg := range cmd.Arguments {
+		v := zc2001Canonical(arg.String())
+		switch v {
+		case "EVALLINENO":
+			if !enabling {
+				return zc2001Hit(cmd, "unsetopt EVAL_LINENO")
+			}
+		case "NOEVALLINENO":
+			if enabling {
+				return zc2001Hit(cmd, "setopt NO_EVAL_LINENO")
+			}
+		}
+	}
+	return nil
+}
+
+func zc2001Canonical(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || c == '-' {
+			continue
+		}
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func zc2001Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC2001",
+		Message: "`" + form + "` reverts `$LINENO` inside `eval` to the outer line — " +
+			"errors in generated configs collapse to a single source line and " +
+			"stack frames past `eval` vanish. Keep on; scope via `emulate -LR sh`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 997 Katas = 0.9.97
-const Version = "0.9.97"
+// 998 Katas = 0.9.98
+const Version = "0.9.98"


### PR DESCRIPTION
ZC2001 — Warn on `unsetopt EVAL_LINENO` — `\$LINENO` inside `eval` stops tracking source, stack traces go blank

What: Script flips `EVAL_LINENO` off (`unsetopt EVAL_LINENO` or `setopt NO_EVAL_LINENO`).
Why: On by default, `EVAL_LINENO` keeps `\$LINENO`, `\$funcfiletrace`, and `\$funcstack` pointing at the line inside the `eval`ed string where the error actually happened. Off, `\$LINENO` collapses to the line that launched the `eval`, so every runtime error in a generated config, lazy-loaded function, or `compile`d string reports the same line and the stack trace drops every frame past the eval.
Fix suggestion: Keep the option on. If strict POSIX-matching line numbers are needed for one helper, scope with `emulate -LR sh` inside that function.
Severity: Warning

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC2001` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.98