### PR TITLE
fix: use correct pre-commit language

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,5 +2,5 @@
     name: ZShellCheck
     description: Static analysis tool for Zsh scripts.
     entry: zshellcheck
-    language: go
+    language: golang
     files: \.zsh$


### PR DESCRIPTION
## Summary

Replace `go` with `golang` in the pre-commit hook configuration.

## Background

While `go` is a common abbreviation, it should actually be `golang`. Ran into this when installing this using [prek](https://prek.j178.dev/) which produced an error:

```
  caused by: error: line 5 column 15: unknown variant `go`, expected one of bun, conda, coursier, dart, deno, docker, docker_image, dotnet, fail, golang, haskell, julia, lua, node, perl, pygrep, python, r, ruby, rust, script, unsupported_script, swift, system, unsupported
```

Ref: https://pre-commit.com/#golang
Ref: https://github.com/j178/prek/blob/fba1c85b1f2ce244e4b491ccaa0edffbdee01348/crates/prek/src/languages/version.rs#L42

## Type of change

- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `docs`: Documentation update
- [ ] `chore`: Maintenance (deps, build, etc.)
- [ ] `refactor`: Code restructuring
- [ ] `test`: Adding missing tests

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
- [x] I have read the [DEVELOPMENT.md](DEVELOPMENT.md) guide.
- [ ] **Linting**: My code passes `go fmt` and `go vet`.
- [ ] **Tests**: I have added tests for my changes (especially for new Katas).
- [ ] **Integration**: I have run `./tests/integration_test.zsh` and it passes.
- [x] **Documentation**: I have updated relevant documentation (if applicable).

_Since the change is so trivial, I changed the file within GitHub's web interface directly. I have not run local lints/tests, but do not believe they are needed._

## For New Katas (If Applicable)

- [ ] Added `pkg/katas/zcXXXX.go`
- [ ] Registered in `pkg/katas/katas.go`
- [ ] Added tests in `pkg/katas/katatests/zcXXXX_test.go`
- [ ] Verified that the ID (`ZCXXXX`) is unique and sequential.