### PR TITLE
fix: declarations with empty RHS at end of line

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -680,16 +680,25 @@ func (p *Parser) parseDeclarationStatement() *ast.DeclarationStatement {
 			}
 			// Peek the =/+= before consuming the name so we can decide
 			// whether to stay on the name token (bare declaration) or
-			// move onto the operator (value follows).
+			// move onto the operator (value follows). An empty RHS
+			// (`typeset -g VAR=` at end-of-line) is valid Zsh and sets
+			// the variable to the empty string — do NOT try to parse
+			// the next-line token as the value, that over-consumes
+			// into the following statement exactly like the pre-
+			// declaration fix handled for bare declarations.
 			if p.peekTokenIs(token.PLUSEQ) {
 				p.nextToken() // onto +=
 				assign.IsAppend = true
-				p.nextToken() // onto value token
-				assign.Value = p.parseDeclarationValue()
+				if p.peekToken.Line == startLine && !p.peekTokenIs(token.SEMICOLON) && !p.peekTokenIs(token.EOF) {
+					p.nextToken() // onto value token
+					assign.Value = p.parseDeclarationValue()
+				}
 			} else if p.peekTokenIs(token.ASSIGN) {
 				p.nextToken() // onto =
-				p.nextToken() // onto value token
-				assign.Value = p.parseDeclarationValue()
+				if p.peekToken.Line == startLine && !p.peekTokenIs(token.SEMICOLON) && !p.peekTokenIs(token.EOF) {
+					p.nextToken() // onto value token
+					assign.Value = p.parseDeclarationValue()
+				}
 			}
 			stmt.Assignments = append(stmt.Assignments, assign)
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1161,6 +1161,33 @@ func TestBraceParamExpansionSingleCharFlags(t *testing.T) {
 	}
 }
 
+func TestDeclarationEmptyAssignmentAtEOL(t *testing.T) {
+	// `typeset -g VAR=` with nothing after the `=` is valid Zsh
+	// (sets VAR to the empty string). The previous code over-
+	// consumed past the newline trying to read a value, taking
+	// the next statement's first token with it. In the real-world
+	// start.zsh from zsh-autosuggestions this swallowed the `fi`.
+	inputs := []string{
+		`typeset -g VAR=`,
+		`typeset -g A=
+echo after`,
+		`if true; then
+  typeset -g VAR=
+fi`,
+		`local X=
+readonly Y+=
+echo go`,
+	}
+	for _, input := range inputs {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%s:\n  unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
 func TestDeclarationFollowedByIfOnNextLine(t *testing.T) {
 	// Regression: `typeset -g A` directly followed by an `if … then …
 	// fi` on the next line used to swallow the `if` keyword, leaving


### PR DESCRIPTION
Follow-up to the earlier declaration-over-consume fix. `typeset -g VAR=` with nothing after the equals sign is valid Zsh (sets VAR to the empty string), but the parser read the next-line token as the value. In zsh-autosuggestions start.zsh this swallowed the trailing `fi`.

Guard the ASSIGN / PLUSEQ value path with the same peek-line + not-terminator check that already protects the bare-name exit path. start.zsh now parses clean.