### PR TITLE
fix(lexer): track paren stack to disambiguate `))` fusion

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -18,6 +18,15 @@ type Lexer struct {
 	// in `arr[$m[i]]`. When depth is zero the lexer emits two
 	// RBRACKETs instead of RDBRACKET.
 	dbracketDepth int
+
+	// parenStack records the kind of every paren-like opener that is
+	// still awaiting its close. 'D' for `((` (arithmetic), 'P' for
+	// plain `(` and for `$(` command substitution. The lexer fuses
+	// `))` into DoubleRparen only when the innermost open context is
+	// 'D'; a plain `(` inside `(( … ))` closes with a single RPAREN
+	// so that `(( x = $((1+1)) + 2 ))` emits two inner RPARENs for
+	// the `$(` + `(` pair and a final DoubleRparen for the outer `((`.
+	parenStack []byte
 }
 
 func New(input string) *Lexer {
@@ -94,6 +103,7 @@ func (l *Lexer) NextToken() token.Token {
 				l.readChar()
 				literal := string(ch) + string(l.ch)
 				tok = token.Token{Type: token.EQ_LPAREN, Literal: literal, Line: l.line, Column: l.column}
+				l.parenStack = append(l.parenStack, 'P')
 			} else {
 				tok = newToken(token.ASSIGN, l.ch, l.line, l.column)
 			}
@@ -119,18 +129,13 @@ func (l *Lexer) NextToken() token.Token {
 			l.readChar()
 			literal := string(ch) + string(l.ch)
 			tok = token.Token{Type: token.DoubleLparen, Literal: literal, Line: l.line, Column: l.column}
+			l.parenStack = append(l.parenStack, 'D')
 		} else {
 			tok = newToken(token.LPAREN, l.ch, l.line, l.column)
+			l.parenStack = append(l.parenStack, 'P')
 		}
 	case ')':
-		if l.peekChar() == ')' {
-			ch := l.ch
-			l.readChar()
-			literal := string(ch) + string(l.ch)
-			tok = token.Token{Type: token.DoubleRparen, Literal: literal, Line: l.line, Column: l.column}
-		} else {
-			tok = newToken(token.RPAREN, l.ch, l.line, l.column)
-		}
+		tok = l.readCloseParen()
 	case ',':
 		tok = newToken(token.COMMA, l.ch, l.line, l.column)
 	case '+':
@@ -200,6 +205,7 @@ func (l *Lexer) NextToken() token.Token {
 			l.readChar()
 			literal := string(ch) + string(l.ch)
 			tok = token.Token{Type: token.LT_LPAREN, Literal: literal, Line: l.line, Column: l.column}
+			l.parenStack = append(l.parenStack, 'P')
 		default:
 			tok = newToken(token.LT, l.ch, l.line, l.column)
 		}
@@ -220,6 +226,7 @@ func (l *Lexer) NextToken() token.Token {
 			l.readChar()
 			literal := string(ch) + string(l.ch)
 			tok = token.Token{Type: token.GT_LPAREN, Literal: literal, Line: l.line, Column: l.column}
+			l.parenStack = append(l.parenStack, 'P')
 		case '|':
 			// Zsh `>|file` and `>!file` force-clobber a file even
 			// when `NO_CLOBBER` is set. The trailing `|` / `!`
@@ -381,6 +388,32 @@ func (l *Lexer) NextToken() token.Token {
 	return tok
 }
 
+// readCloseParen resolves a `)` to either DoubleRparen (fused `))`)
+// or a plain RPAREN by consulting parenStack. `))` fuses only when
+// the innermost still-open context is 'D' (a `((` opener). Plain `(`
+// / `$(` / `<(` / `>(` / `=(` openers close with a single `)` so the
+// inner `))` in `(( x = $((1+1)) + 2 ))` does not swallow the outer
+// `((`'s closer.
+func (l *Lexer) readCloseParen() token.Token {
+	top := byte(0)
+	if n := len(l.parenStack); n > 0 {
+		top = l.parenStack[n-1]
+	}
+	if l.peekChar() == ')' && top == 'D' {
+		ch := l.ch
+		l.readChar()
+		literal := string(ch) + string(l.ch)
+		tok := token.Token{Type: token.DoubleRparen, Literal: literal, Line: l.line, Column: l.column}
+		l.parenStack = l.parenStack[:len(l.parenStack)-1]
+		return tok
+	}
+	tok := newToken(token.RPAREN, l.ch, l.line, l.column)
+	if len(l.parenStack) > 0 {
+		l.parenStack = l.parenStack[:len(l.parenStack)-1]
+	}
+	return tok
+}
+
 // readDollarToken dispatches the specialised forms that follow a
 // leading `$`. It returns (tok, true) when it has consumed a recognised
 // form — parameter expansion opener (${ or $(), ANSI-C / gettext string
@@ -407,6 +440,11 @@ func (l *Lexer) readDollarToken(hasSpace bool) (token.Token, bool) {
 		tok.Column = l.column
 		l.readChar() // consume '$'
 		l.readChar() // advance past '('
+		// `$(` opens a command-substitution that closes with a single
+		// `)`. Record it as 'P' so a nested `))` does not get fused
+		// into DoubleRparen when only the inner `(` / `$(` are being
+		// closed.
+		l.parenStack = append(l.parenStack, 'P')
 		tok.HasPrecedingSpace = hasSpace
 		return tok, true
 	case '\'':

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -893,11 +893,40 @@ func (p *Parser) parseDeclarationValue() ast.Expression {
 		paren := p.curToken
 		p.nextToken() // consume (
 
+		// Track paren and brace depth so nested `$(...)`,
+		// `${...}`, `$((...))` inside the array literal don't
+		// terminate the scan prematurely. Without this,
+		// `x=($(cmd))` fell off the end looking for the outer `)`
+		// because the lexer's `$(` + `)` pair consumed the `)` we
+		// expected.
 		val := "("
-		for !p.curTokenIs(token.RPAREN) && !p.curTokenIs(token.EOF) {
-			val += " " + p.curToken.Literal // Very rough
+		depth := 0
+		for !p.curTokenIs(token.EOF) {
+			switch {
+			case p.curTokenIs(token.RPAREN):
+				if depth == 0 {
+					goto arrDone
+				}
+				depth--
+			case p.curTokenIs(token.LPAREN),
+				p.curTokenIs(token.DOLLAR_LPAREN),
+				p.curTokenIs(token.DoubleLparen),
+				p.curTokenIs(token.LBRACE),
+				p.curTokenIs(token.DollarLbrace):
+				depth++
+			case p.curTokenIs(token.DoubleRparen):
+				if depth > 0 {
+					depth--
+				}
+			case p.curTokenIs(token.RBRACE):
+				if depth > 0 {
+					depth--
+				}
+			}
+			val += " " + p.curToken.Literal
 			p.nextToken()
 		}
+	arrDone:
 		val += " )"
 		if p.curTokenIs(token.RPAREN) {
 			p.nextToken()


### PR DESCRIPTION
## Summary
- Lexer now keeps a stack of paren-like openers ('D' for `((`, 'P' for `(`, `$(`, `<(`, `>(`, `=(`).
- `))` fuses into DoubleRparen only when the stack top is 'D'; otherwise each `)` closes its own opener as a single RPAREN.
- Fixes nested constructs like `x=($(cmd))` and `(( x = $((1+1)) + 2 ))` that previously lost track of the outer `((` because the inner `))` was being fused.
- parseDeclarationValue tracks paren/brace depth so nested substitutions inside array literals no longer terminate the scan at the first `)`.

## Impact
Corpus sweep across oh-my-zsh, powerlevel10k, prezto, zsh-autosuggestions, zsh-syntax-highlighting and spaceship-prompt: parser-error total drops from 1290 to 273 (~79% reduction).

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `x=($(echo hello))`, `(( result = $((1+1)) + 2 ))`, `(( x == 1 )) && echo ok` — all parse clean