### PR TITLE
ci: unblock Spell Check — allowlist `exportfs`, rephrase `mis-keying` in ZC2000

### DIFF
--- a/KATAS.md
+++ b/KATAS.md
@@ -11978,7 +11978,7 @@ Disable by adding `ZC1999` to `disabled_katas` in `.zshellcheckrc`.
 
 **Severity:** `error`
 
-A `NoExecute` taint kicks every existing pod off the node unless the pod spec explicitly tolerates it. Draining one node during a rolling upgrade is one thing; a script that types the taint wrong (mis-keying the toleration value, applying to `--all` nodes, or iterating a node list without a pause) can empty a whole cluster in seconds and trigger cascade reschedules that overwhelm the scheduler. Prefer `kubectl drain $NODE` (which respects PodDisruptionBudget and runs PreStop hooks) or a `NoSchedule` taint for gentle drain; reserve `NoExecute` for genuine incident response with a runbook and a safety countdown.
+A `NoExecute` taint kicks every existing pod off the node unless the pod spec explicitly tolerates it. Draining one node during a rolling upgrade is one thing; a script that types the taint wrong (typoed toleration value, applying to `--all` nodes, or iterating a node list without a pause) can empty a whole cluster in seconds and trigger cascade reschedules that overwhelm the scheduler. Prefer `kubectl drain $NODE` (which respects PodDisruptionBudget and runs PreStop hooks) or a `NoSchedule` taint for gentle drain; reserve `NoExecute` for genuine incident response with a runbook and a safety countdown.
 
 Disable by adding `ZC2000` to `disabled_katas` in `.zshellcheckrc`.
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -16,3 +16,5 @@ unparseable = "unparseable"
 mke2fs = "mke2fs"
 # chage is the GNU password-aging utility
 chage = "chage"
+# exportfs is the NFS export-management tool (see ZC1976)
+exportfs = "exportfs"

--- a/pkg/katas/zc2000.go
+++ b/pkg/katas/zc2000.go
@@ -13,7 +13,7 @@ func init() {
 		Severity: SeverityError,
 		Description: "A `NoExecute` taint kicks every existing pod off the node unless the pod " +
 			"spec explicitly tolerates it. Draining one node during a rolling upgrade " +
-			"is one thing; a script that types the taint wrong (mis-keying the " +
+			"is one thing; a script that types the taint wrong (typoed " +
 			"toleration value, applying to `--all` nodes, or iterating a node list " +
 			"without a pause) can empty a whole cluster in seconds and trigger " +
 			"cascade reschedules that overwhelm the scheduler. Prefer `kubectl drain " +


### PR DESCRIPTION
The `typos` workflow has been red on every push since ~ZC1976 (NFS `exportfs` tool) and ZC2000 (`mis-keying`).

- **`_typos.toml`** — adds `exportfs` to `[default.extend-identifiers]` alongside `mke2fs` / `chage`. That silences 45+ false positives across KATAS.md and `pkg/katas/zc1976.go`.
- **`pkg/katas/zc2000.go`** — rephrases `mis-keying` to `typoed` so `typos` does not trip on the word fragment.
- **`KATAS.md`** regenerated via `go run ./internal/tools/gen-katas-md` so the updated description flows through.

Needed for the v1.0.0 release tag — release-auditor flagged the red workflow as a blocker.

### Test plan
- [x] `go test ./...` green
- [x] `golangci-lint run ./...` clean
- [x] Manual grep confirms no other `mis-` prose in tracked `*.go`