### PR TITLE
fix(parser): drain newline-separated statements inside `$(…)`

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -795,8 +795,20 @@ func (p *Parser) parseDollarParenExpression() ast.Expression {
 	// closing `)` cleanly. The AST keeps the first command; katas
 	// that care about the full body can walk source.
 	exp.Command = p.parseCommandList()
-	for p.peekTokenIs(token.SEMICOLON) {
-		p.nextToken() // onto ;
+	// Drain any further statements inside the `$( … )` body.
+	// Zsh separates statements with `;` or a newline, so advance
+	// past either and re-enter parseStatement. Stops at RPAREN or
+	// EOF; callers handle unexpected EOF as a parse error.
+	for !p.peekTokenIs(token.RPAREN) && !p.peekTokenIs(token.EOF) {
+		if p.peekTokenIs(token.SEMICOLON) {
+			p.nextToken() // onto ;
+		} else if p.peekToken.Line > p.curToken.Line {
+			// implicit newline separator: fall through to nextToken
+		} else {
+			// Unknown continuation — bail so the RPAREN expectPeek
+			// below reports a meaningful error.
+			break
+		}
 		p.nextToken() // onto next stmt head
 		_ = p.parseStatement()
 	}


### PR DESCRIPTION
## Summary

- `parseDollarParenExpression` drained sibling statements only on `;` — missed plain newline separators
- Multi-line `\$( exec 3>&1; typeset -r dir=\$(mktemp -d); { body } always { cleanup } )` stopped after the first pipeline and `expectPeek(RPAREN)` reported "expected ), got TYPESET"
- Loop until peek reaches `RPAREN` / `EOF`, treating newline (`peek.Line > cur.Line`) as an implicit separator like `;`

Error count holds at 11 but one error shape changed from "got TYPESET" to "got IDENT", meaning an earlier layer now parses correctly and only the inner construct (the `{ body } always { cleanup }` try-block) remains.

## Test plan
- [x] `go test ./...` green
- [x] `golangci-lint run ./...` clean
- [x] Compat sweep: no regression, generate.zsh progresses past the TYPESET boundary