### PR TITLE
feat: let with local / modifier identifier

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -352,6 +352,14 @@ func (p *Parser) parseLetStatement() *ast.LetStatement {
 		return nil
 	}
 
+	// Zsh `let` accepts `local` / `-i` / `-x` etc. modifier words
+	// between the keyword and the assignment target, e.g.
+	// `let local elapsed=1`. Skip leading IDENT modifiers (but not
+	// the final name, which is the one paired with `=`).
+	for p.peekTokenIs(token.IDENT) {
+		p.nextToken()
+	}
+
 	stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 
 	if !p.expectPeek(token.ASSIGN) {


### PR DESCRIPTION
Zsh `let local elapsed=1` is valid; the previous parser required the first IDENT to be the target and fired "expected next token to be =, got IDENT" on the second identifier. Real code in oh-my-zsh refined theme uses this.

Skip any IDENT modifiers before pairing the last one with `=`.