### PR TITLE
fix(lexer): accept `\=` in the backslash-word escape list

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -430,7 +430,7 @@ func (l *Lexer) NextToken() (tok token.Token) {
 				next == '{' || next == '}' || next == '$' || next == '\\' ||
 				next == '/' || next == '.' || next == '!' || next == '~' ||
 				next == '^' || next == ' ' || next == '\t' || next == '#' ||
-				next == '"' || next == '\'' {
+				next == '"' || next == '\'' || next == '=' {
 				line, col := l.line, l.column
 				l.readChar() // consume '\'
 				tok = token.Token{


### PR DESCRIPTION
## Summary
Zsh glob patterns occasionally escape `=` with backslash: `pids=(${${(v)jobstates##*:*:}%\=*})`. Lexer emitted ILLEGAL. Add `=` to the escape list.

## Impact
43 → 42. spaceship 2 → 1.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `pids=(${var%\=*})` — parses clean