### PR TITLE
fix: bare dollar at statement boundary parses as identifier

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -245,6 +245,20 @@ func (p *Parser) parseArrayAccess() ast.Expression {
 
 func (p *Parser) parseInvalidArrayAccessPrefix() ast.Expression {
 	dollarToken := p.curToken
+
+	// A bare `$` followed by a command terminator or EOF is a
+	// literal dollar character. Real code in the oh-my-zsh corpus
+	// writes `echo $` (print a literal `$`) or splits long
+	// expressions with `= $` at end of line. Return a $ identifier
+	// so downstream walkers see a well-formed expression rather
+	// than the "expected next token to be IDENT" path below.
+	if p.peekTokenIs(token.SEMICOLON) || p.peekTokenIs(token.EOF) ||
+		p.peekTokenIs(token.PIPE) || p.peekTokenIs(token.AMPERSAND) ||
+		p.peekTokenIs(token.AND) || p.peekTokenIs(token.OR) ||
+		p.peekTokenIs(token.RPAREN) || p.peekTokenIs(token.RBRACE) {
+		return &ast.Identifier{Token: dollarToken, Value: "$"}
+	}
+
 	if p.peekTokenIs(token.HASH) || p.peekTokenIs(token.INT) || p.peekTokenIs(token.ASTERISK) || p.peekTokenIs(token.BANG) || p.peekTokenIs(token.MINUS) {
 		p.nextToken()
 		opToken := p.curToken

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1045,6 +1045,30 @@ func TestArithmeticLogicalChain(t *testing.T) {
 	}
 }
 
+func TestBareDollarAsIdentifier(t *testing.T) {
+	// `echo $` prints a literal dollar. A `$` at end-of-statement
+	// or before a pipe/redirect should lex as DOLLAR and parse as
+	// an Identifier with value "$" rather than falling into the
+	// "expected next token to be IDENT" error path. Real code in
+	// oh-my-zsh's tjkirch theme uses `echo $` in a prompt-char
+	// branch.
+	inputs := []string{
+		`echo $`,
+		`echo $; echo other`,
+		`x=$`,
+		`cmd $ | other`,
+		`cmd $ && other`,
+	}
+	for _, input := range inputs {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%s:\n  unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
 func TestForLoopShortForm(t *testing.T) {
 	// Zsh `for NAME ( items ) body` is the paren-delimited short
 	// form that needs no do/done. Prezto init.zsh uses it to iterate


### PR DESCRIPTION
`echo $` prints a literal dollar; the oh-my-zsh tjkirch theme uses this pattern in its prompt-char branch. The parser errored with "expected next token to be IDENT, got ;" because parseInvalidArrayAccessPrefix assumed an identifier always follows `$`.

Return an Identifier with Value="$" when the next token is a statement terminator (; EOF | & && || ) } ), matching how the shell treats a bare dollar as a literal character.