### PR TITLE
feat: register PLUSEQ as infix for bare var+=value

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -39,6 +39,7 @@ var precedences = map[token.Type]int{
 	token.DOLLAR_LPAREN: CALL,
 	token.DoubleLparen:  CALL,
 	token.ASSIGN:        EQUALS,
+	token.PLUSEQ:        EQUALS,
 	token.EQTILDE:       EQUALS,
 	token.EQ_NUM:        EQUALS,
 	token.NE_NUM:        EQUALS,
@@ -116,6 +117,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.LPAREN, p.parseCallExpression)
 	p.registerInfix(token.LBRACKET, p.parseIndexExpression)
 	p.registerInfix(token.ASSIGN, p.parseInfixExpression)
+	p.registerInfix(token.PLUSEQ, p.parseInfixExpression)
 	p.registerInfix(token.EQTILDE, p.parseInfixExpression)
 	p.registerInfix(token.EQ_NUM, p.parseInfixExpression)
 	p.registerInfix(token.NE_NUM, p.parseInfixExpression)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1045,6 +1045,30 @@ func TestArithmeticLogicalChain(t *testing.T) {
 	}
 }
 
+func TestBareAppendAssignment(t *testing.T) {
+	// `var+=value` is the bare append-assignment form. Prior to this
+	// fix the parser handled the bare `=` assignment but rejected
+	// `+=` with "no prefix parse function for += found" because the
+	// token was not registered as an infix operator. Real oh-my-zsh
+	// themes (bureau, agnoster) and a long tail of plugins rely on
+	// this pattern to build up prompt strings incrementally.
+	inputs := []string{
+		`result+="a"`,
+		`result+="$ZSH_THEME_GIT_PROMPT_STAGED"`,
+		`x=a
+x+=b`,
+		`arr+=(item)`,
+	}
+	for _, input := range inputs {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%s:\n  unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
 func TestSpecialParametersAndLengthOperator(t *testing.T) {
 	// Zsh single-char special parameters: $?, $@, $$, $_. Previously
 	// they lexed as DOLLAR + ILLEGAL (or DOLLAR + QUESTION) and the


### PR DESCRIPTION
Bare `result+="..."` at statement level fired "no prefix parse function for += found" because PLUSEQ was wired only inside declaration-statement parsing, not as a top-level infix operator like ASSIGN. Widespread in oh-my-zsh themes (bureau, agnoster) and plugins for incrementally building prompt strings and arrays.

Register PLUSEQ at EQUALS precedence with parseInfixExpression, mirroring ASSIGN.