### PR TITLE
fix(parser): arithmetic concatenated identifier with glued VARIABLE

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -114,7 +114,20 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 }
 
 func (p *Parser) parseIdentifier() ast.Expression {
-	return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+	tok := p.curToken
+	value := tok.Literal
+	// Inside arithmetic, Zsh concatenates an IDENT with a glued
+	// VARIABLE / INT to form a dynamic variable name:
+	// `(( X_$y == 2 ))` reads as the value of `X_<expanded y>`.
+	// Absorb the glued tokens so the closing `))` lines up.
+	if p.inArithmetic {
+		for !p.peekToken.HasPrecedingSpace &&
+			(p.peekTokenIs(token.VARIABLE) || p.peekTokenIs(token.INT)) {
+			p.nextToken()
+			value += p.curToken.Literal
+		}
+	}
+	return &ast.Identifier{Token: tok, Value: value}
 }
 
 // parseKeywordAsCommand wraps a Zsh keyword (currently RETURN) as a


### PR DESCRIPTION
## Summary
`(( X_$y == 2 ))` reads as the value of `X_<expanded y>`. parseIdentifier returned just the IDENT and `expectPeek('))')` crashed. When inArithmetic, absorb glued VARIABLE / INT into the identifier value.

## Impact
gitstatus.plugin.zsh internal errors: 26 → 6.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `(( X_$y == 2 ))` — parses clean