### PR TITLE
fix: retire 14 duplicate katas (#341 #342 #343 #344 #345)

### DIFF
--- a/KATAS.md
+++ b/KATAS.md
@@ -8,8 +8,8 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | :--- | ---: |
 | `error` | 220 |
 | `warning` | 449 |
-| `info` | 66 |
-| `style` | 265 |
+| `info` | 64 |
+| `style` | 267 |
 | **total** | **1000** |
 
 ## Table of Contents
@@ -31,24 +31,24 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 - [ZC1015: Use `$(...)` for command substitution instead of backticks](#zc1015)
 - [ZC1016: Use `read -s` when reading sensitive information](#zc1016)
 - [ZC1017: Use `print -r` to print strings literally](#zc1017)
-- [ZC1018: Use `((...))` for C-style arithmetic instead of `expr`](#zc1018)
-- [ZC1019: Use `whence` instead of `which`](#zc1019)
+- [ZC1018: Superseded by ZC1009 — retired duplicate](#zc1018)
+- [ZC1019: Superseded by ZC1005 — retired duplicate](#zc1019)
 - [ZC1020: Use `\[\[ ... \]\]` for tests instead of `test`](#zc1020)
 - [ZC1021: Use symbolic permissions with `chmod` instead of octal](#zc1021)
 - [ZC1022: Use `$((...))` for arithmetic expansion](#zc1022)
-- [ZC1023: Use `$((...))` for arithmetic expansion](#zc1023)
-- [ZC1024: Use `$((...))` for arithmetic expansion](#zc1024)
-- [ZC1025: Use `$((...))` for arithmetic expansion](#zc1025)
-- [ZC1026: Use `$((...))` for arithmetic expansion](#zc1026)
-- [ZC1027: Use `$((...))` for arithmetic expansion](#zc1027)
-- [ZC1028: Use `$((...))` for arithmetic expansion](#zc1028)
-- [ZC1029: Use `$((...))` for arithmetic expansion](#zc1029)
+- [ZC1023: Superseded by ZC1022 — retired duplicate `let` detector](#zc1023)
+- [ZC1024: Superseded by ZC1022 — retired duplicate `let` detector](#zc1024)
+- [ZC1025: Superseded by ZC1022 — retired duplicate `let` detector](#zc1025)
+- [ZC1026: Superseded by ZC1022 — retired duplicate `let` detector](#zc1026)
+- [ZC1027: Superseded by ZC1022 — retired duplicate `let` detector](#zc1027)
+- [ZC1028: Superseded by ZC1022 — retired duplicate `let` detector](#zc1028)
+- [ZC1029: Superseded by ZC1022 — retired duplicate `let` detector](#zc1029)
 - [ZC1030: Use `printf` instead of `echo`](#zc1030)
 - [ZC1031: Use `#!/usr/bin/env zsh` for portability](#zc1031)
 - [ZC1032: Use `((...))` for C-style incrementing](#zc1032)
-- [ZC1033: Use `$((...))` for arithmetic expansion](#zc1033)
+- [ZC1033: Superseded by ZC1022 — retired duplicate `let` detector](#zc1033)
 - [ZC1034: Use `command -v` instead of `which`](#zc1034)
-- [ZC1035: Use `$((...))` for arithmetic expansion](#zc1035)
+- [ZC1035: Superseded by ZC1022 — retired duplicate `let` detector](#zc1035)
 - [ZC1036: Prefer `\[\[ ... \]\]` over `test` command](#zc1036)
 - [ZC1037: Use 'print -r --' for variable expansion](#zc1037)
 - [ZC1038: Avoid useless use of cat](#zc1038)
@@ -106,7 +106,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 - [ZC1090: Quoted regex pattern in `=~`](#zc1090)
 - [ZC1091: Use `((...))` for arithmetic comparisons in `\[\[...\]\]`](#zc1091)
 - [ZC1092: Prefer `print` or `printf` over `echo` in Zsh](#zc1092)
-- [ZC1093: Avoid useless `cat`](#zc1093)
+- [ZC1093: Superseded by ZC1038 — retired duplicate](#zc1093)
 - [ZC1094: Use parameter expansion instead of `sed` for simple substitutions](#zc1094)
 - [ZC1095: Use `repeat N` for simple repetition](#zc1095)
 - [ZC1096: Warn on `bc` for simple arithmetic](#zc1096)
@@ -287,8 +287,8 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 - [ZC1274: Use Zsh `${var:t}` instead of `basename`](#zc1274)
 - [ZC1275: Use Zsh `${var:h}` instead of `dirname`](#zc1275)
 - [ZC1276: Use Zsh `{start..end}` instead of `seq`](#zc1276)
-- [ZC1277: Use Zsh `${var:l}` / `${var:u}` instead of `tr` for case conversion](#zc1277)
-- [ZC1278: Use `$(( ))` instead of `expr` for arithmetic](#zc1278)
+- [ZC1277: Superseded by ZC1108 — retired duplicate](#zc1277)
+- [ZC1278: Superseded by ZC1009 — retired duplicate](#zc1278)
 - [ZC1279: Use `realpath` instead of `readlink -f` for canonical paths](#zc1279)
 - [ZC1280: Use `Zsh ${var:e}` instead of shell expansion to extract file extension](#zc1280)
 - [ZC1281: Use `sort -u` instead of `sort \| uniq` for deduplication](#zc1281)
@@ -1205,22 +1205,22 @@ Disable by adding `ZC1017` to `disabled_katas` in `.zshellcheckrc`.
 ---
 
 <a id="zc1018"></a>
-### ZC1018 — Use `((...))` for C-style arithmetic instead of `expr`
+### ZC1018 — Superseded by ZC1009 — retired duplicate
 
-**Severity:** `info`
+**Severity:** `style`
 
-The `((...))` construct in Zsh allows for C-style arithmetic. It is generally more efficient and readable than using `expr` or other external commands for arithmetic.
+Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. See https://github.com/afadesigns/zshellcheck/issues/343 for context; the canonical detection lives in ZC1009.
 
 Disable by adding `ZC1018` to `disabled_katas` in `.zshellcheckrc`.
 
 ---
 
 <a id="zc1019"></a>
-### ZC1019 — Use `whence` instead of `which`
+### ZC1019 — Superseded by ZC1005 — retired duplicate
 
-**Severity:** `info`
+**Severity:** `style`
 
-The `which` command is an external command and may not be available on all systems. The `whence` command is a built-in Zsh command that provides a more reliable and consistent way to find the location of a command.
+Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. See https://github.com/afadesigns/zshellcheck/issues/342 for context; the canonical detection lives in ZC1005.
 
 Disable by adding `ZC1019` to `disabled_katas` in `.zshellcheckrc`.
 
@@ -1260,77 +1260,77 @@ Disable by adding `ZC1022` to `disabled_katas` in `.zshellcheckrc`.
 ---
 
 <a id="zc1023"></a>
-### ZC1023 — Use `$((...))` for arithmetic expansion
+### ZC1023 — Superseded by ZC1022 — retired duplicate `let` detector
 
 **Severity:** `style`
 
-The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. It is more readable and can be nested easily, unlike `let`.
+Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.
 
 Disable by adding `ZC1023` to `disabled_katas` in `.zshellcheckrc`.
 
 ---
 
 <a id="zc1024"></a>
-### ZC1024 — Use `$((...))` for arithmetic expansion
+### ZC1024 — Superseded by ZC1022 — retired duplicate `let` detector
 
 **Severity:** `style`
 
-The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. It is more readable and can be nested easily, unlike `let`.
+Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.
 
 Disable by adding `ZC1024` to `disabled_katas` in `.zshellcheckrc`.
 
 ---
 
 <a id="zc1025"></a>
-### ZC1025 — Use `$((...))` for arithmetic expansion
+### ZC1025 — Superseded by ZC1022 — retired duplicate `let` detector
 
 **Severity:** `style`
 
-The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. It is more readable and can be nested easily, unlike `let`.
+Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.
 
 Disable by adding `ZC1025` to `disabled_katas` in `.zshellcheckrc`.
 
 ---
 
 <a id="zc1026"></a>
-### ZC1026 — Use `$((...))` for arithmetic expansion
+### ZC1026 — Superseded by ZC1022 — retired duplicate `let` detector
 
 **Severity:** `style`
 
-The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. It is more readable and can be nested easily, unlike `let`.
+Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.
 
 Disable by adding `ZC1026` to `disabled_katas` in `.zshellcheckrc`.
 
 ---
 
 <a id="zc1027"></a>
-### ZC1027 — Use `$((...))` for arithmetic expansion
+### ZC1027 — Superseded by ZC1022 — retired duplicate `let` detector
 
 **Severity:** `style`
 
-The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. It is more readable and can be nested easily, unlike `let`.
+Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.
 
 Disable by adding `ZC1027` to `disabled_katas` in `.zshellcheckrc`.
 
 ---
 
 <a id="zc1028"></a>
-### ZC1028 — Use `$((...))` for arithmetic expansion
+### ZC1028 — Superseded by ZC1022 — retired duplicate `let` detector
 
 **Severity:** `style`
 
-The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. It is more readable and can be nested easily, unlike `let`.
+Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.
 
 Disable by adding `ZC1028` to `disabled_katas` in `.zshellcheckrc`.
 
 ---
 
 <a id="zc1029"></a>
-### ZC1029 — Use `$((...))` for arithmetic expansion
+### ZC1029 — Superseded by ZC1022 — retired duplicate `let` detector
 
 **Severity:** `style`
 
-The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. It is more readable and can be nested easily, unlike `let`.
+Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.
 
 Disable by adding `ZC1029` to `disabled_katas` in `.zshellcheckrc`.
 
@@ -1370,11 +1370,11 @@ Disable by adding `ZC1032` to `disabled_katas` in `.zshellcheckrc`.
 ---
 
 <a id="zc1033"></a>
-### ZC1033 — Use `$((...))` for arithmetic expansion
+### ZC1033 — Superseded by ZC1022 — retired duplicate `let` detector
 
 **Severity:** `style`
 
-The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. It is more readable and can be nested easily, unlike `let`.
+Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.
 
 Disable by adding `ZC1033` to `disabled_katas` in `.zshellcheckrc`.
 
@@ -1392,11 +1392,11 @@ Disable by adding `ZC1034` to `disabled_katas` in `.zshellcheckrc`.
 ---
 
 <a id="zc1035"></a>
-### ZC1035 — Use `$((...))` for arithmetic expansion
+### ZC1035 — Superseded by ZC1022 — retired duplicate `let` detector
 
 **Severity:** `style`
 
-The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. It is more readable and can be nested easily, unlike `let`.
+Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.
 
 Disable by adding `ZC1035` to `disabled_katas` in `.zshellcheckrc`.
 
@@ -2030,11 +2030,11 @@ Disable by adding `ZC1092` to `disabled_katas` in `.zshellcheckrc`.
 ---
 
 <a id="zc1093"></a>
-### ZC1093 — Avoid useless `cat`
+### ZC1093 — Superseded by ZC1038 — retired duplicate
 
 **Severity:** `style`
 
-`cat file | command` spawns an unnecessary process. Use `command < file` or pass the file as an argument directly.
+Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. See https://github.com/afadesigns/zshellcheck/issues/341 for context; the canonical detection lives in ZC1038.
 
 Disable by adding `ZC1093` to `disabled_katas` in `.zshellcheckrc`.
 
@@ -4021,22 +4021,22 @@ Disable by adding `ZC1276` to `disabled_katas` in `.zshellcheckrc`.
 ---
 
 <a id="zc1277"></a>
-### ZC1277 — Use Zsh `${var:l}` / `${var:u}` instead of `tr` for case conversion
+### ZC1277 — Superseded by ZC1108 — retired duplicate
 
 **Severity:** `style`
 
-Zsh provides the `:l` (lowercase) and `:u` (uppercase) modifiers for parameter expansion, avoiding the overhead of piping through `tr` for case conversion.
+Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. See https://github.com/afadesigns/zshellcheck/issues/344 for context; the canonical detection lives in ZC1108.
 
 Disable by adding `ZC1277` to `disabled_katas` in `.zshellcheckrc`.
 
 ---
 
 <a id="zc1278"></a>
-### ZC1278 — Use `$(( ))` instead of `expr` for arithmetic
+### ZC1278 — Superseded by ZC1009 — retired duplicate
 
 **Severity:** `style`
 
-`expr` is an external command for arithmetic. Zsh has native arithmetic expansion `$(( ))` which is faster and more readable.
+Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. See https://github.com/afadesigns/zshellcheck/issues/343 for context; the canonical detection lives in ZC1009.
 
 Disable by adding `ZC1278` to `disabled_katas` in `.zshellcheckrc`.
 

--- a/pkg/katas/katatests/zc1018_test.go
+++ b/pkg/katas/katatests/zc1018_test.go
@@ -7,32 +7,19 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/testutil"
 )
 
-func TestCheckZC1018(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected []katas.Violation
-	}{
-		{
-			input: `expr 1 + 1`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1018",
-					Message: "Use `((...))` for C-style arithmetic instead of `expr`.",
-					Line:    1,
-					Column:  1,
-				},
-			},
-		},
-		{
-			input:    `((1 + 1))`,
-			expected: []katas.Violation{},
-		},
-	}
+// ZC1018 was retired as a duplicate of ZC1009. Kept as a no-op stub so
+// legacy `disabled_katas` lists keep parsing; the detection runs under
+// ZC1009 now.
 
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			violations := testutil.Check(tt.input, "ZC1018")
-			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+func TestZC1018Stub(t *testing.T) {
+	cases := []string{
+		"echo hi",
+		"ls",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			v := testutil.Check(in, "ZC1018")
+			testutil.AssertViolations(t, in, v, []katas.Violation{})
 		})
 	}
 }

--- a/pkg/katas/katatests/zc1019_test.go
+++ b/pkg/katas/katatests/zc1019_test.go
@@ -7,32 +7,19 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/testutil"
 )
 
-func TestCheckZC1019(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected []katas.Violation
-	}{
-		{
-			input: `which ls`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1019",
-					Message: "Use `whence` instead of `which`.",
-					Line:    1,
-					Column:  1,
-				},
-			},
-		},
-		{
-			input:    `whence ls`,
-			expected: []katas.Violation{},
-		},
-	}
+// ZC1019 was retired as a duplicate of ZC1005. Kept as a no-op stub so
+// legacy `disabled_katas` lists keep parsing; the detection runs under
+// ZC1005 now.
 
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			violations := testutil.Check(tt.input, "ZC1019")
-			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+func TestZC1019Stub(t *testing.T) {
+	cases := []string{
+		"echo hi",
+		"ls",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			v := testutil.Check(in, "ZC1019")
+			testutil.AssertViolations(t, in, v, []katas.Violation{})
 		})
 	}
 }

--- a/pkg/katas/katatests/zc1023_test.go
+++ b/pkg/katas/katatests/zc1023_test.go
@@ -7,26 +7,18 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/testutil"
 )
 
+// ZC1023 was retired as a duplicate of ZC1022 (see issue #345). It is
+// kept as a no-op stub so legacy `disabled_katas` lists that reference
+// it keep parsing; the canonical `let` → `$((...))` guidance fires
+// under ZC1022 now.
+
 func TestCheckZC1023(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected []katas.Violation
 	}{
-		{
-			input: `let x=1+1`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1023",
-					Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-					Line:    1,
-					Column:  1,
-				},
-			},
-		},
-		{
-			input:    `x=$((1+1))`,
-			expected: []katas.Violation{},
-		},
+		{input: "let x=1+1", expected: []katas.Violation{}},
+		{input: "x=$((1+1))", expected: []katas.Violation{}},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/katatests/zc1024_test.go
+++ b/pkg/katas/katatests/zc1024_test.go
@@ -7,26 +7,18 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/testutil"
 )
 
+// ZC1024 was retired as a duplicate of ZC1022 (see issue #345). It is
+// kept as a no-op stub so legacy `disabled_katas` lists that reference
+// it keep parsing; the canonical `let` → `$((...))` guidance fires
+// under ZC1022 now.
+
 func TestCheckZC1024(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected []katas.Violation
 	}{
-		{
-			input: `let x=1+1`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1024",
-					Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-					Line:    1,
-					Column:  1,
-				},
-			},
-		},
-		{
-			input:    `x=$((1+1))`,
-			expected: []katas.Violation{},
-		},
+		{input: "let x=1+1", expected: []katas.Violation{}},
+		{input: "x=$((1+1))", expected: []katas.Violation{}},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/katatests/zc1025_test.go
+++ b/pkg/katas/katatests/zc1025_test.go
@@ -7,26 +7,18 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/testutil"
 )
 
+// ZC1025 was retired as a duplicate of ZC1022 (see issue #345). It is
+// kept as a no-op stub so legacy `disabled_katas` lists that reference
+// it keep parsing; the canonical `let` → `$((...))` guidance fires
+// under ZC1022 now.
+
 func TestCheckZC1025(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected []katas.Violation
 	}{
-		{
-			input: `let x=1+1`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1025",
-					Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-					Line:    1,
-					Column:  1,
-				},
-			},
-		},
-		{
-			input:    `x=$((1+1))`,
-			expected: []katas.Violation{},
-		},
+		{input: "let x=1+1", expected: []katas.Violation{}},
+		{input: "x=$((1+1))", expected: []katas.Violation{}},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/katatests/zc1026_test.go
+++ b/pkg/katas/katatests/zc1026_test.go
@@ -7,26 +7,18 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/testutil"
 )
 
+// ZC1026 was retired as a duplicate of ZC1022 (see issue #345). It is
+// kept as a no-op stub so legacy `disabled_katas` lists that reference
+// it keep parsing; the canonical `let` → `$((...))` guidance fires
+// under ZC1022 now.
+
 func TestCheckZC1026(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected []katas.Violation
 	}{
-		{
-			input: `let x=1+1`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1026",
-					Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-					Line:    1,
-					Column:  1,
-				},
-			},
-		},
-		{
-			input:    `x=$((1+1))`,
-			expected: []katas.Violation{},
-		},
+		{input: "let x=1+1", expected: []katas.Violation{}},
+		{input: "x=$((1+1))", expected: []katas.Violation{}},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/katatests/zc1027_test.go
+++ b/pkg/katas/katatests/zc1027_test.go
@@ -7,26 +7,18 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/testutil"
 )
 
+// ZC1027 was retired as a duplicate of ZC1022 (see issue #345). It is
+// kept as a no-op stub so legacy `disabled_katas` lists that reference
+// it keep parsing; the canonical `let` → `$((...))` guidance fires
+// under ZC1022 now.
+
 func TestCheckZC1027(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected []katas.Violation
 	}{
-		{
-			input: `let x=1+1`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1027",
-					Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-					Line:    1,
-					Column:  1,
-				},
-			},
-		},
-		{
-			input:    `x=$((1+1))`,
-			expected: []katas.Violation{},
-		},
+		{input: "let x=1+1", expected: []katas.Violation{}},
+		{input: "x=$((1+1))", expected: []katas.Violation{}},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/katatests/zc1028_test.go
+++ b/pkg/katas/katatests/zc1028_test.go
@@ -7,26 +7,18 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/testutil"
 )
 
+// ZC1028 was retired as a duplicate of ZC1022 (see issue #345). It is
+// kept as a no-op stub so legacy `disabled_katas` lists that reference
+// it keep parsing; the canonical `let` → `$((...))` guidance fires
+// under ZC1022 now.
+
 func TestCheckZC1028(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected []katas.Violation
 	}{
-		{
-			input: `let x=1+1`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1028",
-					Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-					Line:    1,
-					Column:  1,
-				},
-			},
-		},
-		{
-			input:    `x=$((1+1))`,
-			expected: []katas.Violation{},
-		},
+		{input: "let x=1+1", expected: []katas.Violation{}},
+		{input: "x=$((1+1))", expected: []katas.Violation{}},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/katatests/zc1029_test.go
+++ b/pkg/katas/katatests/zc1029_test.go
@@ -7,26 +7,18 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/testutil"
 )
 
+// ZC1029 was retired as a duplicate of ZC1022 (see issue #345). It is
+// kept as a no-op stub so legacy `disabled_katas` lists that reference
+// it keep parsing; the canonical `let` → `$((...))` guidance fires
+// under ZC1022 now.
+
 func TestCheckZC1029(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected []katas.Violation
 	}{
-		{
-			input: `let x=1+1`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1029",
-					Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-					Line:    1,
-					Column:  1,
-				},
-			},
-		},
-		{
-			input:    `x=$((1+1))`,
-			expected: []katas.Violation{},
-		},
+		{input: "let x=1+1", expected: []katas.Violation{}},
+		{input: "x=$((1+1))", expected: []katas.Violation{}},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/katatests/zc1033_test.go
+++ b/pkg/katas/katatests/zc1033_test.go
@@ -7,26 +7,18 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/testutil"
 )
 
+// ZC1033 was retired as a duplicate of ZC1022 (see issue #345). It is
+// kept as a no-op stub so legacy `disabled_katas` lists that reference
+// it keep parsing; the canonical `let` → `$((...))` guidance fires
+// under ZC1022 now.
+
 func TestCheckZC1033(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected []katas.Violation
 	}{
-		{
-			input: `let x=1+1`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1033",
-					Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-					Line:    1,
-					Column:  1,
-				},
-			},
-		},
-		{
-			input:    `x=$((1+1))`,
-			expected: []katas.Violation{},
-		},
+		{input: "let x=1+1", expected: []katas.Violation{}},
+		{input: "x=$((1+1))", expected: []katas.Violation{}},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/katatests/zc1035_test.go
+++ b/pkg/katas/katatests/zc1035_test.go
@@ -7,26 +7,18 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/testutil"
 )
 
+// ZC1035 was retired as a duplicate of ZC1022 (see issue #345). It is
+// kept as a no-op stub so legacy `disabled_katas` lists that reference
+// it keep parsing; the canonical `let` → `$((...))` guidance fires
+// under ZC1022 now.
+
 func TestCheckZC1035(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected []katas.Violation
 	}{
-		{
-			input: `let x=1+1`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1035",
-					Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-					Line:    1,
-					Column:  1,
-				},
-			},
-		},
-		{
-			input:    `x=$((1+1))`,
-			expected: []katas.Violation{},
-		},
+		{input: "let x=1+1", expected: []katas.Violation{}},
+		{input: "x=$((1+1))", expected: []katas.Violation{}},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/katatests/zc1093_test.go
+++ b/pkg/katas/katatests/zc1093_test.go
@@ -7,57 +7,19 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/testutil"
 )
 
-func TestZC1093(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected []katas.Violation
-	}{
-		{
-			name:     "valid redirect",
-			input:    `grep pattern < file.txt`,
-			expected: []katas.Violation{},
-		},
-		{
-			name:     "valid cat with flags",
-			input:    `cat -n file.txt | head`,
-			expected: []katas.Violation{},
-		},
-		{
-			name:     "valid cat multiple files",
-			input:    `cat file1 file2 | sort`,
-			expected: []katas.Violation{},
-		},
-		{
-			name:  "invalid useless cat",
-			input: `cat file.txt | grep pattern`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1093",
-					Message: "`cat file | command` is inefficient. Use `command < file` or pass the filename as an argument.",
-					Line:    1,
-					Column:  14,
-				},
-			},
-		},
-		{
-			name:  "invalid useless cat with sort",
-			input: `cat data.csv | sort`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1093",
-					Message: "`cat file | command` is inefficient. Use `command < file` or pass the filename as an argument.",
-					Line:    1,
-					Column:  14,
-				},
-			},
-		},
-	}
+// ZC1093 was retired as a duplicate of ZC1038. Kept as a no-op stub so
+// legacy `disabled_katas` lists keep parsing; the detection runs under
+// ZC1038 now.
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			violations := testutil.Check(tt.input, "ZC1093")
-			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+func TestZC1093Stub(t *testing.T) {
+	cases := []string{
+		"echo hi",
+		"ls",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			v := testutil.Check(in, "ZC1093")
+			testutil.AssertViolations(t, in, v, []katas.Violation{})
 		})
 	}
 }

--- a/pkg/katas/katatests/zc1277_test.go
+++ b/pkg/katas/katatests/zc1277_test.go
@@ -7,52 +7,19 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/testutil"
 )
 
-func TestZC1277(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected []katas.Violation
-	}{
-		{
-			name:     "valid tr for other transformations",
-			input:    `tr -d '\n'`,
-			expected: []katas.Violation{},
-		},
-		{
-			name:     "valid Zsh :l modifier",
-			input:    `echo ${var:l}`,
-			expected: []katas.Violation{},
-		},
-		{
-			name:  "invalid tr uppercase to lowercase POSIX class",
-			input: `tr '[:upper:]' '[:lower:]'`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1277",
-					Message: "Use Zsh parameter expansion `${var:l}` for lowercase conversion instead of `tr`. The `:l` modifier is built-in.",
-					Line:    1,
-					Column:  1,
-				},
-			},
-		},
-		{
-			name:  "invalid tr lowercase to uppercase range",
-			input: `tr '[a-z]' '[A-Z]'`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1277",
-					Message: "Use Zsh parameter expansion `${var:u}` for uppercase conversion instead of `tr`. The `:u` modifier is built-in.",
-					Line:    1,
-					Column:  1,
-				},
-			},
-		},
-	}
+// ZC1277 was retired as a duplicate of ZC1108. Kept as a no-op stub so
+// legacy `disabled_katas` lists keep parsing; the detection runs under
+// ZC1108 now.
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			violations := testutil.Check(tt.input, "ZC1277")
-			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+func TestZC1277Stub(t *testing.T) {
+	cases := []string{
+		"echo hi",
+		"ls",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			v := testutil.Check(in, "ZC1277")
+			testutil.AssertViolations(t, in, v, []katas.Violation{})
 		})
 	}
 }

--- a/pkg/katas/katatests/zc1278_test.go
+++ b/pkg/katas/katatests/zc1278_test.go
@@ -7,40 +7,19 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/testutil"
 )
 
-func TestZC1278(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected []katas.Violation
-	}{
-		{
-			name:     "valid arithmetic expansion",
-			input:    `echo $(( 1 + 2 ))`,
-			expected: []katas.Violation{},
-		},
-		{
-			name:     "valid other command",
-			input:    `echo hello`,
-			expected: []katas.Violation{},
-		},
-		{
-			name:  "invalid expr usage",
-			input: `expr 1 + 2`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1278",
-					Message: "Use Zsh arithmetic expansion `$(( ))` instead of `expr`. It is built-in and avoids forking.",
-					Line:    1,
-					Column:  1,
-				},
-			},
-		},
-	}
+// ZC1278 was retired as a duplicate of ZC1009. Kept as a no-op stub so
+// legacy `disabled_katas` lists keep parsing; the detection runs under
+// ZC1009 now.
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			violations := testutil.Check(tt.input, "ZC1278")
-			testutil.AssertViolations(t, tt.input, violations, tt.expected)
+func TestZC1278Stub(t *testing.T) {
+	cases := []string{
+		"echo hi",
+		"ls",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			v := testutil.Check(in, "ZC1278")
+			testutil.AssertViolations(t, in, v, []katas.Violation{})
 		})
 	}
 }

--- a/pkg/katas/zc1018.go
+++ b/pkg/katas/zc1018.go
@@ -4,34 +4,21 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
+// Issue #343: ZC1018 fires on the same input as the canonical
+// ZC1009 with overlapping advice. Stubbed to a no-op so legacy
+// `disabled_katas` lists keep parsing; the detection now lives in
+// ZC1009.
+
 func init() {
 	RegisterKata(ast.SimpleCommandNode, Kata{
-		ID:    "ZC1018",
-		Title: "Use `((...))` for C-style arithmetic instead of `expr`",
-		Description: "The `((...))` construct in Zsh allows for C-style arithmetic. " +
-			"It is generally more efficient and readable than using `expr` or other " +
-			"external commands for arithmetic.",
-		Severity: SeverityInfo,
-		Check:    checkZC1018,
+		ID:          "ZC1018",
+		Title:       "Superseded by ZC1009 — retired duplicate",
+		Severity:    SeverityStyle,
+		Description: "Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. See https://github.com/afadesigns/zshellcheck/issues/343 for context; the canonical detection lives in ZC1009.",
+		Check:       checkZC1018,
 	})
 }
 
-func checkZC1018(node ast.Node) []Violation {
-	violations := []Violation{}
-
-	if cmd, ok := node.(*ast.SimpleCommand); ok {
-		if ident, ok := cmd.Name.(*ast.Identifier); ok {
-			if ident.Value == "expr" {
-				violations = append(violations, Violation{
-					KataID:  "ZC1018",
-					Message: "Use `((...))` for C-style arithmetic instead of `expr`.",
-					Line:    ident.Token.Line,
-					Column:  ident.Token.Column,
-					Level:   SeverityInfo,
-				})
-			}
-		}
-	}
-
-	return violations
+func checkZC1018(ast.Node) []Violation {
+	return nil
 }

--- a/pkg/katas/zc1019.go
+++ b/pkg/katas/zc1019.go
@@ -4,34 +4,21 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
+// Issue #342: ZC1019 fires on the same input as the canonical
+// ZC1005 with overlapping advice. Stubbed to a no-op so legacy
+// `disabled_katas` lists keep parsing; the detection now lives in
+// ZC1005.
+
 func init() {
 	RegisterKata(ast.SimpleCommandNode, Kata{
-		ID:    "ZC1019",
-		Title: "Use `whence` instead of `which`",
-		Description: "The `which` command is an external command and may not be available on all systems. " +
-			"The `whence` command is a built-in Zsh command that provides a more reliable and consistent " +
-			"way to find the location of a command.",
-		Severity: SeverityInfo,
-		Check:    checkZC1019,
+		ID:          "ZC1019",
+		Title:       "Superseded by ZC1005 — retired duplicate",
+		Severity:    SeverityStyle,
+		Description: "Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. See https://github.com/afadesigns/zshellcheck/issues/342 for context; the canonical detection lives in ZC1005.",
+		Check:       checkZC1019,
 	})
 }
 
-func checkZC1019(node ast.Node) []Violation {
-	violations := []Violation{}
-
-	if cmd, ok := node.(*ast.SimpleCommand); ok {
-		if ident, ok := cmd.Name.(*ast.Identifier); ok {
-			if ident.Value == "which" {
-				violations = append(violations, Violation{
-					KataID:  "ZC1019",
-					Message: "Use `whence` instead of `which`.",
-					Line:    ident.Token.Line,
-					Column:  ident.Token.Column,
-					Level:   SeverityInfo,
-				})
-			}
-		}
-	}
-
-	return violations
+func checkZC1019(ast.Node) []Violation {
+	return nil
 }

--- a/pkg/katas/zc1023.go
+++ b/pkg/katas/zc1023.go
@@ -4,29 +4,24 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
+// Per issue #345: ZC1023–ZC1029, ZC1033, ZC1035 were identical copies of
+// the canonical ZC1022 `let` detection, each emitting the same violation
+// on the same input. Ten fires per `let` line inflated user-visible noise.
+// Project rule ("once committed, fix — don't remove") keeps the IDs alive
+// as no-op stubs so existing `disabled_katas` lists that reference them
+// keep parsing, but the duplicate detection is retired in favour of
+// ZC1022.
+
 func init() {
 	RegisterKata(ast.LetStatementNode, Kata{
-		ID:    "ZC1023",
-		Title: "Use `$((...))` for arithmetic expansion",
-		Description: "The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. " +
-			"It is more readable and can be nested easily, unlike `let`.",
-		Severity: SeverityStyle,
-		Check:    checkZC1023,
+		ID:          "ZC1023",
+		Title:       "Superseded by ZC1022 — retired duplicate `let` detector",
+		Severity:    SeverityStyle,
+		Description: "Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.",
+		Check:       checkZC1023,
 	})
 }
 
-func checkZC1023(node ast.Node) []Violation {
-	violations := []Violation{}
-
-	if let, ok := node.(*ast.LetStatement); ok {
-		violations = append(violations, Violation{
-			KataID:  "ZC1023",
-			Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-			Line:    let.Token.Line,
-			Column:  let.Token.Column,
-			Level:   SeverityStyle,
-		})
-	}
-
-	return violations
+func checkZC1023(ast.Node) []Violation {
+	return nil
 }

--- a/pkg/katas/zc1024.go
+++ b/pkg/katas/zc1024.go
@@ -4,29 +4,24 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
+// Per issue #345: ZC1023–ZC1029, ZC1033, ZC1035 were identical copies of
+// the canonical ZC1022 `let` detection, each emitting the same violation
+// on the same input. Ten fires per `let` line inflated user-visible noise.
+// Project rule ("once committed, fix — don't remove") keeps the IDs alive
+// as no-op stubs so existing `disabled_katas` lists that reference them
+// keep parsing, but the duplicate detection is retired in favour of
+// ZC1022.
+
 func init() {
 	RegisterKata(ast.LetStatementNode, Kata{
-		ID:    "ZC1024",
-		Title: "Use `$((...))` for arithmetic expansion",
-		Description: "The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. " +
-			"It is more readable and can be nested easily, unlike `let`.",
-		Severity: SeverityStyle,
-		Check:    checkZC1024,
+		ID:          "ZC1024",
+		Title:       "Superseded by ZC1022 — retired duplicate `let` detector",
+		Severity:    SeverityStyle,
+		Description: "Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.",
+		Check:       checkZC1024,
 	})
 }
 
-func checkZC1024(node ast.Node) []Violation {
-	violations := []Violation{}
-
-	if let, ok := node.(*ast.LetStatement); ok {
-		violations = append(violations, Violation{
-			KataID:  "ZC1024",
-			Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-			Line:    let.Token.Line,
-			Column:  let.Token.Column,
-			Level:   SeverityStyle,
-		})
-	}
-
-	return violations
+func checkZC1024(ast.Node) []Violation {
+	return nil
 }

--- a/pkg/katas/zc1025.go
+++ b/pkg/katas/zc1025.go
@@ -4,29 +4,24 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
+// Per issue #345: ZC1023–ZC1029, ZC1033, ZC1035 were identical copies of
+// the canonical ZC1022 `let` detection, each emitting the same violation
+// on the same input. Ten fires per `let` line inflated user-visible noise.
+// Project rule ("once committed, fix — don't remove") keeps the IDs alive
+// as no-op stubs so existing `disabled_katas` lists that reference them
+// keep parsing, but the duplicate detection is retired in favour of
+// ZC1022.
+
 func init() {
 	RegisterKata(ast.LetStatementNode, Kata{
-		ID:    "ZC1025",
-		Title: "Use `$((...))` for arithmetic expansion",
-		Description: "The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. " +
-			"It is more readable and can be nested easily, unlike `let`.",
-		Severity: SeverityStyle,
-		Check:    checkZC1025,
+		ID:          "ZC1025",
+		Title:       "Superseded by ZC1022 — retired duplicate `let` detector",
+		Severity:    SeverityStyle,
+		Description: "Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.",
+		Check:       checkZC1025,
 	})
 }
 
-func checkZC1025(node ast.Node) []Violation {
-	violations := []Violation{}
-
-	if let, ok := node.(*ast.LetStatement); ok {
-		violations = append(violations, Violation{
-			KataID:  "ZC1025",
-			Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-			Line:    let.Token.Line,
-			Column:  let.Token.Column,
-			Level:   SeverityStyle,
-		})
-	}
-
-	return violations
+func checkZC1025(ast.Node) []Violation {
+	return nil
 }

--- a/pkg/katas/zc1026.go
+++ b/pkg/katas/zc1026.go
@@ -4,29 +4,24 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
+// Per issue #345: ZC1023–ZC1029, ZC1033, ZC1035 were identical copies of
+// the canonical ZC1022 `let` detection, each emitting the same violation
+// on the same input. Ten fires per `let` line inflated user-visible noise.
+// Project rule ("once committed, fix — don't remove") keeps the IDs alive
+// as no-op stubs so existing `disabled_katas` lists that reference them
+// keep parsing, but the duplicate detection is retired in favour of
+// ZC1022.
+
 func init() {
 	RegisterKata(ast.LetStatementNode, Kata{
-		ID:    "ZC1026",
-		Title: "Use `$((...))` for arithmetic expansion",
-		Description: "The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. " +
-			"It is more readable and can be nested easily, unlike `let`.",
-		Severity: SeverityStyle,
-		Check:    checkZC1026,
+		ID:          "ZC1026",
+		Title:       "Superseded by ZC1022 — retired duplicate `let` detector",
+		Severity:    SeverityStyle,
+		Description: "Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.",
+		Check:       checkZC1026,
 	})
 }
 
-func checkZC1026(node ast.Node) []Violation {
-	violations := []Violation{}
-
-	if let, ok := node.(*ast.LetStatement); ok {
-		violations = append(violations, Violation{
-			KataID:  "ZC1026",
-			Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-			Line:    let.Token.Line,
-			Column:  let.Token.Column,
-			Level:   SeverityStyle,
-		})
-	}
-
-	return violations
+func checkZC1026(ast.Node) []Violation {
+	return nil
 }

--- a/pkg/katas/zc1027.go
+++ b/pkg/katas/zc1027.go
@@ -4,29 +4,24 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
+// Per issue #345: ZC1023–ZC1029, ZC1033, ZC1035 were identical copies of
+// the canonical ZC1022 `let` detection, each emitting the same violation
+// on the same input. Ten fires per `let` line inflated user-visible noise.
+// Project rule ("once committed, fix — don't remove") keeps the IDs alive
+// as no-op stubs so existing `disabled_katas` lists that reference them
+// keep parsing, but the duplicate detection is retired in favour of
+// ZC1022.
+
 func init() {
 	RegisterKata(ast.LetStatementNode, Kata{
-		ID:    "ZC1027",
-		Title: "Use `$((...))` for arithmetic expansion",
-		Description: "The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. " +
-			"It is more readable and can be nested easily, unlike `let`.",
-		Severity: SeverityStyle,
-		Check:    checkZC1027,
+		ID:          "ZC1027",
+		Title:       "Superseded by ZC1022 — retired duplicate `let` detector",
+		Severity:    SeverityStyle,
+		Description: "Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.",
+		Check:       checkZC1027,
 	})
 }
 
-func checkZC1027(node ast.Node) []Violation {
-	violations := []Violation{}
-
-	if let, ok := node.(*ast.LetStatement); ok {
-		violations = append(violations, Violation{
-			KataID:  "ZC1027",
-			Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-			Line:    let.Token.Line,
-			Column:  let.Token.Column,
-			Level:   SeverityStyle,
-		})
-	}
-
-	return violations
+func checkZC1027(ast.Node) []Violation {
+	return nil
 }

--- a/pkg/katas/zc1028.go
+++ b/pkg/katas/zc1028.go
@@ -4,29 +4,24 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
+// Per issue #345: ZC1023–ZC1029, ZC1033, ZC1035 were identical copies of
+// the canonical ZC1022 `let` detection, each emitting the same violation
+// on the same input. Ten fires per `let` line inflated user-visible noise.
+// Project rule ("once committed, fix — don't remove") keeps the IDs alive
+// as no-op stubs so existing `disabled_katas` lists that reference them
+// keep parsing, but the duplicate detection is retired in favour of
+// ZC1022.
+
 func init() {
 	RegisterKata(ast.LetStatementNode, Kata{
-		ID:    "ZC1028",
-		Title: "Use `$((...))` for arithmetic expansion",
-		Description: "The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. " +
-			"It is more readable and can be nested easily, unlike `let`.",
-		Severity: SeverityStyle,
-		Check:    checkZC1028,
+		ID:          "ZC1028",
+		Title:       "Superseded by ZC1022 — retired duplicate `let` detector",
+		Severity:    SeverityStyle,
+		Description: "Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.",
+		Check:       checkZC1028,
 	})
 }
 
-func checkZC1028(node ast.Node) []Violation {
-	violations := []Violation{}
-
-	if let, ok := node.(*ast.LetStatement); ok {
-		violations = append(violations, Violation{
-			KataID:  "ZC1028",
-			Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-			Line:    let.Token.Line,
-			Column:  let.Token.Column,
-			Level:   SeverityStyle,
-		})
-	}
-
-	return violations
+func checkZC1028(ast.Node) []Violation {
+	return nil
 }

--- a/pkg/katas/zc1029.go
+++ b/pkg/katas/zc1029.go
@@ -4,29 +4,24 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
+// Per issue #345: ZC1023–ZC1029, ZC1033, ZC1035 were identical copies of
+// the canonical ZC1022 `let` detection, each emitting the same violation
+// on the same input. Ten fires per `let` line inflated user-visible noise.
+// Project rule ("once committed, fix — don't remove") keeps the IDs alive
+// as no-op stubs so existing `disabled_katas` lists that reference them
+// keep parsing, but the duplicate detection is retired in favour of
+// ZC1022.
+
 func init() {
 	RegisterKata(ast.LetStatementNode, Kata{
-		ID:    "ZC1029",
-		Title: "Use `$((...))` for arithmetic expansion",
-		Description: "The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. " +
-			"It is more readable and can be nested easily, unlike `let`.",
-		Severity: SeverityStyle,
-		Check:    checkZC1029,
+		ID:          "ZC1029",
+		Title:       "Superseded by ZC1022 — retired duplicate `let` detector",
+		Severity:    SeverityStyle,
+		Description: "Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.",
+		Check:       checkZC1029,
 	})
 }
 
-func checkZC1029(node ast.Node) []Violation {
-	violations := []Violation{}
-
-	if let, ok := node.(*ast.LetStatement); ok {
-		violations = append(violations, Violation{
-			KataID:  "ZC1029",
-			Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-			Line:    let.Token.Line,
-			Column:  let.Token.Column,
-			Level:   SeverityStyle,
-		})
-	}
-
-	return violations
+func checkZC1029(ast.Node) []Violation {
+	return nil
 }

--- a/pkg/katas/zc1033.go
+++ b/pkg/katas/zc1033.go
@@ -4,29 +4,24 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
+// Per issue #345: ZC1023–ZC1029, ZC1033, ZC1035 were identical copies of
+// the canonical ZC1022 `let` detection, each emitting the same violation
+// on the same input. Ten fires per `let` line inflated user-visible noise.
+// Project rule ("once committed, fix — don't remove") keeps the IDs alive
+// as no-op stubs so existing `disabled_katas` lists that reference them
+// keep parsing, but the duplicate detection is retired in favour of
+// ZC1022.
+
 func init() {
 	RegisterKata(ast.LetStatementNode, Kata{
-		ID:    "ZC1033",
-		Title: "Use `$((...))` for arithmetic expansion",
-		Description: "The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. " +
-			"It is more readable and can be nested easily, unlike `let`.",
-		Severity: SeverityStyle,
-		Check:    checkZC1033,
+		ID:          "ZC1033",
+		Title:       "Superseded by ZC1022 — retired duplicate `let` detector",
+		Severity:    SeverityStyle,
+		Description: "Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.",
+		Check:       checkZC1033,
 	})
 }
 
-func checkZC1033(node ast.Node) []Violation {
-	violations := []Violation{}
-
-	if let, ok := node.(*ast.LetStatement); ok {
-		violations = append(violations, Violation{
-			KataID:  "ZC1033",
-			Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-			Line:    let.Token.Line,
-			Column:  let.Token.Column,
-			Level:   SeverityStyle,
-		})
-	}
-
-	return violations
+func checkZC1033(ast.Node) []Violation {
+	return nil
 }

--- a/pkg/katas/zc1035.go
+++ b/pkg/katas/zc1035.go
@@ -4,29 +4,24 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
+// Per issue #345: ZC1023–ZC1029, ZC1033, ZC1035 were identical copies of
+// the canonical ZC1022 `let` detection, each emitting the same violation
+// on the same input. Ten fires per `let` line inflated user-visible noise.
+// Project rule ("once committed, fix — don't remove") keeps the IDs alive
+// as no-op stubs so existing `disabled_katas` lists that reference them
+// keep parsing, but the duplicate detection is retired in favour of
+// ZC1022.
+
 func init() {
 	RegisterKata(ast.LetStatementNode, Kata{
-		ID:    "ZC1035",
-		Title: "Use `$((...))` for arithmetic expansion",
-		Description: "The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. " +
-			"It is more readable and can be nested easily, unlike `let`.",
-		Severity: SeverityStyle,
-		Check:    checkZC1035,
+		ID:          "ZC1035",
+		Title:       "Superseded by ZC1022 — retired duplicate `let` detector",
+		Severity:    SeverityStyle,
+		Description: "Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. The canonical `let` → `$((...))` guidance lives in ZC1022; see https://github.com/afadesigns/zshellcheck/issues/345.",
+		Check:       checkZC1035,
 	})
 }
 
-func checkZC1035(node ast.Node) []Violation {
-	violations := []Violation{}
-
-	if let, ok := node.(*ast.LetStatement); ok {
-		violations = append(violations, Violation{
-			KataID:  "ZC1035",
-			Message: "Use `$((...))` for arithmetic expansion instead of `let`.",
-			Line:    let.Token.Line,
-			Column:  let.Token.Column,
-			Level:   SeverityStyle,
-		})
-	}
-
-	return violations
+func checkZC1035(ast.Node) []Violation {
+	return nil
 }

--- a/pkg/katas/zc1093.go
+++ b/pkg/katas/zc1093.go
@@ -4,52 +4,21 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
+// Issue #341: ZC1093 fires on the same input as the canonical
+// ZC1038 with overlapping advice. Stubbed to a no-op so legacy
+// `disabled_katas` lists keep parsing; the detection now lives in
+// ZC1038.
+
 func init() {
-	RegisterKata(ast.InfixExpressionNode, Kata{
-		ID:    "ZC1093",
-		Title: "Avoid useless `cat`",
-		Description: "`cat file | command` spawns an unnecessary process. " +
-			"Use `command < file` or pass the file as an argument directly.",
-		Severity: SeverityStyle,
-		Check:    checkZC1093,
+	RegisterKata(ast.SimpleCommandNode, Kata{
+		ID:          "ZC1093",
+		Title:       "Superseded by ZC1038 — retired duplicate",
+		Severity:    SeverityStyle,
+		Description: "Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. See https://github.com/afadesigns/zshellcheck/issues/341 for context; the canonical detection lives in ZC1038.",
+		Check:       checkZC1093,
 	})
 }
 
-func checkZC1093(node ast.Node) []Violation {
-	pipe, ok := node.(*ast.InfixExpression)
-	if !ok || pipe.Operator != "|" {
-		return nil
-	}
-
-	catCmd, ok := pipe.Left.(*ast.SimpleCommand)
-	if !ok {
-		return nil
-	}
-
-	ident, ok := catCmd.Name.(*ast.Identifier)
-	if !ok || ident.Value != "cat" {
-		return nil
-	}
-
-	// cat with flags like -n, -v, -e is not useless
-	for _, arg := range catCmd.Arguments {
-		val := arg.String()
-		if len(val) > 0 && val[0] == '-' {
-			return nil
-		}
-	}
-
-	// Must have exactly one file argument
-	if len(catCmd.Arguments) != 1 {
-		return nil
-	}
-
-	return []Violation{{
-		KataID: "ZC1093",
-		Message: "`cat file | command` is inefficient. " +
-			"Use `command < file` or pass the filename as an argument.",
-		Line:   pipe.TokenLiteralNode().Line,
-		Column: pipe.TokenLiteralNode().Column,
-		Level:  SeverityStyle,
-	}}
+func checkZC1093(ast.Node) []Violation {
+	return nil
 }

--- a/pkg/katas/zc1277.go
+++ b/pkg/katas/zc1277.go
@@ -1,63 +1,24 @@
 package katas
 
 import (
-	"strings"
-
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
+// Issue #344: ZC1277 fires on the same input as the canonical
+// ZC1108 with overlapping advice. Stubbed to a no-op so legacy
+// `disabled_katas` lists keep parsing; the detection now lives in
+// ZC1108.
+
 func init() {
 	RegisterKata(ast.SimpleCommandNode, Kata{
-		ID:       "ZC1277",
-		Title:    "Use Zsh `${var:l}` / `${var:u}` instead of `tr` for case conversion",
-		Severity: SeverityStyle,
-		Description: "Zsh provides the `:l` (lowercase) and `:u` (uppercase) modifiers for parameter " +
-			"expansion, avoiding the overhead of piping through `tr` for case conversion.",
-		Check: checkZC1277,
+		ID:          "ZC1277",
+		Title:       "Superseded by ZC1108 — retired duplicate",
+		Severity:    SeverityStyle,
+		Description: "Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. See https://github.com/afadesigns/zshellcheck/issues/344 for context; the canonical detection lives in ZC1108.",
+		Check:       checkZC1277,
 	})
 }
 
-func checkZC1277(node ast.Node) []Violation {
-	cmd, ok := node.(*ast.SimpleCommand)
-	if !ok {
-		return nil
-	}
-
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok || ident.Value != "tr" {
-		return nil
-	}
-
-	if len(cmd.Arguments) < 2 {
-		return nil
-	}
-
-	first := strings.Trim(cmd.Arguments[0].String(), "'\"")
-	second := strings.Trim(cmd.Arguments[1].String(), "'\"")
-
-	if (first == "[:upper:]" && second == "[:lower:]") ||
-		(first == "[A-Z]" && second == "[a-z]") ||
-		(first == "A-Z" && second == "a-z") {
-		return []Violation{{
-			KataID:  "ZC1277",
-			Message: "Use Zsh parameter expansion `${var:l}` for lowercase conversion instead of `tr`. The `:l` modifier is built-in.",
-			Line:    cmd.Token.Line,
-			Column:  cmd.Token.Column,
-			Level:   SeverityStyle,
-		}}
-	}
-
-	if (first == "[:lower:]" && second == "[:upper:]") ||
-		(first == "[a-z]" && second == "[A-Z]") ||
-		(first == "a-z" && second == "A-Z") {
-		return []Violation{{
-			KataID:  "ZC1277",
-			Message: "Use Zsh parameter expansion `${var:u}` for uppercase conversion instead of `tr`. The `:u` modifier is built-in.",
-			Line:    cmd.Token.Line,
-			Column:  cmd.Token.Column,
-			Level:   SeverityStyle,
-		}}
-	}
-
+func checkZC1277(ast.Node) []Violation {
 	return nil
 }

--- a/pkg/katas/zc1278.go
+++ b/pkg/katas/zc1278.go
@@ -4,33 +4,21 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 )
 
+// Issue #343: ZC1278 fires on the same input as the canonical
+// ZC1009 with overlapping advice. Stubbed to a no-op so legacy
+// `disabled_katas` lists keep parsing; the detection now lives in
+// ZC1009.
+
 func init() {
 	RegisterKata(ast.SimpleCommandNode, Kata{
-		ID:       "ZC1278",
-		Title:    "Use `$(( ))` instead of `expr` for arithmetic",
-		Severity: SeverityStyle,
-		Description: "`expr` is an external command for arithmetic. Zsh has native arithmetic " +
-			"expansion `$(( ))` which is faster and more readable.",
-		Check: checkZC1278,
+		ID:          "ZC1278",
+		Title:       "Superseded by ZC1009 — retired duplicate",
+		Severity:    SeverityStyle,
+		Description: "Retained as a no-op stub so legacy `.zshellcheckrc` files that disable this ID keep parsing. See https://github.com/afadesigns/zshellcheck/issues/343 for context; the canonical detection lives in ZC1009.",
+		Check:       checkZC1278,
 	})
 }
 
-func checkZC1278(node ast.Node) []Violation {
-	cmd, ok := node.(*ast.SimpleCommand)
-	if !ok {
-		return nil
-	}
-
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok || ident.Value != "expr" {
-		return nil
-	}
-
-	return []Violation{{
-		KataID:  "ZC1278",
-		Message: "Use Zsh arithmetic expansion `$(( ))` instead of `expr`. It is built-in and avoids forking.",
-		Line:    cmd.Token.Line,
-		Column:  cmd.Token.Column,
-		Level:   SeverityStyle,
-	}}
+func checkZC1278(ast.Node) []Violation {
+	return nil
 }


### PR DESCRIPTION
Closes #341 #342 #343 #344 #345.

## What

Fourteen katas were firing on the same input as another kata with identical advice:

| Duplicate IDs | Canonical | Issue |
| :--- | :--- | :--- |
| ZC1023, ZC1024, ZC1025, ZC1026, ZC1027, ZC1028, ZC1029, ZC1033, ZC1035 (nine `let` clones) | **ZC1022** | #345 |
| ZC1093 | **ZC1038** (useless `cat`) | #341 |
| ZC1019 | **ZC1005** (`which` → `whence`) | #342 |
| ZC1018 + ZC1278 | **ZC1009** (`expr` → `((...))`) | #343 |
| ZC1277 | **ZC1108** (`tr` → Zsh case conversion) | #344 |

## How

Per project rule *"once committed, fix — don't remove"*, the 14 IDs stay alive as documented no-op stubs so existing `.zshellcheckrc` files that say `disabled_katas: [ZC1023]` keep parsing. Each stub carries a title that points at the canonical kata and a description linking the tracking issue.

## Test plan
- [x] `go test ./...` green — every stub test asserts no violations
- [x] `golangci-lint run ./...` clean
- [x] KATAS.md regenerated via `go run ./internal/tools/gen-katas-md`