### PR TITLE
fix(parser): allow `==` pre-flag inside `${==name}` parameter expansion

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -370,7 +370,11 @@ func (p *Parser) parseArrayAccess() ast.Expression {
 	// care about them walk the source directly. Without this guard the
 	// generic prefix-expression path rejects `=` and `^`, breaking real
 	// scripts like `strategies=(${=VAR})` from zsh-autosuggestions.
-	for p.peekTokenIs(token.ASSIGN) || p.peekTokenIs(token.TILDE) || p.peekTokenIs(token.CARET) {
+	for p.peekTokenIs(token.ASSIGN) || p.peekTokenIs(token.TILDE) ||
+		p.peekTokenIs(token.CARET) || p.peekTokenIs(token.EQ) {
+		// `${==X}` is the double-`=` form (strip an outer `=`
+		// flag); the lexer fuses `==` into a single EQ token, so
+		// allow that as a pre-flag here too.
 		p.nextToken()
 	}
 


### PR DESCRIPTION
## Summary
Zsh `${==X}` strips an outer `=` flag from the expansion (double-equal form). Lexer fuses `==` into EQ. parseArrayAccess pre-flag loop only matched ASSIGN/TILDE/CARET. Add EQ.

## Impact
18 → 17. oh-my-zsh 8 → 7.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `arr=(${==X})` — parses clean