### PR TITLE
fix(parser): advance past inner `)` on glob-alt case labels

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -800,18 +800,20 @@ func (p *Parser) parseDollarParenExpression() ast.Expression {
 	// past either and re-enter parseStatement. Stops at RPAREN or
 	// EOF; callers handle unexpected EOF as a parse error.
 	for !p.peekTokenIs(token.RPAREN) && !p.peekTokenIs(token.EOF) {
-		if p.peekTokenIs(token.SEMICOLON) {
+		switch {
+		case p.peekTokenIs(token.SEMICOLON):
 			p.nextToken() // onto ;
-		} else if p.peekToken.Line > p.curToken.Line {
+		case p.peekToken.Line > p.curToken.Line:
 			// implicit newline separator: fall through to nextToken
-		} else {
+		default:
 			// Unknown continuation — bail so the RPAREN expectPeek
 			// below reports a meaningful error.
-			break
+			goto drainDone
 		}
 		p.nextToken() // onto next stmt head
 		_ = p.parseStatement()
 	}
+drainDone:
 	if !p.expectPeek(token.RPAREN) {
 		return nil
 	}

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -835,9 +835,15 @@ func (p *Parser) parseCaseStatement() *ast.CaseStatement {
 		}
 		// curToken may already be on `)` when parseCommandWord
 		// absorbed an inline glob group like `(a|b)*` whose close
-		// IS the label terminator. Otherwise expectPeek(RPAREN)
-		// to advance onto the label close.
-		if !p.curTokenIs(token.RPAREN) {
+		// IS the label terminator. When the absorbed `)` is just
+		// the glob close and the actual label terminator is the
+		// NEXT `)` — e.g. `plugin::(disable|enable|load))` —
+		// advance once so we land on the label's own `)`. Otherwise
+		// expectPeek(RPAREN) to reach the label close from any
+		// other tail token.
+		if p.curTokenIs(token.RPAREN) && p.peekTokenIs(token.RPAREN) {
+			p.nextToken()
+		} else if !p.curTokenIs(token.RPAREN) {
 			if !p.expectPeek(token.RPAREN) {
 				return nil
 			}


### PR DESCRIPTION
## Summary

- `plugin::(disable|enable|load))` and `+(e|U|W|D))` style case patterns absorb the inner `)` of the glob-alt group into `parseCommandWord`; the label terminator is the SECOND `)`
- `parseCaseStatement` previously treated curToken=`)` as "label already at terminator" and skipped `expectPeek`, causing the outer `)` to leak into the clause body and error
- Advance once when curToken=`)` and peek=`)` so we land on the actual label close
- Refactor `$( … )` drain loop to satisfy gocritic's `ifElseChain` rule

Clears `p10k/gitstatus/gitstatus.plugin.zsh`; `omz/lib/cli.zsh` now parses its case patterns and surfaces a downstream issue unrelated to this fix.

## Test plan
- [x] `go test ./...` green
- [x] `golangci-lint run ./...` clean
- [x] Compat sweep: 11 → 10 parse errors