### PR TITLE
fix(parser): treat bare `$` before `]` / `]]` as literal dollar

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -325,7 +325,8 @@ func (p *Parser) parseInvalidArrayAccessPrefix() ast.Expression {
 	if p.peekTokenIs(token.SEMICOLON) || p.peekTokenIs(token.EOF) ||
 		p.peekTokenIs(token.PIPE) || p.peekTokenIs(token.AMPERSAND) ||
 		p.peekTokenIs(token.AND) || p.peekTokenIs(token.OR) ||
-		p.peekTokenIs(token.RPAREN) || p.peekTokenIs(token.RBRACE) {
+		p.peekTokenIs(token.RPAREN) || p.peekTokenIs(token.RBRACE) ||
+		p.peekTokenIs(token.RDBRACKET) || p.peekTokenIs(token.RBRACKET) {
 		return &ast.Identifier{Token: dollarToken, Value: "$"}
 	}
 


### PR DESCRIPTION
## Summary
Anchored regex RHS in `[[ … ]]` conditionals ends with `$` (e.g. `[[ $1 =~ ^(a|b).*$ ]]`). The bare-`$` fallback already handled most terminators but not RDBRACKET / RBRACKET. Add them.

## Impact
87 → 85. spaceship-prompt 10 → 8.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `[[ $1 =~ ^(a|b).*$ ]]` — parses clean