### PR TITLE
feat: ZC2002 — detect `crictl rmi -a`/`rm -af` node-level CRI wipe

### DIFF
--- a/pkg/katas/katatests/zc2002_test.go
+++ b/pkg/katas/katatests/zc2002_test.go
@@ -1,0 +1,58 @@
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+func TestZC2002(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []katas.Violation
+	}{
+		{
+			name:     "valid — `crictl ps`",
+			input:    `crictl ps`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — `crictl rmi $IMAGE_ID`",
+			input:    `crictl rmi $IMAGE_ID`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `crictl rmi -a`",
+			input: `crictl rmi -a`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC2002",
+					Message: "`crictl rmi -a` talks to the node CRI directly, under the kubelet — images/containers backing running pods disappear, kubelet must re-pull or re-run. Route through `kubectl drain`/`delete pod`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `crictl rm -af`",
+			input: `crictl rm -af`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC2002",
+					Message: "`crictl rm -af` talks to the node CRI directly, under the kubelet — images/containers backing running pods disappear, kubelet must re-pull or re-run. Route through `kubectl drain`/`delete pod`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			violations := testutil.Check(tt.input, "ZC2002")
+			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+		})
+	}
+}

--- a/pkg/katas/zc2002.go
+++ b/pkg/katas/zc2002.go
@@ -1,0 +1,75 @@
+package katas
+
+import (
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+func init() {
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:       "ZC2002",
+		Title:    "Error on `crictl rmi -a` / `crictl rm -af` — wipes every image/container on the Kubernetes node",
+		Severity: SeverityError,
+		Description: "`crictl` talks directly to the node's CRI runtime (containerd, CRI-O), " +
+			"below the kubelet and the cluster API. `crictl rmi -a` removes every " +
+			"cached image including the ones currently backing running pods — the " +
+			"kubelet must immediately re-pull from the registry, and image-pull rate " +
+			"limits or network blips turn the node Unready. `crictl rm -af` force-" +
+			"removes every container on the node, killing pods without running " +
+			"PreStop hooks or honoring PodDisruptionBudget. Route maintenance through " +
+			"`kubectl drain $NODE` + `kubectl delete pod --grace-period=30`; use " +
+			"`crictl` at most on a cordoned, drained node with a documented recovery " +
+			"plan.",
+		Check: checkZC2002,
+	})
+}
+
+func checkZC2002(node ast.Node) []Violation {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "crictl" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	sub := cmd.Arguments[0].String()
+	if sub != "rmi" && sub != "rm" {
+		return nil
+	}
+	hasAll := false
+	hasForce := false
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if v == "-a" || v == "--all" || v == "-af" || v == "-fa" {
+			hasAll = true
+		}
+		if v == "-f" || v == "--force" || v == "-af" || v == "-fa" {
+			hasForce = true
+		}
+	}
+	if sub == "rmi" && hasAll {
+		return zc2002Hit(cmd, "crictl rmi -a")
+	}
+	if sub == "rm" && hasAll && hasForce {
+		return zc2002Hit(cmd, "crictl rm -af")
+	}
+	return nil
+}
+
+func zc2002Hit(cmd *ast.SimpleCommand, form string) []Violation {
+	return []Violation{{
+		KataID: "ZC2002",
+		Message: "`" + form + "` talks to the node CRI directly, under the kubelet — " +
+			"images/containers backing running pods disappear, kubelet must " +
+			"re-pull or re-run. Route through `kubectl drain`/`delete pod`.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityError,
+	}}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,5 +2,5 @@ package version
 
 // Version is the current version of ZShellCheck.
 // It is calculated based on the number of implemented Katas.
-// 998 Katas = 0.9.98
-const Version = "0.9.98"
+// 999 Katas = 0.9.99
+const Version = "0.9.99"


### PR DESCRIPTION
ZC2002 — Error on `crictl rmi -a` / `crictl rm -af` — wipes every image/container on the Kubernetes node

What: Script calls `crictl rmi -a` or `crictl rm -af` (full `-a --all` + `-f --force`).
Why: `crictl` talks directly to the node CRI runtime (containerd, CRI-O), below the kubelet and the cluster API. `rmi -a` removes every cached image, including the ones currently backing running pods — the kubelet must re-pull and a registry blip turns the node Unready. `rm -af` force-removes every container on the node, skipping PreStop hooks and PodDisruptionBudget.
Fix suggestion: Route maintenance through `kubectl drain \$NODE` + `kubectl delete pod --grace-period=30`. Reserve `crictl` for a cordoned, drained node with a documented recovery plan.
Severity: Error

## Test plan
- [x] `go test ./pkg/katas/katatests/ -run TestZC2002` passes
- [x] `golangci-lint run ./...` clean
- [x] `scripts/update-version.sh` → 0.9.99