### PR TITLE
fix(parser): support arithmetic ternary `cond ? a : b` operator

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -51,6 +51,11 @@ var precedences = map[token.Type]int{
 	token.INC:           POSTFIX,
 	token.DEC:           POSTFIX,
 	token.PIPE:          LOWEST + 1,
+	// Zsh arithmetic ternary `cond ? a : b`. QUESTION uses LOGICAL
+	// precedence; COLON is consumed inside parseInfixExpression's
+	// right-hand parse so it doesn't need its own infix entry (and
+	// adding one regressed several files outside arithmetic).
+	token.QUESTION: LOGICAL,
 }
 
 type (
@@ -153,6 +158,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.SLASH, p.parseInfixExpression)
 	p.registerInfix(token.ASTERISK, p.parseInfixExpression)
 	p.registerInfix(token.PERCENT, p.parseInfixExpression)
+	p.registerInfix(token.QUESTION, p.parseTernaryExpression)
 	p.registerInfix(token.AND, p.parseInfixExpression)
 	p.registerInfix(token.OR, p.parseInfixExpression)
 	p.registerInfix(token.EQ, p.parseInfixExpression)

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -199,6 +199,32 @@ func (p *Parser) parseDoubleBracketExpression() ast.Expression {
 	return &ast.DoubleBracketExpression{Token: bracketToken, Elements: expressions}
 }
 
+// parseTernaryExpression handles Zsh arithmetic ternary
+// `cond ? then : else`. Builds an InfixExpression `?` whose Right
+// is itself an InfixExpression `:` between the then- and else-
+// branches — keeps the AST shape simple while letting katas walk
+// either branch via Left / Right traversal.
+func (p *Parser) parseTernaryExpression(left ast.Expression) ast.Expression {
+	tok := p.curToken
+	p.nextToken() // past `?`
+	thenExpr := p.parseExpression(LOWEST)
+	// expectPeek consumes `:` if present; otherwise return the
+	// partial ternary so the parser can recover.
+	if p.peekTokenIs(token.COLON) {
+		p.nextToken()
+		colonTok := p.curToken
+		p.nextToken()
+		elseExpr := p.parseExpression(LOWEST)
+		thenExpr = &ast.InfixExpression{
+			Token:    colonTok,
+			Operator: ":",
+			Left:     thenExpr,
+			Right:    elseExpr,
+		}
+	}
+	return &ast.InfixExpression{Token: tok, Operator: "?", Left: left, Right: thenExpr}
+}
+
 func (p *Parser) parseInfixExpression(left ast.Expression) ast.Expression {
 	expression := &ast.InfixExpression{
 		Token:    p.curToken,


### PR DESCRIPTION
## Summary
`(( s = a > 0 ? b : $? ))` crashed because QUESTION had no infix parse function. Register `parseTernaryExpression` at LOGICAL precedence; helper builds nested InfixExpression for `? :`. Avoids registering COLON as a standalone infix (regressed files outside arithmetic).

## Impact
27 → 26. oh-my-zsh 16 → 15.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `(( s = a > 0 ? b : c ))` — parses clean