### PR TITLE
feat: ZC1004 Fix — exit to return (with arg-less detection)

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -84,6 +84,26 @@ func TestFixIntegration_NestedKatas_OuterWins(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1004_ExitToReturn(t *testing.T) {
+	src := `foo() {
+  if [[ -z "$1" ]]; then
+    exit 1
+  fi
+  exit
+}
+`
+	want := `foo() {
+  if [[ -z "$1" ]]; then
+    return 1
+  fi
+  return
+}
+`
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1004.go
+++ b/pkg/katas/zc1004.go
@@ -13,9 +13,23 @@ func init() {
 			"in interactive sessions or sourced scripts. Use `return` to exit the function.",
 		Severity: SeverityWarning,
 		Check:    checkZC1004,
+		Fix:      fixZC1004,
 	}
 	RegisterKata(ast.FunctionDefinitionNode, kata)
 	RegisterKata(ast.FunctionLiteralNode, kata)
+}
+
+// fixZC1004 rewrites `exit` to `return` at the command-name position
+// inside a function body. Arguments (the exit/return code) stay
+// unchanged — `exit 1` becomes `return 1` with the `1` byte-identical.
+// The violation's Line/Column already point at the command name.
+func fixZC1004(node ast.Node, v Violation, source []byte) []FixEdit {
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("exit"),
+		Replace: "return",
+	}}
 }
 
 func checkZC1004(node ast.Node) []Violation {
@@ -49,13 +63,31 @@ func checkZC1004(node ast.Node) []Violation {
 			}
 		}
 
-		if cmd, ok := n.(*ast.SimpleCommand); ok {
-			if cmd.Name.String() == "exit" {
+		// Match both SimpleCommand (`exit 1`) and bare Identifier
+		// wrapped in an ExpressionStatement (`exit` with no args —
+		// the parser folds zero-arg command invocations into a plain
+		// identifier expression rather than a SimpleCommand).
+		switch sn := n.(type) {
+		case *ast.SimpleCommand:
+			if sn.Name != nil && sn.Name.String() == "exit" {
 				violations = append(violations, Violation{
 					KataID:  "ZC1004",
 					Message: "Use `return` instead of `exit` in functions to avoid killing the shell.",
-					Line:    cmd.Token.Line,
-					Column:  cmd.Token.Column,
+					Line:    sn.Token.Line,
+					Column:  sn.Token.Column,
+					Level:   SeverityWarning,
+				})
+			}
+			// Don't descend — the Name Identifier would otherwise
+			// double-count as a bare-`exit` hit below.
+			return false
+		case *ast.Identifier:
+			if sn.Value == "exit" {
+				violations = append(violations, Violation{
+					KataID:  "ZC1004",
+					Message: "Use `return` instead of `exit` in functions to avoid killing the shell.",
+					Line:    sn.Token.Line,
+					Column:  sn.Token.Column,
 					Level:   SeverityWarning,
 				})
 			}


### PR DESCRIPTION
Adds a Fix implementation for ZC1004 that rewrites `exit` -> `return` at the command-name position inside function bodies. Arguments stay byte-identical.

Detection was also extended to catch bare `exit` with no arguments. The parser folds zero-arg command invocations into an Identifier expression rather than a SimpleCommand, so the previous match-only-SimpleCommand check missed that shape. New Identifier arm catches it; the SimpleCommand arm now returns false from Walk to avoid double-counting the Name.

Integration test exercises both forms in the same function body.