### PR TITLE
fix(parser): add DSEMI to parseExpression early-return

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -23,7 +23,7 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 	case token.RDBRACKET, token.AND, token.OR,
 		token.THEN, token.ELSE, token.ELIF, token.Fi,
 		token.DO, token.DONE, token.ESAC,
-		token.SEMICOLON:
+		token.SEMICOLON, token.DSEMI:
 		return nil
 	}
 	prefix := p.prefixParseFns[p.curToken.Type]

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -145,7 +145,7 @@ func (p *Parser) parseStatement() ast.Statement {
 			p.peekTokenIs(token.DOLLAR_LPAREN) || p.peekTokenIs(token.SLASH) ||
 			p.peekTokenIs(token.TILDE) || p.peekTokenIs(token.ASTERISK) ||
 			p.peekTokenIs(token.BANG) || p.peekTokenIs(token.LBRACE) ||
-			// Zero-arg commands followed by a pipe / logical chain
+// Zero-arg commands followed by a pipe / logical chain
 			// must route through parseSimpleCommandStatement so the
 			// pipeline / AND / OR chain is parsed at the command
 			// layer. Without this `cmd1 |\n cmd2` left `cmd1` as a

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -145,7 +145,7 @@ func (p *Parser) parseStatement() ast.Statement {
 			p.peekTokenIs(token.DOLLAR_LPAREN) || p.peekTokenIs(token.SLASH) ||
 			p.peekTokenIs(token.TILDE) || p.peekTokenIs(token.ASTERISK) ||
 			p.peekTokenIs(token.BANG) || p.peekTokenIs(token.LBRACE) ||
-// Zero-arg commands followed by a pipe / logical chain
+			// Zero-arg commands followed by a pipe / logical chain
 			// must route through parseSimpleCommandStatement so the
 			// pipeline / AND / OR chain is parsed at the command
 			// layer. Without this `cmd1 |\n cmd2` left `cmd1` as a


### PR DESCRIPTION
## Summary
`case x in nn) return ;;` crashed with "no prefix parse function for ;;" because parseReturnStatement called parseExpression with curToken=DSEMI. Add DSEMI to parseExpression's terminator early-return so bare `return` / `break` / `continue` inside a case clause close cleanly at `;;`.

## Impact
49 → 46. oh-my-zsh 29 → 27; spaceship 5 → 4.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `case x in nn) return ;; *) echo ;; esac` — parses clean