### PR TITLE
fix(parser): stop infix loop when curToken lands on `]]`

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -46,6 +46,18 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 		if p.peekTokenIs(token.RDBRACKET) {
 			break
 		}
+		// When the infix chain has already landed curToken on
+		// `]]`, the conditional is finished. Stop the outer loop
+		// before it reaches across the bracket and picks up the
+		// next statement's `&&` / `||` as a continuation of the
+		// bracket expression. Without this, patterns that end in
+		// an ASTERISK (`[[ $x = /* ]]`) left curToken on RDBRACKET
+		// with peek on OR, and LOWEST's precedence table let OR
+		// win, swallowing the following command into the bracket
+		// body.
+		if p.curTokenIs(token.RDBRACKET) {
+			break
+		}
 		// Inside a `[[ … ]]` conditional, adjacent `(…)` groups are
 		// glob alternations being concatenated — not function calls
 		// on the left-hand expression. Stop the infix loop from


### PR DESCRIPTION
## Summary
Patterns ending in ASTERISK inside `[[ … ]]` (e.g. `[[ $file = /* ]] || echo`) caused the outer `parseExpression(LOWEST)` loop to swallow the following `||` / `&&` chain, blowing up `parseDoubleBracketExpression` when it couldn't find its closing token. Add a symmetric `curTokenIs(RDBRACKET)` break alongside the existing peek guard.

## Impact
110 → 101. oh-my-zsh 67 → 59; autosuggestions 3 → 2.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `[[ $x = /* ]] || echo a`, `[[ $x = y* ]] || echo` — parse clean