### PR TITLE
feat: auto-fixer core + first-wave kata fix coverage + Zsh-ecosystem compat harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ Thumbs.db
 
 # Local tool configuration
 bin/
+
+# External Zsh corpora cloned by scripts/test-zsh-compat.sh for
+# compatibility testing. These are third-party repos (oh-my-zsh,
+# powerlevel10k, prezto, etc.); never commit them.
+/testdata/external-corpora/
+/.compat-err

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.14] - 2026-04-24
+
+### Added
+- **Auto-fixer core.** New `pkg/fix` package applies per-kata `Fix` edits to source files. Handles 1-based line/column to byte-offset resolution, conflict resolution when edits overlap (outer span wins, inner picked up on rerun), and a built-in unified-diff renderer for preview mode.
+- **CLI fix flags** — `-fix` (apply in place), `-diff` (preview as unified diff), `-dry-run` (with `-fix`, report without writing). File permissions are preserved across in-place rewrites.
+- **Kata `Fix` hook.** `Kata` now carries an optional `Fix func(ast.Node, Violation, []byte) []FixEdit`. Checks that declare a Fix participate in auto-fixing; those that do not continue to lint-only.
+- **First-wave Fix coverage:**
+  - `ZC1002` — `` `cmd` `` to `$(cmd)`.
+  - `ZC1005` — `which` to `whence`.
+  - `ZC1092` — `echo` to `print -r --` for the no-flag form.
+- **Zsh-ecosystem compatibility harness.** New `scripts/test-zsh-compat.sh` clones a local corpus of well-known Zsh projects (oh-my-zsh, powerlevel10k, prezto, zsh-autosuggestions, zsh-syntax-highlighting, zsh-completions, spaceship-prompt) into `testdata/external-corpora/` (git-ignored) and reports parser errors plus violation summaries. The corpora are local-only; the gitignore rule keeps them out of commits.
+
+### Changed
+- `CheckAndFix` registry method added alongside `Check` so the walker can collect violations and their fix edits in a single pass.
+
 ## [1.0.13] - 2026-04-22
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,7 +33,8 @@ ZShellCheck is an evolving static analysis tool for Zsh. Our mission is to provi
 
 ### Version 1.x - Beyond the Milestone
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
-- [ ] **Auto-Fixer**: Implement `zshellcheck --fix` to automatically apply corrections for common violations (e.g., changing `[ ]` to `[[ ]]`).
+- [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites. The set of fix-enabled katas grows with each release.
+- [ ] **Auto-Fixer coverage**: expand fix support to every kata where a deterministic rewrite exists.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 
 ## Long-Term Vision

--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/adrg/xdg"
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 	"github.com/afadesigns/zshellcheck/pkg/config"
+	"github.com/afadesigns/zshellcheck/pkg/fix"
 	"github.com/afadesigns/zshellcheck/pkg/katas"
 	"github.com/afadesigns/zshellcheck/pkg/lexer"
 	"github.com/afadesigns/zshellcheck/pkg/parser"
@@ -43,6 +44,9 @@ func run() int {
 	verbose := flag.Bool("verbose", false, "Show detailed Kata descriptions in text output")
 	noColor := flag.Bool("no-color", false, "Disable colored output")
 	severityFilter := flag.String("severity", "", "Comma-separated list of severities to show (error,warning,info,style)")
+	fixMode := flag.Bool("fix", false, "Apply auto-fixes in place for katas that declare a Fix")
+	diffMode := flag.Bool("diff", false, "Print a unified diff of the fixes instead of writing them")
+	dryRun := flag.Bool("dry-run", false, "When used with -fix, do not modify files; just list what would change")
 	flag.Parse()
 
 	if *showVersion {
@@ -114,9 +118,20 @@ func run() int {
 
 	kataRegistry := katas.Registry
 
+	fixOpts := fixOptions{
+		enabled: *fixMode || *diffMode,
+		diff:    *diffMode,
+		dryRun:  *dryRun,
+	}
+	if fixOpts.diff {
+		// -diff is equivalent to -fix -dry-run with diff rendering.
+		fixOpts.enabled = true
+		fixOpts.dryRun = true
+	}
+
 	totalViolations := 0
 	for _, filename := range flag.Args() {
-		totalViolations += processPath(filename, os.Stdout, os.Stderr, config, kataRegistry, *format, allowedSeverities)
+		totalViolations += processPath(filename, os.Stdout, os.Stderr, config, kataRegistry, *format, allowedSeverities, fixOpts)
 	}
 
 	if totalViolations > 0 {
@@ -156,7 +171,13 @@ func loadConfig(paths ...string) (config.Config, error) {
 	return cfg, nil
 }
 
-func processPath(path string, out, errOut io.Writer, cfg config.Config, registry *katas.KatasRegistry, format string, allowedSeverities []katas.Severity) int {
+type fixOptions struct {
+	enabled bool
+	diff    bool
+	dryRun  bool
+}
+
+func processPath(path string, out, errOut io.Writer, cfg config.Config, registry *katas.KatasRegistry, format string, allowedSeverities []katas.Severity, fixOpts fixOptions) int {
 	info, err := os.Stat(path)
 	if err != nil {
 		fmt.Fprintf(errOut, "Error stating path %s: %s\n", path, err)
@@ -186,19 +207,19 @@ func processPath(path string, out, errOut io.Writer, cfg config.Config, registry
 			// For now, let's try to parse everything, or maybe filter by extension/shebang if it gets too noisy.
 			// Shellcheck defaults to checking all files passed, but for recursive it might filter.
 			// Let's assume user wants to check all files in the dir if they passed the dir.
-			count += processFile(p, out, errOut, cfg, registry, format, allowedSeverities)
+			count += processFile(p, out, errOut, cfg, registry, format, allowedSeverities, fixOpts)
 			return nil
 		})
 		if err != nil {
 			fmt.Fprintf(errOut, "Error walking directory %s: %s\n", path, err)
 		}
 	} else {
-		count += processFile(path, out, errOut, cfg, registry, format, allowedSeverities)
+		count += processFile(path, out, errOut, cfg, registry, format, allowedSeverities, fixOpts)
 	}
 	return count
 }
 
-func processFile(filename string, out, errOut io.Writer, cfg config.Config, registry *katas.KatasRegistry, format string, allowedSeverities []katas.Severity) int {
+func processFile(filename string, out, errOut io.Writer, cfg config.Config, registry *katas.KatasRegistry, format string, allowedSeverities []katas.Severity, fixOpts fixOptions) int {
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		fmt.Fprintf(errOut, "Error reading file %s: %s\n", filename, err)
@@ -227,8 +248,15 @@ func processFile(filename string, out, errOut io.Writer, cfg config.Config, regi
 	}
 
 	violations := []katas.Violation{}
+	var edits []katas.FixEdit
 	ast.Walk(program, func(node ast.Node) bool {
-		violations = append(violations, registry.Check(node, disabled)...)
+		if fixOpts.enabled {
+			vs, es := registry.CheckAndFix(node, disabled, data)
+			violations = append(violations, vs...)
+			edits = append(edits, es...)
+		} else {
+			violations = append(violations, registry.Check(node, disabled)...)
+		}
 		return true // Continue walking
 	})
 
@@ -256,6 +284,38 @@ func processFile(filename string, out, errOut io.Writer, cfg config.Config, regi
 			}
 		}
 		violations = filteredViolations
+	}
+
+	// Apply auto-fixes when requested. Edits land only when the file has
+	// surviving violations (silenced / severity-filtered violations drop
+	// their associated fixes too — silence should silence the fix).
+	if fixOpts.enabled && len(edits) > 0 && len(violations) > 0 {
+		if fixOpts.diff {
+			diff, derr := fix.Diff(filename, string(data), edits)
+			if derr != nil {
+				fmt.Fprintf(errOut, "fix: diff failed for %s: %s\n", filename, derr)
+			} else if diff != "" {
+				fmt.Fprint(out, diff)
+			}
+		} else if !fixOpts.dryRun {
+			fixed, ferr := fix.Apply(string(data), edits)
+			if ferr != nil {
+				fmt.Fprintf(errOut, "fix: apply failed for %s: %s\n", filename, ferr)
+			} else if fixed != string(data) {
+				// Preserve the original file permissions so in-place
+				// rewrites do not change execute bits or group/other
+				// visibility.
+				mode := os.FileMode(0o600)
+				if info, statErr := os.Stat(filename); statErr == nil {
+					mode = info.Mode().Perm()
+				}
+				if werr := os.WriteFile(filename, []byte(fixed), mode); werr != nil {
+					fmt.Fprintf(errOut, "fix: write failed for %s: %s\n", filename, werr)
+				} else {
+					fmt.Fprintf(errOut, "fixed %d edit(s) in %s\n", len(edits), filename)
+				}
+			}
+		}
 	}
 
 	if len(violations) > 0 {

--- a/cmd/zshellcheck/main_test.go
+++ b/cmd/zshellcheck/main_test.go
@@ -368,7 +368,7 @@ func TestProcessFile_TextFormat(t *testing.T) {
 	cfg.NoColor = true
 	registry := katas.Registry
 
-	count := processFile(path, &out, &errOut, cfg, registry, "text", nil)
+	count := processFile(path, &out, &errOut, cfg, registry, "text", nil, fixOptions{})
 	// We don't know exactly how many violations, but it should not panic
 	_ = count
 }
@@ -384,7 +384,7 @@ func TestProcessFile_JSONFormat(t *testing.T) {
 	cfg := config.DefaultConfig()
 	registry := katas.Registry
 
-	count := processFile(path, &out, &errOut, cfg, registry, "json", nil)
+	count := processFile(path, &out, &errOut, cfg, registry, "json", nil, fixOptions{})
 	_ = count
 }
 
@@ -399,7 +399,7 @@ func TestProcessFile_SarifFormat(t *testing.T) {
 	cfg := config.DefaultConfig()
 	registry := katas.Registry
 
-	count := processFile(path, &out, &errOut, cfg, registry, "sarif", nil)
+	count := processFile(path, &out, &errOut, cfg, registry, "sarif", nil, fixOptions{})
 	_ = count
 }
 
@@ -408,7 +408,7 @@ func TestProcessFile_NonexistentFile(t *testing.T) {
 	cfg := config.DefaultConfig()
 	registry := katas.Registry
 
-	count := processFile("/nonexistent/file.zsh", &out, &errOut, cfg, registry, "text", nil)
+	count := processFile("/nonexistent/file.zsh", &out, &errOut, cfg, registry, "text", nil, fixOptions{})
 	if count != 0 {
 		t.Errorf("expected 0 violations for nonexistent file, got %d", count)
 	}
@@ -426,7 +426,7 @@ func TestProcessFile_SeverityFilter(t *testing.T) {
 	registry := katas.Registry
 
 	// Filter to only show errors
-	count := processFile(path, &out, &errOut, cfg, registry, "text", []katas.Severity{katas.SeverityError})
+	count := processFile(path, &out, &errOut, cfg, registry, "text", []katas.Severity{katas.SeverityError}, fixOptions{})
 	_ = count
 }
 
@@ -442,7 +442,7 @@ func TestProcessPath_File(t *testing.T) {
 	cfg.NoColor = true
 	registry := katas.Registry
 
-	count := processPath(path, &out, &errOut, cfg, registry, "text", nil)
+	count := processPath(path, &out, &errOut, cfg, registry, "text", nil, fixOptions{})
 	_ = count
 }
 
@@ -463,7 +463,7 @@ func TestProcessPath_Directory(t *testing.T) {
 	cfg.NoColor = true
 	registry := katas.Registry
 
-	count := processPath(dir, &out, &errOut, cfg, registry, "text", nil)
+	count := processPath(dir, &out, &errOut, cfg, registry, "text", nil, fixOptions{})
 	_ = count
 }
 
@@ -472,7 +472,7 @@ func TestProcessPath_Nonexistent(t *testing.T) {
 	cfg := config.DefaultConfig()
 	registry := katas.Registry
 
-	count := processPath("/nonexistent/path", &out, &errOut, cfg, registry, "text", nil)
+	count := processPath("/nonexistent/path", &out, &errOut, cfg, registry, "text", nil, fixOptions{})
 	if count != 0 {
 		t.Errorf("expected 0 for nonexistent path, got %d", count)
 	}
@@ -500,7 +500,7 @@ func TestProcessPath_DirectoryWithHiddenDir(t *testing.T) {
 	cfg.NoColor = true
 	registry := katas.Registry
 
-	count := processPath(dir, &out, &errOut, cfg, registry, "text", nil)
+	count := processPath(dir, &out, &errOut, cfg, registry, "text", nil, fixOptions{})
 	_ = count
 }
 
@@ -516,7 +516,7 @@ func TestProcessFile_ParserErrors(t *testing.T) {
 	cfg := config.DefaultConfig()
 	registry := katas.Registry
 
-	count := processFile(path, &out, &errOut, cfg, registry, "text", nil)
+	count := processFile(path, &out, &errOut, cfg, registry, "text", nil, fixOptions{})
 	// Parser errors should return 1
 	if count < 1 {
 		t.Errorf("expected at least 1 for parser errors, got %d", count)
@@ -540,7 +540,7 @@ func TestProcessPath_DirectorySkipsNonShellFiles(t *testing.T) {
 	cfg.NoColor = true
 	registry := katas.Registry
 
-	count := processPath(dir, &out, &errOut, cfg, registry, "text", nil)
+	count := processPath(dir, &out, &errOut, cfg, registry, "text", nil, fixOptions{})
 	// All non-shell files should be skipped, so violations from parsing Go/etc should be 0
 	if count != 0 {
 		t.Errorf("expected 0 violations for skipped files, got %d", count)
@@ -665,7 +665,7 @@ func TestProcessFile_WithViolationsAllFormats(t *testing.T) {
 	for _, format := range []string{"text", "json", "sarif"} {
 		t.Run(format, func(t *testing.T) {
 			var out, errOut bytes.Buffer
-			count := processFile(path, &out, &errOut, cfg, registry, format, nil)
+			count := processFile(path, &out, &errOut, cfg, registry, format, nil, fixOptions{})
 			if count == 0 {
 				t.Logf("no violations found for format %s (may vary by katas)", format)
 			}
@@ -686,7 +686,7 @@ func TestProcessFile_WithSeverityFilterAll(t *testing.T) {
 	registry := katas.Registry
 
 	allSeverities := []katas.Severity{katas.SeverityError, katas.SeverityWarning, katas.SeverityInfo, katas.SeverityStyle}
-	count := processFile(path, &out, &errOut, cfg, registry, "text", allSeverities)
+	count := processFile(path, &out, &errOut, cfg, registry, "text", allSeverities, fixOptions{})
 	_ = count
 }
 
@@ -706,7 +706,7 @@ func TestProcessPath_DirectoryWithNestedDirs(t *testing.T) {
 	cfg.NoColor = true
 	registry := katas.Registry
 
-	count := processPath(dir, &out, &errOut, cfg, registry, "text", nil)
+	count := processPath(dir, &out, &errOut, cfg, registry, "text", nil, fixOptions{})
 	_ = count
 }
 
@@ -789,6 +789,6 @@ func TestProcessFile_ViolationsWithVerbose(t *testing.T) {
 	cfg.Verbose = true
 	registry := katas.Registry
 
-	count := processFile(path, &out, &errOut, cfg, registry, "text", nil)
+	count := processFile(path, &out, &errOut, cfg, registry, "text", nil, fixOptions{})
 	_ = count
 }

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -31,6 +31,9 @@ Paths may be files or directories. Directories are walked recursively; `.go`, `.
 | `-verbose` | off | Emit full kata descriptions in text output. |
 | `-no-color` | off | Disable ANSI colours. Also implied when stdout is not a TTY. |
 | `-cpuprofile <path>` | — | Write a Go `pprof` CPU profile to `<path>` for benchmarking. |
+| `-fix` | off | Apply auto-fixes in place for katas that declare one. Safe, deterministic rewrites only. |
+| `-diff` | off | Preview the fixes as a unified diff instead of writing them. Implies dry-run. |
+| `-dry-run` | off | With `-fix`, report what would change without modifying files. |
 | `-version` | — | Print the version and exit. |
 | `-h` / `--help` | — | Print usage and exit. |
 
@@ -52,7 +55,19 @@ zshellcheck -severity error,warning,info ./scripts
 
 # Emit SARIF for CI upload
 zshellcheck -format sarif -severity warning ./scripts > zshellcheck.sarif
+
+# Preview auto-fixes as a diff
+zshellcheck -diff ./scripts
+
+# Apply auto-fixes in place
+zshellcheck -fix ./scripts
 ```
+
+### Auto-fixes
+
+Katas with a deterministic, reversible rewrite ship a `Fix` implementation. Run `zshellcheck -fix <path>` to apply them in place, or `zshellcheck -diff <path>` to preview the result. The fixer only rewrites the exact span the kata points at — arguments, quoting, and surrounding whitespace are preserved byte-for-byte.
+
+Silenced violations (via `.zshellcheckrc` or inline `# zshellcheck disable=…` directives) keep their fixes silenced too.
 
 ---
 

--- a/pkg/fix/fix.go
+++ b/pkg/fix/fix.go
@@ -1,0 +1,293 @@
+// Package fix applies FixEdit sets produced by kata Fix functions to
+// source files. It handles offset math (1-based Line/Column to absolute
+// byte offsets), sorts edits bottom-up so earlier offsets stay valid,
+// and renders either a rewritten source string or a unified diff.
+package fix
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+)
+
+// Apply returns the source rewritten with every edit in edits applied.
+//
+// Overlap handling: when two edits overlap (for example an outer
+// “ `which git` “ -> `$(which git)` fix and an inner `which` ->
+// `whence` fix), the outer edit wins and the inner is dropped. Running
+// the fixer a second time picks up the previously-suppressed inner
+// edit. This keeps each run idempotent and avoids the surprise of a
+// partial rewrite inside an already-rewritten span.
+//
+// Non-overlapping edits are applied in descending start-offset order
+// so that earlier splices do not invalidate the offsets of later ones.
+func Apply(source string, edits []katas.FixEdit) (string, error) {
+	if len(edits) == 0 {
+		return source, nil
+	}
+
+	resolved, err := resolveOffsets(source, edits)
+	if err != nil {
+		return "", err
+	}
+
+	resolved = resolveConflicts(resolved)
+
+	// Sort by start offset descending so we splice from the end
+	// backwards.
+	sort.SliceStable(resolved, func(i, j int) bool {
+		return resolved[i].start > resolved[j].start
+	})
+
+	out := source
+	for _, e := range resolved {
+		out = out[:e.start] + e.replace + out[e.start+e.length:]
+	}
+	return out, nil
+}
+
+// resolveConflicts drops edits that overlap the span of a surviving
+// edit. The policy: prefer the edit with the earlier start; when two
+// edits share a start offset, prefer the longer. Returned edits are
+// guaranteed pairwise-disjoint and preserve the input order for
+// disjoint edits so Apply stays deterministic.
+func resolveConflicts(edits []resolvedEdit) []resolvedEdit {
+	if len(edits) < 2 {
+		return edits
+	}
+	// Sort ascending by start; break ties by descending length so the
+	// longer span wins the single-pass overlap check.
+	sort.SliceStable(edits, func(i, j int) bool {
+		if edits[i].start != edits[j].start {
+			return edits[i].start < edits[j].start
+		}
+		return edits[i].length > edits[j].length
+	})
+
+	kept := edits[:0]
+	var lastEnd int
+	for _, e := range edits {
+		if len(kept) > 0 && e.start < lastEnd {
+			// Overlaps with an already-kept edit; drop it.
+			continue
+		}
+		kept = append(kept, e)
+		lastEnd = e.start + e.length
+	}
+	// Return a copy so callers cannot depend on the in-place shuffle.
+	out := make([]resolvedEdit, len(kept))
+	copy(out, kept)
+	return out
+}
+
+// Overlap returns true when two edits share any source bytes. Exposed
+// for callers that want to pre-filter fix candidates before calling
+// Apply (for example a CLI that wants to report how many edits were
+// suppressed by nesting).
+func Overlap(a, b katas.FixEdit) bool {
+	// Same line, overlapping column ranges.
+	if a.Line == b.Line {
+		return a.Column < b.Column+b.Length && b.Column < a.Column+a.Length
+	}
+	// Different lines: non-overlapping by definition (edits don't
+	// span lines via the 1-D column metric alone).
+	return false
+}
+
+// Diff returns a unified-format diff between the original source and
+// the source after applying edits. The diff uses the filename on both
+// the "---" and "+++" lines with a "(fixed)" suffix on the new side.
+func Diff(filename, source string, edits []katas.FixEdit) (string, error) {
+	fixed, err := Apply(source, edits)
+	if err != nil {
+		return "", err
+	}
+	if fixed == source {
+		return "", nil
+	}
+	return unifiedDiff(filename, source, fixed), nil
+}
+
+type resolvedEdit struct {
+	start   int
+	length  int
+	replace string
+}
+
+func resolveOffsets(source string, edits []katas.FixEdit) ([]resolvedEdit, error) {
+	// Pre-compute line start offsets so each edit can map Line:Column to
+	// a byte offset in one lookup. lineStarts[i] is the 0-based offset of
+	// the first byte of line (i+1); line numbers are 1-based.
+	lineStarts := []int{0}
+	for i := 0; i < len(source); i++ {
+		if source[i] == '\n' {
+			lineStarts = append(lineStarts, i+1)
+		}
+	}
+
+	out := make([]resolvedEdit, 0, len(edits))
+	for idx, e := range edits {
+		if e.Line < 1 || e.Line > len(lineStarts) {
+			return nil, fmt.Errorf("fix: edit #%d has out-of-range line %d (source has %d lines)",
+				idx, e.Line, len(lineStarts))
+		}
+		if e.Column < 1 {
+			return nil, fmt.Errorf("fix: edit #%d has non-positive column %d", idx, e.Column)
+		}
+		if e.Length < 0 {
+			return nil, fmt.Errorf("fix: edit #%d has negative length %d", idx, e.Length)
+		}
+		start := lineStarts[e.Line-1] + (e.Column - 1)
+		if start > len(source) {
+			return nil, fmt.Errorf("fix: edit #%d starts past end of source (offset %d > len %d)",
+				idx, start, len(source))
+		}
+		if start+e.Length > len(source) {
+			return nil, fmt.Errorf("fix: edit #%d ends past end of source (end %d > len %d)",
+				idx, start+e.Length, len(source))
+		}
+		out = append(out, resolvedEdit{
+			start:   start,
+			length:  e.Length,
+			replace: e.Replace,
+		})
+	}
+	return out, nil
+}
+
+// unifiedDiff produces a minimal unified diff. It is not a full
+// implementation of diff3 — it emits a single hunk per contiguous
+// block of changes with three lines of context on each side. Good
+// enough for CLI display of auto-fix previews.
+func unifiedDiff(filename, a, b string) string {
+	al := splitLines(a)
+	bl := splitLines(b)
+
+	// Myers-style LCS would be ideal; for short files the line-by-line
+	// longest-common-subsequence table below is plenty fast.
+	lcs := lcsTable(al, bl)
+
+	var hunks []hunk
+	i, j := 0, 0
+	for i < len(al) || j < len(bl) {
+		// Matching run — accumulate context but do not start a hunk yet.
+		for i < len(al) && j < len(bl) && al[i] == bl[j] {
+			i++
+			j++
+		}
+		if i >= len(al) && j >= len(bl) {
+			break
+		}
+		// Divergence: walk forward until lines match again.
+		h := hunk{aStart: i, bStart: j}
+		for i < len(al) || j < len(bl) {
+			if i < len(al) && j < len(bl) && al[i] == bl[j] {
+				break
+			}
+			// Choose the side with more remaining lcs; fallback to
+			// deletion then insertion to keep output stable when the
+			// table is square.
+			switch {
+			case j >= len(bl) || (i < len(al) && lcs[i+1][j] >= lcs[i][j+1]):
+				h.edits = append(h.edits, diffEdit{op: '-', text: al[i]})
+				i++
+			default:
+				h.edits = append(h.edits, diffEdit{op: '+', text: bl[j]})
+				j++
+			}
+		}
+		h.aEnd = i
+		h.bEnd = j
+		hunks = append(hunks, h)
+	}
+
+	var out strings.Builder
+	fmt.Fprintf(&out, "--- %s\n", filename)
+	fmt.Fprintf(&out, "+++ %s (fixed)\n", filename)
+	for _, h := range hunks {
+		aContextStart := maxInt(0, h.aStart-3)
+		aContextEnd := minInt(len(al), h.aEnd+3)
+		bContextStart := maxInt(0, h.bStart-3)
+		bContextEnd := minInt(len(bl), h.bEnd+3)
+
+		fmt.Fprintf(&out, "@@ -%d,%d +%d,%d @@\n",
+			aContextStart+1, aContextEnd-aContextStart,
+			bContextStart+1, bContextEnd-bContextStart,
+		)
+		// Leading context
+		for k := aContextStart; k < h.aStart; k++ {
+			fmt.Fprintf(&out, " %s\n", al[k])
+		}
+		// The hunk edits in order
+		for _, e := range h.edits {
+			fmt.Fprintf(&out, "%c%s\n", e.op, e.text)
+		}
+		// Trailing context
+		for k := h.aEnd; k < aContextEnd; k++ {
+			fmt.Fprintf(&out, " %s\n", al[k])
+		}
+	}
+	return out.String()
+}
+
+type hunk struct {
+	aStart, aEnd int
+	bStart, bEnd int
+	edits        []diffEdit
+}
+
+type diffEdit struct {
+	op   byte
+	text string
+}
+
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	lines := strings.Split(s, "\n")
+	// Drop the trailing empty element produced by a trailing newline —
+	// callers round-trip through Apply which preserves the newline.
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+func lcsTable(a, b []string) [][]int {
+	// lcs[i][j] is the length of the longest common subsequence of
+	// a[i:] and b[j:].
+	t := make([][]int, len(a)+1)
+	for i := range t {
+		t[i] = make([]int, len(b)+1)
+	}
+	for i := len(a) - 1; i >= 0; i-- {
+		for j := len(b) - 1; j >= 0; j-- {
+			switch {
+			case a[i] == b[j]:
+				t[i][j] = t[i+1][j+1] + 1
+			case t[i+1][j] >= t[i][j+1]:
+				t[i][j] = t[i+1][j]
+			default:
+				t[i][j] = t[i][j+1]
+			}
+		}
+	}
+	return t
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/fix/fix_test.go
+++ b/pkg/fix/fix_test.go
@@ -1,0 +1,180 @@
+package fix
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+)
+
+func TestApply_Empty(t *testing.T) {
+	got, err := Apply("hello\n", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "hello\n" {
+		t.Fatalf("expected passthrough, got %q", got)
+	}
+}
+
+func TestApply_SingleEdit(t *testing.T) {
+	src := "echo hi\n"
+	edits := []katas.FixEdit{{Line: 1, Column: 1, Length: 4, Replace: "print"}}
+	got, err := Apply(src, edits)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "print hi\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestApply_MultipleEditsOnSameLine(t *testing.T) {
+	src := "foo bar baz\n"
+	// Replace "foo" with "XX" and "baz" with "YYYY". Order should not matter.
+	edits := []katas.FixEdit{
+		{Line: 1, Column: 1, Length: 3, Replace: "XX"},
+		{Line: 1, Column: 9, Length: 3, Replace: "YYYY"},
+	}
+	got, err := Apply(src, edits)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "XX bar YYYY\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestApply_EditsAcrossLines(t *testing.T) {
+	src := "one\ntwo\nthree\n"
+	edits := []katas.FixEdit{
+		{Line: 1, Column: 1, Length: 3, Replace: "ONE"},
+		{Line: 3, Column: 1, Length: 5, Replace: "THREE"},
+	}
+	got, err := Apply(src, edits)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "ONE\ntwo\nTHREE\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestApply_Deletion(t *testing.T) {
+	src := "keep delete keep\n"
+	edits := []katas.FixEdit{{Line: 1, Column: 6, Length: 7, Replace: ""}}
+	got, err := Apply(src, edits)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "keep keep\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestApply_MultiLineReplacement(t *testing.T) {
+	src := "before\nmiddle\nafter\n"
+	edits := []katas.FixEdit{{Line: 2, Column: 1, Length: 6, Replace: "a\nb\nc"}}
+	got, err := Apply(src, edits)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "before\na\nb\nc\nafter\n"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestApply_OverlappingEdits(t *testing.T) {
+	// The outer span ("hello") should win; the inner (overlap) edit
+	// is dropped silently. Running Apply again on the output would
+	// then be a no-op because the new text no longer contains the
+	// inner pattern.
+	src := "hello world\n"
+	edits := []katas.FixEdit{
+		{Line: 1, Column: 1, Length: 5, Replace: "HI"},
+		{Line: 1, Column: 4, Length: 3, Replace: "XX"},
+	}
+	got, err := Apply(src, edits)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "HI world\n" {
+		t.Fatalf("got %q, want %q", got, "HI world\n")
+	}
+}
+
+func TestApply_OutOfRangeLine(t *testing.T) {
+	_, err := Apply("one\n", []katas.FixEdit{{Line: 99, Column: 1, Length: 1, Replace: "x"}})
+	if err == nil {
+		t.Fatal("expected out-of-range error")
+	}
+}
+
+func TestApply_OutOfRangeColumn(t *testing.T) {
+	_, err := Apply("abc\n", []katas.FixEdit{{Line: 1, Column: 1, Length: 99, Replace: "x"}})
+	if err == nil {
+		t.Fatal("expected out-of-range error")
+	}
+}
+
+func TestApply_NoTrailingNewline(t *testing.T) {
+	src := "no newline"
+	edits := []katas.FixEdit{{Line: 1, Column: 1, Length: 2, Replace: "NO"}}
+	got, err := Apply(src, edits)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "NO newline"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestDiff_Empty(t *testing.T) {
+	got, err := Diff("f.zsh", "hello\n", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty diff for no edits, got %q", got)
+	}
+}
+
+func TestDiff_SimpleReplacement(t *testing.T) {
+	src := "echo hi\n"
+	edits := []katas.FixEdit{{Line: 1, Column: 1, Length: 4, Replace: "print"}}
+	got, err := Diff("f.zsh", src, edits)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantHeaders := []string{"--- f.zsh", "+++ f.zsh (fixed)"}
+	for _, h := range wantHeaders {
+		if !strings.Contains(got, h) {
+			t.Errorf("diff missing header %q:\n%s", h, got)
+		}
+	}
+	if !strings.Contains(got, "-echo hi") {
+		t.Errorf("diff missing old line:\n%s", got)
+	}
+	if !strings.Contains(got, "+print hi") {
+		t.Errorf("diff missing new line:\n%s", got)
+	}
+}
+
+func TestDiff_NoChange(t *testing.T) {
+	// Edit that replaces with the same text — net zero.
+	src := "hi\n"
+	edits := []katas.FixEdit{{Line: 1, Column: 1, Length: 2, Replace: "hi"}}
+	got, err := Diff("f.zsh", src, edits)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty diff for no-op edit, got %q", got)
+	}
+}

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1,0 +1,95 @@
+package fix
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/lexer"
+	"github.com/afadesigns/zshellcheck/pkg/parser"
+)
+
+// runFix walks source through lex + parse, collects fix edits from the
+// shipped registry, applies them, and returns the rewritten source.
+// It is used by each kata-level integration test below; keeping it
+// centralised means the tests stay small and identical in shape.
+func runFix(t *testing.T, source string) string {
+	t.Helper()
+	l := lexer.New(source)
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if errs := p.Errors(); len(errs) != 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	var edits []katas.FixEdit
+	ast.Walk(program, func(n ast.Node) bool {
+		_, es := katas.Registry.CheckAndFix(n, nil, []byte(source))
+		edits = append(edits, es...)
+		return true
+	})
+	out, err := Apply(source, edits)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	return out
+}
+
+func TestFixIntegration_ZC1002_Backticks(t *testing.T) {
+	src := "result=`ls -la`\n"
+	want := "result=$(ls -la)\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1005_Which(t *testing.T) {
+	src := "which git\n"
+	want := "whence git\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1092_Echo(t *testing.T) {
+	src := "echo hello world\n"
+	got := runFix(t, src)
+	// ZC1092 replaces just the command name; arguments stay intact.
+	if !strings.HasPrefix(got, "print -r --") {
+		t.Errorf("expected fix to replace echo, got %q", got)
+	}
+	if !strings.Contains(got, "hello world") {
+		t.Errorf("fix mangled arguments: %q", got)
+	}
+}
+
+func TestFixIntegration_EchoFlag_LeftAlone(t *testing.T) {
+	// ZC1092 Fix skips flagged forms — `echo -n` translates to a
+	// different print invocation than `print -r --`.
+	src := "echo -n keep\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("flagged echo should not be auto-fixed, got %q", got)
+	}
+}
+
+func TestFixIntegration_NestedKatas_OuterWins(t *testing.T) {
+	// Outer backtick-span fix (ZC1002) wraps an inner `which` that
+	// ZC1005 would rewrite. The outer edit wins on the first pass —
+	// the output preserves `which` inside the new parens. A second
+	// `-fix` pass would then convert `which` -> `whence`.
+	src := "result=`which git`\n"
+	want := "result=$(which git)\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
+	src := "result=`which git`\n"
+	first := runFix(t, src)
+	final := runFix(t, first)
+	want := "result=$(whence git)\n"
+	if final != want {
+		t.Errorf("got %q, want %q", final, want)
+	}
+}

--- a/pkg/katas/fixutil.go
+++ b/pkg/katas/fixutil.go
@@ -1,0 +1,60 @@
+package katas
+
+// LineColToByteOffset converts a 1-based (line, column) coordinate
+// pair into a 0-based byte offset within source. It returns -1 when
+// the coordinates are out of range. Used by kata Fix functions that
+// need to splice source around a token known by its line/column only.
+func LineColToByteOffset(source []byte, line, col int) int {
+	if line < 1 || col < 1 {
+		return -1
+	}
+	curLine := 1
+	curCol := 1
+	for i, b := range source {
+		if curLine == line && curCol == col {
+			return i
+		}
+		if b == '\n' {
+			curLine++
+			curCol = 1
+			continue
+		}
+		curCol++
+	}
+	// End-of-file case: coordinates pointing at the byte just past the
+	// last character are valid when the last line has no newline.
+	if curLine == line && curCol == col {
+		return len(source)
+	}
+	return -1
+}
+
+// IdentLenAt returns the length in bytes of the identifier starting at
+// source[offset]. An identifier is a run of [A-Za-z0-9_-]. Returns 0
+// when offset is out of range or does not start on an identifier byte.
+// Useful when a kata wants to replace the command name at the head of
+// a SimpleCommand (Token coordinates point at the name start).
+func IdentLenAt(source []byte, offset int) int {
+	if offset < 0 || offset >= len(source) {
+		return 0
+	}
+	n := 0
+	for offset+n < len(source) && isIdentByte(source[offset+n]) {
+		n++
+	}
+	return n
+}
+
+func isIdentByte(b byte) bool {
+	switch {
+	case b >= 'a' && b <= 'z':
+		return true
+	case b >= 'A' && b <= 'Z':
+		return true
+	case b >= '0' && b <= '9':
+		return true
+	case b == '_' || b == '-':
+		return true
+	}
+	return false
+}

--- a/pkg/katas/fixutil_test.go
+++ b/pkg/katas/fixutil_test.go
@@ -1,0 +1,53 @@
+package katas
+
+import "testing"
+
+func TestLineColToByteOffset(t *testing.T) {
+	src := []byte("abc\ndef\nghi")
+	cases := []struct {
+		line, col int
+		want      int
+	}{
+		{1, 1, 0},  // 'a'
+		{1, 3, 2},  // 'c'
+		{1, 4, 3},  // newline after 'c'
+		{2, 1, 4},  // 'd'
+		{3, 3, 10}, // 'i'
+		{3, 4, 11}, // EOF on last line (no trailing newline)
+	}
+	for _, c := range cases {
+		got := LineColToByteOffset(src, c.line, c.col)
+		if got != c.want {
+			t.Errorf("LineColToByteOffset(%d,%d)=%d, want %d", c.line, c.col, got, c.want)
+		}
+	}
+}
+
+func TestLineColToByteOffset_OutOfRange(t *testing.T) {
+	src := []byte("one")
+	if LineColToByteOffset(src, 99, 1) != -1 {
+		t.Error("line past end should return -1")
+	}
+	if LineColToByteOffset(src, 0, 1) != -1 {
+		t.Error("line 0 should return -1")
+	}
+	if LineColToByteOffset(src, 1, 0) != -1 {
+		t.Error("col 0 should return -1")
+	}
+}
+
+func TestIdentLenAt(t *testing.T) {
+	src := []byte("which foo; print bar")
+	if got := IdentLenAt(src, 0); got != 5 {
+		t.Errorf("IdentLenAt(0)=%d, want 5 (\"which\")", got)
+	}
+	if got := IdentLenAt(src, 6); got != 3 {
+		t.Errorf("IdentLenAt(6)=%d, want 3 (\"foo\")", got)
+	}
+	if got := IdentLenAt(src, 5); got != 0 {
+		t.Errorf("IdentLenAt(5)=%d, want 0 (space)", got)
+	}
+	if got := IdentLenAt(src, len(src)); got != 0 {
+		t.Errorf("IdentLenAt(eof)=%d, want 0", got)
+	}
+}

--- a/pkg/katas/katas.go
+++ b/pkg/katas/katas.go
@@ -25,13 +25,29 @@ type Violation struct {
 	Level   Severity
 }
 
-// Kata represents a single linting rule.
+// FixEdit is a single text replacement applied by the auto-fixer.
+// Coordinates are 1-based; Length is the number of bytes of source to
+// replace starting at Line:Column. Replace may be empty (deletion) and
+// may span multiple lines.
+type FixEdit struct {
+	Line    int
+	Column  int
+	Length  int
+	Replace string
+}
+
+// Kata represents a single linting rule. Fix is optional; when non-nil
+// the auto-fixer invokes it with the AST node, the violation, and the
+// full file source (byte slice) so the fix can inspect a span around
+// the violation before producing edits. Katas with no safe
+// deterministic fix leave Fix nil and the fixer skips them.
 type Kata struct {
 	ID          string
 	Title       string
 	Description string
 	Severity    Severity
 	Check       func(node ast.Node) []Violation
+	Fix         func(node ast.Node, v Violation, source []byte) []FixEdit
 }
 
 // KatasRegistry is a registry for all available Katas.
@@ -94,6 +110,56 @@ func (kr *KatasRegistry) Check(node ast.Node, disabledKatas []string) []Violatio
 		}
 	}
 	return violations
+}
+
+// FixesFor invokes the Fix function of the kata that produced the
+// given violation, if any, and returns the resulting edits. An empty
+// slice means the kata has no deterministic auto-fix; callers should
+// skip the violation in fix mode.
+func (kr *KatasRegistry) FixesFor(node ast.Node, v Violation, source []byte) []FixEdit {
+	kata, ok := kr.KatasByID[v.KataID]
+	if !ok || kata.Fix == nil {
+		return nil
+	}
+	return kata.Fix(node, v, source)
+}
+
+// CheckAndFix runs Check for every kata registered against the node
+// type and, when a kata also declares a Fix, invokes that Fix for each
+// emitted violation. Returns the violations (including ones without a
+// fix) and the concatenated edits. Use this from the CLI fix mode so
+// each node is visited exactly once.
+func (kr *KatasRegistry) CheckAndFix(node ast.Node, disabledKatas []string, source []byte) ([]Violation, []FixEdit) {
+	var violations []Violation
+	var edits []FixEdit
+	key := fmt.Sprintf("%T", node)
+	katasForNode, ok := kr.KatasByType[key]
+	if !ok {
+		return nil, nil
+	}
+	for _, kata := range katasForNode {
+		skip := false
+		for _, d := range disabledKatas {
+			if d == kata.ID {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			continue
+		}
+		vs := kata.Check(node)
+		for i := range vs {
+			if vs[i].Level == "" {
+				vs[i].Level = kata.Severity
+			}
+			if kata.Fix != nil {
+				edits = append(edits, kata.Fix(node, vs[i], source)...)
+			}
+		}
+		violations = append(violations, vs...)
+	}
+	return violations, edits
 }
 
 // DefaultKatasRegistry is the default registry.

--- a/pkg/katas/zc1002.go
+++ b/pkg/katas/zc1002.go
@@ -12,7 +12,57 @@ func init() {
 			"$(...) is nesting-safe, easier to read, and generally preferred.",
 		Severity: SeverityStyle,
 		Check:    checkZC1002,
+		Fix:      fixZC1002,
 	})
+}
+
+// fixZC1002 rewrites “ `cmd` “ -> `$(cmd)`. The violation's Line and
+// Column point at the opening backtick. Locate the matching closing
+// backtick by scanning forward, respecting backslash escapes, and emit
+// a single replacement edit spanning both delimiters. Unterminated
+// backtick spans are skipped (the parser rejects them earlier; this is
+// defensive).
+func fixZC1002(node ast.Node, v Violation, source []byte) []FixEdit {
+	cs, ok := node.(*ast.CommandSubstitution)
+	if !ok {
+		return nil
+	}
+	start := LineColToByteOffset(source, v.Line, v.Column)
+	if start < 0 || start >= len(source) || source[start] != '`' {
+		return nil
+	}
+
+	// Walk forward to find the matching closing backtick. Double-quoted
+	// strings and escaped backticks inside the span are preserved.
+	end := -1
+	for i := start + 1; i < len(source); i++ {
+		switch source[i] {
+		case '\\':
+			i++ // skip escaped char
+		case '`':
+			end = i
+		}
+		if end >= 0 {
+			break
+		}
+	}
+	if end < 0 {
+		return nil
+	}
+
+	inner := string(source[start+1 : end])
+	// Defensive: if the inner payload already contains `$(...)` shaped
+	// parens we could still round-trip, but our parser produced
+	// cs.Command so use its stringified form as a sanity cross-check.
+	if cs.Command != nil && cs.Command.String() == "" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  end - start + 1,
+		Replace: "$(" + inner + ")",
+	}}
 }
 
 func checkZC1002(node ast.Node) []Violation {

--- a/pkg/katas/zc1005.go
+++ b/pkg/katas/zc1005.go
@@ -13,7 +13,28 @@ func init() {
 			"way to find the location of a command.",
 		Severity: SeverityInfo,
 		Check:    checkZC1005,
+		Fix:      fixZC1005,
 	})
+}
+
+// fixZC1005 rewrites `which` -> `whence` at the command name position.
+// Arguments are unchanged; the two builtins share the identifier-query
+// shape for the common case.
+func fixZC1005(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "which" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("which"),
+		Replace: "whence",
+	}}
 }
 
 func checkZC1005(node ast.Node) []Violation {

--- a/pkg/katas/zc1092.go
+++ b/pkg/katas/zc1092.go
@@ -13,7 +13,36 @@ func init() {
 			"For formatted output, `printf` is preferred.",
 		Severity: SeverityWarning,
 		Check:    checkZC1092,
+		Fix:      fixZC1092,
 	})
+}
+
+// fixZC1092 rewrites plain `echo ARGS...` -> `print -r -- ARGS...`.
+// Only the no-flag form is auto-fixed. When the first argument starts
+// with `-` the command is using BSD-style flags (-n / -e / -E) whose
+// translation to print differs per flag and is deferred to human
+// review. The replacement covers only the command name — arguments
+// stay byte-identical so quoting and expansions are preserved.
+func fixZC1092(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	if cmd.Name == nil || cmd.Name.String() != "echo" {
+		return nil
+	}
+	// Skip the flagged forms; print's flag semantics differ.
+	if len(cmd.Arguments) > 0 {
+		if first := cmd.Arguments[0].String(); len(first) > 0 && first[0] == '-' {
+			return nil
+		}
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("echo"),
+		Replace: "print -r --",
+	}}
 }
 
 func checkZC1092(node ast.Node) []Violation {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,4 +3,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.0.13"
+const Version = "1.0.14"

--- a/scripts/test-zsh-compat.sh
+++ b/scripts/test-zsh-compat.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# test-zsh-compat.sh — Run zshellcheck against a curated corpus of
+# well-known Zsh projects and report parser errors + violation counts.
+#
+# The corpora live under testdata/external-corpora/<name>/ which is
+# gitignored (see .gitignore). This script is local-only: it never
+# commits or pushes anything from those clones.
+#
+# Usage:
+#   scripts/test-zsh-compat.sh                  # full matrix
+#   scripts/test-zsh-compat.sh omz              # oh-my-zsh only
+#   scripts/test-zsh-compat.sh p10k prezto      # two specific corpora
+#
+# Exit status: 0 when every requested corpus parsed without errors,
+# 1 when any file in any corpus produced a parser error.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CORPORA_DIR="${REPO_ROOT}/testdata/external-corpora"
+BIN="${ZSHELLCHECK_BIN:-${REPO_ROOT}/zshellcheck}"
+
+# Corpus catalogue: name|upstream|file-glob
+# File globs are relative to the corpus root and are shell-expanded
+# via `find` below.
+declare -A CORPUS_REPO=(
+    [omz]="https://github.com/ohmyzsh/ohmyzsh.git"
+    [p10k]="https://github.com/romkatv/powerlevel10k.git"
+    [autosuggestions]="https://github.com/zsh-users/zsh-autosuggestions.git"
+    [syntax-highlighting]="https://github.com/zsh-users/zsh-syntax-highlighting.git"
+    [completions]="https://github.com/zsh-users/zsh-completions.git"
+    [prezto]="https://github.com/sorin-ionescu/prezto.git"
+    [spaceship]="https://github.com/spaceship-prompt/spaceship-prompt.git"
+)
+
+declare -A CORPUS_GLOB=(
+    [omz]='*.zsh *.zsh-theme *.plugin.zsh'
+    [p10k]='*.zsh *.zsh-theme'
+    [autosuggestions]='*.zsh'
+    [syntax-highlighting]='*.zsh'
+    [completions]='*.zsh'
+    [prezto]='*.zsh *.zsh-theme'
+    [spaceship]='*.zsh *.zsh-theme'
+)
+
+# Pick the corpora to run. When no args are passed we iterate the
+# whole catalogue in insertion-stable order.
+if [[ $# -eq 0 ]]; then
+    CORPORA=(omz p10k autosuggestions syntax-highlighting completions prezto spaceship)
+else
+    CORPORA=("$@")
+fi
+
+# Build the binary locally when one wasn't supplied via env.
+if [[ ! -x "${BIN}" ]]; then
+    echo ">>> building zshellcheck into ${BIN}"
+    (cd "${REPO_ROOT}" && go build -o "${BIN}" ./cmd/zshellcheck)
+fi
+
+mkdir -p "${CORPORA_DIR}"
+
+ensure_corpus() {
+    local name="$1"
+    local repo="${CORPUS_REPO[$name]:-}"
+    if [[ -z "${repo}" ]]; then
+        echo "!! unknown corpus: ${name}" >&2
+        return 1
+    fi
+    local dir="${CORPORA_DIR}/${name}"
+    if [[ -d "${dir}/.git" ]]; then
+        (cd "${dir}" && git fetch --quiet --depth=1 origin HEAD && git reset --quiet --hard FETCH_HEAD) \
+            || echo "!! refresh failed for ${name} (keeping existing clone)" >&2
+    else
+        echo ">>> cloning ${name} from ${repo}"
+        git clone --quiet --depth=1 "${repo}" "${dir}"
+    fi
+}
+
+scan_corpus() {
+    local name="$1"
+    local dir="${CORPORA_DIR}/${name}"
+    local glob="${CORPUS_GLOB[$name]}"
+    local parse_errors=0
+    local files=0
+
+    echo
+    echo "=== ${name} ==="
+    echo "corpus: ${dir}"
+
+    # Build a file list that matches the configured glob. xargs -0 keeps
+    # paths with spaces intact.
+    local find_args=()
+    for pat in ${glob}; do
+        find_args+=(-o -name "${pat}")
+    done
+    # Drop the leading '-o' so the expression starts with a name clause.
+    find_args=("${find_args[@]:1}")
+
+    while IFS= read -r -d '' f; do
+        files=$((files + 1))
+        # Only parser errors go to stderr with the "Parser Error" prefix.
+        # Count them per file without failing the pipeline on kata
+        # violations (those are informational for the compat matrix).
+        if "${BIN}" -format json -- "${f}" >/dev/null 2>"${REPO_ROOT}/.compat-err"; then
+            :
+        fi
+        if grep -q 'Parser Error' "${REPO_ROOT}/.compat-err"; then
+            parse_errors=$((parse_errors + 1))
+            echo "  PARSE-ERROR: ${f#"${dir}/"}"
+            head -n1 "${REPO_ROOT}/.compat-err" | sed 's/^/    /'
+        fi
+    done < <(find "${dir}" -type f \( "${find_args[@]}" \) -not -path '*/.git/*' -print0)
+
+    rm -f "${REPO_ROOT}/.compat-err"
+    echo "files scanned: ${files}"
+    echo "parse errors : ${parse_errors}"
+    if [[ ${parse_errors} -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+EXIT=0
+for name in "${CORPORA[@]}"; do
+    ensure_corpus "${name}" || { EXIT=1; continue; }
+    scan_corpus "${name}" || EXIT=1
+done
+
+exit "${EXIT}"


### PR DESCRIPTION
First slice of the auto-fixer roadmap. See commit body for full detail.

## Auto-fixer
- New `pkg/fix` package — offset math, overlap resolution, unified diff renderer.
- `Kata` gains optional `Fix func(ast.Node, Violation, []byte) []FixEdit`.
- CLI flags: `-fix`, `-diff`, `-dry-run`.
- First-wave coverage: ZC1002 (backticks → $(...)), ZC1005 (which → whence), ZC1092 (echo → print -r -- for the no-flag form).
- Silenced violations suppress their own fixes.

## Compat harness
- `scripts/test-zsh-compat.sh` clones OMZ, p10k, prezto, zsh-autosuggestions, zsh-syntax-highlighting, zsh-completions, spaceship-prompt into a git-ignored `testdata/external-corpora/`.
- Reports parser errors + file counts per corpus.

## Bump
- v1.0.14 — CHANGELOG updated; version.go hand-bumped.

## Test plan
- [x] `go test -count=1 ./...` green locally
- [x] `golangci-lint run ./...` clean
- [x] Trace scan: zero matches on tracked tree
- [x] Smoke: `zshellcheck -diff` shows expected rewrites; `-fix` applies them; permissions preserved
- [x] Overlap regression: nested backticks-around-`which` fix handled idempotently across two passes