### PR TITLE
fix(parser): accept `(…)`, `[[ … ]]`, `((…))` as pipeline RHS

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -264,6 +264,19 @@ func (p *Parser) parseCommandPipeline() ast.Expression {
 	switch p.curToken.Type {
 	case token.WHILE:
 		left = p.parseWhileLoopStatement()
+	case token.LPAREN:
+		// Subshell group: `( cmd1; cmd2 )` appears as the RHS of
+		// logical chains like `[[ … ]] && ( … )`. Parse the group
+		// as a grouped expression so parseSingleCommand doesn't
+		// treat `(` as a command name.
+		left = p.parseGroupedExpression()
+	case token.LDBRACKET:
+		// `[[ … ]]` condition as a pipeline term (RHS of `&&`/`||`
+		// or head of a pipe). Call the prefix directly so the
+		// caller doesn't try to use it as a simple-command name.
+		left = p.parseDoubleBracketExpression()
+	case token.DoubleLparen:
+		left = p.parseArithmeticCommand()
 	default:
 		left = p.parseSingleCommand()
 	}


### PR DESCRIPTION
## Summary
parseCommandPipeline only dispatched IDENT heads through parseSingleCommand (and WHILE through its loop parser). Subshell groups, double-bracket conditionals, and arithmetic commands on the RHS of logical chains like `[[ $x ]] && ([[ $y ]] || [[ $z ]])` or `cmd && (( x > 0 ))` fell through to parseSingleCommand which treated `(` / `[[` / `((` as a command name and exploded on the next structural token.

Add dedicated cases for LPAREN, LDBRACKET, DoubleLparen that call the appropriate prefix parser.

## Impact
75 → 72. oh-my-zsh 39 → 38; prezto 9 → 7.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `[[ -n $x ]] && ([[ -n $y ]] || [[ -n $z ]])`, `cmd && (( x > 0 ))` — parse clean