### PR TITLE
fix(lexer): stamp VARIABLE token line at start, not after readIdentifier

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -719,10 +719,19 @@ func (l *Lexer) readDollarToken(hasSpace bool) (token.Token, bool) {
 	}
 	if isLetter(l.peekChar()) {
 		col := l.column
+		line := l.line
 		l.readChar() // consume '$'
 		tok.Type = token.VARIABLE
 		tok.Literal = "$" + l.readIdentifier()
-		tok.Line = l.line
+		// Stamp the START line, not the line after readIdentifier
+		// — readIdentifier advances PAST the last identifier byte,
+		// which on `$name\n` lands l.ch on the newline and bumps
+		// l.line. Without capturing `line` first, every variable
+		// followed by a newline got tagged as the next line, which
+		// confused the parser's same-line argument check (e.g.
+		// `for x in $files\ndo` exited the items loop too early
+		// because $files looked like it was on the do-line).
+		tok.Line = line
 		tok.Column = col
 		tok.HasPrecedingSpace = hasSpace
 		return tok, true


### PR DESCRIPTION
## Summary
`readIdentifier` advances past the last identifier byte, so `$name\n` bumped `l.line` before the VARIABLE token was stamped. `for x in $files\ndo` exited the items loop early because `$files` looked like it lived on the `do` line. Capture `l.line` first.

## Impact
23 → 22. oh-my-zsh 12 → 11.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `for f in $files\ndo\necho $f\ndone` — parses clean