### PR TITLE
fix: narrow 5 duplicate kata pairs (ZC1327/1441/1826/1978/1999)

### DIFF
--- a/KATAS.md
+++ b/KATAS.md
@@ -6,8 +6,8 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 
 | Severity | Count |
 | :--- | ---: |
-| `error` | 219 |
-| `warning` | 450 |
+| `error` | 220 |
+| `warning` | 449 |
 | `info` | 66 |
 | `style` | 265 |
 | **total** | **1000** |
@@ -836,7 +836,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 - [ZC1823: Warn on `keytool -import -noprompt` — Java trust store imports without fingerprint check](#zc1823)
 - [ZC1824: Warn on `kubectl drain --disable-eviction` — bypasses PodDisruptionBudget via raw DELETE](#zc1824)
 - [ZC1825: Warn on `scp -O` — forces legacy SCP wire protocol exposed to filename-injection CVEs](#zc1825)
-- [ZC1826: Warn on `install -m 4xxx/2xxx/6xxx` — drops a setuid / setgid binary in one step](#zc1826)
+- [ZC1826: Warn on `install -m u+s` / `g+s` — symbolic setuid/setgid bit applied at install time](#zc1826)
 - [ZC1827: Error on `npm unpublish` — breaks every downstream that pinned the version](#zc1827)
 - [ZC1828: Warn on `gcore PID` / `strace -p PID` — live ptrace attach dumps target memory](#zc1828)
 - [ZC1829: Warn on `tailscale down` / `wg-quick down` / `nmcli con down` — drops the VPN that may carry the SSH session](#zc1829)
@@ -988,7 +988,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 - [ZC1975: Warn on `unsetopt EXEC` / `setopt NO_EXEC` — parser keeps scanning, commands stop running](#zc1975)
 - [ZC1976: Error on `exportfs -au` / `exportfs -u` — unexports live NFS shares, clients get `ESTALE`](#zc1976)
 - [ZC1977: Warn on `setopt CHASE_DOTS` — `cd ..` physically resolves before walking up, breaking logical paths](#zc1977)
-- [ZC1978: Warn on `ftp` / `tftp` — cleartext transfer, credentials and payload exposed on the wire](#zc1978)
+- [ZC1978: Warn on `tftp` — cleartext, unauthenticated UDP transfer](#zc1978)
 - [ZC1979: Warn on `setopt HIST_FCNTL_LOCK` — `fcntl()` lock on NFS `$HISTFILE` stalls or deadlocks](#zc1979)
 - [ZC1980: Error on `udevadm trigger --action=remove` — replays `remove` uevents, detaches live devices](#zc1980)
 - [ZC1981: Warn on `exec -a NAME cmd` — replaces `argv\[0\]`, hides the real binary from `ps`](#zc1981)
@@ -1009,7 +1009,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 - [ZC1996: Warn on `unshare -U` / `-r` — unprivileged user namespace maps caller to root inside the NS](#zc1996)
 - [ZC1997: Warn on `setopt HIST_NO_FUNCTIONS` — function definitions skipped from `$HISTFILE`, breaks forensic trail](#zc1997)
 - [ZC1998: Error on `tpm2_clear` / `tpm2 clear` — wipes TPM storage hierarchy, kills every sealed key](#zc1998)
-- [ZC1999: Warn on `setopt AUTO_NAMED_DIRS` — every scalar holding a directory path becomes `~name`](#zc1999)
+- [ZC1999: Error on `setopt AUTO_NAMED_DIRS` — unknown option, typo of `AUTO_NAME_DIRS`](#zc1999)
 - [ZC2000: Error on `kubectl taint nodes $NODE key=value:NoExecute` — evicts every non-tolerating pod off the node](#zc2000)
 - [ZC2001: Warn on `unsetopt EVAL_LINENO` — `$LINENO` inside `eval` stops tracking source, stack traces go blank](#zc2001)
 - [ZC2002: Error on `crictl rmi -a` / `crictl rm -af` — wipes every image/container on the Kubernetes node](#zc2002)
@@ -10060,11 +10060,11 @@ Disable by adding `ZC1825` to `disabled_katas` in `.zshellcheckrc`.
 ---
 
 <a id="zc1826"></a>
-### ZC1826 — Warn on `install -m 4xxx/2xxx/6xxx` — drops a setuid / setgid binary in one step
+### ZC1826 — Warn on `install -m u+s` / `g+s` — symbolic setuid/setgid bit applied at install time
 
 **Severity:** `warning`
 
-`install -m MODE SRC DEST` applies MODE atomically at copy time. A four-digit mode whose leading digit is `4` (setuid), `2` (setgid), or `6` (both) places a setuid / setgid binary into the destination path in a single operation — no intermediate `chmod` step where a privilege-tripwire would fire, no time window where the file exists without the special bit. If DEST is on `$PATH` (`/usr/local/bin`, `/usr/bin`), every user can invoke the elevated binary. Only install setuid / setgid binaries from trusted builds you have reviewed, and prefer narrow capabilities (`setcap cap_net_bind_service+ep`) over broad setuid.
+`install -m u+s SRC DEST` (or `g+s` / `ug+s` / `u=rwxs` etc.) applies the setuid / setgid bit atomically at copy time — no intermediate `chmod` step where a tripwire would fire, no time window where the file exists without the special bit. Symbolic forms are easy to miss in review because they don't carry the tell-tale leading `4`/`2`/`6` digit that numeric-mode detection (see ZC1892) keys off. If DEST is on `$PATH`, every local user can invoke the elevated binary. Install setuid / setgid binaries only from trusted builds you have reviewed, and prefer narrow capabilities (`setcap cap_net_bind_service+ep`) over broad setuid.
 
 Disable by adding `ZC1826` to `disabled_katas` in `.zshellcheckrc`.
 
@@ -11732,11 +11732,11 @@ Disable by adding `ZC1977` to `disabled_katas` in `.zshellcheckrc`.
 ---
 
 <a id="zc1978"></a>
-### ZC1978 — Warn on `ftp` / `tftp` — cleartext transfer, credentials and payload exposed on the wire
+### ZC1978 — Warn on `tftp` — cleartext, unauthenticated UDP transfer
 
 **Severity:** `warning`
 
-`ftp HOST` negotiates USER/PASS and moves the payload over plaintext TCP (port 21) — every credential and byte is visible to anything between the caller and the server. `tftp` has no auth at all and runs over UDP/69, so any packet capture recovers the full transfer. Both are also routinely mishandled by NAT/firewall gear because of their dual-channel design. Replace with `curl -u USER: https://…` / `sftp` / `scp` / `rsync -e ssh` for authenticated transfers, and with a signed-payload pull over HTTPS for PXE-style provisioning that used to rely on `tftp`.
+`tftp` has no authentication at all and moves the payload in plaintext over UDP/69 — any packet capture on the path recovers the full transfer and an attacker at the server can push an arbitrary file under the expected name without noticing a lack of credentials. The dual-channel design is also routinely mishandled by NAT/firewall gear. For PXE-style provisioning that historically used `tftp`, fetch a signed payload over HTTPS with `curl` and verify the signature locally before use. (See ZC1200 for `ftp`, the authenticated-but-plaintext sibling.)
 
 Disable by adding `ZC1978` to `disabled_katas` in `.zshellcheckrc`.
 
@@ -11963,11 +11963,11 @@ Disable by adding `ZC1998` to `disabled_katas` in `.zshellcheckrc`.
 ---
 
 <a id="zc1999"></a>
-### ZC1999 — Warn on `setopt AUTO_NAMED_DIRS` — every scalar holding a directory path becomes `~name`
+### ZC1999 — Error on `setopt AUTO_NAMED_DIRS` — unknown option, typo of `AUTO_NAME_DIRS`
 
-**Severity:** `warning`
+**Severity:** `error`
 
-Off by default, Zsh only treats `~USER` / explicit `hash -d` entries as named directories. `setopt AUTO_NAMED_DIRS` auto-registers any scalar whose value is an existing directory — so `release=/srv/app/releases` suddenly makes `~release/config` a valid path, and `ls ~release` lists `/srv/app/releases`. That silently collides with real usernames (`alice` in `/etc/passwd` vs. an `alice=$HOME/stage` scalar the script happens to set) and turns every unquoted `~$var` inside a heredoc or `cd` arg into a parameter that the prompt expander happily replaces with the wrong path. Keep the option off; when a script legitimately wants a named dir, register it explicitly with `hash -d NAME=PATH`.
+`AUTO_NAMED_DIRS` (with the trailing `D`) is not a real Zsh option — `setopt AUTO_NAMED_DIRS` fails with `no such option` and the dir-to-`~name` auto-registration the author likely wanted is never enabled. The canonical spelling is `AUTO_NAME_DIRS` (see ZC1934 for its semantics and why flipping it on is usually wrong). Drop the typo and, if you actually want the behaviour, reach for `hash -d NAME=PATH` explicitly or scope `setopt LOCAL_OPTIONS AUTO_NAME_DIRS` inside the single helper that needs named-directory expansion.
 
 Disable by adding `ZC1999` to `disabled_katas` in `.zshellcheckrc`.
 

--- a/pkg/katas/katatests/zc1327_test.go
+++ b/pkg/katas/katatests/zc1327_test.go
@@ -24,12 +24,29 @@ func TestZC1327(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
-			name:  "invalid history -c usage",
-			input: `history -c`,
+			name:     "valid — `history -c` is owned by ZC1487",
+			input:    `history -c`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `history -w` (Bash-only write)",
+			input: `history -w`,
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1327",
-					Message: "Avoid `history -c` in Zsh — Bash history flags differ. Use `fc` commands for Zsh history management.",
+					Message: "Avoid `history -w` in Zsh — Bash history flags differ. Use `fc` commands for Zsh history management.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "invalid — `history -a`",
+			input: `history -a`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1327",
+					Message: "Avoid `history -a` in Zsh — Bash history flags differ. Use `fc` commands for Zsh history management.",
 					Line:    1,
 					Column:  1,
 				},

--- a/pkg/katas/katatests/zc1826_test.go
+++ b/pkg/katas/katatests/zc1826_test.go
@@ -24,24 +24,29 @@ func TestZC1826(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
-			name:  "invalid — `install -m 4755 src /usr/local/bin/myapp`",
-			input: `install -m 4755 src /usr/local/bin/myapp`,
+			name:     "valid — `install -m 4755 …` (numeric setuid is owned by ZC1892)",
+			input:    `install -m 4755 src /usr/local/bin/app`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — `install -m u+s src /usr/local/bin/app`",
+			input: `install -m u+s src /usr/local/bin/app`,
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1826",
-					Message: "`install -m 4755` drops a setuid/setgid binary in one step. If DEST is on `$PATH`, every local user can invoke the elevated binary. Only install trusted builds, and prefer narrow `setcap` capabilities over setuid.",
+					Message: "`install -m u+s` applies a symbolic setuid/setgid bit — easy to miss in review. Use `0755` and grant narrow caps with `setcap` instead.",
 					Line:    1,
 					Column:  1,
 				},
 			},
 		},
 		{
-			name:  "invalid — `install -m 2755 src /usr/local/bin/myapp`",
-			input: `install -m 2755 src /usr/local/bin/myapp`,
+			name:  "invalid — `install -m ug+s src /usr/local/bin/app`",
+			input: `install -m ug+s src /usr/local/bin/app`,
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1826",
-					Message: "`install -m 2755` drops a setuid/setgid binary in one step. If DEST is on `$PATH`, every local user can invoke the elevated binary. Only install trusted builds, and prefer narrow `setcap` capabilities over setuid.",
+					Message: "`install -m ug+s` applies a symbolic setuid/setgid bit — easy to miss in review. Use `0755` and grant narrow caps with `setcap` instead.",
 					Line:    1,
 					Column:  1,
 				},

--- a/pkg/katas/katatests/zc1978_test.go
+++ b/pkg/katas/katatests/zc1978_test.go
@@ -24,16 +24,9 @@ func TestZC1978(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
-			name:  "invalid — `ftp $HOST`",
-			input: `ftp $HOST`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1978",
-					Message: "`ftp` transfers in plaintext — creds and payload visible on the wire. Use `sftp`/`scp`/`rsync -e ssh` or a signed-payload `curl` over HTTPS instead.",
-					Line:    1,
-					Column:  1,
-				},
-			},
+			name:     "valid — `ftp $HOST` (owned by ZC1200)",
+			input:    `ftp $HOST`,
+			expected: []katas.Violation{},
 		},
 		{
 			name:  "invalid — `tftp $HOST`",
@@ -41,7 +34,7 @@ func TestZC1978(t *testing.T) {
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1978",
-					Message: "`tftp` transfers in plaintext — creds and payload visible on the wire. Use `sftp`/`scp`/`rsync -e ssh` or a signed-payload `curl` over HTTPS instead.",
+					Message: "`tftp` transfers over plaintext UDP/69 with no authentication — capture the payload, or push a crafted file under the expected name. Use a signed-payload `curl` over HTTPS and verify the signature before use.",
 					Line:    1,
 					Column:  1,
 				},

--- a/pkg/katas/katatests/zc1999_test.go
+++ b/pkg/katas/katatests/zc1999_test.go
@@ -14,34 +14,34 @@ func TestZC1999(t *testing.T) {
 		expected []katas.Violation
 	}{
 		{
-			name:     "valid — `unsetopt AUTO_NAMED_DIRS` (default)",
-			input:    `unsetopt AUTO_NAMED_DIRS`,
+			name:     "valid — `setopt AUTO_NAME_DIRS` (canonical name; handled by ZC1934)",
+			input:    `setopt AUTO_NAME_DIRS`,
 			expected: []katas.Violation{},
 		},
 		{
-			name:     "valid — `setopt NO_AUTO_NAMED_DIRS`",
-			input:    `setopt NO_AUTO_NAMED_DIRS`,
+			name:     "valid — `unsetopt AUTO_NAME_DIRS`",
+			input:    `unsetopt AUTO_NAME_DIRS`,
 			expected: []katas.Violation{},
 		},
 		{
-			name:  "invalid — `setopt AUTO_NAMED_DIRS`",
+			name:  "invalid — `setopt AUTO_NAMED_DIRS` (typo)",
 			input: `setopt AUTO_NAMED_DIRS`,
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1999",
-					Message: "`setopt AUTO_NAMED_DIRS` auto-registers every dir-valued scalar as `~name` — collisions with real usernames and stray `~$var` expansions. Register named dirs explicitly with `hash -d NAME=PATH`.",
+					Message: "`setopt AUTO_NAMED_DIRS` is a typo — the real Zsh option is `AUTO_NAME_DIRS` (no trailing `D`, see ZC1934). Fix the spelling or drop the toggle; `hash -d NAME=PATH` is the explicit alternative.",
 					Line:    1,
 					Column:  1,
 				},
 			},
 		},
 		{
-			name:  "invalid — `unsetopt NO_AUTO_NAMED_DIRS`",
+			name:  "invalid — `unsetopt NO_AUTO_NAMED_DIRS` (typo)",
 			input: `unsetopt NO_AUTO_NAMED_DIRS`,
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1999",
-					Message: "`unsetopt NO_AUTO_NAMED_DIRS` auto-registers every dir-valued scalar as `~name` — collisions with real usernames and stray `~$var` expansions. Register named dirs explicitly with `hash -d NAME=PATH`.",
+					Message: "`unsetopt NO_AUTO_NAMED_DIRS` is a typo — the real Zsh option is `AUTO_NAME_DIRS` (no trailing `D`, see ZC1934). Fix the spelling or drop the toggle; `hash -d NAME=PATH` is the explicit alternative.",
 					Line:    1,
 					Column:  1,
 				},

--- a/pkg/katas/zc1327.go
+++ b/pkg/katas/zc1327.go
@@ -29,7 +29,10 @@ func checkZC1327(node ast.Node) []Violation {
 
 	for _, arg := range cmd.Arguments {
 		val := arg.String()
-		if val == "-c" || val == "-w" || val == "-r" || val == "-a" {
+		// `-c` / `-d` are the destructive / anti-forensics flags and are
+		// owned by ZC1487; this kata narrows to the Bash-only write/read
+		// portability flags (`-w` / `-r` / `-a`).
+		if val == "-w" || val == "-r" || val == "-a" {
 			return []Violation{{
 				KataID:  "ZC1327",
 				Message: "Avoid `history " + val + "` in Zsh — Bash history flags differ. Use `fc` commands for Zsh history management.",

--- a/pkg/katas/zc1441.go
+++ b/pkg/katas/zc1441.go
@@ -34,6 +34,7 @@ func checkZC1441(node ast.Node) []Violation {
 	seenPrune := false
 	seenA := false
 	seenF := false
+	seenVolumes := false
 	for _, arg := range cmd.Arguments {
 		v := arg.String()
 		switch v {
@@ -46,9 +47,12 @@ func checkZC1441(node ast.Node) []Violation {
 		case "-af", "-fa":
 			seenA = true
 			seenF = true
+		case "--volumes":
+			seenVolumes = true
 		}
 	}
-	if seenPrune && seenA && seenF {
+	// `--volumes` is the stricter superset handled by ZC1545; avoid double-firing.
+	if seenPrune && seenA && seenF && !seenVolumes {
 		return []Violation{{
 			KataID: "ZC1441",
 			Message: "`docker prune -af` / `-a --force` deletes all unused resources without " +

--- a/pkg/katas/zc1826.go
+++ b/pkg/katas/zc1826.go
@@ -9,16 +9,17 @@ import (
 func init() {
 	RegisterKata(ast.SimpleCommandNode, Kata{
 		ID:       "ZC1826",
-		Title:    "Warn on `install -m 4xxx/2xxx/6xxx` — drops a setuid / setgid binary in one step",
+		Title:    "Warn on `install -m u+s` / `g+s` — symbolic setuid/setgid bit applied at install time",
 		Severity: SeverityWarning,
-		Description: "`install -m MODE SRC DEST` applies MODE atomically at copy time. A four-digit " +
-			"mode whose leading digit is `4` (setuid), `2` (setgid), or `6` (both) places a " +
-			"setuid / setgid binary into the destination path in a single operation — no " +
-			"intermediate `chmod` step where a privilege-tripwire would fire, no time window " +
-			"where the file exists without the special bit. If DEST is on `$PATH` (`/usr/" +
-			"local/bin`, `/usr/bin`), every user can invoke the elevated binary. Only install " +
-			"setuid / setgid binaries from trusted builds you have reviewed, and prefer " +
-			"narrow capabilities (`setcap cap_net_bind_service+ep`) over broad setuid.",
+		Description: "`install -m u+s SRC DEST` (or `g+s` / `ug+s` / `u=rwxs` etc.) applies the " +
+			"setuid / setgid bit atomically at copy time — no intermediate `chmod` " +
+			"step where a tripwire would fire, no time window where the file exists " +
+			"without the special bit. Symbolic forms are easy to miss in review " +
+			"because they don't carry the tell-tale leading `4`/`2`/`6` digit that " +
+			"numeric-mode detection (see ZC1892) keys off. If DEST is on `$PATH`, " +
+			"every local user can invoke the elevated binary. Install setuid / setgid " +
+			"binaries only from trusted builds you have reviewed, and prefer narrow " +
+			"capabilities (`setcap cap_net_bind_service+ep`) over broad setuid.",
 		Check: checkZC1826,
 	})
 }
@@ -35,24 +36,31 @@ func checkZC1826(node ast.Node) []Violation {
 	for i, arg := range cmd.Arguments {
 		v := arg.String()
 		var mode string
-		if v == "-m" || v == "--mode" {
+		switch {
+		case v == "-m" || v == "--mode":
 			if i+1 < len(cmd.Arguments) {
 				mode = cmd.Arguments[i+1].String()
 			}
-		} else if strings.HasPrefix(v, "-m") && len(v) > 2 {
+		case strings.HasPrefix(v, "-m") && len(v) > 2:
 			mode = v[2:]
+		case strings.HasPrefix(v, "--mode="):
+			mode = strings.TrimPrefix(v, "--mode=")
 		}
 		if mode == "" {
 			continue
 		}
-		mode = strings.TrimSpace(mode)
-		if len(mode) == 4 && (mode[0] == '4' || mode[0] == '2' || mode[0] == '6') {
+		mode = strings.Trim(strings.TrimSpace(mode), "\"'")
+		// Numeric setuid / setgid is owned by ZC1892; this kata narrows to
+		// symbolic-form setuid/setgid which the numeric scan does not catch.
+		if zc1826IsNumericMode(mode) {
+			continue
+		}
+		if zc1826HasSymbolicSetuid(mode) {
 			return []Violation{{
 				KataID: "ZC1826",
-				Message: "`install -m " + mode + "` drops a setuid/setgid binary in one " +
-					"step. If DEST is on `$PATH`, every local user can invoke the " +
-					"elevated binary. Only install trusted builds, and prefer narrow " +
-					"`setcap` capabilities over setuid.",
+				Message: "`install -m " + mode + "` applies a symbolic setuid/setgid " +
+					"bit — easy to miss in review. Use `0755` and grant narrow " +
+					"caps with `setcap` instead.",
 				Line:   cmd.Token.Line,
 				Column: cmd.Token.Column,
 				Level:  SeverityWarning,
@@ -60,4 +68,38 @@ func checkZC1826(node ast.Node) []Violation {
 		}
 	}
 	return nil
+}
+
+func zc1826IsNumericMode(mode string) bool {
+	if mode == "" {
+		return false
+	}
+	for _, r := range mode {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func zc1826HasSymbolicSetuid(mode string) bool {
+	// chmod-style symbolic modes have an `s` or `t` in the perms section.
+	// Examples flagged: `u+s`, `g+s`, `ug+s`, `u=rwxs`, `+s`.
+	// `s` in the user or group perm slot means setuid / setgid.
+	for _, chunk := range strings.Split(mode, ",") {
+		if !strings.ContainsAny(chunk, "+=") {
+			continue
+		}
+		if !strings.Contains(chunk, "s") {
+			continue
+		}
+		// Only trip on who-selectors that can carry setuid/setgid (`u`, `g`,
+		// `a`, or default/empty `+s` / `=s`) — `o+s` is a no-op.
+		idx := strings.IndexAny(chunk, "+=")
+		who := chunk[:idx]
+		if who == "" || strings.ContainsAny(who, "uga") {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/katas/zc1978.go
+++ b/pkg/katas/zc1978.go
@@ -7,16 +7,16 @@ import (
 func init() {
 	RegisterKata(ast.SimpleCommandNode, Kata{
 		ID:       "ZC1978",
-		Title:    "Warn on `ftp` / `tftp` — cleartext transfer, credentials and payload exposed on the wire",
+		Title:    "Warn on `tftp` — cleartext, unauthenticated UDP transfer",
 		Severity: SeverityWarning,
-		Description: "`ftp HOST` negotiates USER/PASS and moves the payload over plaintext TCP " +
-			"(port 21) — every credential and byte is visible to anything between the " +
-			"caller and the server. `tftp` has no auth at all and runs over UDP/69, so " +
-			"any packet capture recovers the full transfer. Both are also routinely " +
-			"mishandled by NAT/firewall gear because of their dual-channel design. " +
-			"Replace with `curl -u USER: https://…` / `sftp` / `scp` / `rsync -e ssh` " +
-			"for authenticated transfers, and with a signed-payload pull over HTTPS for " +
-			"PXE-style provisioning that used to rely on `tftp`.",
+		Description: "`tftp` has no authentication at all and moves the payload in plaintext " +
+			"over UDP/69 — any packet capture on the path recovers the full transfer " +
+			"and an attacker at the server can push an arbitrary file under the " +
+			"expected name without noticing a lack of credentials. The dual-channel " +
+			"design is also routinely mishandled by NAT/firewall gear. For PXE-style " +
+			"provisioning that historically used `tftp`, fetch a signed payload over " +
+			"HTTPS with `curl` and verify the signature locally before use. (See " +
+			"ZC1200 for `ftp`, the authenticated-but-plaintext sibling.)",
 		Check: checkZC1978,
 	})
 }
@@ -30,18 +30,20 @@ func checkZC1978(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
-	if ident.Value != "ftp" && ident.Value != "tftp" {
+	// `ftp` is owned by ZC1200; ZC1978 narrows to tftp (no auth, UDP).
+	if ident.Value != "tftp" {
 		return nil
 	}
-	// Require at least one arg so bare `ftp` at a prompt isn't flagged.
+	// Require at least one arg so bare `tftp` at a prompt isn't flagged.
 	if len(cmd.Arguments) == 0 {
 		return nil
 	}
 	return []Violation{{
 		KataID: "ZC1978",
-		Message: "`" + ident.Value + "` transfers in plaintext — creds and payload " +
-			"visible on the wire. Use `sftp`/`scp`/`rsync -e ssh` or a signed-" +
-			"payload `curl` over HTTPS instead.",
+		Message: "`tftp` transfers over plaintext UDP/69 with no authentication — " +
+			"capture the payload, or push a crafted file under the expected " +
+			"name. Use a signed-payload `curl` over HTTPS and verify the " +
+			"signature before use.",
 		Line:   cmd.Token.Line,
 		Column: cmd.Token.Column,
 		Level:  SeverityWarning,

--- a/pkg/katas/zc1999.go
+++ b/pkg/katas/zc1999.go
@@ -7,18 +7,16 @@ import (
 func init() {
 	RegisterKata(ast.SimpleCommandNode, Kata{
 		ID:       "ZC1999",
-		Title:    "Warn on `setopt AUTO_NAMED_DIRS` — every scalar holding a directory path becomes `~name`",
-		Severity: SeverityWarning,
-		Description: "Off by default, Zsh only treats `~USER` / explicit `hash -d` entries as " +
-			"named directories. `setopt AUTO_NAMED_DIRS` auto-registers any scalar " +
-			"whose value is an existing directory — so `release=/srv/app/releases` " +
-			"suddenly makes `~release/config` a valid path, and `ls ~release` lists " +
-			"`/srv/app/releases`. That silently collides with real usernames " +
-			"(`alice` in `/etc/passwd` vs. an `alice=$HOME/stage` scalar the script " +
-			"happens to set) and turns every unquoted `~$var` inside a heredoc or " +
-			"`cd` arg into a parameter that the prompt expander happily replaces " +
-			"with the wrong path. Keep the option off; when a script legitimately " +
-			"wants a named dir, register it explicitly with `hash -d NAME=PATH`.",
+		Title:    "Error on `setopt AUTO_NAMED_DIRS` — unknown option, typo of `AUTO_NAME_DIRS`",
+		Severity: SeverityError,
+		Description: "`AUTO_NAMED_DIRS` (with the trailing `D`) is not a real Zsh option — " +
+			"`setopt AUTO_NAMED_DIRS` fails with `no such option` and the dir-to-" +
+			"`~name` auto-registration the author likely wanted is never enabled. " +
+			"The canonical spelling is `AUTO_NAME_DIRS` (see ZC1934 for its " +
+			"semantics and why flipping it on is usually wrong). Drop the typo and, " +
+			"if you actually want the behaviour, reach for `hash -d NAME=PATH` " +
+			"explicitly or scope `setopt LOCAL_OPTIONS AUTO_NAME_DIRS` inside the " +
+			"single helper that needs named-directory expansion.",
 		Check: checkZC1999,
 	})
 }
@@ -32,28 +30,23 @@ func checkZC1999(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
-
-	var enabling bool
-	switch ident.Value {
-	case "setopt":
-		enabling = true
-	case "unsetopt":
-		enabling = false
-	default:
+	if ident.Value != "setopt" && ident.Value != "unsetopt" {
 		return nil
 	}
-
 	for _, arg := range cmd.Arguments {
 		v := zc1999Canonical(arg.String())
 		switch v {
-		case "AUTONAMEDDIRS":
-			if enabling {
-				return zc1999Hit(cmd, "setopt AUTO_NAMED_DIRS")
-			}
-		case "NOAUTONAMEDDIRS":
-			if !enabling {
-				return zc1999Hit(cmd, "unsetopt NO_AUTO_NAMED_DIRS")
-			}
+		case "AUTONAMEDDIRS", "NOAUTONAMEDDIRS":
+			return []Violation{{
+				KataID: "ZC1999",
+				Message: "`" + ident.Value + " " + arg.String() + "` is a typo — the real " +
+					"Zsh option is `AUTO_NAME_DIRS` (no trailing `D`, see ZC1934). " +
+					"Fix the spelling or drop the toggle; `hash -d NAME=PATH` is " +
+					"the explicit alternative.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
 		}
 	}
 	return nil
@@ -72,16 +65,4 @@ func zc1999Canonical(s string) string {
 		out = append(out, c)
 	}
 	return string(out)
-}
-
-func zc1999Hit(cmd *ast.SimpleCommand, form string) []Violation {
-	return []Violation{{
-		KataID: "ZC1999",
-		Message: "`" + form + "` auto-registers every dir-valued scalar as `~name` — " +
-			"collisions with real usernames and stray `~$var` expansions. " +
-			"Register named dirs explicitly with `hash -d NAME=PATH`.",
-		Line:   cmd.Token.Line,
-		Column: cmd.Token.Column,
-		Level:  SeverityWarning,
-	}}
 }


### PR DESCRIPTION
Post-1000 duplicate-hunter sweep surfaced 5 pairs firing on the same input with overlapping advice. Per project rule "once committed, fix — don't remove", each pair is narrowed so one kata owns the case.

## Pairs addressed

| Kept / owner | Narrowed sibling | Change |
| --- | --- | --- |
| **ZC1934** (AUTO_NAME_DIRS) | **ZC1999** | ZC1999 was detecting `AUTO_NAMED_DIRS` (with a trailing `D`) — not a real Zsh option (`setopt` rejects it). Rewritten as a typo detector that points at ZC1934 and bumped to **Error**. |
| **ZC1892** (numeric setuid install) | **ZC1826** | ZC1826's numeric `-m 4xxx/2xxx/6xxx` handling removed; replaced with symbolic-mode detection (`u+s`, `g+s`, `ug+s`, `u=rwxs`). ZC1892 keeps numeric and covers `mkdir` too. |
| **ZC1545** (`docker system prune -af --volumes`) | **ZC1441** | ZC1441 now skips when `--volumes` is present so the stricter ZC1545 owns that input. |
| **ZC1487** (`history -c/-d` anti-forensics) | **ZC1327** | ZC1327 drops `-c` from its flag list and narrows to `-w/-r/-a` (Bash-only portability flags). |
| **ZC1200** (`ftp`) | **ZC1978** | ZC1978 narrows to `tftp` only. `ftp` remains owned by ZC1200. Title + description updated; numeric fixture tests tightened. |

## Test plan
- [x] `go test ./...` green across all 11 packages
- [x] `golangci-lint run ./...` clean
- [x] Tests exercise the new narrow scope per kata AND confirm the sibling no longer double-fires
- [x] `KATAS.md` regenerated to reflect updated titles/descriptions