### PR TITLE
feat(cli): print summary footer for `-fix` over directory trees

### DIFF
--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -129,10 +129,18 @@ func run() int {
 		fixOpts.enabled = true
 		fixOpts.dryRun = true
 	}
+	if fixOpts.enabled {
+		fixOpts.stats = &fixStats{}
+	}
 
 	totalViolations := 0
 	for _, filename := range flag.Args() {
 		totalViolations += processPath(filename, os.Stdout, os.Stderr, config, kataRegistry, *format, allowedSeverities, fixOpts)
+	}
+
+	if fixOpts.stats != nil && fixOpts.stats.filesScanned > 1 {
+		fmt.Fprintf(os.Stderr, "\nfix summary: %d edit(s) across %d file(s) (scanned %d)\n",
+			fixOpts.stats.totalEdits, fixOpts.stats.filesModified, fixOpts.stats.filesScanned)
 	}
 
 	if totalViolations > 0 {
@@ -177,6 +185,18 @@ type fixOptions struct {
 	diff      bool
 	dryRun    bool
 	maxPasses int
+	// stats tracks per-run aggregate fix activity so processPath
+	// can print a one-line summary footer when -fix runs over a
+	// directory tree. nil when -fix is disabled.
+	stats *fixStats
+}
+
+// fixStats accumulates fix activity across all files visited in one
+// run. Updated by processFile when an in-place rewrite lands.
+type fixStats struct {
+	filesScanned  int
+	filesModified int
+	totalEdits    int
 }
 
 // applyFixesUntilStable runs fix.Apply repeatedly, re-parsing and
@@ -409,8 +429,15 @@ func processFile(filename string, out, errOut io.Writer, cfg config.Config, regi
 					fmt.Fprintf(errOut, "fix: write failed for %s: %s\n", filename, werr)
 				} else {
 					fmt.Fprintf(errOut, "fixed %d edit(s) in %s\n", totalEdits, filename)
+					if fixOpts.stats != nil {
+						fixOpts.stats.filesModified++
+						fixOpts.stats.totalEdits += totalEdits
+					}
 				}
 			}
+		}
+		if fixOpts.stats != nil {
+			fixOpts.stats.filesScanned++
 		}
 	}
 


### PR DESCRIPTION
## Summary
When `-fix` runs over more than one file (typically a directory tree), append a one-line summary to stderr:

    fix summary: N edit(s) across M file(s) (scanned K)

Single-file invocations stay silent (footer only fires when filesScanned > 1).

Closes the per-directory progress roadmap entry.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `zshellcheck -fix dir/` shows footer; single-file `-fix` doesn't