### PR TITLE
fix(parser): pipeline heads starting with backtick/$() + glob subscripts

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -589,6 +589,28 @@ func (p *Parser) parseIndexExpression(left ast.Expression) ast.Expression {
 		}
 		// Advance onto the subject after the closing paren.
 		p.nextToken()
+		// When a flag tuple was present the subject is a glob
+		// pattern (`arr[(r)*.zsh]`, `${1[(wr)^(*=*|sudo)]}`), not
+		// an arithmetic expression. Consume the remainder of the
+		// body opaquely so mixed glob alternations, negations, and
+		// nested classes don't crash the arithmetic parser. The
+		// AST keeps Index set to a placeholder; detection katas
+		// that need the raw subscript text read it from source.
+		exp.Index = &ast.StringLiteral{Token: p.curToken, Value: p.curToken.Literal}
+		bdepth := 0
+		for !p.curTokenIs(token.EOF) {
+			switch {
+			case p.curTokenIs(token.RBRACKET):
+				if bdepth == 0 {
+					return exp
+				}
+				bdepth--
+			case p.curTokenIs(token.LBRACKET):
+				bdepth++
+			}
+			p.nextToken()
+		}
+		return exp
 	}
 
 	prevInArithmetic := p.inArithmetic

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -80,6 +80,15 @@ func (p *Parser) parseStatement() ast.Statement {
 	case token.COLON, token.DOT, token.LBRACKET,
 		token.GT, token.LT, token.GTGT, token.LTLT, token.GTAMP, token.LTAMP, token.AMPERSAND, token.SLASH:
 		return p.parseSimpleCommandStatement()
+	case token.BACKTICK, token.DOLLAR_LPAREN:
+		// A command-producing expression (`cmd` or $(cmd)) can stand
+		// on its own as a statement, but it can also head a pipeline
+		// or a logical chain: `` `_cmd` | sed … ``, `$(date) && ...`.
+		// Parse the expression via the normal prefix path, then fold
+		// any pipeline / AND / OR continuations into an infix tree
+		// so the trailing `|` / `&&` / `||` do not leak back into
+		// parseStatement's next-iteration dispatch.
+		return p.parsePipelineStartingWithExpression()
 	case token.CASE:
 		return p.parseCaseStatement()
 	case token.IDENT:
@@ -168,6 +177,32 @@ func (p *Parser) parseExpressionOrFunctionDefinition() ast.Statement {
 		}
 	}
 	return stmt
+}
+
+// parsePipelineStartingWithExpression parses a statement whose head
+// is a command-producing expression (backtick or `$(…)`) and then
+// folds any trailing pipeline / logical chain onto it. The generic
+// parseSingleCommand path can't handle this because it expects the
+// head to be an IDENT; doing the expression parse first and grafting
+// the pipeline on top keeps the AST shape identical to what the
+// IDENT path would produce for `cmd | other`.
+func (p *Parser) parsePipelineStartingWithExpression() ast.Statement {
+	tok := p.curToken
+	expr := p.parseExpression(LOWEST)
+	if expr == nil {
+		return nil
+	}
+	for p.peekTokenIs(token.PIPE) || p.peekTokenIs(token.AND) || p.peekTokenIs(token.OR) {
+		p.nextToken()
+		op := p.curToken
+		p.nextToken()
+		right := p.parseCommandPipeline()
+		expr = &ast.InfixExpression{Token: op, Operator: op.Literal, Left: expr, Right: right}
+	}
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+	}
+	return &ast.ExpressionStatement{Token: tok, Expression: expr}
 }
 
 func (p *Parser) parseSimpleCommandStatement() ast.Statement {


### PR DESCRIPTION
## Summary
1. Command-producing expressions (backtick, `$(…)`) can now head a pipeline or logical chain. Previously `\`_cmd\` | sed …` and `$(date) && echo` left the `|` / `&&` for the statement dispatcher, which reported "no prefix parse function for |". A new `parsePipelineStartingWithExpression` folds pipeline / logical continuations onto the head expression.
2. Subscripts with a `(flags)` tuple — e.g. `arr[(r)pat]`, `${1[(wr)^(*=*|sudo|-*)]}` — are Zsh glob matches, not arithmetic. `parseIndexExpression` now consumes the subject opaquely, tracking bracket depth only, instead of routing it through the arithmetic expression parser.

## Impact
Corpus sweep: 130 → 122 parser errors.
- prezto: 14 → 9
- omz: 82 → 79

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `` `cmd` | sed s/a/b/ ``, `$(date) && echo`, `${1[(wr)^(*=*|sudo|-*)]}` — parse clean