### PR TITLE
fix: parse bare `$+name[idx]` and `(( )) && (( ))` chains (#1047)

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -179,6 +179,29 @@ func (p *Parser) parseInvalidArrayAccessPrefix() ast.Expression {
 		return &ast.PrefixExpression{Token: dollarToken, Operator: "$", Right: ident}
 	}
 
+	// `$+name` / `$+name[key]` — parameter-existence test, equivalent to
+	// `${+name}` / `${+name[key]}`. Commonly used inside `(( ... ))`.
+	if p.peekTokenIs(token.PLUS) {
+		p.nextToken() // move to '+'
+		plusToken := p.curToken
+		if !p.expectPeek(token.IDENT) {
+			return nil
+		}
+		ident := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+		plus := &ast.PrefixExpression{Token: plusToken, Operator: "+", Right: ident}
+		if !p.peekTokenIs(token.LBRACKET) {
+			return &ast.PrefixExpression{Token: dollarToken, Operator: "$", Right: plus}
+		}
+		p.nextToken() // consume [
+		exp := &ast.InvalidArrayAccess{Token: dollarToken, Left: plus}
+		p.nextToken()
+		exp.Index = p.parseExpression(LOWEST)
+		if !p.expectPeek(token.RBRACKET) {
+			return nil
+		}
+		return exp
+	}
+
 	if !p.expectPeek(token.IDENT) {
 		return nil
 	}

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -45,6 +45,28 @@ func (p *Parser) parseStatement() ast.Statement {
 		if cmd == nil {
 			return nil
 		}
+		// Chain with `&&` / `||` when the arithmetic command is followed
+		// by a logical operator: `(( A )) && (( B )) || other-command`.
+		if p.peekTokenIs(token.AND) || p.peekTokenIs(token.OR) {
+			var left ast.Expression = cmd
+			for p.peekTokenIs(token.AND) || p.peekTokenIs(token.OR) {
+				p.nextToken()
+				op := p.curToken
+				p.nextToken() // move to start of right command
+				right := p.parseCommandPipeline()
+				left = &ast.InfixExpression{
+					Token:    op,
+					Operator: op.Literal,
+					Left:     left,
+					Right:    right,
+				}
+			}
+			stmt := &ast.ExpressionStatement{Token: cmd.Token, Expression: left}
+			if p.peekTokenIs(token.SEMICOLON) {
+				p.nextToken()
+			}
+			return stmt
+		}
 		return cmd
 	case token.COLON, token.DOT, token.LBRACKET,
 		token.GT, token.LT, token.GTGT, token.LTLT, token.GTAMP, token.LTAMP, token.AMPERSAND, token.SLASH:

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1008,6 +1008,56 @@ func TestArithmeticCommand(t *testing.T) {
 	}
 }
 
+func TestArithmeticParamExistenceBare(t *testing.T) {
+	// `(( $+name ))` and `(( $+name[key] ))` — bare `$+...` inside arithmetic.
+	// Regression test for issue #1047.
+	cases := []string{
+		`(( $+commands[ls] ))`,
+		`(( $+foo ))`,
+		`(( $+arr[key] ))`,
+	}
+	for _, input := range cases {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%s: unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
+func TestArithmeticLogicalChain(t *testing.T) {
+	// `(( A )) && (( B ))`, `(( A )) || (( B ))`, and mixed chains.
+	// Regression test for issue #1047.
+	cases := []string{
+		`(( 1 )) && (( 2 ))`,
+		`(( 1 )) || (( 2 ))`,
+		`(( $+commands[ls] )) && (( $+commands[eza] ))`,
+		`(( 1 )) && (( 2 )) || (( 3 ))`,
+	}
+	for _, input := range cases {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%s: unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
+func TestArithmeticInsideIfWithLogicalChain(t *testing.T) {
+	// The original repro from #1047.
+	input := `if (( $+commands[ls] )) && (( $+commands[eza] )); then
+  echo "ok"
+fi`
+	l := lexer.New(input)
+	p := New(l)
+	_ = p.ParseProgram()
+	if errs := p.Errors(); len(errs) != 0 {
+		t.Errorf("unexpected parser errors: %v", errs)
+	}
+}
+
 func TestSubshellStatement(t *testing.T) {
 	input := "(echo hello)"
 	l := lexer.New(input)


### PR DESCRIPTION
Closes #1047.

## Bugs

1. **Bare `$+name` / `$+name[key]` inside `(( … ))`** errored with `expected next token to be IDENT, got + instead`. Worked only in braced form `${+name[key]}`.
2. **`(( A )) && (( B ))` chains** (and `||`) errored with `no prefix parse function for && found`. Logical operators between arithmetic commands dropped on the floor.

## Fixes

1. `parser_expr.go` — `parseInvalidArrayAccessPrefix`: when the token after `$` is `+`, consume `+`, read the identifier, and attach optional `[key]` as `InvalidArrayAccess`. Produces the same shape as the working `${+name[key]}` path.
2. `parser_stmt.go` — `parseStatement` `DoubleLparen` case: after the `ArithmeticCommand`, loop on `AND`/`OR` building an `InfixExpression` whose right side comes from `parseCommandPipeline`. Wrap in `ExpressionStatement` so downstream walkers see a normal logical command.

## Tests

`parser_test.go` — three new tests covering bare-form primitives, `&&`/`||`/mixed chains, and the original issue repro inside an `if` block.

## Not in this PR

`${var:-default}` / `${var:=x}` / `${var##glob}` — tracked in #129. Needs a new `ast.ParameterExpansion` node plus lexer tokens for `:-`, `:+`, `:?`, `:=`, `##`, `%%`. Separate design pass.

## Test plan

- [x] `go test -count=1 ./...` green locally
- [x] `/srv/tools/go/bin/golangci-lint run ./...` clean
- [x] Original repro from #1047 parses without errors
- [ ] CI required checks (test / security / sbom) green