### PR TITLE
fix(parser): glued `/` outside arithmetic is a path separator, not division

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -68,6 +68,16 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 		if p.curTokenIs(token.RDBRACKET) {
 			break
 		}
+		// Outside arithmetic, a `/` glued to the previous token is
+		// a path separator, not a division operator. Treat
+		// `$(cmd)/` or `x/y` at statement level as end-of-
+		// expression so SLASH's PRODUCT precedence doesn't sweep
+		// the next line's keyword (`if`, `for`, etc.) in as the
+		// division RHS. Spaced forms `5 / 5` still enter the infix
+		// path so arithmetic tests keep working.
+		if !p.inArithmetic && p.peekTokenIs(token.SLASH) && !p.peekToken.HasPrecedingSpace {
+			break
+		}
 		// Inside a `[[ … ]]` conditional, adjacent `(…)` groups are
 		// glob alternations being concatenated — not function calls
 		// on the left-hand expression. Stop the infix loop from


### PR DESCRIPTION
## Summary
`HOST=$(cmd)/` followed by a newline and `if` crashed with "no prefix parse function for IF" because SLASH's PRODUCT precedence pulled the next line's keyword in as the division RHS. When peek is SLASH, we're outside arithmetic, and the slash is glued to the previous token, break out of the infix loop.

## Impact
Fixes multiple "no prefix parse function for IF" cascades. Total holds at 64 because downstream errors for those files are different.

## Test plan
- [x] `go test ./...` passes (including `5 / 5` infix test)
- [x] `golangci-lint run ./...` clean
- [x] Manual: `HOST=$(cmd)/\nif …` parses