### PR TITLE
fix(parser): drain subscript opaquely in `$+name[expr]` arithmetic checks

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -424,6 +424,27 @@ func (p *Parser) parseInvalidArrayAccessPrefix() ast.Expression {
 		exp := &ast.InvalidArrayAccess{Token: dollarToken, Left: plus}
 		p.nextToken()
 		exp.Index = p.parseExpression(LOWEST)
+		// Subscript body may carry tokens the arithmetic expression
+		// parser didn't consume — e.g. `_$cmd` lexes as IDENT +
+		// VARIABLE; the first IDENT returns from parseExpression
+		// and the VARIABLE falls out. Drain opaquely to the
+		// matching `]` so `$+name[_$cmd]` parses cleanly.
+		if !p.peekTokenIs(token.RBRACKET) {
+			bdepth := 0
+			for !p.peekTokenIs(token.EOF) {
+				p.nextToken()
+				switch {
+				case p.curTokenIs(token.LBRACKET):
+					bdepth++
+				case p.curTokenIs(token.RBRACKET):
+					if bdepth == 0 {
+						return exp
+					}
+					bdepth--
+				}
+			}
+			return exp
+		}
 		if !p.expectPeek(token.RBRACKET) {
 			return nil
 		}


### PR DESCRIPTION
## Summary
`(( $+functions[_$cmd] ))` crashed because parseInvalidArrayAccessPrefix consumed only the first subscript token via parseExpression then expected `]`. Subscripts often carry extras the arithmetic parser can't digest (IDENT + VARIABLE in `_$cmd`, punctuation). Mirror parseIndexExpression's opaque bracket-depth scan to drain to the matching `]`.

## Impact
53 → 49. prezto 4 → 2; spaceship 6 → 5; oh-my-zsh 30 → 29.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `(( $+functions[_$cmd] ))`, `(( $+commands[foo-bar] ))` — parse clean