### PR TITLE
fix(parser): `$(cmd)` / `` `cmd` `` heads in parseSingleCommand

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -360,6 +360,25 @@ func (p *Parser) parseCommandPipeline() ast.Expression {
 }
 
 func (p *Parser) parseSingleCommand() ast.Expression {
+	// When the head is a command-producing expression (`$(cmd)`,
+	// `` `cmd` ``, `$VAR`, `${name}`), let the prefix parser run
+	// so DollarParenExpression / CommandSubstitution / Identifier
+	// is captured properly. Without this, the head was forced into
+	// an Identifier whose Value was the literal `$(` and the
+	// trailing `)` of the substitution leaked back to the dispatch
+	// loop. parseSimpleCommand still wraps the result so downstream
+	// argument gathering and pipeline chaining keep working.
+	if p.curTokenIs(token.DOLLAR_LPAREN) || p.curTokenIs(token.BACKTICK) ||
+		p.curTokenIs(token.VARIABLE) || p.curTokenIs(token.DollarLbrace) {
+		startTok := p.curToken
+		head := p.parseExpression(LOWEST)
+		cmd := &ast.SimpleCommand{Token: startTok, Name: head, Arguments: []ast.Expression{}}
+		for !p.isCommandDelimiter(p.peekToken) && p.peekOnSameLogicalLine() {
+			p.nextToken()
+			cmd.Arguments = append(cmd.Arguments, p.parseCommandWord())
+		}
+		return cmd
+	}
 	cmd := &ast.SimpleCommand{
 		Token: p.curToken,
 		Name:  &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal},


### PR DESCRIPTION
## Summary
`if x && $(y); then` crashed because parseSingleCommand forced `$(` into an Identifier and the trailing `)` of the substitution leaked back to the dispatch loop. Detect command-producing expression heads (DOLLAR_LPAREN/BACKTICK/VARIABLE/DollarLbrace) and run parseExpression first, then continue with normal argument gathering.

## Impact
46 → 44. spaceship 4 → 3; oh-my-zsh 27 → 26.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `if x && $(y); then z; fi`, `cmd1 || \`f\` arg` — parse clean