### PR TITLE
feat: lex ANSI-C and gettext dollar-quoted strings

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -239,50 +239,10 @@ func (l *Lexer) NextToken() token.Token {
 			tok = newToken(token.RBRACKET, l.ch, l.line, l.column)
 		}
 	case '$':
-		switch l.peekChar() {
-		case '{':
-			tok.Type = token.DollarLbrace
-			tok.Literal = "${"
-			tok.Line = l.line
-			tok.Column = l.column
-			l.readChar()
-		case '(':
-			tok.Type = token.DOLLAR_LPAREN
-			tok.Literal = "$("
-			tok.Line = l.line
-			tok.Column = l.column
-			l.readChar()
-		default:
-			if isLetter(l.peekChar()) {
-				col := l.column
-				l.readChar() // consume '$'
-				tok.Type = token.VARIABLE
-				tok.Literal = "$" + l.readIdentifier()
-				tok.Line = l.line
-				tok.Column = col
-				tok.HasPrecedingSpace = hasSpace
-				return tok
-			}
-			// Zsh single-character special parameters. These are
-			// atomic variable names: $? (exit status), $@ (all
-			// positional), $$ (PID), $_ (last arg). $#, $*, $!, $-
-			// already reach the parser as DOLLAR + separate token and
-			// are recombined there; these three were leaking through
-			// as DOLLAR + ILLEGAL or DOLLAR + QUESTION, breaking real
-			// scripts that use `retval=$?` or similar.
-			if c := l.peekChar(); c == '?' || c == '@' || c == '$' || c == '_' {
-				col := l.column
-				l.readChar() // consume '$'
-				tok.Type = token.VARIABLE
-				tok.Literal = "$" + string(l.ch)
-				tok.Line = l.line
-				tok.Column = col
-				tok.HasPrecedingSpace = hasSpace
-				l.readChar() // consume the special char
-				return tok
-			}
-			tok = newToken(token.DOLLAR, l.ch, l.line, l.column)
+		if dollarTok, ok := l.readDollarToken(hasSpace); ok {
+			return dollarTok
 		}
+		tok = newToken(token.DOLLAR, l.ch, l.line, l.column)
 
 	case '&':
 		if l.peekChar() == '&' {
@@ -362,6 +322,91 @@ func (l *Lexer) NextToken() token.Token {
 	l.readChar()
 	tok.HasPrecedingSpace = hasSpace
 	return tok
+}
+
+// readDollarToken dispatches the specialised forms that follow a
+// leading `$`. It returns (tok, true) when it has consumed a recognised
+// form — parameter expansion opener (${ or $(), ANSI-C / gettext string
+// ($'…' or $"…"), a named variable ($name), or a single-character
+// special parameter ($? / $@ / $$ / $_). Otherwise it returns
+// (zero, false) and the caller falls back to emitting a bare DOLLAR
+// token.
+func (l *Lexer) readDollarToken(hasSpace bool) (token.Token, bool) {
+	var tok token.Token
+	switch l.peekChar() {
+	case '{':
+		tok.Type = token.DollarLbrace
+		tok.Literal = "${"
+		tok.Line = l.line
+		tok.Column = l.column
+		l.readChar() // consume '$'
+		l.readChar() // step past the shared tail; advances past '{'
+		tok.HasPrecedingSpace = hasSpace
+		return tok, true
+	case '(':
+		tok.Type = token.DOLLAR_LPAREN
+		tok.Literal = "$("
+		tok.Line = l.line
+		tok.Column = l.column
+		l.readChar() // consume '$'
+		l.readChar() // advance past '('
+		tok.HasPrecedingSpace = hasSpace
+		return tok, true
+	case '\'':
+		// Zsh ANSI-C quoting: $'…' processes backslash escapes like
+		// \n, \t etc. Emit one STRING token spanning the $' opener
+		// through the matching closing quote so the parser sees a
+		// literal value rather than DOLLAR + bare quoted string.
+		col := l.column
+		l.readChar() // consume '$'
+		body := l.readString('\'')
+		tok.Type = token.STRING
+		tok.Literal = "$" + body
+		tok.Line = l.line
+		tok.Column = col
+		tok.HasPrecedingSpace = hasSpace
+		l.readChar() // step past the closing quote
+		return tok, true
+	case '"':
+		// Zsh gettext quoting: $"…" marks a string for translation.
+		// The payload is otherwise a regular double-quoted string.
+		col := l.column
+		l.readChar() // consume '$'
+		body := l.readString('"')
+		tok.Type = token.STRING
+		tok.Literal = "$" + body
+		tok.Line = l.line
+		tok.Column = col
+		tok.HasPrecedingSpace = hasSpace
+		l.readChar() // step past the closing quote
+		return tok, true
+	}
+	if isLetter(l.peekChar()) {
+		col := l.column
+		l.readChar() // consume '$'
+		tok.Type = token.VARIABLE
+		tok.Literal = "$" + l.readIdentifier()
+		tok.Line = l.line
+		tok.Column = col
+		tok.HasPrecedingSpace = hasSpace
+		return tok, true
+	}
+	// Zsh single-character special parameters: $? (exit status),
+	// $@ (all positional), $$ (PID), $_ (last arg). The other
+	// single-char specials ($#, $*, $!, $-) are assembled by the
+	// parser from DOLLAR + the following punctuation token.
+	if c := l.peekChar(); c == '?' || c == '@' || c == '$' || c == '_' {
+		col := l.column
+		l.readChar() // consume '$'
+		tok.Type = token.VARIABLE
+		tok.Literal = "$" + string(l.ch)
+		tok.Line = l.line
+		tok.Column = col
+		tok.HasPrecedingSpace = hasSpace
+		l.readChar() // consume the special char
+		return tok, true
+	}
+	return token.Token{}, false
 }
 
 func (l *Lexer) readIdentifier() string {

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -6,6 +6,33 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/token"
 )
 
+func TestDollarQuotedStrings(t *testing.T) {
+	// Zsh ANSI-C quoting `$'…'` and gettext quoting `$"…"` must lex
+	// as single STRING tokens. Previously the `$` was emitted as
+	// DOLLAR and the quote contents as STRING, producing a pair the
+	// parser could not consume on an assignment RHS. Widely used in
+	// oh-my-zsh themes (darkblood and many more) to embed escape
+	// sequences inside prompt strings.
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{`$'hello'`, `$'hello'`},
+		{`$'a\nb'`, `$'a\nb'`},
+		{`$"gettext"`, `$"gettext"`},
+	}
+	for _, c := range cases {
+		l := New(c.in)
+		tok := l.NextToken()
+		if tok.Type != token.STRING {
+			t.Errorf("%q: want STRING, got %s", c.in, tok.Type)
+		}
+		if tok.Literal != c.want {
+			t.Errorf("%q: literal = %q, want %q", c.in, tok.Literal, c.want)
+		}
+	}
+}
+
 func TestNextToken(t *testing.T) {
 	input := `let five = 5;
 let ten = 10;


### PR DESCRIPTION
`$.'...'` (ANSI-C) and `$."..."` (gettext) previously lexed as two tokens (DOLLAR + STRING), which the parser rejected on the RHS of an assignment with "expected next token to be IDENT, got STRING". oh-my-zsh themes (darkblood and many more) use this pervasively for prompt strings with embedded escape sequences.

Lex them as a single STRING token; dollar-branch dispatch extracted into a new readDollarToken helper to keep NextToken under the funlen bar. darkblood.zsh-theme goes from 4 errors to 0.