### PR TITLE
feat: lex backslash-newline as line continuation

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -458,11 +458,27 @@ func (l *Lexer) readString(quote byte) string {
 
 func (l *Lexer) skipWhitespace() bool {
 	skipped := false
-	for l.ch == ' ' || l.ch == '\t' || l.ch == '\n' || l.ch == '\r' {
-		skipped = true
-		l.readChar()
+	for {
+		switch l.ch {
+		case ' ', '\t', '\n', '\r':
+			skipped = true
+			l.readChar()
+			continue
+		case '\\':
+			// Line continuation: an unquoted backslash immediately
+			// followed by a newline joins the next line to the
+			// current one. Skip both characters so the lexer treats
+			// `cmd \<NL>arg` as `cmd arg`. Any other use of `\`
+			// falls through to the regular token handler.
+			if l.peekChar() == '\n' {
+				l.readChar() // consume '\'
+				l.readChar() // consume '\n'
+				skipped = true
+				continue
+			}
+		}
+		return skipped
 	}
-	return skipped
 }
 
 func (l *Lexer) skipComment() {

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -6,6 +6,32 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/token"
 )
 
+func TestLineContinuation(t *testing.T) {
+	// `\<newline>` outside a string is Zsh's line-continuation
+	// sequence: the lexer should skip both characters so downstream
+	// parsing treats `cmd \<NL>arg` as a single logical line. Real
+	// oh-my-zsh themes (bureau, many others) use this to split long
+	// pipelines across lines.
+	src := "cmd arg1 arg2 \\\nmore args\n"
+	l := New(src)
+	var literals []string
+	for {
+		tok := l.NextToken()
+		if tok.Type == token.EOF {
+			break
+		}
+		literals = append(literals, tok.Literal)
+		if len(literals) > 20 {
+			t.Fatalf("too many tokens; line continuation did not collapse input")
+		}
+	}
+	for _, lit := range literals {
+		if lit == "\\" || lit == "ILLEGAL" {
+			t.Errorf("stray backslash token in stream: %v", literals)
+		}
+	}
+}
+
 func TestDollarQuotedStrings(t *testing.T) {
 	// Zsh ANSI-C quoting `$'…'` and gettext quoting `$"…"` must lex
 	// as single STRING tokens. Previously the `$` was emitted as


### PR DESCRIPTION
Unquoted `\<newline>` is Zsh line-continuation: the pair should be skipped so a pipeline split across lines is treated as one logical command. Previously the lexer kept the backslash as ILLEGAL, producing "no prefix parse function for ILLEGAL" on real oh-my-zsh themes (bureau and many more).

Handle the continuation inside skipWhitespace so every token producer benefits without per-site guards. bureau.zsh-theme error count drops from 10 to 5; the rest are unrelated modifier / STRING cases tracked for later iterations.