### PR TITLE
fix(parser): stop parseBlockStatement from stepping past the terminator

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -478,6 +478,24 @@ func (p *Parser) parseBlockStatement(terminators ...token.Type) *ast.BlockStatem
 			block.Statements = append(block.Statements, stmt)
 		}
 
+		// A statement whose natural terminator is the block
+		// terminator itself (e.g. bare `return` / `break` right
+		// before `fi`, `done`, `esac`) leaves curToken sitting on
+		// that terminator because parseExpression/LOWEST yields nil
+		// on block keywords. Advancing unconditionally here would
+		// step past it and the outer if/loop/case would then see
+		// EOF and report "expected FI got EOF".
+		curIsTerm := false
+		for _, t := range terminators {
+			if p.curTokenIs(t) {
+				curIsTerm = true
+				break
+			}
+		}
+		if curIsTerm {
+			break
+		}
+
 		p.nextToken()
 	}
 	return block


### PR DESCRIPTION
## Summary
- `parseBlockStatement` advanced unconditionally after every inner statement, overshooting the block terminator when a bare `return` / `break` sat right before `fi` / `done` / `esac`.
- Re-checks whether curToken is already a terminator before the final `nextToken()` and breaks out of the loop if so.

## Impact
Corpus sweep: total parser errors 236 → 161.
- oh-my-zsh: 155 → 85 (-70)
- spaceship-prompt: 38 → 34
- zsh-autosuggestions: 4 → 3

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `if (( x == 1 )); then return; fi`, `for x in a b; do break; done`, `case x in y) return;; esac` — parse clean