### PR TITLE
fix(parser): treat tokens without a prefix inside `[[ … ]]` as literals

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -26,6 +26,15 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 	}
 	prefix := p.prefixParseFns[p.curToken.Type]
 	if prefix == nil {
+		// Inside a `[[ … ]]` conditional, tokens without a prefix
+		// (`--`, `++`, `,`, bare punctuation words) routinely
+		// appear as literal test arguments: `[[ $1 == -- ]]`,
+		// `[[ $x != ++ ]]`. Treat them as identifiers rather than
+		// errroring so the bracket expression closes cleanly.
+		if p.inDoubleBracket {
+			tok := p.curToken
+			return &ast.Identifier{Token: tok, Value: tok.Literal}
+		}
 		p.noPrefixParseFnError(p.curToken.Type)
 		return nil
 	}


### PR DESCRIPTION
## Summary
Inside `[[ … ]]` conditionals tokens without a prefix parse function (`--`, `++`, bare punctuation words) often appear as literal test arguments. Previously every one crashed with "no prefix parse function for <tok>". Emit an Identifier with the literal text when inDoubleBracket is set and no prefix exists.

## Impact
92 → 87. oh-my-zsh 51 → 47; spaceship-prompt 11 → 10.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `[[ $1 == -- ]]`, `[[ $x != ++ ]]` — parse clean