### PR TITLE
docs: align v1.0.0 — 1000 katas across README/USER_GUIDE/REFERENCE/ROADMAP/CITATION/man/CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-04-20
+
+**1000 Katas milestone.** The kata-count formula (MAJOR = count/1000,
+MINOR = (count%1000)/100, PATCH = count%100) now resolves to exactly
+`1.0.0`. This is the first stable release of ZShellCheck, targeted at
+the GitHub Marketplace launch.
+
+### Added
+- **665 new Katas** bringing the total from 335 (v0.3.35) to **1000**
+  (ZC1339 through ZC2003). Highlights:
+  - **Zsh semantics & `setopt` subtleties** — `PROMPT_SUBST`,
+    `GLOBAL_RCS`, `POSIX_IDENTIFIERS`, `CHASE_DOTS`, `SH_FILE_EXPANSION`,
+    `CSH_JUNKIE_QUOTES`, `REMATCH_PCRE`, `KSH_TYPESET`, `BRACE_CCL`,
+    `CSH_NULLCMD`, `AUTO_NAMED_DIRS`, `EVAL_LINENO`, `KSH_ZERO_SUBSCRIPT`,
+    `HIST_NO_FUNCTIONS`, `HIST_FCNTL_LOCK`, `BG_NICE`, and many more.
+  - **Storage & filesystem safety** — `zpool import -f`/`export -f`,
+    `dmsetup remove_all`, `losetup -P`/`kpartx -a`/`partprobe`,
+    `sgdisk -Z`/`-o`, `lvreduce -f`/`-y`, `exportfs -au`.
+  - **Kernel/devices** — `udevadm trigger --action=remove`,
+    `tpm2_clear`, `ipcrm -a`, `unshare -U`/`-r`.
+  - **Platform ops** — `crictl rmi -a`/`rm -af`,
+    `kubectl taint nodes …:NoExecute`, `dnf/yum versionlock add`.
+  - **Shell hygiene** — `zsh -f`/`-d` bypassing startup files,
+    `exec -a NAME` masking `argv[0]`, `touch -d`/`-t`/`-r` timestamp
+    rewrite, `nsupdate -y` TSIG-in-argv, `openssl passwd -crypt`/`-1`/`-apr1`,
+    `ftp`/`tftp` plaintext, `pkexec` script elevation.
+- **Test triplet per kata** — `pkg/katas/katatests/zc####_test.go` with
+  valid + invalid cases across every new ID.
+- **Misspell ignore-words entry for `exportfs`** — prevents false
+  positives on legitimate NFS-tool references.
+
+### Changed
+- README, USER_GUIDE, REFERENCE, ROADMAP, CITATION.cff, and the
+  `zshellcheck(1)` man page updated for v1.0.0 and the 1000-kata total.
+- `-severity`, `--no-color`, `--version`, and `-format sarif` now
+  documented in the man page.
+
+### Documentation
+- CHANGELOG gains this 1.0.0 section covering the ZC1339–ZC2003 range.
+- ROADMAP marks the 250, 500, and 1000-kata milestones complete and
+  advances the LSP / auto-fixer / plugin work into the 1.x bucket.
+
 ## [0.3.35] - 2026-04-17
 
 **Public beta.** First release with successfully built, signed, and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ authors:
   given-names: "Afa"
   alias: "afadesigns"
 title: "ZShellCheck"
-version: 0.0.97
-date-released: 2024-05-20
+version: 1.0.0
+date-released: 2026-04-20
 url: "https://github.com/afadesigns/zshellcheck"
 repository-code: "https://github.com/afadesigns/zshellcheck"
 license: "MIT"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck)
 
-**ZShellCheck** (`v0.3.35` -- 335 Katas) is the definitive static analysis and comprehensive development suite for the entire Zsh ecosystem, meticulously engineered as the full Zsh equivalent of ShellCheck for Bash. It offers intelligent automatic fixes (planned), advanced formatting capabilities, and deep code analysis to deliver unparalleled quality, performance, and reliability for Zsh scripts, functions, and configurations.
+**ZShellCheck** (`v1.0.0` -- 1000 Katas) is the definitive static analysis and comprehensive development suite for the entire Zsh ecosystem, meticulously engineered as the full Zsh equivalent of ShellCheck for Bash. It offers intelligent automatic fixes (planned), advanced formatting capabilities, and deep code analysis to deliver unparalleled quality, performance, and reliability for Zsh scripts, functions, and configurations.
 
 ## Inspiration
 
@@ -127,7 +127,7 @@ Add this to your `.pre-commit-config.yaml`:
 
 ```yaml
 -   repo: https://github.com/afadesigns/zshellcheck
-    rev: v0.3.35
+    rev: v1.0.0
     hooks:
     -   id: zshellcheck
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,16 +20,18 @@ ZShellCheck is an evolving static analysis tool for Zsh. Our mission is to provi
 - [x] Add source code context to violation output.
 - [x] Enhanced installer with auto-sudo, CI detection, man pages, and completions.
 - [x] Reach 166 Katas (ZC1001 - ZC1169).
-- [ ] Reach 250 Katas covering core Zsh idioms and common anti-patterns.
-- [ ] Reach 500 Katas as the halfway milestone to 1.0.
+- [x] Reach 250 Katas covering core Zsh idioms and common anti-patterns.
+- [x] Reach 500 Katas as the halfway milestone to 1.0.
 
-### Version 1.0.0 - The 1000 Kata Milestone
-- [ ] **Goal:** Implement 1000 Katas (ZC1000 - ZC2000) covering:
+### Version 1.0.0 - The 1000 Kata Milestone (Complete)
+- [x] **Goal:** Implement 1000 Katas (ZC1001 - ZC2003) covering:
     - Syntax errors
     - Portability issues
     - Performance bottlenecks
     - Security vulnerabilities
     - Best practices
+
+### Version 1.x - Beyond the Milestone
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [ ] **Auto-Fixer**: Implement `zshellcheck --fix` to automatically apply corrections for common violations (e.g., changing `[ ]` to `[[ ]]`).
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
@@ -40,10 +42,10 @@ ZShellCheck is an evolving static analysis tool for Zsh. Our mission is to provi
 
 ## Progress Tracking
 
-**Current Progress:** Version 0.3.35 (335/1000 Katas -- 33.5%).
+**Current Progress:** Version 1.0.0 (1000/1000 Katas -- 100%).
 
 ```
-[===================================>                                                ] 335/1000
+[================================================================================] 1000/1000
 ```
 
 For the list of currently implemented Katas, please refer to [KATAS.md](KATAS.md).

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -32,7 +32,7 @@ Decisions are made by consensus. The Lead Maintainer has the casting vote in dea
 | **Focus** | `sh`/`bash` (POSIX) | **`zsh`** (Native) |
 | **Language** | Haskell | Go |
 | **Philosophy** | Portability | Zsh Power |
-| **Checks** | ~500 | 166 (growing toward 1000) |
+| **Checks** | ~500 | 1000 |
 | **Output** | Text, JSON, GCC, TTY | Text, JSON, SARIF |
 | **Severity** | error, warning, info, style | error, warning, info, style |
 | **Auto-fix** | Partial | Planned |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2,7 +2,7 @@
 
 This guide covers the configuration, usage, and troubleshooting of ZShellCheck.
 
-ZShellCheck currently implements **335 Katas** (checks) covering syntax errors, security issues, performance improvements, and Zsh best practices.
+ZShellCheck currently implements **1000 Katas** (checks) covering syntax errors, security issues, performance improvements, and Zsh best practices.
 
 ## Table of Contents
 
@@ -111,7 +111,7 @@ Add to `.pre-commit-config.yaml`:
 
 ```yaml
 -   repo: https://github.com/afadesigns/zshellcheck
-    rev: v0.3.35
+    rev: v1.0.0
     hooks:
     -   id: zshellcheck
 ```

--- a/man/man1/zshellcheck.1
+++ b/man/man1/zshellcheck.1
@@ -1,4 +1,4 @@
-.TH ZSHELLCHECK 1 "November 2025" "v0.0.72" "ZShellCheck Manual"
+.TH ZSHELLCHECK 1 "April 2026" "v1.0.0" "ZShellCheck Manual"
 .SH NAME
 zshellcheck \- Static analysis tool for Zsh scripts
 .SH SYNOPSIS
@@ -24,7 +24,22 @@ Specify the output format.
 .TP
 .B json
 Machine-readable JSON output.
+.TP
+.B sarif
+SARIF 2.1.0 output for GitHub Security integration.
 .RE
+.TP
+.BR \-severity \ \fIlevel\fR
+Minimum severity to report: \fBerror\fR, \fBwarning\fR, \fBinfo\fR, or \fBstyle\fR. Default: \fBstyle\fR (all levels).
+.TP
+.BR \-\-no\-color
+Disable ANSI color in the text formatter. Useful for CI logs and file redirects.
+.TP
+.BR \-\-verbose
+Emit additional diagnostic output alongside the results.
+.TP
+.BR \-version
+Print the ZShellCheck version and exit.
 .TP
 .BR \-help
 Display help message and exit.
@@ -54,6 +69,12 @@ Check a directory recursively:
 .TP
 Output in JSON format:
 .B zshellcheck -format json script.zsh
+.TP
+Only errors and warnings, no color:
+.B zshellcheck --severity warning --no-color script.zsh
+.TP
+SARIF output for GitHub code-scanning:
+.B zshellcheck -format sarif script.zsh
 
 .SH EXIT STATUS
 .TP


### PR DESCRIPTION
Docs update ahead of v1.0.0 tag. No code changes.

## What
- **README.md** — `v0.3.35 / 335 Katas` → `v1.0.0 / 1000 Katas`; pre-commit `rev:` pin updated.
- **docs/USER_GUIDE.md** — kata count updated; pre-commit pin updated.
- **docs/REFERENCE.md** — comparison table: `166 (growing toward 1000)` → `1000`.
- **ROADMAP.md** — 166/250/500/1000 milestones marked complete; 1.x bucket introduced for LSP / auto-fixer / plugin work; progress bar 100%.
- **CITATION.cff** — `version: 1.0.0`, `date-released: 2026-04-20`.
- **man/man1/zshellcheck.1** — header bumped to `April 2026 / v1.0.0`; OPTIONS now covers `-format sarif`, `-severity`, `--no-color`, `--verbose`, `-version`; matching EXAMPLES.
- **CHANGELOG.md** — new `[1.0.0]` section summarising the 665 katas added since v0.3.35 (ZC1339–ZC2003), grouped by theme (Zsh semantics, storage safety, kernel/devices, platform ops, shell hygiene).

## Why
Docs audit flagged stale version/count strings across the tree. Release-auditor blocked v1.0.0 tag on CHANGELOG drift. This PR clears both.

## Test plan
- [x] `go test ./...` — all packages green (docs-only edits)
- [x] `golangci-lint run ./...` — clean
- [x] Manual grep confirms no surviving `v0.3.35` / `335 Katas` in tracked files outside CHANGELOG history