### PR TITLE
feat(zc1003): add Fix that rewrites `[ x -eq y ]` to `(( x == y ))`

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -134,6 +134,24 @@ func TestFixIntegration_ZC1004_ExitToReturn(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1003_TestToArith(t *testing.T) {
+	src := `if [ $count -eq 0 ]; then
+  :
+fi
+[ "$n" -lt 10 ] && :
+[ "$a" -ge "$b" ] || :
+`
+	want := `if (( $count == 0 )); then
+  :
+fi
+(( "$n" < 10 )) && :
+(( "$a" >= "$b" )) || :
+`
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1003.go
+++ b/pkg/katas/zc1003.go
@@ -14,7 +14,20 @@ func init() {
 			"which is cleaner and faster than `[` or `test` for numeric comparisons.",
 		Severity: SeverityStyle,
 		Check:    checkZC1003,
+		Fix:      fixZC1003,
 	})
+}
+
+// arithCmpReplacements maps the dash-prefixed test-comparison
+// operators to their arithmetic equivalents. Used by fixZC1003 to
+// rewrite `[ x -eq y ]` → `(( x == y ))`.
+var arithCmpReplacements = map[string]string{
+	"-eq": "==",
+	"-ne": "!=",
+	"-lt": "<",
+	"-le": "<=",
+	"-gt": ">",
+	"-ge": ">=",
 }
 
 func checkZC1003(node ast.Node) []Violation {
@@ -28,7 +41,7 @@ func checkZC1003(node ast.Node) []Violation {
 				// Trim parens added by AST String() method for expressions
 				val = strings.Trim(val, "()")
 
-				if val == "-eq" || val == "-ne" || val == "-lt" || val == "-le" || val == "-gt" || val == "-ge" {
+				if _, found := arithCmpReplacements[val]; found {
 					violations = append(violations, Violation{
 						KataID:  "ZC1003",
 						Message: "Use `((...))` for arithmetic comparisons instead of `[` or `test`.",
@@ -43,4 +56,55 @@ func checkZC1003(node ast.Node) []Violation {
 	}
 
 	return violations
+}
+
+// fixZC1003 rewrites `[ x -eq y ]` to `(( x == y ))`. Only the
+// `[` form is auto-fixable: replace the opening `[` with `((`,
+// the matching `]` with `))`, and the `-eq`/etc. operator with
+// its arithmetic equivalent. The `test` form has no closing
+// terminator on the line and the surrounding context (pipelines,
+// chains) makes a safe rewrite ambiguous; it stays detection-only.
+//
+// Bails when the command shape doesn't match: more than one
+// comparison operator, no `[` byte at the violation column,
+// missing close bracket, or no recognised operator.
+func fixZC1003(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok || cmd.Name == nil {
+		return nil
+	}
+	if cmd.Name.String() != "[" {
+		return nil
+	}
+	var op string
+	var opIdx int
+	for i, arg := range cmd.Arguments {
+		val := strings.Trim(arg.String(), "()")
+		if _, found := arithCmpReplacements[val]; found {
+			if op != "" {
+				return nil // multiple ops — not safe to auto-fix
+			}
+			op = val
+			opIdx = i
+		}
+	}
+	if op == "" {
+		return nil
+	}
+	openOff := LineColToByteOffset(source, v.Line, v.Column)
+	if openOff < 0 || openOff >= len(source) || source[openOff] != '[' {
+		return nil
+	}
+	closeOff := findTestCloseBracket(source, openOff)
+	if closeOff < 0 {
+		return nil
+	}
+	opTok := cmd.Arguments[opIdx]
+	opLine := opTok.TokenLiteralNode().Line
+	opCol := opTok.TokenLiteralNode().Column
+	return []FixEdit{
+		{Line: v.Line, Column: v.Column, Length: 1, Replace: "(("},
+		{Line: opLine, Column: opCol, Length: len(op), Replace: arithCmpReplacements[op]},
+		offsetToEdit(source, closeOff, 1, "))"),
+	}
 }


### PR DESCRIPTION
## Summary
ZC1003 detects `[` / `test` numeric comparisons but had no Fix. Add one that rewrites the `[` form in place: opening `[` → `((`, comparison operator (`-eq`/`-ne`/`-lt`/`-le`/`-gt`/`-ge`) → arithmetic equivalent (`==`/`!=`/`<`/`<=`/`>`/`>=`), closing `]` → `))`.

The `test` form stays detection-only because it lacks an explicit closer.

Closes the ZC1003 fix-coverage roadmap entry.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] New TestFixIntegration_ZC1003_TestToArith covers if-condition and standalone forms