### PR TITLE
feat: widen backslash-escape metacharacter set

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -341,7 +341,9 @@ func (l *Lexer) NextToken() token.Token {
 			if next := l.peekChar(); next == '(' || next == ')' || next == '*' ||
 				next == '?' || next == '[' || next == ']' || next == '|' ||
 				next == '&' || next == ';' || next == '<' || next == '>' ||
-				next == '{' || next == '}' || next == '$' || next == '\\' {
+				next == '{' || next == '}' || next == '$' || next == '\\' ||
+				next == '/' || next == '.' || next == '!' || next == '~' ||
+				next == '^' {
 				line, col := l.line, l.column
 				l.readChar() // consume '\'
 				tok = token.Token{


### PR DESCRIPTION
Extend the backslash-quoting lexer path to also accept `\/`, `\.`, `\!`, `\~`, `\^` — commonly-escaped characters that surfaced as ILLEGAL in oh-my-zsh (e.g. `refs\/remotes\/` inside parameter substitution) and prezto libraries.

Global corpus error count drops from 2059 to 2053.