### PR TITLE
fix(parser): advance past inner `esac` so nested case statements don't collapse

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -605,6 +605,22 @@ func (p *Parser) parseCaseStatement() *ast.CaseStatement {
 			p.nextToken()
 		}
 	}
+	// Consume the closing ESAC so a caller parsing a nested case
+	// (`case x in a) case y in …;; esac ;; esac`) doesn't see the
+	// inner `esac` as the outer's terminator. Without this advance
+	// parseBlockStatement's terminator check would fire on the
+	// inner ESAC and collapse the outer case body.
+	if p.curTokenIs(token.ESAC) {
+		// Leave at-ESAC if we're the outermost call (no advance
+		// necessary — parseBlockStatement will re-check peek);
+		// but always leave curToken pointing at ESAC's successor
+		// when there is one so the outer DSEMI check works.
+		// Peek past ESAC only if there's a trailing `;;` pattern
+		// terminator or ;/newline.
+		if p.peekTokenIs(token.DSEMI) || p.peekTokenIs(token.SEMICOLON) {
+			p.nextToken()
+		}
+	}
 	return stmt
 }
 


### PR DESCRIPTION
## Summary
Nested `case` statements misread because parseCaseStatement left curToken on its closing `esac`. When the outer's block terminator list included ESAC the outer parseBlockStatement saw the inner `esac` and broke out, swallowing the rest of the outer clause and reporting "no prefix parse function for ;;" on the outer's own terminator. After the inner loop closes, step off ESAC onto trailing `;;` or `;` if present.

## Impact
96 → 92. oh-my-zsh 55 → 51.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `case x in a) case y in "b") echo b ;; esac ;; esac` — parses clean