### PR TITLE
feat: SLASH as expression prefix for path literals

### DIFF
--- a/pkg/katas/zc1039.go
+++ b/pkg/katas/zc1039.go
@@ -31,17 +31,27 @@ func checkZC1039(node ast.Node) []Violation {
 	violations := []Violation{}
 
 	for _, arg := range cmd.Arguments {
-		if str, ok := arg.(*ast.StringLiteral); ok {
-			val := strings.Trim(str.Value, "\"'")
-			if val == "/" {
-				violations = append(violations, Violation{
-					KataID:  "ZC1039",
-					Message: "Avoid `rm` on the root directory `/`. This is highly dangerous.",
-					Line:    str.Token.Line,
-					Column:  str.Token.Column,
-					Level:   SeverityWarning,
-				})
-			}
+		// Bare `/` argument arrives as an Identifier with Value "/"
+		// after the SLASH prefix registration; quoted forms arrive
+		// as StringLiteral. Cover both shapes.
+		var val string
+		var line, col int
+		switch n := arg.(type) {
+		case *ast.StringLiteral:
+			val = strings.Trim(n.Value, "\"'")
+			line, col = n.Token.Line, n.Token.Column
+		case *ast.Identifier:
+			val = n.Value
+			line, col = n.Token.Line, n.Token.Column
+		}
+		if val == "/" {
+			violations = append(violations, Violation{
+				KataID:  "ZC1039",
+				Message: "Avoid `rm` on the root directory `/`. This is highly dangerous.",
+				Line:    line,
+				Column:  col,
+				Level:   SeverityWarning,
+			})
 		}
 	}
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -98,6 +98,12 @@ func New(l *lexer.Lexer) *Parser {
 	// parseCommandWord. Without this, every prompt-style argument
 	// produced "no prefix parse function for %".
 	p.registerPrefix(token.PERCENT, p.parseIdentifier)
+	// SLASH as a prefix covers path-literal arguments like `/`,
+	// `/tmp`, `/usr/bin/*`, where the leading slash starts a
+	// command-word. Without this the test `[[ "$dir" != / ]]`
+	// fired "no prefix parse function for /". SLASH has no infix
+	// entry so this only widens prefix acceptance.
+	p.registerPrefix(token.SLASH, p.parseIdentifier)
 	p.registerPrefix(token.INT, p.parseIntegerLiteral)
 	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)


### PR DESCRIPTION
A bare `/` argument fired "no prefix parse function for /" in test conditions like `[[ "$dir" != / ]] || return 0` (oh-my-zsh opentofu plugin). Register SLASH with parseIdentifier.

ZC1039 detection updated in lockstep: it matched only StringLiteral args (quoted `/`); bare `/` now lands as an Identifier, so the kata gains an Identifier arm. Existing quoted-and-unquoted tests now exercise both AST shapes.