### PR TITLE
fix(parser): accept numeric positional names in `for` loop bindings

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -770,7 +770,13 @@ func (p *Parser) parseForLoopStatement() *ast.ForLoopStatement {
 	}
 
 	// For-each loop: for name [in words]; do
-	if !p.expectPeek(token.IDENT) {
+	// Zsh accepts numeric positional names like `for 1 in "$@"; do`
+	// (shorthand to iterate over positionals). Allow INT as the
+	// binding name alongside IDENT.
+	if p.peekTokenIs(token.IDENT) || p.peekTokenIs(token.INT) {
+		p.nextToken()
+	} else {
+		p.peekError(token.IDENT)
 		return nil
 	}
 	stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}


### PR DESCRIPTION
## Summary
Zsh shorthand `for 1 ; do … done` (aliased to `for 1 in "$@"; do`) uses a numeric positional parameter name as the loop binding. parseForLoopStatement only accepted IDENT, so the construct exploded with "expected IDENT, got INT". Allow INT too.

## Impact
49 → 49 net (error was shared within a file that still has unrelated issues). Removes one class of crash.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `for 1 ; do echo $1; done`, `for 2 in a b; do echo $2; done` — parse clean