### PR TITLE
feat: ZC1013 Fix — let NAME=EXPR to (( NAME = EXPR ))

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -84,6 +84,20 @@ func TestFixIntegration_NestedKatas_OuterWins(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1013_LetToArith(t *testing.T) {
+	src := `let x=5
+let y=$((x + 1))
+let counter=counter+1
+`
+	want := `(( x = 5 ))
+(( y = $((x + 1)) ))
+(( counter = counter+1 ))
+`
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1004_ExitToReturn(t *testing.T) {
 	src := `foo() {
   if [[ -z "$1" ]]; then

--- a/pkg/katas/zc1013.go
+++ b/pkg/katas/zc1013.go
@@ -12,7 +12,66 @@ func init() {
 			"and generally preferred for arithmetic operations in Zsh.",
 		Severity: SeverityInfo,
 		Check:    checkZC1013,
+		Fix:      fixZC1013,
 	})
+}
+
+// fixZC1013 rewrites `let NAME=EXPR` -> `(( NAME = EXPR ))`. The
+// replacement spans from the `let` keyword to the end of the logical
+// line (first `;`, `\n`, or EOF). The original expression text is
+// preserved byte-identical so operator precedence and side effects
+// match the source. Multi-assignment forms (`let a=1 b=2`) are not
+// attempted — the Fix bails when the AST does not have a single
+// Name/Value pair.
+func fixZC1013(node ast.Node, v Violation, source []byte) []FixEdit {
+	stmt, ok := node.(*ast.LetStatement)
+	if !ok {
+		return nil
+	}
+	if stmt.Name == nil || stmt.Value == nil {
+		return nil
+	}
+	start := LineColToByteOffset(source, v.Line, v.Column)
+	if start < 0 {
+		return nil
+	}
+	// Scan for the end of the statement: first semicolon, newline,
+	// or EOF.
+	end := start
+	for end < len(source) {
+		b := source[end]
+		if b == '\n' || b == ';' {
+			break
+		}
+		end++
+	}
+	// `let NAME=EXPR` — after the keyword the source is NAME=EXPR.
+	// Split on the first `=` to honour the original spelling (the
+	// AST stores Name separately but Value.String() can lose
+	// whitespace or parentheses that matter).
+	prefix := "let "
+	if start+len(prefix) > end {
+		return nil
+	}
+	body := string(source[start+len(prefix) : end])
+	eq := -1
+	for i := 0; i < len(body); i++ {
+		if body[i] == '=' {
+			eq = i
+			break
+		}
+	}
+	if eq < 0 {
+		return nil
+	}
+	name := body[:eq]
+	rhs := body[eq+1:]
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  end - start,
+		Replace: "(( " + name + " = " + rhs + " ))",
+	}}
 }
 
 func checkZC1013(node ast.Node) []Violation {


### PR DESCRIPTION
Adds a Fix implementation for ZC1013 that rewrites `let NAME=EXPR` to `(( NAME = EXPR ))`. The span scan runs from the `let` keyword to the end of the logical line; RHS bytes are preserved so operator precedence and nested arithmetic stay intact. Multi-assignment forms remain on the roadmap.

Integration test covers three common shapes including a nested `$(( … ))` RHS.