### PR TITLE
fix: only fuse ]] when a [[ is open

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -11,6 +11,13 @@ type Lexer struct {
 	ch           byte // current char under examination
 	line         int  // current line number
 	column       int  // current column number
+
+	// dbracketDepth tracks nesting of `[[ … ]]` conditional blocks.
+	// Without this we cannot distinguish a conditional close (the
+	// fused `]]` token) from two consecutive single-bracket closes
+	// in `arr[$m[i]]`. When depth is zero the lexer emits two
+	// RBRACKETs instead of RDBRACKET.
+	dbracketDepth int
 }
 
 func New(input string) *Lexer {
@@ -226,15 +233,21 @@ func (l *Lexer) NextToken() token.Token {
 			l.readChar()
 			literal := string(ch) + string(l.ch)
 			tok = token.Token{Type: token.LDBRACKET, Literal: literal, Line: l.line, Column: l.column}
+			l.dbracketDepth++
 		} else {
 			tok = newToken(token.LBRACKET, l.ch, l.line, l.column)
 		}
 	case ']':
-		if l.peekChar() == ']' {
+		// `]]` only means RDBRACKET when there is a pending
+		// `[[` to close. In array-subscript contexts like
+		// `arr[$m[i]]` the two brackets close two independent
+		// subscripts and must lex as two RBRACKET tokens.
+		if l.peekChar() == ']' && l.dbracketDepth > 0 {
 			ch := l.ch
 			l.readChar()
 			literal := string(ch) + string(l.ch)
 			tok = token.Token{Type: token.RDBRACKET, Literal: literal, Line: l.line, Column: l.column}
+			l.dbracketDepth--
 		} else {
 			tok = newToken(token.RBRACKET, l.ch, l.line, l.column)
 		}

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -6,6 +6,47 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/token"
 )
 
+func TestNestedSubscriptClose(t *testing.T) {
+	// `arr[$m[i]]` has two consecutive `]` that must lex as two
+	// RBRACKET tokens, not a single RDBRACKET. The lexer now
+	// tracks `[[ … ]]` conditional depth and only fuses `]]` when
+	// there is an open conditional waiting to close.
+	cases := []struct {
+		in          string
+		wantTypes   []token.Type
+		lastLiteral string
+	}{
+		{
+			in:        `FG[$colors[i]]`,
+			wantTypes: []token.Type{token.IDENT, token.LBRACKET, token.VARIABLE, token.LBRACKET, token.IDENT, token.RBRACKET, token.RBRACKET, token.EOF},
+		},
+		{
+			in:        `[[ $x ]]`,
+			wantTypes: []token.Type{token.LDBRACKET, token.VARIABLE, token.RDBRACKET, token.EOF},
+		},
+	}
+	for _, c := range cases {
+		l := New(c.in)
+		var got []token.Type
+		for {
+			tok := l.NextToken()
+			got = append(got, tok.Type)
+			if tok.Type == token.EOF || len(got) > 20 {
+				break
+			}
+		}
+		if len(got) != len(c.wantTypes) {
+			t.Errorf("%q: got %v, want %v", c.in, got, c.wantTypes)
+			continue
+		}
+		for i, want := range c.wantTypes {
+			if got[i] != want {
+				t.Errorf("%q: token %d = %s, want %s", c.in, i, got[i], want)
+			}
+		}
+	}
+}
+
 func TestLineContinuation(t *testing.T) {
 	// `\<newline>` outside a string is Zsh's line-continuation
 	// sequence: the lexer should skip both characters so downstream


### PR DESCRIPTION
The lexer unconditionally fused two consecutive `]` into RDBRACKET. That hid the outer bracket in nested array subscripts like `FG[arr[i]]` — the parser errored with "expected next token to be ], got ]]".

Fix: track `[[ … ]]` depth in the lexer and only fuse `]]` when depth is positive; otherwise emit two RBRACKETs. Conditional expressions still close correctly; array-of-array subscripts now parse.

Prezto modules/spectrum/init.zsh parses cleanly.