### PR TITLE
fix: register return as prefix for logical-chain RHS

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -76,6 +76,14 @@ func New(l *lexer.Lexer) *Parser {
 
 	p.prefixParseFns = make(map[token.Type]prefixParseFn)
 	p.registerPrefix(token.IDENT, p.parseIdentifier)
+	// Zsh `return` can legitimately appear as the right-hand side
+	// of a logical chain (`cmd || return`, `[[ … ]] && return 0`).
+	// Top-level statement parsing of the RETURN keyword still wins
+	// via the parseStatement switch because that runs before
+	// expression dispatch. Registering it as a prefix only matters
+	// when the parser is already mid-expression (OR/AND folded as
+	// infix into an expression chain with `return` on the RHS).
+	p.registerPrefix(token.RETURN, p.parseKeywordAsCommand)
 	p.registerPrefix(token.INT, p.parseIntegerLiteral)
 	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -35,6 +35,25 @@ func (p *Parser) parseIdentifier() ast.Expression {
 	return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 }
 
+// parseKeywordAsCommand wraps a Zsh keyword (currently RETURN) as a
+// SimpleCommand so it can appear as the right-hand side of a logical
+// expression chain like `cmd || return 0`. Any arguments on the same
+// line are collected via parseCommandWord so `return 1` or
+// `break 2` (when BREAK/CONTINUE get their own tokens) round-trip
+// through the expression layer.
+func (p *Parser) parseKeywordAsCommand() ast.Expression {
+	tok := p.curToken
+	cmd := &ast.SimpleCommand{
+		Token: tok,
+		Name:  &ast.Identifier{Token: tok, Value: tok.Literal},
+	}
+	for !p.isCommandDelimiter(p.peekToken) && p.peekToken.Line == tok.Line {
+		p.nextToken()
+		cmd.Arguments = append(cmd.Arguments, p.parseCommandWord())
+	}
+	return cmd
+}
+
 func (p *Parser) parseIntegerLiteral() ast.Expression {
 	lit := &ast.IntegerLiteral{Token: p.curToken}
 	value, err := strconv.ParseInt(p.curToken.Literal, 0, 64)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1045,6 +1045,31 @@ func TestArithmeticLogicalChain(t *testing.T) {
 	}
 }
 
+func TestReturnAsLogicalRhs(t *testing.T) {
+	// `cmd || return`, `cmd && return 0`, etc. are idiomatic guards.
+	// When OR/AND got folded into an expression InfixExpression the
+	// right-hand side reached parseExpression's prefix table and
+	// `return` had no entry, producing "no prefix parse function
+	// for RETURN". Registering RETURN as a prefix that builds a
+	// SimpleCommand unblocks the chain; top-level `return` keeps
+	// its dedicated parseReturnStatement path.
+	inputs := []string{
+		`ref=$(cmd) || return`,
+		`ref=$(cmd) || return 1`,
+		`ref=$(cmd) && return`,
+		`[[ -n "$x" ]] && return 0`,
+		`(( n > 0 )) || return`,
+	}
+	for _, input := range inputs {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%s:\n  unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
 func TestDoubleBracketLogicalChain(t *testing.T) {
 	// `[[ … ]] && cmd` and `[[ … ]] || cmd` are idiomatic short-
 	// circuit guards. The parser used to let the generic expression


### PR DESCRIPTION
`cmd || return` and `cmd && return 0` are idiomatic guards used throughout oh-my-zsh themes. When OR/AND got folded into an InfixExpression, the chain RHS reached the expression layer and `return` had no prefix entry, producing "no prefix parse function for RETURN".

Fix: register RETURN as a prefix that wraps the keyword in a SimpleCommand and collects same-line arguments. Top-level `return` keeps its dedicated parseReturnStatement path (parseStatement runs before expression dispatch). Regression tests cover assignment-RHS, arithmetic-chain, and double-bracket-chain shapes.