### PR TITLE
fix(parser): backtick command substitution drains extra statements

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -656,7 +656,17 @@ func (p *Parser) parseCommandSubstitution() ast.Expression {
 	p.nextToken()
 
 	p.inBackticks++
+	// Backtick body can be a multi-statement list `\`a; b; c\`` —
+	// parseCommandList alone only handles one pipeline + logical
+	// chain, so subsequent `;` separators fired
+	// "expected `, got ;". Drain extras opaquely after the first
+	// command, mirroring parseDollarParenExpression's fix.
 	exp.Command = p.parseCommandList()
+	for p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		p.nextToken()
+		_ = p.parseStatement()
+	}
 	p.inBackticks--
 
 	if !p.expectPeek(token.BACKTICK) {


### PR DESCRIPTION
## Summary
`` `cd "$DIR"; pwd` `` crashed because parseCommandSubstitution called parseCommandList which only handles one pipeline + logical chain. Drain `;`-separated extras after the first command, mirroring the fix in `$(…)`.

## Impact
24 → 23. oh-my-zsh 13 → 12.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `` `a; b; c` `` — parses clean