### PR TITLE
docs: correct author name (Andreas Fahl) + contact email (github@afadesign.co)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,10 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 authors:
-- family-names: "Designs"
-  given-names: "Afa"
+- family-names: "Fahl"
+  given-names: "Andreas"
   alias: "afadesigns"
+  email: "github@afadesign.co"
 title: "ZShellCheck"
 version: 1.0.0
 date-released: 2026-04-20

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 ## Reporting Guidelines
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement by contacting **@afadesigns** on GitHub or via email at `afadesign.official@gmail.com`.
+reported to the community leaders responsible for enforcement by contacting **@afadesigns** on GitHub or via email at `github@afadesign.co`.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ We take security seriously. If you have discovered a vulnerability in ZShellChec
 ### Process
 
 1.  **Do NOT open a public GitHub issue.** This allows us to assess the risk and fix the issue before it can be exploited.
-2.  **Email**: Please email the maintainer directly at `afadesign.official@gmail.com` (or contact **@afadesigns** via GitHub private (if available) or other social channels linked on the profile).
+2.  **Email**: Please email the maintainer directly at `github@afadesign.co` (or contact **@afadesigns** via GitHub private (if available) or other social channels linked on the profile).
 3.  **Details**: Please include as much information as possible:
     - The type of vulnerability.
     - Full steps to reproduce.


### PR DESCRIPTION
Fix author metadata and contact channels so all public-facing docs point at the correct identity and inbox.

## Changes

- **`CITATION.cff`** — `family-names: Fahl`, `given-names: Andreas` (was incorrectly filled as `Designs, Afa`); adds `email: github@afadesign.co`.
- **`SECURITY.md`** — reporting email now `github@afadesign.co` (was the legacy `afadesign.official@gmail.com`).
- **`CODE_OF_CONDUCT.md`** — enforcement email now `github@afadesign.co` (same migration).

Historical `CHANGELOG.md` entries that reference the older `afadesign.official@gmail.com` are left untouched as accurate records of what was true at the time of each release.