### PR TITLE
fix(parser): accept `for x in items; { body }` brace-body form

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -828,8 +828,8 @@ func (p *Parser) parseForLoopStatement() *ast.ForLoopStatement {
 	// `do … done` with a brace block. Accept LBRACE here alongside
 	// the classic DO keyword.
 	if p.peekTokenIs(token.LBRACE) {
-		p.nextToken()  // onto {
-		p.nextToken()  // into body
+		p.nextToken() // onto {
+		p.nextToken() // into body
 		stmt.Body = p.parseBlockStatement(token.RBRACE)
 		return stmt
 	}

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -824,6 +824,16 @@ func (p *Parser) parseForLoopStatement() *ast.ForLoopStatement {
 		p.nextToken()
 	}
 
+	// Zsh short body form: `for x in items; { body }` replaces
+	// `do … done` with a brace block. Accept LBRACE here alongside
+	// the classic DO keyword.
+	if p.peekTokenIs(token.LBRACE) {
+		p.nextToken()  // onto {
+		p.nextToken()  // into body
+		stmt.Body = p.parseBlockStatement(token.RBRACE)
+		return stmt
+	}
+
 	if !p.expectPeek(token.DO) {
 		return nil
 	}


### PR DESCRIPTION
## Summary
Zsh supports `for NAME in ITEMS; { BODY }` as a short alternative to `do … done`. parseForLoopStatement expected DO, so brace-body loops reported "expected DO, got {". Accept LBRACE alongside DO; terminate the body at RBRACE.

## Impact
65 → 64. oh-my-zsh 37 → 36.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `for x in a b c; { echo $x }` — parses clean