### PR TITLE
feat: composite declaration name shapes

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -757,33 +757,50 @@ func (p *Parser) parseDeclarationStatement() *ast.DeclarationStatement {
 			assign := &ast.DeclarationAssignment{
 				Name: &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal},
 			}
-			// Brace expansion inside the name: p10k config files
-			// declare `typeset -g X_{A,B,C}_Y=1` and expect the
-			// parser to treat the whole `X_{A,B,C}_Y` as one name.
-			// Consume a matching `{…}` span plus any trailing IDENT
-			// suffix so the `=` positions correctly relative to the
-			// logical name.
-			if p.peekTokenIs(token.LBRACE) && !p.peekToken.HasPrecedingSpace {
-				p.nextToken() // onto {
-				depth := 1
-				for depth > 0 && !p.peekTokenIs(token.EOF) {
-					p.nextToken()
-					switch {
-					case p.curTokenIs(token.LBRACE):
-						depth++
-					case p.curTokenIs(token.RBRACE):
-						depth--
+			// Non-trivial composite names: the parser should treat
+			// `X_{A,B}_Y`, `prefix"${1:-}"_suffix`, and
+			// `${arr[$i]}=value` as one logical name. Consume any
+			// sequence of adjacent (no preceding space) tokens that
+			// can participate in a shell-word: LBRACE expansions,
+			// STRING literals, DollarLbrace expansions, VARIABLE
+			// references, and plain IDENT suffixes.
+			for !p.peekToken.HasPrecedingSpace && p.peekToken.Line == startLine {
+				switch {
+				case p.peekTokenIs(token.LBRACE):
+					p.nextToken() // onto {
+					depth := 1
+					for depth > 0 && !p.peekTokenIs(token.EOF) {
+						p.nextToken()
+						switch {
+						case p.curTokenIs(token.LBRACE):
+							depth++
+						case p.curTokenIs(token.RBRACE):
+							depth--
+						}
 					}
-				}
-				// After the matching `}`, an IDENT suffix (the `_Y`
-				// in `X_{…}_Y`) belongs to the same name. Walk
-				// through any suffix tokens on the same line until
-				// we hit a terminator or =/+= operator.
-				for p.peekTokenIs(token.IDENT) && p.peekToken.Line == startLine &&
-					!p.peekToken.HasPrecedingSpace {
+				case p.peekTokenIs(token.DollarLbrace):
+					p.nextToken() // onto ${
+					depth := 1
+					for depth > 0 && !p.peekTokenIs(token.EOF) {
+						p.nextToken()
+						switch {
+						case p.curTokenIs(token.DollarLbrace) || p.curTokenIs(token.LBRACE):
+							depth++
+						case p.curTokenIs(token.RBRACE):
+							depth--
+						}
+					}
+				case p.peekTokenIs(token.STRING):
 					p.nextToken()
+				case p.peekTokenIs(token.IDENT):
+					p.nextToken()
+				case p.peekTokenIs(token.VARIABLE):
+					p.nextToken()
+				default:
+					goto nameDone
 				}
 			}
+		nameDone:
 			// Peek the =/+= before consuming the name so we can decide
 			// whether to stay on the name token (bare declaration) or
 			// move onto the operator (value follows). An empty RHS


### PR DESCRIPTION
Extend the declaration name consumer to treat any adjacent non-whitespace token that can form part of a shell word as part of the same logical name: brace-expansion `X_{A,B}_Y`, STRING literals `pre"${1:-}"post`, DollarLbrace expansions `name${suffix}`, VARIABLE references `n$x`, and chained IDENT suffixes.

Fixes cascades in Powerlevel10k gitstatus.plugin.zsh and similar Zsh modules that declare variables with parameter expansion embedded in the identifier.

Global corpus error count drops from 1683 to 1648.