### PR TITLE
fix(parser): treat reserved-word tokens as literals in command-arg context

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -442,7 +442,18 @@ func (p *Parser) parseCommandWord() ast.Expression {
 			// or `env FOO=bar cmd`). Treat it as a literal word part
 			// when it appears mid-command. The declaration parser has
 			// its own dedicated handling for the IDENT=VALUE form.
-			t == token.ASSIGN || t == token.PLUSEQ {
+			t == token.ASSIGN || t == token.PLUSEQ ||
+			// Reserved-word tokens (FUNCTION/SELECT/COPROC/etc.) are
+			// keywords in statement position but routinely appear as
+			// literal arguments — `reserved_words=( do done … function
+			// repeat select … )`, `print -l function`. Treat them as
+			// literal strings in command-arg / array-element contexts.
+			t == token.FUNCTION || t == token.SELECT || t == token.COPROC ||
+			t == token.DO || t == token.DONE || t == token.ESAC ||
+			t == token.THEN || t == token.ELSE || t == token.ELIF || t == token.Fi ||
+			t == token.If || t == token.FOR || t == token.WHILE || t == token.CASE ||
+			t == token.IN || t == token.LET || t == token.RETURN ||
+			t == token.TYPESET || t == token.DECLARE {
 			return false
 		}
 		return p.prefixParseFns[t] != nil


### PR DESCRIPTION
## Summary
`reserved_words=( do done function select coproc … )` crashed because parseCommandWord dispatched parseFunctionLiteral on the keyword token. Reserved words appear routinely as literal arguments in arrays / print -l / alias bodies. Add FUNCTION/SELECT/COPROC/DO/DONE/etc. to parseCommandWord's literal-token list.

## Impact
34 → 33. oh-my-zsh 22 → 21.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `arr=( do done case esac function )` — parses clean