### PR TITLE
feat: ZC1010 Fix — [ ... ] to [[ ... ]]

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -84,6 +84,22 @@ func TestFixIntegration_NestedKatas_OuterWins(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1010_TestToDoubleBracket(t *testing.T) {
+	src := `if [ -f /tmp/foo ]; then
+  :
+fi
+[ "$x" = "y" ] && :
+`
+	want := `if [[ -f /tmp/foo ]]; then
+  :
+fi
+[[ "$x" = "y" ]] && :
+`
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1013_LetToArith(t *testing.T) {
 	src := `let x=5
 let y=$((x + 1))

--- a/pkg/katas/zc1010.go
+++ b/pkg/katas/zc1010.go
@@ -12,7 +12,103 @@ func init() {
 			"It supports pattern matching, regex, and doesn't require quoting variables to prevent word splitting.",
 		Severity: SeverityStyle,
 		Check:    checkZC1010,
+		Fix:      fixZC1010,
 	})
+}
+
+// fixZC1010 rewrites a `[ … ]` test command to `[[ … ]]`. The opening
+// bracket at the violation's coordinates becomes `[[`; the matching
+// closing bracket on the same logical line becomes `]]`. Contents
+// stay byte-identical so quoting and expansions are preserved.
+//
+// Bail when the shape is not a simple `[ … ]` test (e.g. second token
+// is not `[`, or the logical line has no closing bracket): a
+// malformed test is not safely auto-fixable.
+func fixZC1010(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	if cmd.Name == nil || cmd.Name.String() != "[" {
+		return nil
+	}
+	open := LineColToByteOffset(source, v.Line, v.Column)
+	if open < 0 || open >= len(source) || source[open] != '[' {
+		return nil
+	}
+	close := findTestCloseBracket(source, open)
+	if close < 0 {
+		return nil
+	}
+	return []FixEdit{
+		{Line: v.Line, Column: v.Column, Length: 1, Replace: "[["},
+		offsetToEdit(source, close, 1, "]]"),
+	}
+}
+
+// findTestCloseBracket returns the byte offset of the closing `]`
+// that terminates a `[ … ]` test opened at open, or -1 when no clean
+// close is found before an end-of-statement terminator. Single- and
+// double-quoted strings, and `${…}` braces are respected so the scan
+// doesn't match `]` inside `"$arr[idx]"`.
+func findTestCloseBracket(source []byte, open int) int {
+	inSingle := false
+	inDouble := false
+	braceDepth := 0
+	for i := open + 1; i < len(source); i++ {
+		c := source[i]
+		switch {
+		case inSingle:
+			if c == '\'' {
+				inSingle = false
+			}
+		case inDouble:
+			if c == '\\' && i+1 < len(source) {
+				i++
+				continue
+			}
+			if c == '"' {
+				inDouble = false
+			}
+		default:
+			switch c {
+			case '\'':
+				inSingle = true
+			case '"':
+				inDouble = true
+			case '{':
+				braceDepth++
+			case '}':
+				if braceDepth > 0 {
+					braceDepth--
+				}
+			case '\n', ';':
+				return -1
+			case ']':
+				if braceDepth == 0 {
+					return i
+				}
+			}
+		}
+	}
+	return -1
+}
+
+// offsetToEdit builds a FixEdit whose Line/Column correspond to the
+// given byte offset inside source. Used when a Fix already has a
+// byte offset but the FixEdit type expects 1-based coordinates.
+func offsetToEdit(source []byte, offset, length int, replace string) FixEdit {
+	line := 1
+	col := 1
+	for i := 0; i < offset && i < len(source); i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return FixEdit{Line: line, Column: col, Length: length, Replace: replace}
 }
 
 func checkZC1010(node ast.Node) []Violation {


### PR DESCRIPTION
Adds a Fix implementation for ZC1010 that rewrites the POSIX test command `[ ... ]` to the Zsh conditional `[[ ... ]]`. Two-edit rewrite: opening `[` becomes `[[`, closing `]` located via a small quote/brace-aware scanner becomes `]]`. Contents are preserved byte-for-byte.

Conservative: bails when the line lacks a clean closing bracket before a semicolon or newline.