### PR TITLE
feat: for NAME ( items ) body short form

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -592,6 +592,40 @@ func (p *Parser) parseForLoopStatement() *ast.ForLoopStatement {
 	}
 	stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 
+	// Zsh short form: `for NAME ( items ) body`. The item list is
+	// wrapped in parentheses and the body is a single command (or
+	// block) with no `do`/`done`. Real-world example in prezto
+	// init.zsh: `for zmodule ("$zmodules[@]") zmodload "zsh/…"`.
+	if p.peekTokenIs(token.LPAREN) {
+		p.nextToken() // consume (
+		stmt.Items = []ast.Expression{}
+		for !p.peekTokenIs(token.RPAREN) && !p.peekTokenIs(token.EOF) {
+			p.nextToken()
+			if p.curTokenIs(token.RPAREN) {
+				break
+			}
+			arg := p.parseCommandWord()
+			stmt.Items = append(stmt.Items, arg)
+		}
+		if !p.expectPeek(token.RPAREN) {
+			return nil
+		}
+		// Body is a single statement on the same line (usually a
+		// command) or a braced block. Wrap non-block statements in
+		// a BlockStatement so the Body field stays homogeneous.
+		p.nextToken()
+		body := p.parseStatement()
+		if block, ok := body.(*ast.BlockStatement); ok {
+			stmt.Body = block
+		} else if body != nil {
+			stmt.Body = &ast.BlockStatement{
+				Token:      stmt.Token,
+				Statements: []ast.Statement{body},
+			}
+		}
+		return stmt
+	}
+
 	if p.peekTokenIs(token.IN) {
 		p.nextToken()
 		stmt.Items = []ast.Expression{}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1045,6 +1045,27 @@ func TestArithmeticLogicalChain(t *testing.T) {
 	}
 }
 
+func TestForLoopShortForm(t *testing.T) {
+	// Zsh `for NAME ( items ) body` is the paren-delimited short
+	// form that needs no do/done. Prezto init.zsh uses it to iterate
+	// zmodules. The parser previously expected DO after the name and
+	// failed with "expected next token to be DO, got (".
+	inputs := []string{
+		`for x ("a" "b" "c") echo $x`,
+		`for mod ("$arr[@]") zmodload "zsh/${mod}"`,
+		`for f (*.zsh) source $f`,
+		`for i (1 2 3) { echo $i }`,
+	}
+	for _, input := range inputs {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%s:\n  unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
 func TestReturnAsLogicalRhs(t *testing.T) {
 	// `cmd || return`, `cmd && return 0`, etc. are idiomatic guards.
 	// When OR/AND got folded into an expression InfixExpression the


### PR DESCRIPTION
Zsh supports a paren-delimited short form of the for-each loop that uses no do/done keywords. Prezto init.zsh uses it: `for mod ("$zmodules[@]") zmodload "zsh/${mod}"`. Previously the parser expected DO after the loop variable and errored with "expected next token to be DO, got (".

Add a third branch to parseForLoopStatement: consume the paren-wrapped item list, then parse the body as a single statement on the same line (or a braced block). Non-block bodies are wrapped in BlockStatement so the Body field stays homogeneous.

Regression tests cover positional, array-splat, glob, and braced-block bodies. prezto/init.zsh error count drops from 9 to 3.