### PR TITLE
docs: pass 1 — correctness fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,144 +1,102 @@
 # Contributing to ZShellCheck
 
-We welcome contributions! Whether it's adding new Katas, improving the parser, or fixing bugs, your help is appreciated.
+Thanks for helping improve ZShellCheck. This guide covers the PR workflow, how to add a kata, and the local checks you should run before pushing.
+
+For deeper internals (lexer/parser/AST design, release process, architecture diagrams), see the [Developer Guide](docs/DEVELOPER.md).
 
 ## Quick Start
 
-To set up your development environment and install the binary locally:
-
 ```bash
-# This will build from source and install to your local bin
+git clone https://github.com/afadesigns/zshellcheck.git
+cd zshellcheck
 ./install.sh
 ```
 
-For detailed instructions, see the [Developer Guide](docs/DEVELOPER.md).
+The installer builds from source when run inside the repo, or downloads the signed release binary otherwise. See [Developer Guide — Getting Started](docs/DEVELOPER.md#getting-started) for prerequisites.
 
-## Fuzz Testing
+## Pull Request Workflow
 
-We use native Go fuzzing to ensure the stability of our lexer and parser.
-To run the fuzz tests locally:
+1. **Sync `main`**
+   ```bash
+   git switch main
+   git pull origin main
+   ```
+2. **Branch** with a conventional prefix (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`, `perf/`, `test/`, `ci/`):
+   ```bash
+   git switch -c fix/short-description
+   ```
+3. **Implement + test locally.** See [Local Checks](#local-checks) below.
+4. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/):
+   - `feat: ZC#### — detect <pattern>`
+   - `fix: ZC#### false positive on <case>`
+   - `docs: update USER_GUIDE for inline directives`
+   - `ci: tighten golangci timeout`
+   - `chore: bump go-release action pin`
+   - Commits are **GPG-signed**. `commit.gpgsign=true` or append `-S`.
+5. **Push + PR:**
+   ```bash
+   git push -u origin <branch>
+   gh pr create --fill
+   ```
+6. **Review:** CODEOWNERS (@afadesigns) must approve. All required checks (`test`, `security`, `sbom`) must pass. CI will reject unsigned commits.
+7. **Merge:** maintainer squash-merges on green.
+
+### Link issues
+Use `Closes #N` / `Fixes #N` in the PR body so the issue auto-closes on merge.
+
+## Local Checks
+
+Before pushing, run:
+
+```bash
+go test -count=1 ./...
+/srv/tools/go/bin/golangci-lint run ./...
+go vet ./...
+```
+
+Or run `pre-commit run --all-files` if you have `pre-commit` installed — the project ships `.pre-commit-config.yaml` and `.pre-commit-hooks.yaml` covering lint, format, tests, and a trace scan.
+
+Fuzz tests are time-boxed; run them when touching lexer/parser:
 
 ```bash
 go test -fuzz=FuzzLexer -fuzztime=10s ./pkg/lexer
 go test -fuzz=FuzzParser -fuzztime=10s ./pkg/parser
 ```
 
-## Security Reporting
+## Adding a New Kata
 
-Please refer to [SECURITY.md](SECURITY.md) for our security policy and how to report vulnerabilities.
+A kata is a Zsh-specific detection rule. Full scaffold + conventions live in the [Developer Guide — Creating a New Kata](docs/DEVELOPER.md#creating-a-new-kata). Short form:
 
+1. Pick the next ID: `ls pkg/katas/zc*.go | sort | tail -1`
+2. Create `pkg/katas/zc<NNNN>.go` registering the kata.
+3. Create `pkg/katas/katatests/zc<NNNN>_test.go` with valid + invalid fixtures.
+4. Once committed, **fix — don't remove** a kata. Retire duplicates as no-op stubs (pattern: `ZC1018`, `ZC1022`).
 
+### Kata Conventions
 
-We follow a strict Pull Request (PR) workflow to ensure code quality and maintain a clear history. This workflow is designed to facilitate smooth collaboration and maintain an organized project.
+- **Zsh-specific only.** Reject generic POSIX-sh anti-patterns — ShellCheck covers those.
+- **Severity required.** One of `SeverityError`, `SeverityWarning`, `SeverityInfo`, `SeverityStyle`. See [Severity Levels](docs/USER_GUIDE.md#severity-levels).
+- **Never `panic()` in `Check`.** Use `ok`-checked type assertions. A kata panic kills the linter.
+- **No duplicates.** Grep existing katas before writing a new one.
+- **Backtick-quote shell syntax** in titles, descriptions, and messages. End sentences with a period.
 
-1.  **Sync `main`**: Before starting new work, ensure your local `main` branch is up-to-date with the remote `main`.
-    ```bash
-    git checkout main
-    git pull origin main
-    ```
-2.  **Create a Branch**: Always create a new, descriptive branch for your changes. Use a prefix that indicates the type of change (e.g., `feat/`, `fix/`, `docs/`, `chore/`).
-    ```bash
-    git checkout -b feat/your-feature-name
-    ```
-3.  **Implement & Test**: Make your changes, adhering to coding style and conventions.
-    *   **Unit Tests:** `go test -v -coverprofile=coverage.out ./...`
-    *   **Integration Tests:** `./tests/integration_test.zsh`
-    *   **Linting:** `golangci-lint run ./...` (or use `pre-commit run --all-files`)
-    *   **Formatting:** `gofumpt -w .`
-    *   **Spell Check:** `typos` (if installed) or rely on CI.
-4.  **Commit**: Commit your changes using [Conventional Commits](https://www.conventionalcommits.org/) for clear history. Examples:
-    *   `feat: Implement new Kata ZCXXXX (Short description)`
-    *   `fix: Resolve parser bug in arithmetic expressions`
-    *   `docs: Update wiki links`
-    *   `chore: Upgrade npm dependencies`
-5.  **Push**: Push your local branch to the remote repository.
-    ```bash
-    git push origin your-branch-name
-    ```
-6.  **Create Pull Request**: Use the GitHub CLI to create a Pull Request from your branch to `main`.
-    ```bash
-    gh pr create --title "feat: Your feature title" --body "A detailed description of your changes." --base main
-    ```
-    *   Provide a clear title and body explaining the *why* and *what* of your changes.
-    *   Link any relevant issues (e.g., `Closes #123`, `Fixes #45`).
-        *   **Labels**: Apply [appropriate labels](#project-labels) to your PR.
-    7.  **Review & Merge**: Address any review comments. Once approved and all CI checks pass, an administrator will merge the PR. We use squash merges to maintain a clean Git history.
-    
-    ## Documentation
-    
-    For comprehensive documentation, including detailed usage, configuration, and a full list of implemented Katas, please refer to [KATAS.md](KATAS.md).
-    
-    For developers, please refer to:
-    *   [Developer Guide](docs/DEVELOPER.md) - How to build, test, and debug.
-    *   [AST Reference](docs/DEVELOPER.md#ast-reference) - Detailed documentation of the Abstract Syntax Tree nodes.
-    *   [Architecture](docs/DEVELOPER.md#architecture-overview) - High-level overview of the system.
-    
-    ## Coding Style        *   We use `gofmt` for Go code formatting.
-    *   We follow the standard Go coding conventions.
-    *   Please ensure that your code is well-documented and easy to understand.
-    
-    ### Running Linters and Formatters
-    
-    Before submitting a Pull Request, please ensure your code passes all linting and formatting checks:
-    
-    ```bash
-    go fmt ./...       # Format Go code
-    go vet ./...       # Run Go vet (static analysis)
-    golangci-lint run  # Run golangci-lint (if installed)
-    ```
-    
-    ## Adding a New Kata
-    
-    Katas are the core rules of `zshellcheck`. To add one:
-    
-    1.  **Define the Kata:** Create a new file `pkg/katas/zcXXXX.go`.
-    2.  **Register:** In the `init()` function, register the Kata with the `RegisterKata` function, specifying the AST node type it targets.
-    3.  **Implement Logic:** Write the check function that inspects the node and returns a list of `Violation`s.
-    4.  **Add Tests:** Create `pkg/katas/katatests/zcXXXX_test.go` with test cases covering valid and invalid Zsh code.
-    
-    ### Severity Levels
+## Security
 
-    Every Kata must be assigned a severity level:
+Do not file vulnerabilities as public issues. See [SECURITY.md](SECURITY.md) for the reporting process.
 
-    | Level | Constant | When to Use |
-    | :--- | :--- | :--- |
-    | **error** | `SeverityError` | Bugs or dangerous constructs causing incorrect behavior |
-    | **warning** | `SeverityWarning` | Risky patterns with subtle issues or security concerns |
-    | **info** | `SeverityInfo` | Suggestions for improved practices and portability |
-    | **style** | `SeverityStyle` | Cosmetic or idiomatic improvements |
+## Labels
 
-    ### Example Kata
-
-    ```go
-    func init() {
-        RegisterKata(ast.SimpleCommandNode, Kata{
-            ID:          "ZC1099",
-            Title:       "Avoid foo command",
-            Description: "The foo command is deprecated.",
-            Severity:    SeverityStyle,
-            Check:       checkZC1099,
-        })
-    }
-    ```
-    
-    ## Project Labels
-    
-    We use a specific set of labels to categorize issues and pull requests, helping us organize and prioritize work effectively. Please use them appropriately.
-    
-    | Label | Description |
-    | :--- | :--- |
-    | **`feat`** | New features or significant enhancements. |
-    | **`fix`** | Bug fixes. |
-    | **`docs`** | Documentation changes or improvements. |
-    | **`ci`** | Updates to CI/CD configurations or workflows. |
-    | **`deps`** | Dependency updates. |
-    | **`refactor`** | Code restructuring without behavior changes. |
-    | **`test`** | Additions or corrections to tests. |
-    | **`chore`** | Routine maintenance tasks (e.g., updating build scripts, `.gitignore`). |
-    | **`starter`** | Good entry-level tasks for new contributors. |
-    | **`help`** | Requires extra attention or assistance. |
-    | **`question`** | Seeking further information or clarification. |
-    | **`nofix`** | The issue or request will not be addressed. |
-    | **`duplicate`** | This issue or PR is a duplicate. |
-    | **`invalid`** | The issue or PR is invalid or not applicable. |
-    
+| Label | Meaning |
+|---|---|
+| `feat` | New feature or significant enhancement |
+| `fix` | Bug fix |
+| `docs` | Documentation change |
+| `ci` | CI/CD change |
+| `deps` | Dependency bump |
+| `refactor` | Restructuring without behavior change |
+| `perf` | Performance improvement |
+| `test` | Test additions or fixes |
+| `chore` | Maintenance |
+| `starter` | Good first issue |
+| `help wanted` | Needs community input |
+| `duplicate` | Supersedes another issue/PR |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck)
 
-**ZShellCheck** (`v1.0.0` -- 1000 Katas) is the definitive static analysis and comprehensive development suite for the entire Zsh ecosystem, meticulously engineered as the full Zsh equivalent of ShellCheck for Bash. It offers intelligent automatic fixes (planned), advanced formatting capabilities, and deep code analysis to deliver unparalleled quality, performance, and reliability for Zsh scripts, functions, and configurations.
+**ZShellCheck** is a native static analyser for Zsh — 1000 Zsh-specific checks ("katas") covering syntax, security, portability, and style. Treat it as ShellCheck's counterpart for scripts that rely on Zsh-only features (parameter-expansion flags, glob qualifiers, `print`, `[[`, array semantics, modifiers).
 
 ## Inspiration
 
@@ -127,7 +127,7 @@ Add this to your `.pre-commit-config.yaml`:
 
 ```yaml
 -   repo: https://github.com/afadesigns/zshellcheck
-    rev: v1.0.0
+    rev: v1.0.13
     hooks:
     -   id: zshellcheck
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,10 +42,12 @@ ZShellCheck is an evolving static analysis tool for Zsh. Our mission is to provi
 
 ## Progress Tracking
 
-**Current Progress:** Version 1.0.0 (1000/1000 Katas -- 100%).
+**Current release:** v1.0.13 — 1000 katas.
 
 ```
 [================================================================================] 1000/1000
 ```
+
+v1.x hotfixes (parser, dedup, severity rebalance, XDG config, inline disable directives, Marketplace action rename) shipped between v1.0.0 and the current tag. See `CHANGELOG.md` for the full per-release history.
 
 For the list of currently implemented Katas, please refer to [KATAS.md](KATAS.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,12 @@
 
 ## Supported Versions
 
-Only the latest major version of ZShellCheck is officially supported with security updates.
+| Version | Supported |
+| ------- | --------- |
+| `v1.0.x` (latest minor) | Yes |
+| `< v1.0.0` | No |
 
-| Version | Supported          |
-| ------- | ------------------ |
-| Latest  | :white_check_mark: |
-| < 0.0.x | :x:                |
+Only the latest `v1.0.x` release receives security fixes. Upgrade to the latest tag before reporting — fixes land as new patch releases, not as backports.
 
 ## Reporting a Vulnerability
 
@@ -25,7 +25,7 @@ We take security seriously. If you have discovered a vulnerability in ZShellChec
 
 ### Response
 
-We will acknowledge your report within **48 hours** and provide an estimated timeline for the fix.
+Acknowledgement target: **7 days**. ZShellCheck is maintained by a solo developer; critical issues will be triaged sooner, but please do not assume a same-day response.
 
 ## Vulnerability Categories
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -44,9 +44,8 @@ This document serves as the comprehensive manual for contributing to the ZShellC
 ```
 
 **Manual Build:**
-To build the binary directly:
 ```bash
-go build -o zshellcheck cmd/zshellcheck/main.go
+go build ./cmd/zshellcheck
 ```
 
 ### Running Tests
@@ -71,32 +70,53 @@ We use the standard Go testing framework.
 
 ### Creating a New Kata
 
-1.  **Identify the Anti-Pattern**: What Zsh issue do you want to catch?
-2.  **Determine the AST Node**: Use the [AST Reference](#ast-reference) below to find the relevant node type.
-3.  **Create the File**: Add `pkg/katas/zcXXXX.go` (next available ID).
-4.  **Implement**:
+1.  **Identify the anti-pattern.** It must be **Zsh-specific** — generic POSIX-sh issues belong in ShellCheck, not here.
+2.  **Determine the AST node.** See the [AST Reference](#ast-reference) below.
+3.  **Grep existing katas** to avoid duplication: `grep -rn 'Title:' pkg/katas/ | grep -i '<keyword>'`.
+4.  **Scaffold the detection file** `pkg/katas/zc<NNNN>.go`:
+
     ```go
     package katas
+
     import "github.com/afadesigns/zshellcheck/pkg/ast"
 
     func init() {
         RegisterKata(ast.SimpleCommandNode, Kata{
             ID:          "ZCXXXX",
-            Title:       "Title of your check",
-            Description: "Description of what is wrong.",
-            Severity:    SeverityStyle, // See Severity Levels below
+            Title:       "Avoid `foo` — prefer `${bar:h}`",
+            Description: "Foo is a bash-ism; Zsh provides `${bar:h}` natively.",
+            Severity:    SeverityStyle,
             Check:       checkZCXXXX,
         })
     }
 
     func checkZCXXXX(node ast.Node) []Violation {
-        // Cast node to specific type
-        cmd := node.(*ast.SimpleCommand)
-        // Check logic...
-        return nil
+        cmd, ok := node.(*ast.SimpleCommand)
+        if !ok {
+            return nil
+        }
+        ident, ok := cmd.Name.(*ast.Identifier)
+        if !ok {
+            return nil
+        }
+        if ident.Value != "foo" {
+            return nil
+        }
+        return []Violation{{
+            KataID:  "ZCXXXX",
+            Message: "Avoid `foo` — use `${bar:h}`.",
+            Line:    cmd.Token.Line,
+            Column:  cmd.Token.Column,
+            Level:   SeverityStyle,
+        }}
     }
     ```
-5.  **Test**: Add `pkg/katas/katatests/zcXXXX_test.go` with test cases.
+
+    **Never `panic()` in `Check`.** Always use `ok`-checked type assertions. A kata panic kills the entire linter run. Return `nil` (not an empty slice) when no violations.
+
+5.  **Write tests** in `pkg/katas/katatests/zc<NNNN>_test.go` covering at least one violation case and one no-violation case.
+
+6.  **Once committed, fix — don't remove.** Retire duplicates as no-op stubs (see `ZC1018`, `ZC1022` for the pattern).
 
 ### Severity Levels
 
@@ -144,17 +164,33 @@ Understanding AST nodes is crucial for writing Katas.
 
 ### Common Node Types
 
--   **`SimpleCommandNode`**: Basic command execution (e.g., `ls -la`).
-    -   Fields: `Name` (Expression), `Arguments` ([]Expression).
--   **`IfStatementNode`**: `if` control structure.
-    -   Fields: `Condition`, `Consequence`, `Alternative` (BlockStatements).
--   **`ForLoopStatementNode`**: `for` loops (C-style and for-each).
-    -   Fields: `Init`, `Condition`, `Post`, `Items`, `Body`.
--   **`CommandSubstitutionNode`**: Backticks `` `...` ``.
--   **`DollarParenExpressionNode`**: `$(...)`.
--   **`ArithmeticCommandNode`**: `(( ... ))`.
--   **`BracketExpressionNode`**: `[ ... ]`.
--   **`DoubleBracketExpressionNode`**: `[[ ... ]]`.
+**Statements**
+-   **`SimpleCommandNode`** — basic command: `ls -la`. Fields: `Name` (Expression), `Arguments` ([]Expression), `Redirections`.
+-   **`IfStatementNode`** — `if … then … elif … else … fi`. Fields: `Condition`, `Consequence`, `Alternative`.
+-   **`WhileLoopStatementNode`** — `while … do … done`. Fields: `Condition`, `Body`.
+-   **`ForLoopStatementNode`** — both `for x in …` and C-style `for ((init; cond; post))`. Fields: `Init`, `Condition`, `Post`, `Items`, `Body`.
+-   **`CaseStatementNode`** — `case … in … esac`. Fields: `Subject`, `Cases`.
+-   **`FunctionDefinitionNode`** — `name() { … }` and `function name { … }`. Fields: `Name`, `Params`, `Body`.
+-   **`BlockStatementNode`** — statement lists.
+-   **`LetStatementNode`** — `let x=1`.
+-   **`DeclarationStatementNode`** — `typeset`, `declare`, `local`, `readonly`, `export`.
+-   **`SubshellNode`** — `( … )`.
+-   **`ArithmeticCommandNode`** — `(( … ))`.
+
+**Expressions**
+-   **`IdentifierNode`** — bare words.
+-   **`StringLiteralNode`** — quoted strings.
+-   **`InfixExpressionNode`** — binary ops and command chains (`&&`, `||`, `|`).
+-   **`PrefixExpressionNode`** — unary ops.
+-   **`CommandSubstitutionNode`** — backticks `` `…` ``.
+-   **`DollarParenExpressionNode`** — `$(…)`.
+-   **`ArrayAccessNode`** — `${arr[key]}`.
+-   **`InvalidArrayAccessNode`** — bare `$arr[key]` (raised as a kata, not a parser error).
+-   **`BracketExpressionNode`** — `[ … ]`.
+-   **`DoubleBracketExpressionNode`** — `[[ … ]]`.
+-   **`RedirectionNode`** — wraps a statement with `>`, `<`, `>>`, `<<`, `>&`, `<&`.
+
+Not every Zsh construct has its own node yet. Known gaps: parameter-expansion modifiers `${var:-default}` / `${var##glob}` (tracked in [#129](https://github.com/afadesigns/zshellcheck/issues/129)).
 
 ### Visitor Pattern
 
@@ -173,15 +209,35 @@ ast.Walk(rootNode, func(node ast.Node) bool {
 
 ## Release Process
 
-Releases are automated via [GoReleaser](https://goreleaser.com/).
+Since v1.0.10 ZShellCheck follows standard [semantic versioning](https://semver.org) and `pkg/version/version.go` is **hand-maintained** — the kata-count formula is retired. Tags are cut **manually** by the maintainer.
 
-1.  **Prepare**: Update `CHANGELOG.md`.
-2.  **Tag**: Push a semantic version tag (e.g., `v0.0.80`).
-    ```bash
-    git tag v0.0.80
-    git push origin v0.0.80
+1.  **Hand-bump** `pkg/version/version.go`:
+    ```go
+    const Version = "1.0.14"
     ```
-3.  **Build**: GitHub Actions will detect the tag, run tests, build binaries, and publish a GitHub Release.
+2.  **Update** `CHANGELOG.md` with a new `[1.0.14] - YYYY-MM-DD` section.
+3.  **Commit** the bump via PR → merge to main:
+    ```bash
+    git switch -c chore/bump-v1.0.14
+    git add pkg/version/version.go CHANGELOG.md
+    git commit -S -m "chore: bump version to 1.0.14"
+    git push -u origin chore/bump-v1.0.14
+    gh pr create --fill && gh pr merge --squash --auto
+    ```
+4.  **Sign + push the tag** at the merge SHA:
+    ```bash
+    git switch main && git pull --ff-only
+    git tag -s v1.0.14 $(git rev-parse main) -m 'v1.0.14'
+    git push origin v1.0.14
+    ```
+5.  **Release workflow fires** on tag push: GoReleaser builds signed binaries for Linux/macOS/Windows × x86_64/arm64/i386, attaches cosign signatures + SBOMs, and publishes SLSA provenance.
+6.  **Release title** = tag name only (e.g. `v1.0.14`). No descriptive suffix.
+
+### Gotchas
+
+-   Commit bodies must **not** contain the literal strings `#patch`, `#minor`, or `#major` — Release-Drafter matches these as version-bump keywords and will create ghost drafts. Use `#none` as a safety directive when the phrasing risks a match.
+-   Tags must be **signed** (`-s`). The required GPG key is `B5690EEEBB952194`.
+-   Never force-push `main`. For behind feature branches use merge-forward, not rebase.
 
 ---
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -131,7 +131,7 @@ Add to `.pre-commit-config.yaml`:
 
 ```yaml
 -   repo: https://github.com/afadesigns/zshellcheck
-    rev: v1.0.0
+    rev: v1.0.13
     hooks:
     -   id: zshellcheck
 ```


### PR DESCRIPTION
Pass 1 of a 3-pass doc audit. Fixes wrong or broken content across README, CONTRIBUTING, DEVELOPER, SECURITY, ROADMAP, USER_GUIDE. See the commit body for the detailed change list. Pass 2 will dedupe repeated tables; pass 3 adds missing sections (Marketplace example, CLI reference, FAQ).