### PR TITLE
chore: rename action to 'ZshellCheck v1' + bump to 1.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.12] - 2026-04-20
+
+### Changed
+- `action.yml` — extend `name` to `ZshellCheck v1` (the `ZshellCheck` form from v1.0.11 still collided with an existing Marketplace registry entry). The action identifier (`afadesigns/zshellcheck@vX.Y.Z`) is unchanged.
+
 ## [1.0.11] - 2026-04-20
 
 ### Changed

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'ZshellCheck'
+name: 'ZshellCheck v1'
 description: 'Static analysis for Zsh scripts — 1000 Zsh-native checks (katas) covering syntax, security, portability, and style.'
 author: 'afadesigns'
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,4 +3,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.0.11"
+const Version = "1.0.12"


### PR DESCRIPTION
The `ZshellCheck` name still collided on Marketplace. Append ` v1` to disambiguate.

Action identifier unchanged.