### PR TITLE
fix: 3 parser/lexer bugs (#126 elif, #347, #435)

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -315,6 +315,15 @@ func (l *Lexer) NextToken() token.Token {
 			line, col := l.line, l.column
 			tok.Literal = l.readIdentifier()
 			tok.Type = token.LookupIdent(tok.Literal)
+			// An identifier that happens to match a keyword but is immediately
+			// followed by `=` is a flag/argument assignment (e.g. `if=foo`
+			// inside `dd if=foo of=bar`), not the keyword itself. Demote it
+			// to a plain identifier so the parser treats the following `=`
+			// as part of the same word rather than trying to open an
+			// if-statement.
+			if tok.Type != token.IDENT && l.ch == '=' {
+				tok.Type = token.IDENT
+			}
 			tok.Line = line
 			tok.Column = col
 			tok.HasPrecedingSpace = hasSpace

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -623,3 +623,61 @@ func TestNextToken_LineAndColumnTracking(t *testing.T) {
 		t.Errorf("second token line expected 2, got %d", tok2.Line)
 	}
 }
+
+// TestNextToken_KeywordFollowedByEquals exercises the regression fix for
+// https://github.com/afadesigns/zshellcheck/issues/435: when an identifier
+// that happens to match a Zsh keyword (`if`, `of`, `while`, `do`, etc.) is
+// immediately followed by `=`, it is a flag-style assignment token (as in
+// `dd if=foo of=bar`), not the keyword. The lexer must return IDENT so the
+// parser treats the whole run as a single word.
+func TestNextToken_KeywordFollowedByEquals(t *testing.T) {
+	cases := []struct {
+		input  string
+		expect []struct {
+			t token.Type
+			l string
+		}
+	}{
+		{
+			input: `dd if=src of=dst`,
+			expect: []struct {
+				t token.Type
+				l string
+			}{
+				{token.IDENT, "dd"},
+				{token.IDENT, "if"},
+				{token.ASSIGN, "="},
+				{token.IDENT, "src"},
+				{token.IDENT, "of"},
+				{token.ASSIGN, "="},
+				{token.IDENT, "dst"},
+			},
+		},
+		{
+			input: `while=10 do=go`,
+			expect: []struct {
+				t token.Type
+				l string
+			}{
+				{token.IDENT, "while"},
+				{token.ASSIGN, "="},
+				{token.INT, "10"},
+				{token.IDENT, "do"},
+				{token.ASSIGN, "="},
+				{token.IDENT, "go"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			l := New(c.input)
+			for i, exp := range c.expect {
+				tok := l.NextToken()
+				if tok.Type != exp.t || tok.Literal != exp.l {
+					t.Fatalf("token[%d]: expected {%s %q}, got {%s %q}", i, exp.t, exp.l, tok.Type, tok.Literal)
+				}
+			}
+		})
+	}
+}

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -330,11 +330,39 @@ func (p *Parser) parseIfStatement() *ast.IfStatement {
 	}
 
 	p.nextToken() // consume "then"
-	stmt.Consequence = p.parseBlockStatement(token.ELSE, token.Fi)
+	stmt.Consequence = p.parseBlockStatement(token.ELSE, token.ELIF, token.Fi)
+
+	// Collapse any chain of `elif CONDITION; then BODY` clauses into a
+	// right-nested IfStatement stored on the outer `Alternative`. We
+	// thread the latest elif so the next one can attach to it.
+	var tailElif *ast.IfStatement
+	for p.curTokenIs(token.ELIF) {
+		elifToken := p.curToken
+		p.nextToken() // consume "elif"
+		elif := &ast.IfStatement{Token: elifToken}
+		elif.Condition = p.parseBlockStatement(token.THEN)
+		if !p.curTokenIs(token.THEN) {
+			return nil
+		}
+		p.nextToken() // consume "then"
+		elif.Consequence = p.parseBlockStatement(token.ELSE, token.ELIF, token.Fi)
+
+		if tailElif == nil {
+			stmt.Alternative = elif
+		} else {
+			tailElif.Alternative = elif
+		}
+		tailElif = elif
+	}
 
 	if p.curTokenIs(token.ELSE) {
 		p.nextToken() // consume "else"
-		stmt.Alternative = p.parseBlockStatement(token.Fi)
+		tail := p.parseBlockStatement(token.Fi)
+		if tailElif == nil {
+			stmt.Alternative = tail
+		} else {
+			tailElif.Alternative = tail
+		}
 	}
 	if !p.curTokenIs(token.Fi) {
 		p.peekError(token.Fi)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -2818,3 +2818,60 @@ func TestCaseStatementSemicolonsInBody(t *testing.T) {
 		t.Fatalf("expected 1 clause, got %d", len(stmt.Clauses))
 	}
 }
+
+// TestParser_DDCommandWithIfOfKeywords is the regression test for
+// https://github.com/afadesigns/zshellcheck/issues/435. `dd if=foo of=bar`
+// contains identifiers that happen to match the `if`/`of` keyword prefix
+// — the lexer must demote them to IDENT when `=` follows so the parser
+// does not try to open an if-statement.
+func TestParser_DDCommandWithIfOfKeywords(t *testing.T) {
+	inputs := []string{
+		`dd if=src of=dst`,
+		`dd if=/tmp/x of=/tmp/y bs=4M`,
+		`some_tool if=arg`,
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			l := lexer.New(input)
+			p := New(l)
+			p.ParseProgram()
+			if errs := p.Errors(); len(errs) > 0 {
+				t.Fatalf("unexpected parser errors on %q: %v", input, errs)
+			}
+		})
+	}
+}
+
+// TestParser_ForLoopAndOr is the regression test for
+// https://github.com/afadesigns/zshellcheck/issues/347. `for ... in ...;
+// do ...; done` and `||` previously raised parser errors; both must
+// parse cleanly now.
+func TestParser_ForLoopAndOr(t *testing.T) {
+	inputs := []string{
+		`for x in a b c; do echo $x; done`,
+		`true || echo fail`,
+		`cmd1 || cmd2 || cmd3`,
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			l := lexer.New(input)
+			p := New(l)
+			p.ParseProgram()
+			if errs := p.Errors(); len(errs) > 0 {
+				t.Fatalf("unexpected parser errors on %q: %v", input, errs)
+			}
+		})
+	}
+}
+
+// TestParser_IfElifElseFi is the regression test for the elif branch of
+// https://github.com/afadesigns/zshellcheck/issues/126.
+func TestParser_IfElifElseFi(t *testing.T) {
+	input := "if [[ $a == 1 ]]; then\n  echo one\nelif [[ $a == 2 ]]; then\n  echo two\nelse\n  echo other\nfi\n"
+	l := lexer.New(input)
+	p := New(l)
+	p.ParseProgram()
+	if errs := p.Errors(); len(errs) > 0 {
+		t.Fatalf("unexpected parser errors: %v", errs)
+	}
+}


### PR DESCRIPTION
Closes #347 #435. Partially closes #126 (elif branch — alias-dash part and remaining #126 sub-bug stay open).

## Lexer (#435)

`dd if=src of=dst` used to raise `no prefix parse function for = found` because the lexer unconditionally promoted `if` / `of` to the `IF` / `OF`-prefix keyword token even when `=` was immediately next. Fix in `pkg/lexer/lexer.go`: after `LookupIdent`, if the matched keyword is immediately followed by `=`, demote back to `IDENT`. Applies to every keyword on the `token.keywords` table.

## Parser (#126 elif branch)

`parseIfStatement` terminated `Consequence` on `ELSE` / `Fi` only — an `elif` clause fell through to the generic `parseStatement` path and errored with `no prefix parse function for ELIF found`. Fix in `pkg/parser/parser_stmt.go`: extend the terminator set to include `ELIF`, and loop while `curToken` is `ELIF` to build a right-nested `IfStatement` chain on `Alternative`. Trailing `else` block attaches to the innermost elif.

## Tests

- `pkg/lexer/lexer_test.go`: `TestNextToken_KeywordFollowedByEquals` exercises `dd if=foo of=bar` and `while=10 do=go`.
- `pkg/parser/parser_test.go`:
  - `TestParser_DDCommandWithIfOfKeywords` — regression for #435 parsed without errors.
  - `TestParser_ForLoopAndOr` — locks in that `for … in … do … done` and `||` chains parse cleanly (issue #347 already fixed; no behaviour change, just a guard-rail).
  - `TestParser_IfElifElseFi` — regression for #126 elif branch.

## Test plan
- [x] `go test -count=1 ./...` green across all packages
- [x] `golangci-lint run ./...` clean
- [x] Manual repro: `echo 'dd if=src of=dst' | zshellcheck /dev/stdin` now exits 0

## Outstanding

- #129 parameter-expansion operators (`${var:-default}`, `${var#prefix}`, …) require a new `ast.ParameterExpansion` node and a reshape of `parseArrayAccess`. That's a dedicated PR; tracked in #129.