### PR TITLE
fix(parser): register `++` (INC) as prefix for pre-increment in arithmetic

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -120,6 +120,14 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.ASTERISK, p.parsePrefixExpression)
 	p.registerPrefix(token.QUESTION, p.parsePrefixExpression)
 	p.registerPrefix(token.TILDE, p.parsePrefixExpression)
+	// `++x` is pre-increment in Zsh arithmetic (`(( ++x ))`).
+	// Register INC as prefix so the body parses alongside its
+	// postfix counterpart. DEC is deliberately NOT registered as
+	// prefix because many katas' existing test fixtures route
+	// `--flag` arg handling through paths that assume DEC is only
+	// postfix; a parser-wide change there needs a coordinated kata
+	// cleanup first.
+	p.registerPrefix(token.INC, p.parsePrefixExpression)
 	p.registerPrefix(token.TRUE, p.parseBoolean)
 	p.registerPrefix(token.FALSE, p.parseBoolean)
 	p.registerPrefix(token.LPAREN, p.parseGroupedExpression)


### PR DESCRIPTION
## Summary
`(( ++x ))` pre-increment crashed with "no prefix parse function for ++". Register INC as prefix using `parsePrefixExpression`. DEC intentionally stays postfix-only because kata fixtures around `--flag` rely on that — coordinated cleanup required (issue #129).

## Impact
59 → 58. syntax-highlighting 7 → 6.

## Test plan
- [x] `go test ./...` passes (including `--flag` kata fixtures)
- [x] `golangci-lint run ./...` clean
- [x] Manual: `(( ++x ))`, `if [[ -z $skip ]]; then (( ++count )); fi` — parse clean