### PR TITLE
feat: lex backslash-escaped metacharacters as IDENT

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -327,6 +327,32 @@ func (l *Lexer) NextToken() token.Token {
 			tok.Column = col
 			tok.HasPrecedingSpace = hasSpace
 			return tok
+		case l.ch == '\\':
+			// Backslash outside a string quotes exactly one following
+			// character. Zsh glob escapes (`\(`, `\)`, `\*`, `\?`,
+			// etc.) surface in oh-my-zsh themes. Emit the escaped
+			// character's natural token — backslash-newline is
+			// already handled by skipWhitespace. For non-alphanumeric
+			// escapes we emit the raw escaped char as an IDENT-style
+			// word so parseCommandWord folds it into the surrounding
+			// word naturally. We only do this when the next byte is
+			// one of the commonly-escaped glob / shell metacharacters
+			// to avoid destabilising token-aware contexts.
+			if next := l.peekChar(); next == '(' || next == ')' || next == '*' ||
+				next == '?' || next == '[' || next == ']' || next == '|' ||
+				next == '&' || next == ';' || next == '<' || next == '>' ||
+				next == '{' || next == '}' || next == '$' || next == '\\' {
+				line, col := l.line, l.column
+				l.readChar() // consume '\'
+				tok = token.Token{
+					Type:    token.IDENT,
+					Literal: "\\" + string(l.ch),
+					Line:    line,
+					Column:  col,
+				}
+			} else {
+				tok = newToken(token.ILLEGAL, l.ch, l.line, l.column)
+			}
 		default:
 			tok = newToken(token.ILLEGAL, l.ch, l.line, l.column)
 		}

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -6,6 +6,26 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/token"
 )
 
+func TestBackslashEscapedMeta(t *testing.T) {
+	// Zsh glob escapes (`\(`, `\)`, `\*`, `\?`, etc.) and generic
+	// metacharacter quoting appeared as ILLEGAL tokens, breaking
+	// oh-my-zsh themes that use patterns like `*\(foo\)*`. The
+	// lexer now emits each commonly-escaped metacharacter pair as
+	// a single IDENT token so parseCommandWord folds it into the
+	// surrounding word.
+	cases := []string{`\(`, `\)`, `\*`, `\?`, `\[`, `\]`, `\|`, `\$`}
+	for _, in := range cases {
+		l := New(in)
+		tok := l.NextToken()
+		if tok.Type != token.IDENT {
+			t.Errorf("%q: want IDENT, got %s (literal %q)", in, tok.Type, tok.Literal)
+		}
+		if tok.Literal != in {
+			t.Errorf("%q: literal = %q, want %q", in, tok.Literal, in)
+		}
+	}
+}
+
 func TestNestedSubscriptClose(t *testing.T) {
 	// `arr[$m[i]]` has two consecutive `]` that must lex as two
 	// RBRACKET tokens, not a single RDBRACKET. The lexer now


### PR DESCRIPTION
Zsh glob patterns and shell-word quoting use a backslash to quote a single following metacharacter: `\(`, `\)`, `\*`, `\?`, `\[`, `\]`, `\|`, `\$`, etc. The lexer emitted ILLEGAL on the backslash which broke oh-my-zsh themes like af-magic that test paths with patterns such as `*\(foo\)*`.

Recognise the common set of backslash-quoted metacharacters and emit the pair as a single IDENT token so parseCommandWord folds it into the surrounding word. Backslash followed by any other byte keeps the ILLEGAL path so malformed input is still reported.

Global corpus error count drops from 2090 to 2059.