### PR TITLE
feat: single-char special params and length-of operator

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -263,6 +263,24 @@ func (l *Lexer) NextToken() token.Token {
 				tok.HasPrecedingSpace = hasSpace
 				return tok
 			}
+			// Zsh single-character special parameters. These are
+			// atomic variable names: $? (exit status), $@ (all
+			// positional), $$ (PID), $_ (last arg). $#, $*, $!, $-
+			// already reach the parser as DOLLAR + separate token and
+			// are recombined there; these three were leaking through
+			// as DOLLAR + ILLEGAL or DOLLAR + QUESTION, breaking real
+			// scripts that use `retval=$?` or similar.
+			if c := l.peekChar(); c == '?' || c == '@' || c == '$' || c == '_' {
+				col := l.column
+				l.readChar() // consume '$'
+				tok.Type = token.VARIABLE
+				tok.Literal = "$" + string(l.ch)
+				tok.Line = l.line
+				tok.Column = col
+				tok.HasPrecedingSpace = hasSpace
+				l.readChar() // consume the special char
+				return tok
+			}
 			tok = newToken(token.DOLLAR, l.ch, l.line, l.column)
 		}
 

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -216,7 +216,25 @@ func (p *Parser) parseInvalidArrayAccessPrefix() ast.Expression {
 	dollarToken := p.curToken
 	if p.peekTokenIs(token.HASH) || p.peekTokenIs(token.INT) || p.peekTokenIs(token.ASTERISK) || p.peekTokenIs(token.BANG) || p.peekTokenIs(token.MINUS) {
 		p.nextToken()
-		ident := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+		opToken := p.curToken
+		// `$#name` is Zsh's length-of operator. When the special char
+		// is followed by an identifier, the identifier names the
+		// parameter being measured and belongs to the same expression
+		// — don't leak it back into the caller's token stream.
+		if opToken.Type == token.HASH && p.peekTokenIs(token.IDENT) {
+			p.nextToken()
+			name := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+			return &ast.PrefixExpression{
+				Token:    dollarToken,
+				Operator: "$",
+				Right: &ast.PrefixExpression{
+					Token:    opToken,
+					Operator: "#",
+					Right:    name,
+				},
+			}
+		}
+		ident := &ast.Identifier{Token: opToken, Value: opToken.Literal}
 		return &ast.PrefixExpression{Token: dollarToken, Operator: "$", Right: ident}
 	}
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1045,6 +1045,37 @@ func TestArithmeticLogicalChain(t *testing.T) {
 	}
 }
 
+func TestSpecialParametersAndLengthOperator(t *testing.T) {
+	// Zsh single-char special parameters: $?, $@, $$, $_. Previously
+	// they lexed as DOLLAR + ILLEGAL (or DOLLAR + QUESTION) and the
+	// parser's prefix table rejected the tail. They now lex as a
+	// single VARIABLE token.
+	//
+	// $#name is the length-of-parameter operator; the identifier
+	// after the `#` is part of the expression, not a fresh token
+	// to be left for the caller to stumble over. Real code like
+	// `(( $#BUFFER > 0 ))` from zsh-autosuggestions widgets.zsh
+	// required both fixes to parse without errors.
+	inputs := []string{
+		"x=$?",
+		"y=$@",
+		"z=$$",
+		"w=$_",
+		"retval=$?",
+		"if (( $#BUFFER )); then echo yes; fi",
+		"if (( $#BUFFER > 0 )); then echo yes; fi",
+		"len=$#ARRAY",
+	}
+	for _, input := range inputs {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%s:\n  unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
 func TestArraySubscriptFlags(t *testing.T) {
 	// Zsh subscript flags before the index value: arr[(R)value]
 	// (reverse match), arr[(r)pat] (key match), arr[(I)i] (integer),


### PR DESCRIPTION
Two closely-related parser gaps surfaced by the zsh-autosuggestions compat sweep.

**Single-char special parameters**: the lexer only fused a VARIABLE token when dollar was followed by a letter. The remaining single-char specials (? @ $ _) leaked through as two tokens, and the prefix table rejected the tail with "expected next token to be IDENT, got ?". `retval=$?` and `return $?` are ubiquitous.

**Length-of operator**: `$#NAME` was parsed only up to the `#`, leaving NAME as an orphan. `(( $#BUFFER > 0 ))` now parses correctly.

Regression tests cover every form. autosuggestions widgets.zsh 27 → 9 errors; highlight.zsh 3 → 1.