### PR TITLE
feat: brace expansion inside declaration names

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -757,6 +757,33 @@ func (p *Parser) parseDeclarationStatement() *ast.DeclarationStatement {
 			assign := &ast.DeclarationAssignment{
 				Name: &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal},
 			}
+			// Brace expansion inside the name: p10k config files
+			// declare `typeset -g X_{A,B,C}_Y=1` and expect the
+			// parser to treat the whole `X_{A,B,C}_Y` as one name.
+			// Consume a matching `{…}` span plus any trailing IDENT
+			// suffix so the `=` positions correctly relative to the
+			// logical name.
+			if p.peekTokenIs(token.LBRACE) && !p.peekToken.HasPrecedingSpace {
+				p.nextToken() // onto {
+				depth := 1
+				for depth > 0 && !p.peekTokenIs(token.EOF) {
+					p.nextToken()
+					switch {
+					case p.curTokenIs(token.LBRACE):
+						depth++
+					case p.curTokenIs(token.RBRACE):
+						depth--
+					}
+				}
+				// After the matching `}`, an IDENT suffix (the `_Y`
+				// in `X_{…}_Y`) belongs to the same name. Walk
+				// through any suffix tokens on the same line until
+				// we hit a terminator or =/+= operator.
+				for p.peekTokenIs(token.IDENT) && p.peekToken.Line == startLine &&
+					!p.peekToken.HasPrecedingSpace {
+					p.nextToken()
+				}
+			}
 			// Peek the =/+= before consuming the name so we can decide
 			// whether to stay on the name token (bare declaration) or
 			// move onto the operator (value follows). An empty RHS

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1092,6 +1092,29 @@ func TestBareDollarAsIdentifier(t *testing.T) {
 	}
 }
 
+func TestDeclarationBraceExpansionInName(t *testing.T) {
+	// Zsh brace-expansion inside an identifier name —
+	// `typeset -g X_{A,B,C}_Y=1` — generates three names from one
+	// declaration. Powerlevel10k's config files use this pattern
+	// heavily to declare per-VI-mode variables in a single line.
+	// Previously the parser consumed X_ as the name, broke the loop
+	// on LBRACE, and cascaded into "no prefix parse function for ,".
+	inputs := []string{
+		`typeset -g X_{A,B}_Y=1`,
+		`typeset -g POWERLEVEL9K_PROMPT_CHAR_{OK,ERROR}_VIINS_CONTENT_EXPANSION='❯'`,
+		`local X_{A,B,C}_Y`,
+		`readonly PREFIX_{DEV,PROD}=value`,
+	}
+	for _, input := range inputs {
+		l := lexer.New(input)
+		p := New(l)
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("%s:\n  unexpected parser errors: %v", input, errs)
+		}
+	}
+}
+
 func TestForLoopShortForm(t *testing.T) {
 	// Zsh `for NAME ( items ) body` is the paren-delimited short
 	// form that needs no do/done. Prezto init.zsh uses it to iterate


### PR DESCRIPTION
Zsh brace-expansion inside an identifier name — `typeset -g X_{A,B,C}_Y=1` — generates three names from one declaration. Powerlevel10k config files lean on this pattern heavily; prezto does the same for category-scoped variables.

parseDeclarationStatement used to consume only the leading IDENT, break its loop on LBRACE, and cascade into "no prefix parse function for ," errors for every comma inside the expansion.

Add a look-ahead: when peek is LBRACE with no preceding space, consume the matching brace-depth span as part of the name, then absorb any trailing IDENT suffix attached without whitespace.

Global corpus error count drops from 2053 to 1902 — 151 errors resolved.