### PR TITLE
fix(parser/lexer): `%` modulo infix + backslash-whitespace/`#` escapes

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -378,7 +378,7 @@ func (l *Lexer) NextToken() (tok token.Token) {
 				next == '&' || next == ';' || next == '<' || next == '>' ||
 				next == '{' || next == '}' || next == '$' || next == '\\' ||
 				next == '/' || next == '.' || next == '!' || next == '~' ||
-				next == '^' {
+				next == '^' || next == ' ' || next == '\t' || next == '#' {
 				line, col := l.line, l.column
 				l.readChar() // consume '\'
 				tok = token.Token{

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -33,6 +33,7 @@ var precedences = map[token.Type]int{
 	token.MINUS:         SUM,
 	token.SLASH:         PRODUCT,
 	token.ASTERISK:      PRODUCT,
+	token.PERCENT:       PRODUCT,
 	token.LPAREN:        CALL,
 	token.LBRACKET:      INDEX,
 	token.DollarLbrace:  INDEX,
@@ -143,6 +144,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.MINUS, p.parseInfixExpression)
 	p.registerInfix(token.SLASH, p.parseInfixExpression)
 	p.registerInfix(token.ASTERISK, p.parseInfixExpression)
+	p.registerInfix(token.PERCENT, p.parseInfixExpression)
 	p.registerInfix(token.AND, p.parseInfixExpression)
 	p.registerInfix(token.OR, p.parseInfixExpression)
 	p.registerInfix(token.EQ, p.parseInfixExpression)


### PR DESCRIPTION
## Summary
- Register PERCENT as infix with PRODUCT precedence so `(( m = $r % 60 ))` and similar arithmetic chains parse.
- Extend the backslash-word escape list to include space, tab, and `#` so `man\ *`, `\#`, and friends fold into the surrounding word instead of producing ILLEGAL.

## Impact
Corpus sweep: 122 → 114. oh-my-zsh 79 → 71; spaceship 12 → 11; p10k steady.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `(( minute = $t % 60 ))`, `[[ "$BUFFER" = man\ * ]]` — parse clean