### PR TITLE
fix(lexer/parser): treat `\<NL>` as logical-line continuation

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -19,6 +19,14 @@ type Lexer struct {
 	// RBRACKETs instead of RDBRACKET.
 	dbracketDepth int
 
+	// pendingContinuation is set when skipWhitespace has just consumed
+	// a `\<NL>` line-continuation pair. It is read and cleared by
+	// NextToken so the next emitted token carries
+	// HasPrecedingContinuation, letting the parser treat it as if it
+	// were on the previous line without altering the physical Line
+	// used for error messages.
+	pendingContinuation bool
+
 	// parenStack records the kind of every paren-like opener that is
 	// still awaiting its close. 'D' for `((` (arithmetic), 'P' for
 	// plain `(` and for `$(` command substitution. The lexer fuses
@@ -60,11 +68,17 @@ func (l *Lexer) peekChar() byte {
 	return l.input[l.readPosition]
 }
 
-func (l *Lexer) NextToken() token.Token {
-	var tok token.Token
-
+func (l *Lexer) NextToken() (tok token.Token) {
+	// skipWhitespace sets pendingContinuation when a `\<NL>` pair
+	// was absorbed; stamp the flag onto the returned token via this
+	// named-return defer so every early return path inherits it.
+	defer func() {
+		if l.pendingContinuation {
+			tok.HasPrecedingContinuation = true
+			l.pendingContinuation = false
+		}
+	}()
 	hasSpace := l.skipWhitespace()
-	// Store hasSpace but set it on tok later because tok is re-assigned below.
 
 	if l.ch == '#' {
 		if l.peekChar() == '!' {
@@ -532,18 +546,39 @@ func (l *Lexer) readString(quote byte) string {
 // the quotation.
 func (l *Lexer) readStringFlavour(quote byte, honourEscapes bool) string {
 	position := l.position // include opening quote
+	// braceDepth tracks `${ … }` parameter expansions embedded in a
+	// double-quoted string. Zsh suspends outer-quote termination
+	// while inside `${…}`, so nested quotes like
+	// `"${var="default"}"` must not split the string at the inner
+	// `"`. Single quotes and ANSI-C strings never embed expansions,
+	// so braceDepth only grows when honourEscapes is true.
+	braceDepth := 0
 	for {
 		l.readChar()
 		if l.ch == 0 {
 			break
 		}
-		if l.ch == quote {
+		if l.ch == quote && braceDepth == 0 {
 			break
 		}
 		if honourEscapes && l.ch == '\\' {
 			l.readChar() // skip escaped char
 			if l.ch == 0 {
 				break
+			}
+			continue
+		}
+		if honourEscapes && l.ch == '$' && l.peekChar() == '{' {
+			l.readChar() // consume `$`
+			braceDepth++
+			continue
+		}
+		if braceDepth > 0 {
+			switch l.ch {
+			case '{':
+				braceDepth++
+			case '}':
+				braceDepth--
 			}
 		}
 	}
@@ -579,6 +614,7 @@ func (l *Lexer) skipWhitespace() bool {
 				l.readChar() // consume '\'
 				l.readChar() // consume '\n'
 				skipped = true
+				l.pendingContinuation = true
 				continue
 			}
 		}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -242,6 +242,15 @@ func (p *Parser) registerInfix(tokenType token.Type, fn infixParseFn) {
 	p.infixParseFns[tokenType] = fn
 }
 
+// peekOnSameLogicalLine reports whether the peek token is part of the
+// same logical command as the current one. A Zsh `\<NL>` pair joins
+// two physical lines into one command; the lexer marks the first token
+// after such a pair with HasPrecedingContinuation so argument-gathering
+// loops don't terminate at the newline.
+func (p *Parser) peekOnSameLogicalLine() bool {
+	return p.peekToken.Line == p.curToken.Line || p.peekToken.HasPrecedingContinuation
+}
+
 func (p *Parser) peekPrecedence() int {
 	if p, ok := precedences[p.peekToken.Type]; ok {
 		return p

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -282,7 +282,7 @@ func (p *Parser) parseSingleCommand() ast.Expression {
 	}
 
 	// Continue parsing arguments
-	for !p.isCommandDelimiter(p.peekToken) && p.peekToken.Line == p.curToken.Line {
+	for !p.isCommandDelimiter(p.peekToken) && p.peekOnSameLogicalLine() {
 		p.nextToken()
 		arg := p.parseCommandWord()
 		cmd.Arguments = append(cmd.Arguments, arg)
@@ -323,7 +323,7 @@ func (p *Parser) parseCommandWord() ast.Expression {
 
 	// Continue parsing while the next token is adjacent (no preceding space)
 	for !p.peekToken.HasPrecedingSpace && !p.isCommandDelimiter(p.peekToken) &&
-		p.peekToken.Line == p.curToken.Line {
+		p.peekOnSameLogicalLine() {
 
 		p.nextToken()
 
@@ -666,7 +666,7 @@ func (p *Parser) parseForLoopStatement() *ast.ForLoopStatement {
 		p.nextToken()
 		stmt.Items = []ast.Expression{}
 		for !p.peekTokenIs(token.SEMICOLON) && !p.peekTokenIs(token.DO) && !p.peekTokenIs(token.EOF) &&
-			p.peekToken.Line == p.curToken.Line {
+			p.peekOnSameLogicalLine() {
 			p.nextToken()
 			arg := p.parseCommandWord()
 			stmt.Items = append(stmt.Items, arg)
@@ -710,7 +710,7 @@ func (p *Parser) parseSelectStatement() *ast.SelectStatement {
 		p.nextToken()
 		stmt.Items = []ast.Expression{}
 		for !p.peekTokenIs(token.SEMICOLON) && !p.peekTokenIs(token.DO) && !p.peekTokenIs(token.EOF) &&
-			p.peekToken.Line == p.curToken.Line {
+			p.peekOnSameLogicalLine() {
 			p.nextToken()
 			arg := p.parseCommandWord()
 			stmt.Items = append(stmt.Items, arg)

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -8,6 +8,13 @@ type Token struct {
 	Line              int
 	Column            int
 	HasPrecedingSpace bool
+	// HasPrecedingContinuation is set when the lexer consumed a
+	// `\<NL>` pair immediately before this token. The Line / Column
+	// fields still refer to the physical source position so error
+	// messages stay accurate, but parsers can treat the token as if
+	// it were on the previous line — matching how Zsh collapses
+	// line-continuations into one logical command.
+	HasPrecedingContinuation bool
 }
 
 const (


### PR DESCRIPTION
## Summary
- Token gains `HasPrecedingContinuation` flag; the lexer stamps it on the first token following a `\<NL>` pair.
- Parser adds `peekOnSameLogicalLine()` and all four argument-gather loops switch to it, so continued args like `cmd \<NL>--flag arg` are picked up as arguments of `cmd` rather than orphaned top-level expressions.
- Same pass fixes `readStringFlavour` to honour `${ … }` brace depth inside double-quoted strings so nested quotes in `"${var="default"}"` no longer split the outer string at the inner quote.

## Impact
Corpus sweep: total parser errors 273 → 236 across oh-my-zsh, powerlevel10k, prezto, zsh-autosuggestions, zsh-syntax-highlighting and spaceship-prompt. Spaceship drops 73 → 38 on its own.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: multi-line `cmd \<NL>--color foo \<NL>--prefix bar`, `"${VAR="default"}"`, `*:- default` patterns — parse clean.