### PR TITLE
fix: double-bracket logical chain short-circuits

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -45,29 +45,38 @@ func (p *Parser) parseStatement() ast.Statement {
 		if cmd == nil {
 			return nil
 		}
-		// Chain with `&&` / `||` when the arithmetic command is followed
-		// by a logical operator: `(( A )) && (( B )) || other-command`.
-		if p.peekTokenIs(token.AND) || p.peekTokenIs(token.OR) {
-			var left ast.Expression = cmd
-			for p.peekTokenIs(token.AND) || p.peekTokenIs(token.OR) {
-				p.nextToken()
-				op := p.curToken
-				p.nextToken() // move to start of right command
-				right := p.parseCommandPipeline()
-				left = &ast.InfixExpression{
-					Token:    op,
-					Operator: op.Literal,
-					Left:     left,
-					Right:    right,
-				}
-			}
-			stmt := &ast.ExpressionStatement{Token: cmd.Token, Expression: left}
-			if p.peekTokenIs(token.SEMICOLON) {
-				p.nextToken()
-			}
-			return stmt
+		if chained := p.chainLogical(cmd, cmd.Token); chained != nil {
+			return chained
 		}
 		return cmd
+	case token.LDBRACKET:
+		// `[[ … ]]` is a prefix expression by default. As a statement
+		// we need to capture the bracketed expression AND the `&&` /
+		// `||` continuations without letting the generic
+		// parseExpression loop pick OR/AND up as internal infix
+		// operators — that swallows the continuation's right-hand
+		// command (e.g. `|| return 0`) into a single expression
+		// whose RHS starts at `return`, which has no prefix parse
+		// entry and errors out.
+		//
+		// Call the prefix function directly so the expression stops
+		// exactly at `]]`, then route post-`]]` logical chains
+		// through chainLogical, which uses parseCommandPipeline for
+		// the RHS — the command-aware path that knows how to handle
+		// `return`, builtins, simple commands, and so on.
+		startTok := p.curToken
+		expr := p.parseDoubleBracketExpression()
+		if expr == nil {
+			return nil
+		}
+		if chained := p.chainLogical(expr, startTok); chained != nil {
+			return chained
+		}
+		stmt := &ast.ExpressionStatement{Token: startTok, Expression: expr}
+		if p.peekTokenIs(token.SEMICOLON) {
+			p.nextToken()
+		}
+		return stmt
 	case token.COLON, token.DOT, token.LBRACKET,
 		token.GT, token.LT, token.GTGT, token.LTLT, token.GTAMP, token.LTAMP, token.AMPERSAND, token.SLASH:
 		return p.parseSimpleCommandStatement()
@@ -89,6 +98,35 @@ func (p *Parser) parseStatement() ast.Statement {
 	default:
 		return p.parseExpressionOrFunctionDefinition()
 	}
+}
+
+// chainLogical threads `&&` / `||` continuations onto an arbitrary
+// left-hand expression, returning a wrapped ExpressionStatement. The
+// helper exists because `(( … ))` and `[[ … ]]` are both legitimate
+// starts of a logical chain but live on different parse paths; both
+// now funnel through here. Returns nil when the peek is not a logical
+// operator so the caller can emit its native shape untouched.
+func (p *Parser) chainLogical(left ast.Expression, startTok token.Token) ast.Statement {
+	if !p.peekTokenIs(token.AND) && !p.peekTokenIs(token.OR) {
+		return nil
+	}
+	for p.peekTokenIs(token.AND) || p.peekTokenIs(token.OR) {
+		p.nextToken()
+		op := p.curToken
+		p.nextToken() // move to start of right-hand command
+		right := p.parseCommandPipeline()
+		left = &ast.InfixExpression{
+			Token:    op,
+			Operator: op.Literal,
+			Left:     left,
+			Right:    right,
+		}
+	}
+	stmt := &ast.ExpressionStatement{Token: startTok, Expression: left}
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+	}
+	return stmt
 }
 
 func (p *Parser) parseExpressionOrFunctionDefinition() ast.Statement {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1045,6 +1045,31 @@ func TestArithmeticLogicalChain(t *testing.T) {
 	}
 }
 
+func TestDoubleBracketLogicalChain(t *testing.T) {
+	// `[[ … ]] && cmd` and `[[ … ]] || cmd` are idiomatic short-
+	// circuit guards. The parser used to let the generic expression
+	// loop treat `||` / `&&` as internal infix operators, swallowing
+	// the right-hand command; RHSes like `return 0` or `break` then
+	// produced "no prefix parse function for RETURN". Now handled
+	// explicitly at statement level via chainLogical.
+	inputs := []string{
+		`[[ -n "$x" ]] || return 0`,
+		`[[ -z "$x" ]] && return 1`,
+		`[[ -n "$x" ]] && echo y || echo n`,
+		`foo() {
+  [[ -n "$x" ]] || return 0
+}`,
+	}
+	for _, input := range inputs {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%s:\n  unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
 func TestBareAppendAssignment(t *testing.T) {
 	// `var+=value` is the bare append-assignment form. Prior to this
 	// fix the parser handled the bare `=` assignment but rejected


### PR DESCRIPTION
`[[ ... ]] || return 0` and `[[ ... ]] && cmd` are idiomatic guards. The parser let the generic parseExpression loop treat `||` and `&&` as internal infix operators, swallowing the right-hand command token; with `return`/`break`/`continue` on the right this produced "no prefix parse function for RETURN" on dozens of oh-my-zsh themes and plugins.

Fix: dedicated parseStatement case for LDBRACKET calls parseDoubleBracketExpression directly and runs the result through a shared chainLogical helper extracted from the earlier arithmetic-chain work. `(( ... ))` and `[[ ... ]]` now use one code path.

oldgallois.zsh-theme goes from 1 error to 0; the cascade of RETURN/FI errors across other themes drops sharply in the next sweep.