### PR TITLE
fix(lexer/parser): track EndLine for multi-line strings + use in same-line check

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -376,11 +376,13 @@ func (l *Lexer) NextToken() (tok token.Token) {
 		tok.Line = l.line
 		tok.Column = l.column
 		tok.Literal = l.readString('"')
+		tok.EndLine = l.line
 	case '\'':
 		tok.Type = token.STRING
 		tok.Line = l.line
 		tok.Column = l.column
 		tok.Literal = l.readString('\'')
+		tok.EndLine = l.line
 	case 0:
 		tok.Literal = ""
 		tok.Type = token.EOF

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -263,9 +263,15 @@ func (p *Parser) registerInfix(tokenType token.Type, fn infixParseFn) {
 // same logical command as the current one. A Zsh `\<NL>` pair joins
 // two physical lines into one command; the lexer marks the first token
 // after such a pair with HasPrecedingContinuation so argument-gathering
-// loops don't terminate at the newline.
+// loops don't terminate at the newline. Multi-line tokens (strings,
+// heredocs) report their closing line via EndLine; falling back to
+// Line when EndLine is zero.
 func (p *Parser) peekOnSameLogicalLine() bool {
-	return p.peekToken.Line == p.curToken.Line || p.peekToken.HasPrecedingContinuation
+	curEnd := p.curToken.EndLine
+	if curEnd == 0 {
+		curEnd = p.curToken.Line
+	}
+	return p.peekToken.Line == curEnd || p.peekToken.HasPrecedingContinuation
 }
 
 func (p *Parser) peekPrecedence() int {

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -3,10 +3,10 @@ package token
 type Type string
 
 type Token struct {
-	Type              Type
-	Literal           string
-	Line              int
-	Column            int
+	Type    Type
+	Literal string
+	Line    int
+	Column  int
 	// EndLine records the source line where the token ended.
 	// Most tokens are single-line (EndLine == Line), but
 	// multi-line strings (`'…\n…\n…'`, `"…\n…"`) and heredoc

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -7,6 +7,13 @@ type Token struct {
 	Literal           string
 	Line              int
 	Column            int
+	// EndLine records the source line where the token ended.
+	// Most tokens are single-line (EndLine == Line), but
+	// multi-line strings (`'…\n…\n…'`, `"…\n…"`) and heredoc
+	// bodies span lines; the parser's "same-line" arg-gathering
+	// checks should consult EndLine of the just-consumed token
+	// when comparing against peek.Line. Zero means "use Line".
+	EndLine           int
 	HasPrecedingSpace bool
 	// HasPrecedingContinuation is set when the lexer consumed a
 	// `\<NL>` pair immediately before this token. The Line / Column


### PR DESCRIPTION
## Summary
Multi-line single/double-quoted strings (`'…\n…\n…'`) reported their START line via Token.Line. After such a string, parseSingleCommand's argument loop saw `peek.Line` on the closing-quote line — different from the string's recorded Line — and exited the args loop, orphaning the next argument and producing `expected ), got STRING` cascades inside `$(…)`.

Add Token.EndLine, set by the lexer to the closing-quote line for multi-line strings. peekOnSameLogicalLine consults EndLine.

## Impact
33 → 31. oh-my-zsh 21 → 19.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `b=$(awk 'multi\nline\nscript' file)` — parses clean