### PR TITLE
fix(parser): route shell `!` negation through the pipeline parser

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -95,6 +95,24 @@ func (p *Parser) parseStatement() ast.Statement {
 	case token.COLON, token.DOT, token.LBRACKET,
 		token.GT, token.LT, token.GTGT, token.LTLT, token.GTAMP, token.LTAMP, token.AMPERSAND, token.SLASH:
 		return p.parseSimpleCommandStatement()
+	case token.BANG:
+		// Shell `!` negates the exit status of the following
+		// pipeline: `! cmd 2>/dev/null | grep`. Route through the
+		// command-pipeline path so redirects and pipes on the
+		// right chain correctly. Keep the expression-level prefix
+		// behaviour for C-style inputs like `!5` / `!true` by
+		// checking peek: IDENT / LPAREN / LBRACKET / LDBRACKET /
+		// DoubleLparen / VARIABLE / DollarLbrace / BACKTICK /
+		// DOLLAR_LPAREN are command starts; anything else falls
+		// back to the expression parser.
+		if p.peekTokenIs(token.IDENT) || p.peekTokenIs(token.LPAREN) ||
+			p.peekTokenIs(token.LBRACKET) || p.peekTokenIs(token.LDBRACKET) ||
+			p.peekTokenIs(token.DoubleLparen) || p.peekTokenIs(token.VARIABLE) ||
+			p.peekTokenIs(token.DollarLbrace) || p.peekTokenIs(token.BACKTICK) ||
+			p.peekTokenIs(token.DOLLAR_LPAREN) {
+			return p.parseSimpleCommandStatement()
+		}
+		return p.parseExpressionOrFunctionDefinition()
 	case token.BACKTICK, token.DOLLAR_LPAREN, token.VARIABLE, token.DollarLbrace:
 		// A command-producing expression (`cmd`, $(cmd), $name,
 		// ${name}) can stand on its own as a statement, but can


### PR DESCRIPTION
## Summary
`! cmd 2>/dev/null | grep` was parsed as an expression-level prefix `!` around just `cmd`; the trailing redirect and pipe leaked back into parseStatement and blew up with "no prefix parse function for |". When `!` is followed by a command start, route through `parseSimpleCommandStatement` so the pipeline parser's BANG branch handles redirects and pipes. Preserve expression behaviour for `!5` / `!true` used by unit tests.

## Impact
68 → 65. prezto 7 → 5.

## Test plan
- [x] `go test ./...` passes (including `TestParsingPrefixExpressions`)
- [x] `golangci-lint run ./...` clean
- [x] Manual: `! cmd 2>/dev/null | grep x`, `!5`, `!true` — all parse