### PR TITLE
fix(parser): consume pipeline tail after a `{ … }` brace group

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -37,6 +37,21 @@ func (p *Parser) parseStatement() ast.Statement {
 		p.nextToken()
 		block := p.parseBlockStatement(token.RBRACE)
 		block.Token = tok
+		// A brace group can head a pipeline or logical chain:
+		// `{ cmd1; cmd2 } | sort`, `{ a || b } | awk`. Consume any
+		// trailing pipeline / logical continuations opaquely so
+		// parseStatement doesn't choke on the leading `|` / `&&`
+		// / `||` as an unknown prefix. The AST keeps the block as
+		// the statement; detection katas that care about the full
+		// pipeline can walk source.
+		for p.peekTokenIs(token.PIPE) || p.peekTokenIs(token.AND) || p.peekTokenIs(token.OR) {
+			p.nextToken() // onto op
+			p.nextToken() // onto RHS head
+			_ = p.parseCommandPipeline()
+		}
+		if p.peekTokenIs(token.SEMICOLON) {
+			p.nextToken()
+		}
 		return block
 	case token.LPAREN:
 		return p.parseSubshellStatement()


### PR DESCRIPTION
## Summary
Brace groups heading a pipeline like `{ cmd } | sort` left `|` dangling for the next parseStatement iteration which reported "no prefix parse function for |". Loop the trailing pipeline / logical continuations and consume each RHS via parseCommandPipeline.

## Impact
97 → 96. oh-my-zsh 56 → 55.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `{ cmd } | sort`, `{ a || b } | awk` — parse clean