### PR TITLE
fix(parser): `$(a;b)` command substitution drains extra statements to its close

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -558,7 +558,19 @@ func (p *Parser) parseDollarParenExpression() ast.Expression {
 	}
 
 	p.nextToken()
+	// First parse as a command list so `$(cmd arg1 arg2 | other)`
+	// returns a SimpleCommand / pipeline — detection katas like
+	// ZC1050 walk `n.Command` expecting that shape. If the body
+	// continues past the first pipeline with a `;` separator,
+	// drain the rest opaquely so `$(cmd1; cmd2)` reaches its
+	// closing `)` cleanly. The AST keeps the first command; katas
+	// that care about the full body can walk source.
 	exp.Command = p.parseCommandList()
+	for p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken() // onto ;
+		p.nextToken() // onto next stmt head
+		_ = p.parseStatement()
+	}
 	if !p.expectPeek(token.RPAREN) {
 		return nil
 	}


### PR DESCRIPTION
## Summary
`$(IFS='.' read a b; echo $a)` and similar multi-statement command substitutions crashed with "expected ), got ;". parseCommandList only consumes one pipeline + logical chain. Keep the first command as AST `Command` (katas like ZC1050 walk that shape) then opaquely drain `;`-separated follow-ups until the matching `)`.

## Impact
54 → 53. oh-my-zsh 31 → 30.

## Test plan
- [x] `go test ./...` passes (ZC1050 still detects `$(ls)`)
- [x] `golangci-lint run ./...` clean
- [x] Manual: `$(cmd1; cmd2)`, `$(ls)` — parse clean