### PR TITLE
fix: declarations no longer swallow next-line statement

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -639,44 +639,69 @@ func (p *Parser) parseCoprocStatement() *ast.CoprocStatement {
 
 func (p *Parser) parseDeclarationStatement() *ast.DeclarationStatement {
 	stmt := &ast.DeclarationStatement{Token: p.curToken, Command: p.curToken.Literal}
+	startLine := stmt.Token.Line
 	p.nextToken()
 
-	for !p.curTokenIs(token.SEMICOLON) && !p.curTokenIs(token.EOF) && p.curToken.Line == stmt.Token.Line {
-		// Check for flags
+	// Consume flags and assignments until the statement's line ends or a
+	// terminator fires. advanceOrStop is the key helper: it only moves
+	// past the current token when the next token is still part of this
+	// declaration (same line, not a terminator). When the next token is
+	// on a new line the declaration ends with curToken on its last real
+	// token so the outer block's unconditional nextToken() advances to
+	// the following statement's first token — without this guard, a
+	// declaration immediately followed by an `if` (or any statement) on
+	// the next line caused the parser to swallow the statement's leading
+	// token. Reported against oh-my-zsh / zsh-autosuggestions bodies.
+	advanceOrStop := func() bool {
+		if p.peekTokenIs(token.SEMICOLON) || p.peekTokenIs(token.EOF) {
+			return false
+		}
+		if p.peekToken.Line != startLine {
+			return false
+		}
+		p.nextToken()
+		return true
+	}
+
+	for !p.curTokenIs(token.SEMICOLON) && !p.curTokenIs(token.EOF) && p.curToken.Line == startLine {
+		// Flags (e.g. -g, -A, -r, --).
 		if p.curTokenIs(token.MINUS) || (p.curTokenIs(token.IDENT) && len(p.curToken.Literal) > 0 && p.curToken.Literal[0] == '-') {
-			// It's a flag (e.g., -A, -r, --)
 			stmt.Flags = append(stmt.Flags, p.curToken.Literal)
-			p.nextToken()
-			continue
-		} else if p.curTokenIs(token.MINUS) {
-			// Standalone minus?
-			stmt.Flags = append(stmt.Flags, "-")
-			p.nextToken()
+			if !advanceOrStop() {
+				break
+			}
 			continue
 		}
 
-		// Expect Identifier
+		// Identifier (optionally followed by = or += value).
 		if p.curTokenIs(token.IDENT) {
 			assign := &ast.DeclarationAssignment{
 				Name: &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal},
 			}
-			p.nextToken() // consume Name
-
-			// Check for = or +=
-			if p.curTokenIs(token.PLUSEQ) {
+			// Peek the =/+= before consuming the name so we can decide
+			// whether to stay on the name token (bare declaration) or
+			// move onto the operator (value follows).
+			if p.peekTokenIs(token.PLUSEQ) {
+				p.nextToken() // onto +=
 				assign.IsAppend = true
-				p.nextToken() // consume +=
+				p.nextToken() // onto value token
 				assign.Value = p.parseDeclarationValue()
-			} else if p.curTokenIs(token.ASSIGN) {
-				p.nextToken() // consume =
+			} else if p.peekTokenIs(token.ASSIGN) {
+				p.nextToken() // onto =
+				p.nextToken() // onto value token
 				assign.Value = p.parseDeclarationValue()
 			}
-
 			stmt.Assignments = append(stmt.Assignments, assign)
-		} else {
-			// Unexpected token in declaration
-			p.nextToken()
+
+			if !advanceOrStop() {
+				break
+			}
+			continue
 		}
+
+		// Unknown token inside a declaration — stop the loop so we do
+		// not skip tokens belonging to the next statement.
+		break
 	}
 
 	if p.peekTokenIs(token.SEMICOLON) {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1045,6 +1045,40 @@ func TestArithmeticLogicalChain(t *testing.T) {
 	}
 }
 
+func TestDeclarationFollowedByIfOnNextLine(t *testing.T) {
+	// Regression: `typeset -g A` directly followed by an `if … then …
+	// fi` on the next line used to swallow the `if` keyword, leaving
+	// the parser unable to consume the subsequent `then` / `fi`. The
+	// body of any well-formed Zsh script inside common plugins hits
+	// this pattern (zsh-autosuggestions src/async.zsh among others).
+	inputs := []string{
+		`foo() {
+  typeset -g A B
+  if [[ -n "$x" ]]; then echo ok; fi
+}`,
+		`foo() {
+  typeset A
+  if [[ 1 -eq 1 ]]; then print hi; fi
+}`,
+		`foo() {
+  local VAR=value
+  if [[ -n "$VAR" ]]; then echo set; fi
+}`,
+		`foo() {
+  readonly FLAG
+  if true; then echo go; fi
+}`,
+	}
+	for _, input := range inputs {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%s:\n  unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
 func TestArithmeticInsideIfWithLogicalChain(t *testing.T) {
 	// The original repro from #1047.
 	input := `if (( $+commands[ls] )) && (( $+commands[eza] )); then


### PR DESCRIPTION
parseDeclarationStatement over-consumed into the next line when a declaration ended at a line break rather than a semicolon. Caught against zsh-autosuggestions src/async.zsh via the compat harness.

## Root cause

The declaration loop kept calling nextToken after processing each flag/assignment, then checked p.curToken.Line against the declaration start. By the time the check fired, the token pointer was already on the next statement's first token. parseBlockStatement then called its unconditional nextToken(), skipping that token and leaving the parser unable to consume the trailing then/fi of the following if.

## Fix

Guard every internal nextToken in the declaration loop with a peek-line check so the loop leaves curToken on the last token that genuinely belongs to the declaration.

## Tests

Regression test covers typeset, local, readonly, and a value-assignment variant followed by if/then/fi on the next line.