### PR TITLE
fix(parser): parseDeclarationValue stops on the array `)`, not past it

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -1143,9 +1143,13 @@ func (p *Parser) parseDeclarationValue() ast.Expression {
 		}
 	arrDone:
 		val += " )"
-		if p.curTokenIs(token.RPAREN) {
-			p.nextToken()
-		}
+		// Leave curToken on the closing `)` rather than advancing
+		// past it. The caller's declaration loop checks
+		// `curToken.Line == startLine`; if we step past `)` onto
+		// the next line's first token, the loop drops out and
+		// parseProgram then re-advances, double-skipping the next
+		// statement (e.g. `typeset -g X=(a b)\ntypeset -g Y=…`
+		// dropped the second TYPESET).
 		return &ast.StringLiteral{Token: paren, Value: val}
 	}
 


### PR DESCRIPTION
## Summary
`typeset -g X=(a b)\ntypeset -g Y=` dropped the second `typeset` because parseDeclarationValue advanced past the closing `)` onto the next line's first token. The startLine check then exited the declaration loop and parseProgram's nextToken double-skipped. Leave curToken on `)`.

## Impact
37 → 36. powerlevel10k 7 → 6.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `typeset -g X=(a b c)\ntypeset -g Y=` parses both lines