### PR TITLE
fix: for (items); do ... done short-form with explicit body

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -617,6 +617,21 @@ func (p *Parser) parseForLoopStatement() *ast.ForLoopStatement {
 		if !p.expectPeek(token.RPAREN) {
 			return nil
 		}
+
+		// Body form varies. Some Zsh code uses the pure short form
+		// (`for x (items) body`); other code mixes short-form items
+		// with a classic `do/done` body (`for x (items); do … done`).
+		// A leading `;` and `do` indicates the latter.
+		if p.peekTokenIs(token.SEMICOLON) {
+			p.nextToken()
+		}
+		if p.peekTokenIs(token.DO) {
+			p.nextToken() // onto DO
+			p.nextToken() // into body
+			stmt.Body = p.parseBlockStatement(token.DONE)
+			return stmt
+		}
+
 		// Body is a single statement on the same line (usually a
 		// command) or a braced block. Wrap non-block statements in
 		// a BlockStatement so the Body field stays homogeneous.


### PR DESCRIPTION
Zsh accepts both `for x (items) body` and the mixed form `for x (items); do … done`. parseForLoopStatement only handled the pure short form; the mixed form fell into the single-statement path and left `do/done` unparsed, producing "no prefix parse function for DONE".

Check for a leading `;` + DO after the closing RPAREN and route through the classic do/done body when present.