### PR TITLE
fix: brace param expansion with empty subject + modifier

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -176,14 +176,26 @@ func (p *Parser) parseArrayAccess() ast.Expression {
 		p.nextToken()
 	}
 
-	p.nextToken() // move to subject
-
-	expr := p.parseExpression(LOWEST)
-	if idxExpr, ok := expr.(*ast.IndexExpression); ok {
-		exp.Left = idxExpr.Left
-		exp.Index = idxExpr.Index
+	// The subject is optional when the only body is a modifier tail
+	// applied to an empty parameter, as in `${(%):-default}` where
+	// the `(%)` flag group is followed directly by `:-`. Without
+	// this guard, parseExpression tries to find a prefix for `:` and
+	// errors out. If the peek is a modifier punctuator, skip straight
+	// to the opaque modifier-tail scanner below.
+	if p.peekTokenIs(token.COLON) || p.peekTokenIs(token.HASH) ||
+		p.peekTokenIs(token.PERCENT) || p.peekTokenIs(token.SLASH) {
+		// Nothing to parse for the subject; the modifier tail loop
+		// will consume the rest of the body.
+		exp.Left = nil
 	} else {
-		exp.Left = expr
+		p.nextToken() // move to subject
+		expr := p.parseExpression(LOWEST)
+		if idxExpr, ok := expr.(*ast.IndexExpression); ok {
+			exp.Left = idxExpr.Left
+			exp.Index = idxExpr.Index
+		} else {
+			exp.Left = expr
+		}
 	}
 
 	if hasLengthOp && exp.Left != nil {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1178,6 +1178,28 @@ func TestArraySubscriptFlags(t *testing.T) {
 	}
 }
 
+func TestBraceParamExpansionEmptySubject(t *testing.T) {
+	// `${(%):-default}` applies the `(%)` flag to an empty parameter
+	// with a default. The subject is legitimately absent; without a
+	// guard the parser tried to parse `:` as a prefix expression and
+	// produced "no prefix parse function for :" on simonoff and
+	// other oh-my-zsh themes.
+	inputs := []string{
+		`x=${(%):-default}`,
+		`y=${(%):--(foo)-}`,
+		`z=${#${(%):--(bar)-}}`,
+		`a=${(l.5.):-default}`,
+	}
+	for _, input := range inputs {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%s:\n  unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
 func TestBraceParamExpansionModifiersAreOpaque(t *testing.T) {
 	// Every Zsh parameter-expansion modifier that comes after the
 	// subject is accepted without a structured AST yet (tracked in


### PR DESCRIPTION
`${(%):-default}` applies the `(%)` flag to an empty parameter with a default. Subject is legitimately absent; the parser errored with "no prefix parse function for :" on simonoff and other themes that use this idiom for prompt-format escapes.

Guard: after flag-tuple consumption, if peek is a modifier punctuator (`:`/`#`/`%`/`/`), skip the subject parse entirely and fall through to the opaque modifier-tail scanner.