### PR TITLE
docs: bug-report template version placeholder refresh

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -50,8 +50,8 @@ body:
     id: version
     attributes:
       label: ZShellCheck Version
-      description: Run `zshellcheck --version` (or `git rev-parse HEAD` if built from source).
-      placeholder: v0.0.72
+      description: Run `zshellcheck -version` (or `git rev-parse HEAD` if built from source).
+      placeholder: v1.0.13
 
   - type: dropdown
     id: os


### PR DESCRIPTION
Stale placeholder v0.0.72 -> v1.0.13. Fix flag form to -version (Go flag single-dash).