### PR TITLE
feat: inline disable directives (#127)

### DIFF
--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -141,7 +141,7 @@ func loadConfig(path string) (config.Config, error) {
 	return config.MergeConfig(cfg, fileConfig), nil
 }
 
-func processPath(path string, out, errOut io.Writer, config config.Config, registry *katas.KatasRegistry, format string, allowedSeverities []katas.Severity) int {
+func processPath(path string, out, errOut io.Writer, cfg config.Config, registry *katas.KatasRegistry, format string, allowedSeverities []katas.Severity) int {
 	info, err := os.Stat(path)
 	if err != nil {
 		fmt.Fprintf(errOut, "Error stating path %s: %s\n", path, err)
@@ -171,19 +171,19 @@ func processPath(path string, out, errOut io.Writer, config config.Config, regis
 			// For now, let's try to parse everything, or maybe filter by extension/shebang if it gets too noisy.
 			// Shellcheck defaults to checking all files passed, but for recursive it might filter.
 			// Let's assume user wants to check all files in the dir if they passed the dir.
-			count += processFile(p, out, errOut, config, registry, format, allowedSeverities)
+			count += processFile(p, out, errOut, cfg, registry, format, allowedSeverities)
 			return nil
 		})
 		if err != nil {
 			fmt.Fprintf(errOut, "Error walking directory %s: %s\n", path, err)
 		}
 	} else {
-		count += processFile(path, out, errOut, config, registry, format, allowedSeverities)
+		count += processFile(path, out, errOut, cfg, registry, format, allowedSeverities)
 	}
 	return count
 }
 
-func processFile(filename string, out, errOut io.Writer, config config.Config, registry *katas.KatasRegistry, format string, allowedSeverities []katas.Severity) int {
+func processFile(filename string, out, errOut io.Writer, cfg config.Config, registry *katas.KatasRegistry, format string, allowedSeverities []katas.Severity) int {
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		fmt.Fprintf(errOut, "Error reading file %s: %s\n", filename, err)
@@ -205,11 +205,29 @@ func processFile(filename string, out, errOut io.Writer, config config.Config, r
 		return 1
 	}
 
+	directives := config.ParseDirectives(string(data))
+	disabled := cfg.DisabledKatas
+	if len(directives.File) > 0 {
+		disabled = append(append([]string(nil), disabled...), directives.File...)
+	}
+
 	violations := []katas.Violation{}
 	ast.Walk(program, func(node ast.Node) bool {
-		violations = append(violations, registry.Check(node, config.DisabledKatas)...)
+		violations = append(violations, registry.Check(node, disabled)...)
 		return true // Continue walking
 	})
+
+	// Drop violations silenced by a per-line `# zshellcheck disable=…` directive.
+	if len(directives.PerLine) > 0 {
+		kept := violations[:0]
+		for _, v := range violations {
+			if directives.IsDisabledOn(v.KataID, v.Line) {
+				continue
+			}
+			kept = append(kept, v)
+		}
+		violations = kept
+	}
 
 	// Filter violations by severity
 	var filteredViolations []katas.Violation
@@ -233,7 +251,7 @@ func processFile(filename string, out, errOut io.Writer, config config.Config, r
 		case "sarif":
 			r = reporter.NewSarifReporter(out, filename)
 		default:
-			r = reporter.NewTextReporter(out, filename, string(data), config)
+			r = reporter.NewTextReporter(out, filename, string(data), cfg)
 		}
 		if err := r.Report(violations); err != nil {
 			fmt.Fprintf(errOut, "Error reporting violations: %s\n", err)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -63,6 +63,24 @@ disabled_katas:
 
 Refer to `KATAS.md` for the list of IDs.
 
+### Inline Disable Directives
+
+Silence katas directly inside a script without touching `.zshellcheckrc`. Comments are recognised in three forms:
+
+```zsh
+# Trailing — silence only this line:
+rm -rf /tmp/noise  # zshellcheck disable=ZC1136,ZC1075
+
+# Preceding — silence only the next non-blank code line:
+# zshellcheck disable=ZC1030
+echo "ok"
+
+# File-tail — a directive with no code after it disables the IDs file-wide:
+# zshellcheck disable=ZC1092
+```
+
+Multiple IDs may be separated by commas or whitespace. IDs disabled inline are merged with any `disabled_katas` from `.zshellcheckrc`.
+
 ---
 
 ## Integrations

--- a/pkg/config/directives.go
+++ b/pkg/config/directives.go
@@ -1,0 +1,136 @@
+package config
+
+import (
+	"bufio"
+	"regexp"
+	"strings"
+)
+
+// Directives captures per-file and per-line `# zshellcheck disable=…`
+// annotations found in a source file. Populated by ParseDirectives and
+// consumed alongside the config-level DisabledKatas list.
+type Directives struct {
+	// File contains kata IDs disabled for every line in the file. Any
+	// `# zshellcheck disable=…` comment with no associated target line
+	// (e.g. on its own line at the top of the file, before any code)
+	// lands here.
+	File []string
+	// PerLine maps a 1-based line number to the kata IDs disabled for
+	// just that line. Two forms produce entries:
+	//  1. Trailing comment: `cmd  # zshellcheck disable=ZC1234`
+	//     disables ZC1234 on the same line.
+	//  2. Preceding directive: a line whose sole content is
+	//     `# zshellcheck disable=ZC1234` disables the IDs on the *next*
+	//     non-blank, non-comment line.
+	PerLine map[int][]string
+}
+
+// HasAny returns true if the directive set disables any kata, anywhere.
+func (d Directives) HasAny() bool {
+	return len(d.File) > 0 || len(d.PerLine) > 0
+}
+
+// directiveRe matches the `zshellcheck disable=<ids>` directive inside
+// any Zsh comment. The leading `#` (and optional whitespace) is handled
+// by the caller — the regexp captures from the directive keyword on.
+var directiveRe = regexp.MustCompile(`zshellcheck\s+disable\s*=\s*([A-Za-z0-9_,\s]+)`)
+
+// ParseDirectives scans source text for `# zshellcheck disable=…`
+// annotations and returns the file-wide and per-line sets.
+func ParseDirectives(source string) Directives {
+	d := Directives{PerLine: make(map[int][]string)}
+
+	scanner := bufio.NewScanner(strings.NewReader(source))
+	// Guard against single very-long lines overflowing the default buffer.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	lineNo := 0
+	pendingFrom := 0 // line number of a "preceding" directive waiting for a target
+	var pendingIDs []string
+
+	for scanner.Scan() {
+		lineNo++
+		raw := scanner.Text()
+		trimmed := strings.TrimSpace(raw)
+
+		hashIdx := strings.Index(raw, "#")
+		if hashIdx < 0 {
+			// No comment on this line. If a pending directive is waiting,
+			// it applies to this line (assuming the line has content).
+			if len(pendingIDs) > 0 && trimmed != "" {
+				d.PerLine[lineNo] = append(d.PerLine[lineNo], pendingIDs...)
+				pendingIDs = nil
+				pendingFrom = 0
+			}
+			continue
+		}
+
+		comment := raw[hashIdx+1:]
+		match := directiveRe.FindStringSubmatch(comment)
+		if match == nil {
+			// A regular comment on this line "consumes" a pending directive
+			// only if the line has code before the comment.
+			if len(pendingIDs) > 0 && strings.TrimSpace(raw[:hashIdx]) != "" {
+				d.PerLine[lineNo] = append(d.PerLine[lineNo], pendingIDs...)
+				pendingIDs = nil
+				pendingFrom = 0
+			}
+			continue
+		}
+
+		ids := splitIDs(match[1])
+
+		// Determine whether the directive is trailing (has code on the same
+		// line) or standalone (comment-only line).
+		before := strings.TrimSpace(raw[:hashIdx])
+		if before != "" {
+			// Trailing comment — applies to this line.
+			d.PerLine[lineNo] = append(d.PerLine[lineNo], ids...)
+			continue
+		}
+
+		// Comment-only directive. If it sits above another directive, the
+		// earlier one also applied to the upcoming code line; merge them.
+		pendingIDs = append(pendingIDs, ids...)
+		pendingFrom = lineNo
+	}
+
+	// Any directive that never found a target line (empty file tail, or
+	// the whole source is just directives) becomes file-wide.
+	if len(pendingIDs) > 0 && pendingFrom > 0 {
+		d.File = append(d.File, pendingIDs...)
+	}
+
+	return d
+}
+
+func splitIDs(list string) []string {
+	raw := strings.FieldsFunc(list, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t'
+	})
+	out := make([]string, 0, len(raw))
+	for _, s := range raw {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// IsDisabledOn reports whether the given kata ID is silenced on the
+// 1-based line number via this directive set.
+func (d Directives) IsDisabledOn(kataID string, line int) bool {
+	for _, id := range d.File {
+		if id == kataID {
+			return true
+		}
+	}
+	for _, id := range d.PerLine[line] {
+		if id == kataID {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/directives_test.go
+++ b/pkg/config/directives_test.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseDirectives_Trailing(t *testing.T) {
+	src := `echo hi  # zshellcheck disable=ZC1075
+echo again
+`
+	d := ParseDirectives(src)
+	if !d.IsDisabledOn("ZC1075", 1) {
+		t.Errorf("expected ZC1075 disabled on line 1")
+	}
+	if d.IsDisabledOn("ZC1075", 2) {
+		t.Errorf("did not expect ZC1075 disabled on line 2")
+	}
+}
+
+func TestParseDirectives_PrecedingOwnLine(t *testing.T) {
+	src := `# zshellcheck disable=ZC1136,ZC1141
+rm -rf /tmp/noisy
+echo after
+`
+	d := ParseDirectives(src)
+	if !d.IsDisabledOn("ZC1136", 2) {
+		t.Errorf("expected ZC1136 disabled on line 2")
+	}
+	if !d.IsDisabledOn("ZC1141", 2) {
+		t.Errorf("expected ZC1141 disabled on line 2")
+	}
+	if d.IsDisabledOn("ZC1136", 3) {
+		t.Errorf("did not expect ZC1136 disabled on line 3")
+	}
+}
+
+func TestParseDirectives_FileTail(t *testing.T) {
+	// Directive at file end with no code after it becomes file-wide.
+	src := `echo hi
+# zshellcheck disable=ZC1075
+`
+	d := ParseDirectives(src)
+	if !d.IsDisabledOn("ZC1075", 42) {
+		t.Errorf("expected ZC1075 disabled file-wide")
+	}
+}
+
+func TestParseDirectives_MultipleIDs(t *testing.T) {
+	src := `rm -rf /tmp/x # zshellcheck disable=ZC1136, ZC1075
+`
+	d := ParseDirectives(src)
+	if !reflect.DeepEqual(d.PerLine[1], []string{"ZC1136", "ZC1075"}) {
+		t.Errorf("expected [ZC1136 ZC1075] on line 1, got %v", d.PerLine[1])
+	}
+}
+
+func TestParseDirectives_None(t *testing.T) {
+	d := ParseDirectives("echo hello\n")
+	if d.HasAny() {
+		t.Error("expected no directives")
+	}
+}


### PR DESCRIPTION
ZC #127 — Inline `# zshellcheck disable=…` directives

## What
Per-line and file-wide suppression via Zsh comments. Three recognised forms:

| Form | Scope |
|---|---|
| `cmd  # zshellcheck disable=ZC1234` | Just this line |
| `# zshellcheck disable=ZC1234` above a code line | Just the next code line |
| `# zshellcheck disable=ZC1234` with no code after it | File-wide |

Multiple IDs: comma- or whitespace-separated. Inline IDs merge with the config `disabled_katas` list.

## Why
Users want targeted one-off suppression at the call site without touching `.zshellcheckrc` or hiding context. Matches the shellcheck ergonomic model users already know.

## Implementation
* `pkg/config/directives.go` — `ParseDirectives(source)` scans once, returns `File []string` + `PerLine map[int][]string`. `IsDisabledOn(id, line)` answers the per-line question.
* `cmd/zshellcheck/main.go` `processFile` — merges `directives.File` into the config disable list before walking, then filters per-line hits after walking.
* Docs: new **Inline Disable Directives** section in USER_GUIDE.md.

## Tests
Five unit tests in `pkg/config/directives_test.go` covering trailing, preceding, file-tail, multi-ID, and no-directive paths. Smoke-tested end-to-end against real violations (`ZC1030` / `ZC1092`) in all three forms.

## Severity
Feature — no severity.