### PR TITLE
fix: route zero-arg commands with pipe chain to simple-command path

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -91,7 +91,14 @@ func (p *Parser) parseStatement() ast.Statement {
 			p.peekTokenIs(token.DOLLAR) || p.peekTokenIs(token.DollarLbrace) ||
 			p.peekTokenIs(token.DOLLAR_LPAREN) || p.peekTokenIs(token.SLASH) ||
 			p.peekTokenIs(token.TILDE) || p.peekTokenIs(token.ASTERISK) ||
-			p.peekTokenIs(token.BANG) || p.peekTokenIs(token.LBRACE) {
+			p.peekTokenIs(token.BANG) || p.peekTokenIs(token.LBRACE) ||
+			// Zero-arg commands followed by a pipe / logical chain
+			// must route through parseSimpleCommandStatement so the
+			// pipeline / AND / OR chain is parsed at the command
+			// layer. Without this `cmd1 |\n cmd2` left `cmd1` as a
+			// bare Identifier expression, and the block loop then
+			// tried to start a new statement at `|`.
+			p.peekTokenIs(token.PIPE) || p.peekTokenIs(token.AND) || p.peekTokenIs(token.OR) {
 			return p.parseSimpleCommandStatement()
 		}
 		return p.parseExpressionOrFunctionDefinition()

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1045,6 +1045,29 @@ func TestArithmeticLogicalChain(t *testing.T) {
 	}
 }
 
+func TestZeroArgCommandFollowedByPipeChain(t *testing.T) {
+	// A zero-argument command followed by a pipe or logical chain
+	// must route through the command-statement path so the chain
+	// is parsed at the command layer. Previously `cmd1 |<NL>cmd2`
+	// left cmd1 as a bare Identifier expression and the block loop
+	// tried to start a new statement at `|`.
+	inputs := []string{
+		"cmd1 |\n  cmd2",
+		"cmd1 ||\n  cmd2",
+		"cmd1 &&\n  cmd2",
+		"ls | wc",
+		"ls | wc | cat",
+	}
+	for _, input := range inputs {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%q:\n  unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
 func TestBareDollarAsIdentifier(t *testing.T) {
 	// `echo $` prints a literal dollar. A `$` at end-of-statement
 	// or before a pipe/redirect should lex as DOLLAR and parse as


### PR DESCRIPTION
A zero-argument command followed by a pipe or logical chain (`cmd |`, `cmd &&`, `cmd ||`) fell into the expression path because the IDENT dispatch only routed to parseSimpleCommandStatement when the peek was a command-word producer. The expression path returned just the Identifier, leaving the block loop to start a fresh statement at the pipe operator with "no prefix parse function for | found".

Add PIPE, AND, OR to the peek set so zero-arg pipelines and guard chains route through the command layer. Line-continued pipelines `cmd |<NL>rest` now parse as expected.