### PR TITLE
docs: pass 5 — CITATION, PR template, shell completions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,33 +1,37 @@
 ## Description
 
 <!--
-Please include a summary of the change and which issue is fixed.
-If this PR adds a new Kata, please describe the check briefly.
+Summarise the change. If this PR adds a new kata, describe the pattern
+it detects and the Zsh semantics behind it.
 -->
 
-Fixes # (issue)
+Closes # (issue)
 
 ## Type of change
 
-- [ ] `feat`: New feature (non-breaking change which adds functionality)
-- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
-- [ ] `docs`: Documentation update
-- [ ] `chore`: Maintenance (deps, build, etc.)
-- [ ] `refactor`: Code restructuring
-- [ ] `test`: Adding missing tests
+- [ ] `feat`: new feature or enhancement
+- [ ] `fix`: bug fix
+- [ ] `docs`: documentation
+- [ ] `ci`: CI/CD
+- [ ] `deps`: dependency bump
+- [ ] `refactor`: restructuring without behavior change
+- [ ] `perf`: performance
+- [ ] `test`: test additions or fixes
+- [ ] `chore`: maintenance
 
 ## Checklist
 
-- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
-- [ ] I have read the [DEVELOPMENT.md](DEVELOPMENT.md) guide.
-- [ ] **Linting**: My code passes `go fmt` and `go vet`.
-- [ ] **Tests**: I have added tests for my changes (especially for new Katas).
-- [ ] **Integration**: I have run `./tests/integration_test.zsh` and it passes.
-- [ ] **Documentation**: I have updated relevant documentation (if applicable).
+- [ ] Read [CONTRIBUTING.md](../CONTRIBUTING.md).
+- [ ] `go test -count=1 ./...` passes locally.
+- [ ] `golangci-lint run ./...` clean.
+- [ ] Relevant documentation updated (`README.md`, `docs/USER_GUIDE.md`, `docs/DEVELOPER.md`, `CHANGELOG.md`).
+- [ ] Commits are GPG-signed.
 
-## For New Katas (If Applicable)
+## For new katas
 
-- [ ] Added `pkg/katas/zcXXXX.go`
-- [ ] Registered in `pkg/katas/katas.go`
-- [ ] Added tests in `pkg/katas/katatests/zcXXXX_test.go`
-- [ ] Verified that the ID (`ZCXXXX`) is unique and sequential.
+- [ ] Detection file at `pkg/katas/zc<NNNN>.go` (self-registers via `init()` — no central file edit needed).
+- [ ] Test file at `pkg/katas/katatests/zc<NNNN>_test.go` with both a violation case and a no-violation case.
+- [ ] `Severity` set on the `Kata{…}` literal (`SeverityError` / `Warning` / `Info` / `Style`).
+- [ ] Pattern is **Zsh-specific** — generic POSIX-sh anti-patterns belong in ShellCheck.
+- [ ] Grepped existing katas for overlap: `grep -rn 'Title:' pkg/katas/ | grep -i '<keyword>'`.
+- [ ] `Check` function uses `ok`-checked type assertions; never calls `panic()`.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,12 +6,12 @@ authors:
   alias: "afadesigns"
   email: "github@afadesign.co"
 title: "ZShellCheck"
-version: 1.0.0
-date-released: 2026-04-20
+version: 1.0.13
+date-released: 2026-04-23
 url: "https://github.com/afadesigns/zshellcheck"
 repository-code: "https://github.com/afadesigns/zshellcheck"
 license: "MIT"
-abstract: "The definitive static analysis and comprehensive development suite for the entire Zsh ecosystem, meticulously engineered as the full Zsh equivalent of ShellCheck for Bash."
+abstract: "Native static analyser for Zsh scripts. 1000 Zsh-specific checks covering syntax, security, portability, and style; the counterpart to ShellCheck for code that uses Zsh-only features."
 keywords:
   - zsh
   - shell

--- a/completions/bash/zshellcheck-completion.bash
+++ b/completions/bash/zshellcheck-completion.bash
@@ -7,13 +7,23 @@ _zshellcheck()
 
     case $prev in
         -format)
-            COMPREPLY=( $(compgen -W "text json" -- "$cur") )
+            COMPREPLY=( $(compgen -W "text json sarif" -- "$cur") )
+            return
+            ;;
+        -severity)
+            COMPREPLY=( $(compgen -W "error warning info style" -- "$cur") )
+            return
+            ;;
+        -cpuprofile)
+            _filedir
             return
             ;;
     esac
 
     if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "-format -help" -- "$cur") )
+        COMPREPLY=( $(compgen -W \
+            "-format -severity --no-color --verbose -cpuprofile -version -h --help" \
+            -- "$cur") )
         return
     fi
 

--- a/completions/zsh/_zshellcheck
+++ b/completions/zsh/_zshellcheck
@@ -3,8 +3,15 @@
 _zshellcheck() {
     local -a arguments
     arguments=(
-        '-format[Specify output format]:format:(text json)'
-        '*:filename:_files -g "*.zsh *.zsh-theme *.sh"'
+        '-format[Output format]:format:(text json sarif)'
+        '-severity[Comma-separated severity filter]:levels:_values -s , "severity" error warning info style'
+        '--no-color[Disable ANSI colours in text output]'
+        '--verbose[Emit full kata descriptions]'
+        '-cpuprofile[Write Go CPU profile to file]:file:_files'
+        '-version[Print version and exit]'
+        '-h[Show help]'
+        '--help[Show help]'
+        '*:target:_files -g "*.zsh *.zsh-theme *.sh" -/'
     )
     _arguments -s $arguments
 }


### PR DESCRIPTION
Pass 5 of the doc audit. Staleness + broken references found in assets the earlier passes skipped:

- CITATION.cff: version 1.0.0 -> 1.0.13, date bumped, abstract tightened to match README.
- PR template: broken link to nonexistent DEVELOPMENT.md, missing ci/deps/perf commit types, incorrect 'Registered in pkg/katas/katas.go' item (katas self-register via init()), missing kata conventions (severity, Zsh-only, no-panic, dupe-check).
- Zsh + Bash completions: only offered -format text|json; every other flag (-severity, --no-color, --verbose, -cpuprofile, -version, --help) and -format sarif were invisible to tab-complete.