### PR TITLE
chore: bump version to 1.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.13] - 2026-04-22
+
+### Fixed
+- **Parser**: bare `$+name` / `$+name[key]` inside `(( … ))` no longer errors with `expected next token to be IDENT, got + instead`. Equivalent shape to the working `${+name[key]}` path. (#1047)
+- **Parser**: `(( A )) && (( B ))` / `||` chains (and mixed) no longer error with `no prefix parse function for && found`. Logical operators after an arithmetic command now parse into a normal `InfixExpression`. (#1047)
+
+### Changed
+- `.pre-commit-hooks.yaml` — `language: go` → `language: golang`, the canonical pre-commit language identifier. Fixes installation under `prek`. (#1046)
+
 ## [1.0.12] - 2026-04-20
 
 ### Changed

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,4 +3,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.0.12"
+const Version = "1.0.13"


### PR DESCRIPTION
Ship v1.0.13 with parser fixes for #1047 and pre-commit language fix from #1046.