### PR TITLE
fix(lexer): treat non-ASCII bytes as identifier characters

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -417,6 +417,25 @@ func (l *Lexer) NextToken() (tok token.Token) {
 			return tok
 		case l.ch == '\\':
 			tok = l.readBackslashEscape()
+		case l.ch >= 0x80:
+			// Non-ASCII byte (UTF-8 continuation or any
+			// multibyte char). Treat as part of an identifier
+			// word so prompt strings and theme code that include
+			// emoji / accented chars don't crash with ILLEGAL.
+			line, col := l.line, l.column
+			start := l.position
+			for l.ch >= 0x80 || isLetter(l.ch) || isDigit(l.ch) {
+				l.readChar()
+			}
+			literal := l.input[start:l.position]
+			tok = token.Token{
+				Type:    token.IDENT,
+				Literal: literal,
+				Line:    line,
+				Column:  col,
+			}
+			tok.HasPrecedingSpace = hasSpace
+			return tok
 		default:
 			tok = newToken(token.ILLEGAL, l.ch, l.line, l.column)
 		}


### PR DESCRIPTION
## Summary
Theme files and prompt strings routinely contain emoji / accented chars that the lexer emitted as ILLEGAL one byte at a time. p10k internals and oh-my-zsh emoji-char-definitions crashed at every multibyte char. In NextToken default branch, accept any byte >= 0x80 as part of an identifier word and walk the run greedily.

## Impact
oh-my-zsh emoji-char-definitions: 1 → 0 internal errors. p10k.zsh: 5 → 3. Net file count unchanged because file-level errors persist for other unrelated cascades.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `x="🐫 some prompt"`, `emoji[grin]=$'\U1F600'` — parse clean