### PR TITLE
docs: README polish — drop MIT badge, add severity mini-badges, restructure sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
  ##mmmm "mmm#" #   #  "#mm"    "mm    "mm   "mmm" #   #  "#mm"  "#mm"  #  "m
 ```
 
-**Native static analysis for Zsh.** 1000 Zsh-specific checks covering syntax, security, portability, and style — the counterpart to ShellCheck for code that uses Zsh-only features.
+### Native static analysis for Zsh
+
+1000 Zsh-specific checks covering syntax, security, portability, and style — the counterpart to ShellCheck for code that relies on Zsh-only features.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
@@ -17,23 +19,27 @@
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)
 [![SLSA](https://img.shields.io/badge/SLSA-Level%203-brightgreen)](https://slsa.dev)
-[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 </div>
 
 ---
 
-## At a glance
+## Katas at a glance
 
-- **1000** Zsh-specific katas (checks) — `error` / `warning` / `info` / `style`
-- **3** output formats — text (coloured), JSON, SARIF (GitHub Code Scanning)
-- **Zero** runtime dependencies — single static Go binary
-- **Signed** releases — cosign keyless + SBOM + SLSA Level 3 provenance
-- **Cross-platform** — Linux / macOS / Windows × x86_64 / arm64 / i386
+<div align="center">
 
-## Quick start
+| ![error](https://img.shields.io/badge/error-220-d73a49?style=flat-square) | ![warning](https://img.shields.io/badge/warning-459-f9a825?style=flat-square) | ![info](https://img.shields.io/badge/info-64-0366d6?style=flat-square) | ![style](https://img.shields.io/badge/style-257-6f42c1?style=flat-square) |
+|:---:|:---:|:---:|:---:|
 
-**Install**
+</div>
+
+- **Single static Go binary** — zero runtime dependencies.
+- **Three output formats** — coloured text, JSON, SARIF (GitHub Code Scanning).
+- **Signed releases** — cosign keyless + SBOM + SLSA Level 3 provenance on every tag.
+- **Cross-platform** — Linux / macOS / Windows × x86_64 / arm64 / i386.
+- **Inline suppression** — `# zshellcheck disable=ZC####` per line, per-next-line, or file-wide.
+
+## Install
 
 ```bash
 # Automatic — downloads signed binary, or builds if Go is present
@@ -43,14 +49,14 @@
 go install github.com/afadesigns/zshellcheck/cmd/zshellcheck@latest
 ```
 
-**Run**
+## Run
 
 ```bash
 zshellcheck path/to/script.zsh
 zshellcheck -severity warning -format sarif ./scripts > zshellcheck.sarif
 ```
 
-**GitHub Actions**
+### GitHub Actions
 
 ```yaml
 - uses: afadesigns/zshellcheck@v1.0.13
@@ -58,7 +64,7 @@ zshellcheck -severity warning -format sarif ./scripts > zshellcheck.sarif
     args: -format sarif -severity warning ./scripts
 ```
 
-**Pre-commit**
+### Pre-commit
 
 ```yaml
 -   repo: https://github.com/afadesigns/zshellcheck
@@ -81,13 +87,9 @@ scripts/backup.zsh:22:1: style: [ZC1030] Prefer `print -r --` over `echo` for pr
 Found 2 violations.
 ```
 
-## Severity
+## ShellCheck vs ZShellCheck
 
-Four levels: `error`, `warning`, `info`, `style`. Filter with `--severity <level>`. Full rubric with examples: [docs/USER_GUIDE.md#severity-levels](docs/USER_GUIDE.md#severity-levels).
-
-## Why ZShellCheck, not ShellCheck?
-
-Run **ShellCheck** for portable `sh` / `bash`. Run **ZShellCheck** for native Zsh — parameter-expansion flags (`${(U)x}`, `${(f)x}`), glob qualifiers (`*.zsh(.)`), `[[`, `(( ))`, `print -r --`, modifiers (`:t`, `:h`, `:r`), associative arrays, `setopt` options, hook functions. Full table: [docs/REFERENCE.md#comparison-vs-shellcheck](docs/REFERENCE.md#comparison-vs-shellcheck).
+Use **ShellCheck** for portable `sh` / `bash`. Use **ZShellCheck** for native Zsh — parameter-expansion flags (`${(U)x}`, `${(f)x}`), glob qualifiers (`*.zsh(.)`), `[[`, `(( ))`, `print -r --`, modifiers (`:t`, `:h`, `:r`), associative arrays, `setopt` options, hook functions. Full matrix: [docs/REFERENCE.md#comparison-vs-shellcheck](docs/REFERENCE.md#comparison-vs-shellcheck).
 
 ## Documentation
 
@@ -100,20 +102,19 @@ Run **ShellCheck** for portable `sh` / `bash`. Run **ZShellCheck** for native Zs
 | [CHANGELOG.md](CHANGELOG.md) | Per-release history |
 | [SECURITY.md](SECURITY.md) | Vulnerability disclosure |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | PR workflow, local checks, conventions |
-| [ROADMAP.md](ROADMAP.md) | What's next (LSP, auto-fixer, plugins) |
+| [ROADMAP.md](ROADMAP.md) | LSP, auto-fixer, plugins |
 
 ## Contributing
 
-PRs welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md). Issues and discussions live on GitHub: [issues](https://github.com/afadesigns/zshellcheck/issues), [discussions](https://github.com/afadesigns/zshellcheck/discussions).
+PRs welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md). Questions and ideas: [discussions](https://github.com/afadesigns/zshellcheck/discussions). Bugs: [issues](https://github.com/afadesigns/zshellcheck/issues).
 
 ## License
 
-MIT. See [LICENSE](LICENSE).
+Distributed under the MIT License. See [LICENSE](LICENSE).
 
 ## Credits
 
-- Andreas Fahl (**@afadesigns**) — author and maintainer.
-- Inspired by [ShellCheck](https://www.shellcheck.net/) — independent implementation focused on Zsh-specific semantics.
+Andreas Fahl (**@afadesigns**) — author and maintainer. Inspired by [ShellCheck](https://www.shellcheck.net/); ZShellCheck is an independent Go implementation focused on Zsh-specific semantics.
 
 <div align="center">
   <a href="https://github.com/afadesigns/zshellcheck/graphs/contributors">


### PR DESCRIPTION
Second README pass. Drop the License badge. Add colour-coded severity mini-badges with actual counts (error 220, warning 459, info 64, style 257). Split Install/Run into their own sections; GitHub Actions + Pre-commit promoted to H3 under Run. Add 'Inline suppression' to at-a-glance bullets. Comparison header renamed to 'ShellCheck vs ZShellCheck' for search ergonomics.