### PR TITLE
feat: array subscript flags (R) (r) (I) (ri)

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -418,6 +418,28 @@ func (p *Parser) parseIndexExpression(left ast.Expression) ast.Expression {
 
 	p.nextToken()
 
+	// Zsh subscript flags: `arr[(R)value]`, `arr[(r)pat]`, `arr[(I)i]`,
+	// `arr[(ri)pat]`, etc. The `(flags)` tuple precedes the actual
+	// index subject and modifies how the match is performed. Consume
+	// the tuple opaquely before handing the remainder to the generic
+	// expression parser. Without this guard the `(…)` was parsed as a
+	// grouped expression, after which the subject IDENT had nowhere
+	// to land and `expectPeek(RBRACKET)` fired on that token.
+	if p.curTokenIs(token.LPAREN) {
+		depth := 1
+		for depth > 0 && !p.peekTokenIs(token.EOF) {
+			p.nextToken()
+			switch {
+			case p.curTokenIs(token.LPAREN):
+				depth++
+			case p.curTokenIs(token.RPAREN):
+				depth--
+			}
+		}
+		// Advance onto the subject after the closing paren.
+		p.nextToken()
+	}
+
 	prevInArithmetic := p.inArithmetic
 	p.inArithmetic = true
 	exp.Index = p.parseExpression(LOWEST)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1045,6 +1045,34 @@ func TestArithmeticLogicalChain(t *testing.T) {
 	}
 }
 
+func TestArraySubscriptFlags(t *testing.T) {
+	// Zsh subscript flags before the index value: arr[(R)value]
+	// (reverse match), arr[(r)pat] (key match), arr[(I)i] (integer),
+	// arr[(ri)pat] (composed). These let code search arrays by
+	// content; every Zsh plugin in the curated corpus uses at least
+	// one form. Before this fix the `(…)` was consumed as a grouped
+	// expression and the subject IDENT was rejected with
+	// "expected next token to be ], got VARIABLE".
+	inputs := []string{
+		"a=${arr[(R)val]}",
+		"b=${arr[(r)pat]}",
+		"c=${arr[(I)i]}",
+		"d=${arr[(ri)pat]}",
+		"e=${arr[(R)$~pattern]}",
+		"f=${history_match_keys[1]}",
+		"g=${arr[1]}",
+		"h=${arr[(R)${nested}]}",
+	}
+	for _, input := range inputs {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%s:\n  unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
 func TestBraceParamExpansionModifiersAreOpaque(t *testing.T) {
 	// Every Zsh parameter-expansion modifier that comes after the
 	// subject is accepted without a structured AST yet (tracked in


### PR DESCRIPTION
Zsh subscript flag tuples `arr[(R)val]`, `arr[(r)pat]`, `arr[(I)i]`, `arr[(ri)pat]` were treated as grouped expressions by parseIndexExpression, leaving the subject token to fire "expected next token to be ]". Fix: skip the flag tuple opaquely with paren-depth tracking before parsing the subject. Against the compat harness this fully clears zsh-autosuggestions bind.zsh and strategies/match_prev_cmd.zsh.

8 regression inputs cover every flag family plus a nested dollar-brace case.