### PR TITLE
ci: drop removed `--skip-git` flag from OSV scanner

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -43,7 +43,6 @@ jobs:
         with:
           scan-args: |-
             --recursive
-            --skip-git
             --format=sarif
             --output=osv-results.sarif
             ./


### PR DESCRIPTION
OSV-Scanner v2 removed the `--skip-git` flag. The workflow was pre-failing every PR with `flag provided but not defined: -skip-git` before a scan ever started. Drop the flag — `--recursive` alone covers the intended scope.