### PR TITLE
fix(parser): register COMMA as prefix for brace-expansion bodies

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -127,6 +127,11 @@ func New(l *lexer.Lexer) *Parser {
 	// token to fold into an Identifier when it appears as the
 	// start of an expression.
 	p.registerPrefix(token.COLON, p.parseIdentifier)
+	// COMMA as prefix folds bare commas (`function {a,b,c}_x()`,
+	// brace-expansion bodies that the parser stumbles into as
+	// individual statements) into Identifier tokens so the
+	// surrounding block parses cleanly.
+	p.registerPrefix(token.COMMA, p.parseIdentifier)
 	p.registerPrefix(token.INT, p.parseIntegerLiteral)
 	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)


### PR DESCRIPTION
## Summary
`function {pp,is,foo}_x() { … }` crashed because parseFunctionLiteral fell through to treating LBRACE as the body opener; parseBlockStatement then crashed on the bare `,`. Register COMMA as a prefix folding into an Identifier so the block parses cleanly.

## Impact
17 → 16. oh-my-zsh 7 → 6.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `function {a,b,c}_x() { echo; }` — parses clean