### PR TITLE
fix(parser): absorb `.<digits>` after INT inside arithmetic for float literals

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -138,6 +138,19 @@ func (p *Parser) parseIntegerLiteral() ast.Expression {
 		return nil
 	}
 	lit.Value = value
+	// Inside arithmetic (`(( … ))`, `$(( … ))`), Zsh accepts
+	// floating-point literals like `1.0` and the trailing-dot
+	// variant `1000.`. The lexer emits these as INT + DOT (+ INT
+	// for the fractional part). Absorb the DOT (and any following
+	// digit run) so the closing `))` aligns. The AST keeps the
+	// integer part as Value; katas that need the source form walk
+	// Token.Literal which still names the int run.
+	if p.inArithmetic && p.peekTokenIs(token.DOT) && !p.peekToken.HasPrecedingSpace {
+		p.nextToken() // consume DOT
+		if p.peekTokenIs(token.INT) && !p.peekToken.HasPrecedingSpace {
+			p.nextToken() // consume fractional INT
+		}
+	}
 	return lit
 }
 


### PR DESCRIPTION
## Summary
Zsh arithmetic accepts float literals like `1.0`, `0.5`, `1000000000.`. Lexer emits INT + DOT (+ INT), and `expectPeek('))')` crashed with "expected ), got ." inside `$(((expr) / 1000000000.))`. When inArithmetic, after parseIntegerLiteral, absorb glued DOT + glued INT so the close lines up. Outside arithmetic preserves existing behaviour (so `sleep 0.1`, `0.0.0.0:port`, `watch` kata fixtures still pass).

## Impact
Reduces gallois.zsh-theme from 7 errors to 1; total stays 27 net (other cascades shifted).

## Test plan
- [x] `go test ./...` passes (ZC1134/1488/1493/1630 still green)
- [x] `golangci-lint run ./...` clean
- [x] Manual: `(( x = a / 1000. ))`, `$((1.5 + 0.5))` — parse clean