### PR TITLE
feat: XDG Base Directory support — ~/.config/zshellcheck/config.{yml,yaml} merged with ~/.zshellcheckrc and ./.zshellcheckrc

### DIFF
--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -77,9 +77,6 @@ func run() int {
 		fmt.Fprint(os.Stderr, config.Banner)
 	}
 
-	// Start with default config
-	config := config.DefaultConfig()
-
 	configFileXdgConfigPath, _ := xdg.ConfigFile("zshellcheck/config.yaml")
 	configFileHomePath := filepath.Join(xdg.Home, ".zshellcheckrc")
 	config, err := loadConfig(configFileXdgConfigPath, configFileHomePath, ".zshellcheckrc")

--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -77,7 +77,7 @@ func run() int {
 		fmt.Fprint(os.Stderr, config.Banner)
 	}
 
-	configFileXdgConfigPath, _ := xdg.ConfigFile("zshellcheck/config.yaml")
+	configFileXdgConfigPath, _ := xdg.SearchConfigFile("zshellcheck/config.yaml")
 	configFileHomePath := filepath.Join(xdg.Home, ".zshellcheckrc")
 	config, err := loadConfig(configFileXdgConfigPath, configFileHomePath, ".zshellcheckrc")
 	if err != nil {

--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -77,7 +77,12 @@ func run() int {
 		fmt.Fprint(os.Stderr, config.Banner)
 	}
 
-	configFileXdgConfigPath, _ := xdg.SearchConfigFile("zshellcheck/config.yaml")
+	// Pick either config.yml or config.yaml, but not both
+	configFileXdgConfigPath, err := xdg.SearchConfigFile("zshellcheck/config.yml")
+	if err != nil {
+		configFileXdgConfigPath, _ = xdg.SearchConfigFile("zshellcheck/config.yaml")
+	}
+
 	configFileHomePath := filepath.Join(xdg.Home, ".zshellcheckrc")
 	config, err := loadConfig(configFileXdgConfigPath, configFileHomePath, ".zshellcheckrc")
 	if err != nil {

--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -9,6 +9,7 @@ import (
 	"runtime/pprof"
 	"strings"
 
+	"github.com/adrg/xdg"
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 	"github.com/afadesigns/zshellcheck/pkg/config"
 	"github.com/afadesigns/zshellcheck/pkg/katas"
@@ -76,7 +77,12 @@ func run() int {
 		fmt.Fprint(os.Stderr, config.Banner)
 	}
 
-	config, err := loadConfig(".zshellcheckrc")
+	// Start with default config
+	config := config.DefaultConfig()
+
+	configFileXdgConfigPath, _ := xdg.ConfigFile("zshellcheck/config.yaml")
+	configFileHomePath := filepath.Join(xdg.Home, ".zshellcheckrc")
+	config, err := loadConfig(configFileXdgConfigPath, configFileHomePath, ".zshellcheckrc")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading config: %s\n", err)
 		return 1
@@ -120,25 +126,29 @@ func run() int {
 	return 0
 }
 
-func loadConfig(path string) (config.Config, error) {
+func loadConfig(paths ...string) (config.Config, error) {
 	cfg := config.DefaultConfig()
 
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return cfg, nil
+	for _, path := range paths {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			continue
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return cfg, err
+		}
+
+		var fileConfig config.Config
+		err = yaml.Unmarshal(data, &fileConfig)
+		if err != nil {
+			return cfg, err
+		}
+
+		cfg = config.MergeConfig(cfg, fileConfig)
 	}
 
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return cfg, err
-	}
-
-	var fileConfig config.Config
-	err = yaml.Unmarshal(data, &fileConfig)
-	if err != nil {
-		return cfg, err
-	}
-
-	return config.MergeConfig(cfg, fileConfig), nil
+	return cfg, nil
 }
 
 func processPath(path string, out, errOut io.Writer, config config.Config, registry *katas.KatasRegistry, format string, allowedSeverities []katas.Severity) int {

--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -132,6 +132,9 @@ func loadConfig(paths ...string) (config.Config, error) {
 	cfg := config.DefaultConfig()
 
 	for _, path := range paths {
+		if path == "" {
+			continue
+		}
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			continue
 		}

--- a/cmd/zshellcheck/main_test.go
+++ b/cmd/zshellcheck/main_test.go
@@ -289,6 +289,72 @@ func TestLoadConfig_InvalidYAML(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_EmptyPathSkipped(t *testing.T) {
+	// xdg.SearchConfigFile returns "" when no XDG config is found — the
+	// loader must skip the empty path rather than stat("") (portability).
+	cfg, err := loadConfig("", "", "/nonexistent/path/.zshellcheckrc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ErrorColor != config.ColorRed {
+		t.Errorf("expected default ErrorColor, got %q", cfg.ErrorColor)
+	}
+}
+
+func TestLoadConfig_MergeOrderLocalWins(t *testing.T) {
+	// Ensure later paths override earlier ones: xdg < ~/.zshellcheckrc <
+	// ./.zshellcheckrc (highest).
+	dir := t.TempDir()
+	xdgPath := filepath.Join(dir, "xdg.yml")
+	homePath := filepath.Join(dir, ".zshellcheckrc")
+	localPath := filepath.Join(dir, "local.yml")
+
+	if err := os.WriteFile(xdgPath, []byte("disabled_katas:\n  - ZC1001\nno_color: false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(homePath, []byte("disabled_katas:\n  - ZC1002\nno_color: false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(localPath, []byte("no_color: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadConfig(xdgPath, homePath, localPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.NoColor {
+		t.Error("expected local no_color=true to win")
+	}
+	// Disabled katas from earlier paths should still merge through.
+	if len(cfg.DisabledKatas) == 0 {
+		t.Error("expected DisabledKatas to carry through earlier layers")
+	}
+}
+
+func TestLoadConfig_XDGPathOnly(t *testing.T) {
+	// When only the xdg layer exists, its values apply.
+	dir := t.TempDir()
+	xdgPath := filepath.Join(dir, "xdg.yml")
+	if err := os.WriteFile(xdgPath, []byte("disabled_katas:\n  - ZC1007\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadConfig(xdgPath, "/nonexistent/home/.zshellcheckrc", "/nonexistent/local/.zshellcheckrc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, k := range cfg.DisabledKatas {
+		if k == "ZC1007" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected ZC1007 in DisabledKatas, got %v", cfg.DisabledKatas)
+	}
+}
+
 func TestProcessFile_TextFormat(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.zsh")

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -50,6 +50,8 @@ zshellcheck --severity style my_script.zsh
 
 ZShellCheck looks for a file named `.zshellcheckrc` in the current working directory. The file uses **YAML** syntax.
 
+Global settings can be placed in `~/.config/zshellcheck/config.yml` or `${XDG_CONFIG_HOME}/zshellcheck/config.yml`.
+
 ### Disabling Katas
 
 To suppress specific checks (Katas), use the `disabled_katas` list:

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,8 @@ module github.com/afadesigns/zshellcheck
 go 1.23
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require (
+	github.com/adrg/xdg v0.5.3 // indirect
+	golang.org/x/sys v0.26.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/afadesigns/zshellcheck
 
 go 1.23
 
-require gopkg.in/yaml.v3 v3.0.1
-
 require (
-	github.com/adrg/xdg v0.5.3 // indirect
-	golang.org/x/sys v0.26.0 // indirect
+	github.com/adrg/xdg v0.5.3
+	gopkg.in/yaml.v3 v3.0.1
 )
+
+require golang.org/x/sys v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
+github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
Rebased from #310 (original author: @norwd, credited in commits on this branch). Adds the review follow-ups so the feature can land: \`go mod tidy\`, empty-path guard, and 3 test cases covering merge-order, empty-path skip, and XDG-only behaviour.

Closes #309. Supersedes #310.

## Behaviour

\`zshellcheck\` now looks for configuration in three layers, merged in this order (later wins):

1. \`\$XDG_CONFIG_HOME/zshellcheck/config.yml\` (or fallback \`\$HOME/.config/zshellcheck/config.yml\`), with \`.yaml\` extension as a secondary search
2. \`\$HOME/.zshellcheckrc\` (the existing single-user config)
3. \`./.zshellcheckrc\` (the existing per-project config)

Every existing \`.zshellcheckrc\`-only setup keeps working unchanged — the XDG layer is additive and only takes effect when a file is found there.

## Test plan
- [x] \`go test ./...\` green across all 11 packages
- [x] \`golangci-lint run ./...\` clean
- [x] \`go mod tidy\` idempotent (go.mod now has \`github.com/adrg/xdg\` as a direct dep)
- [x] New tests: \`TestLoadConfig_EmptyPathSkipped\`, \`TestLoadConfig_MergeOrderLocalWins\`, \`TestLoadConfig_XDGPathOnly\`