### PR TITLE
feat(zc1001): add Fix that wraps `$arr[i]` in `${arr[i]}` braces

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -134,6 +134,20 @@ func TestFixIntegration_ZC1004_ExitToReturn(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1001_BraceArrayAccess(t *testing.T) {
+	src := `x=$arr[1]
+y=$other[2]
+z=$pair[a,b]
+`
+	want := `x=${arr[1]}
+y=${other[2]}
+z=${pair[a,b]}
+`
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1003_TestToArith(t *testing.T) {
 	src := `if [ $count -eq 0 ]; then
   :

--- a/pkg/katas/zc1001.go
+++ b/pkg/katas/zc1001.go
@@ -13,6 +13,7 @@ func init() {
 			"The correct way to access an array element is to use `${my_array[1]}`.",
 		Severity: SeverityStyle,
 		Check:    checkZC1001,
+		Fix:      fixZC1001,
 	})
 	RegisterKata(ast.InvalidArrayAccessNode, Kata{
 		ID:    "ZC1001",
@@ -22,7 +23,84 @@ func init() {
 			"The correct way to access an array element is to use `${my_array[1]}`.",
 		Severity: SeverityStyle,
 		Check:    checkZC1001,
+		Fix:      fixZC1001,
 	})
+}
+
+// fixZC1001 rewrites `$arr[i]` to `${arr[i]}`. Two edits: insert
+// `{` between the `$` and the identifier, then insert `}` after
+// the closing `]`. Source positions are derived from the violation
+// column (which points at the leading `$`) and a quote/brace-aware
+// scan for the matching `]`.
+func fixZC1001(node ast.Node, v Violation, source []byte) []FixEdit {
+	dollarOff := LineColToByteOffset(source, v.Line, v.Column)
+	if dollarOff < 0 || dollarOff >= len(source) || source[dollarOff] != '$' {
+		return nil
+	}
+	// Find the `[` that opens the subscript starting from after `$name`.
+	// Walk identifier chars then expect `[`.
+	i := dollarOff + 1
+	for i < len(source) && (isIdentByte(source[i])) {
+		i++
+	}
+	if i >= len(source) || source[i] != '[' {
+		return nil
+	}
+	closeOff := findSubscriptClose(source, i)
+	if closeOff < 0 {
+		return nil
+	}
+	return []FixEdit{
+		// Insert `{` immediately after the `$`.
+		{Line: v.Line, Column: v.Column + 1, Length: 0, Replace: "{"},
+		// Insert `}` immediately after the closing `]`.
+		offsetToEdit(source, closeOff+1, 0, "}"),
+	}
+}
+
+// findSubscriptClose returns the byte offset of the `]` that closes
+// the subscript opened at open. Tracks single / double quotes and
+// nested `[` so subscripts containing patterns like `arr[$other[i]]`
+// or `arr[(R)pat]` close at the right bracket. Returns -1 when no
+// match is found before EOF.
+func findSubscriptClose(source []byte, open int) int {
+	inSingle := false
+	inDouble := false
+	depth := 1
+	for i := open + 1; i < len(source); i++ {
+		c := source[i]
+		switch {
+		case inSingle:
+			if c == '\'' {
+				inSingle = false
+			}
+		case inDouble:
+			if c == '\\' && i+1 < len(source) {
+				i++
+				continue
+			}
+			if c == '"' {
+				inDouble = false
+			}
+		default:
+			switch c {
+			case '\'':
+				inSingle = true
+			case '"':
+				inDouble = true
+			case '[':
+				depth++
+			case ']':
+				depth--
+				if depth == 0 {
+					return i
+				}
+			case '\n':
+				return -1
+			}
+		}
+	}
+	return -1
 }
 
 func checkZC1001(node ast.Node) []Violation {


### PR DESCRIPTION
## Summary
ZC1001 flagged the braceless `$arr[i]` form (which Zsh misreads as a parameter literally named `arr[i]`) but had no Fix. Add a two-edit rewrite: insert `{` after the `$`, `}` after the closing `]`. Subscript close detection mirrors ZC1010's bracket-aware scanner (quotes tracked, nested `[` adjusts depth, newlines abort).

Closes the ZC1001 fix-coverage roadmap entry.

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] Manual: `x=$arr[1]` → `x=${arr[1]}`, `z=$pair[a,b]` → `z=${pair[a,b]}`