### PR TITLE
fix(parser): consume subscript tails opaquely for multi-token keys

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -630,6 +630,30 @@ func (p *Parser) parseIndexExpression(left ast.Expression) ast.Expression {
 		_ = p.parseExpression(LOWEST)
 	}
 
+	// Zsh associative-array keys accept arbitrary tokens — keys
+	// starting with a digit (`emoji[1st_place_medal]`) tokenise as
+	// INT + IDENT, and keys with punctuation (`arr[foo-bar]`,
+	// `arr[x.y]`) split across multiple tokens. The arithmetic
+	// parse above only consumed the first piece, so if peek isn't
+	// RBRACKET yet, fall through to an opaque scan that tracks
+	// bracket depth and stops at the matching `]`.
+	if !p.peekTokenIs(token.RBRACKET) {
+		bdepth := 0
+		for !p.peekTokenIs(token.EOF) {
+			p.nextToken()
+			switch {
+			case p.curTokenIs(token.LBRACKET):
+				bdepth++
+			case p.curTokenIs(token.RBRACKET):
+				if bdepth == 0 {
+					return exp
+				}
+				bdepth--
+			}
+		}
+		return exp
+	}
+
 	if !p.expectPeek(token.RBRACKET) {
 		return nil
 	}


### PR DESCRIPTION
## Summary
Associative-array keys accept arbitrary tokens. Keys like `1st_place_medal` tokenise as INT + IDENT and `parseIndexExpression` only consumed the first piece before `expectPeek(])` fired on the rest. After the arithmetic parse, fall through to an opaque bracket-depth scan if peek isn't `]` yet.

## Impact
113 → 110. oh-my-zsh 70 → 67.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `emoji[1st_place_medal]=x`, `arr[foo-bar]=y` — parse clean