### PR TITLE
feat: lex force-clobber redirections (>| and >!)

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -220,6 +220,22 @@ func (l *Lexer) NextToken() token.Token {
 			l.readChar()
 			literal := string(ch) + string(l.ch)
 			tok = token.Token{Type: token.GT_LPAREN, Literal: literal, Line: l.line, Column: l.column}
+		case '|':
+			// Zsh `>|file` and `>!file` force-clobber a file even
+			// when `NO_CLOBBER` is set. The trailing `|` / `!`
+			// belongs to the redirection, not to a pipeline or
+			// negation that follows. Emit the pair as a plain GT
+			// so parseCommandPipeline's redirection path handles
+			// it unchanged — the AST form is identical to `>file`.
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.GT, Literal: literal, Line: l.line, Column: l.column}
+		case '!':
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.GT, Literal: literal, Line: l.line, Column: l.column}
 		default:
 			tok = newToken(token.GT, l.ch, l.line, l.column)
 		}


### PR DESCRIPTION
Zsh `>|file` / `>!file` force-clobber a file even under NO_CLOBBER. The trailing `|` / `!` belongs to the redirection, not a pipeline or negation; the lexer fused them as GT + PIPE / GT + BANG, producing "no prefix parse function for |".

Fuse `>|` and `>!` into a single GT token so the redirection path handles them unchanged. Normal `cmd > file | other` is unaffected because the lexer only fuses when the two characters are adjacent.

Real oh-my-zsh lib/history.zsh uses `>| $HISTFILE` to clobber the history file.