### PR TITLE
fix(lexer): accept `\"` and `\'` in the backslash-word escape list

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -409,7 +409,8 @@ func (l *Lexer) NextToken() (tok token.Token) {
 				next == '&' || next == ';' || next == '<' || next == '>' ||
 				next == '{' || next == '}' || next == '$' || next == '\\' ||
 				next == '/' || next == '.' || next == '!' || next == '~' ||
-				next == '^' || next == ' ' || next == '\t' || next == '#' {
+				next == '^' || next == ' ' || next == '\t' || next == '#' ||
+				next == '"' || next == '\'' {
 				line, col := l.line, l.column
 				l.readChar() // consume '\'
 				tok = token.Token{


### PR DESCRIPTION
## Summary
Backslash-escaped quotes outside a string context (e.g. `BUFFER+=\ \"\\\'\\x\"`) emitted ILLEGAL. Add `"` and `'` to the recognised escape list so the pair folds into the surrounding word.

## Impact
72 → 68. powerlevel10k 8 → 7; syntax-highlighting 11 → 8.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `x=\"y`, `x=\'y` — parse clean