### PR TITLE
chore: rename action for Marketplace + bump to 1.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.11] - 2026-04-20
+
+### Changed
+- `action.yml` — rename `name` from `ZShellCheck` to `ZshellCheck` (lowercase `h`). Marketplace requires a unique action name; the original capitalization collided with an existing registry entry. The action identifier (`afadesigns/zshellcheck@vX.Y.Z`) is unchanged.
+
 ## [1.0.10] - 2026-04-20
 
 **Versioning switch.** The kata-count formula (MAJOR = count/1000,

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'ZShellCheck'
+name: 'ZshellCheck'
 description: 'Static analysis for Zsh scripts — 1000 Zsh-native checks (katas) covering syntax, security, portability, and style.'
 author: 'afadesigns'
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,4 +3,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.0.10"
+const Version = "1.0.11"


### PR DESCRIPTION
Marketplace rejected the bare `ZShellCheck` name (collision). Rename to `ZshellCheck` (lowercase h) and bump version.

Action identifier (`afadesigns/zshellcheck@v…`) unchanged.