### PR TITLE
fix(parser): register COLON as prefix for literal `:` values

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -122,6 +122,11 @@ func New(l *lexer.Lexer) *Parser {
 	// single-character `]`. Without a prefix the lexer's RBRACKET
 	// token had nowhere to land at statement / argument position.
 	p.registerPrefix(token.RBRACKET, p.parseIdentifier)
+	// COLON as prefix: `dir=:$X` (literal `:` value), `${(j::)`
+	// flag forms, and `:` (POSIX null-command) all need the
+	// token to fold into an Identifier when it appears as the
+	// start of an expression.
+	p.registerPrefix(token.COLON, p.parseIdentifier)
 	p.registerPrefix(token.INT, p.parseIntegerLiteral)
 	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)


### PR DESCRIPTION
## Summary
`dir=:$GIT_DIR` (literal `:` value before variable), POSIX null-command `:`, and various flag forms need COLON to fold into an Identifier when it appears as the start of an expression. Parser crashed with "no prefix parse function for :".

## Impact
gitstatus.plugin.zsh internal errors: 6 → 3; p10k.zsh: 6 → 5.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `dir=:$X`, `:`, `: arg` — parse clean