### PR TITLE
fix(parser): `for x in items <NL> body` shortest body form

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -947,6 +947,23 @@ func (p *Parser) parseForLoopStatement() *ast.ForLoopStatement {
 		return stmt
 	}
 
+	// Zsh shortest body form: `for x in items <NL> body` where
+	// the body is a single statement on the next line, no `do` /
+	// `done`. Detected by peek being on a different line and not
+	// being DO / SEMICOLON / EOF.
+	if !p.peekTokenIs(token.DO) && !p.peekTokenIs(token.EOF) && !p.peekOnSameLogicalLine() {
+		p.nextToken() // onto body head
+		body := p.parseStatement()
+		if body != nil {
+			if block, ok := body.(*ast.BlockStatement); ok {
+				stmt.Body = block
+			} else {
+				stmt.Body = &ast.BlockStatement{Token: stmt.Token, Statements: []ast.Statement{body}}
+			}
+		}
+		return stmt
+	}
+
 	if !p.expectPeek(token.DO) {
 		return nil
 	}


### PR DESCRIPTION
## Summary
Zsh accepts `for VAR in ITEMS\n BODY` (no do/done) — shortest-form loop where body is a single statement on the next line. parseForLoopStatement crashed with "expected DO, got IDENT". When peek isn't DO/SEMICOLON/EOF and is on a different line, parse the next statement as the body.

## Impact
prezto editor: 9 → 1 internal errors; net file count unchanged.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `for k in a b c\n  bindkey k cmd` — parses clean