### PR TITLE
fix(parser): register RBRACKET as prefix for literal `]` arguments

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -117,6 +117,11 @@ func New(l *lexer.Lexer) *Parser {
 	// fired "no prefix parse function for /". SLASH has no infix
 	// entry so this only widens prefix acceptance.
 	p.registerPrefix(token.SLASH, p.parseIdentifier)
+	// RBRACKET as a prefix covers literal `]` arguments — e.g.
+	// Zsh `alias ]=cat` defines an alias whose name is the
+	// single-character `]`. Without a prefix the lexer's RBRACKET
+	// token had nowhere to land at statement / argument position.
+	p.registerPrefix(token.RBRACKET, p.parseIdentifier)
 	p.registerPrefix(token.INT, p.parseIntegerLiteral)
 	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)


### PR DESCRIPTION
## Summary
Zsh allows `]` as alias / function name (`alias ]=cat`). RBRACKET had no prefix; statement-position `]` crashed. Register parseIdentifier so the token folds as Identifier.

## Impact
21 → 18. oh-my-zsh 10 → 8; syntax-highlighting 3 → 2.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `alias ]=cat`, `] () { echo; }` — parse clean