### PR TITLE
fix(parser): treat `*` / `?` / `-` / `!` as literal subject in `${…}`

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -329,7 +329,13 @@ func (p *Parser) parseArrayAccess() ast.Expression {
 					exp.Index = idx.Index
 				}
 			}
-		case p.curTokenIs(token.VARIABLE), p.curTokenIs(token.INT):
+		case p.curTokenIs(token.VARIABLE), p.curTokenIs(token.INT),
+			p.curTokenIs(token.ASTERISK), p.curTokenIs(token.QUESTION),
+			p.curTokenIs(token.MINUS), p.curTokenIs(token.BANG):
+			// Special positional / array-style subject names like
+			// `${#*}`, `${?}`, `${-}`, `${!}`. Treat the
+			// punctuation as a literal subject so the modifier tail
+			// scanner takes over.
 			exp.Left = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 		default:
 			expr := p.parseExpression(LOWEST)


### PR DESCRIPTION
## Summary
`${#*:#0}` etc. use single-char punctuation as the subject. The narrow-subject fix in #1135 only matched IDENT/VARIABLE/INT, so punctuation fell into parseExpression and crashed on the modifier punctuator. Add ASTERISK/QUESTION/MINUS/BANG.

## Impact
35 → 34. oh-my-zsh 23 → 22.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `${#*:#0}`, `${?}`, `${-}`, `${!}` — parse clean