### PR TITLE
fix: brace param expansion pre-flags = ~ ^

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -146,6 +146,17 @@ func (p *Parser) parseArrayAccess() ast.Expression {
 		hasLengthOp = true
 	}
 
+	// Zsh single-character pre-flags inside `${X name}` that modify the
+	// expansion rather than naming a parameter: `=` (split), `~` (glob
+	// interpret), `^` (rc-style expansion). They precede the subject and
+	// are consumed without producing an AST node — detection katas that
+	// care about them walk the source directly. Without this guard the
+	// generic prefix-expression path rejects `=` and `^`, breaking real
+	// scripts like `strategies=(${=VAR})` from zsh-autosuggestions.
+	for p.peekTokenIs(token.ASSIGN) || p.peekTokenIs(token.TILDE) || p.peekTokenIs(token.CARET) {
+		p.nextToken()
+	}
+
 	p.nextToken() // move to subject
 
 	expr := p.parseExpression(LOWEST)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1045,6 +1045,29 @@ func TestArithmeticLogicalChain(t *testing.T) {
 	}
 }
 
+func TestBraceParamExpansionSingleCharFlags(t *testing.T) {
+	// Zsh single-char pre-flags inside `${X name}` that modify the
+	// expansion: `=` (split), `~` (glob interpret), `^` (rc-style).
+	// Real-world code relies on all three; without explicit handling
+	// the parser tried to run `=` / `^` through the generic prefix
+	// path, which has no entry for ASSIGN / CARET, and produced
+	// "no prefix parse function for =" on zsh-autosuggestions.
+	inputs := []string{
+		`a=(${=VAR})`,
+		`b=(${~PATTERN})`,
+		`c=(${^ARRAY})`,
+		`d=(${=ZSH_AUTOSUGGEST_STRATEGY})`,
+	}
+	for _, input := range inputs {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%s:\n  unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
 func TestDeclarationFollowedByIfOnNextLine(t *testing.T) {
 	// Regression: `typeset -g A` directly followed by an `if … then …
 	// fi` on the next line used to swallow the `if` keyword, leaving


### PR DESCRIPTION
parseArrayAccess handled `${(flags)name}` and `${#name}` but missed the single-character pre-flag family Zsh places before the subject without parentheses:

- `${=name}` — word-split
- `${~name}` — glob interpret
- `${^name}` — rc-style expansion

Real code like `strategies=(${=ZSH_AUTOSUGGEST_STRATEGY})` in zsh-autosuggestions used to error with "no prefix parse function for =". Fix: consume these three flag characters before advancing to the subject. Regression tests cover each flag plus the exact snippet from the compat harness.