### PR TITLE
feat: DOT as expression prefix for literal words

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -84,6 +84,13 @@ func New(l *lexer.Lexer) *Parser {
 	// when the parser is already mid-expression (OR/AND folded as
 	// infix into an expression chain with `return` on the RHS).
 	p.registerPrefix(token.RETURN, p.parseKeywordAsCommand)
+	// DOT as a prefix models literal-word contexts like `*.zsh`
+	// inside a glob, `.*` as a Zsh conditional pattern, or `./path`
+	// inside an argument list. Wrap the dot in an Identifier and
+	// let parseCommandWord / the bracket scanner fold surrounding
+	// tokens in; without this, every dot in a conditional or
+	// subscript expression fired "no prefix parse function for .".
+	p.registerPrefix(token.DOT, p.parseIdentifier)
 	p.registerPrefix(token.INT, p.parseIntegerLiteral)
 	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)


### PR DESCRIPTION
A bare `.` inside expression context (glob pattern, test condition, path argument) had no prefix parse function. Real code like `[[ "$x" = .* ]]` or `[[ -f ./file ]]` fired "no prefix parse function for .".

Register DOT with parseIdentifier so the dot becomes a literal word. parseCommandWord / bracket scanners fold surrounding tokens in. DOT has no infix entry, so this widens what the parser accepts without changing rejection semantics.

Global corpus error count drops from 1902 to 1877.