### PR TITLE
fix(lexer): broaden backslash-word escape list (% , : @ + -)

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -430,7 +430,9 @@ func (l *Lexer) NextToken() (tok token.Token) {
 				next == '{' || next == '}' || next == '$' || next == '\\' ||
 				next == '/' || next == '.' || next == '!' || next == '~' ||
 				next == '^' || next == ' ' || next == '\t' || next == '#' ||
-				next == '"' || next == '\'' || next == '=' {
+				next == '"' || next == '\'' || next == '=' || next == '%' ||
+				next == ',' || next == ':' || next == '@' || next == '+' ||
+				next == '-' {
 				line, col := l.line, l.column
 				l.readChar() // consume '\'
 				tok = token.Token{


### PR DESCRIPTION
## Summary
`\%` appears in Zsh prompt-string substitutions like `${var//\%/%%}`. Add `%`, `,`, `:`, `@`, `+`, `-` to the recognised backslash-escape list.

## Impact
42 → 41. powerlevel10k 8 → 7.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `${var//\%/%%}` — parses clean