### PR TITLE
fix(parser): accept INT as for-loop variable name in implicit-list form

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -955,11 +955,13 @@ func (p *Parser) parseForLoopStatement() *ast.ForLoopStatement {
 
 	// Zsh multi-variable for loop: `for k v in …` / `for a b c in …`
 	// pairs each element of the item list against the declared
-	// variables in turn. The AST currently only models a single
-	// Name, so skip extra names forward until we hit IN / LPAREN /
-	// SEMICOLON / DO. Detection katas that need the full name list
-	// can read source directly.
-	for p.peekTokenIs(token.IDENT) {
+	// variables in turn. The implicit-list form `for k v w; do …`
+	// (no `in` — iterates over `$@`) allows numeric positional
+	// names as well, e.g. `for 1 2 3; do …` in
+	// zsh-syntax-highlighting. Accept IDENT and INT alike; the AST
+	// only models a single Name, so extras are skipped. Detection
+	// katas that need the full name list can read source directly.
+	for p.peekTokenIs(token.IDENT) || p.peekTokenIs(token.INT) {
 		p.nextToken()
 	}
 


### PR DESCRIPTION
## Summary

- Zsh's `for name...; do ... done` iterates declared names over `\$@` (implicit positional-list form)
- Names may be numeric positional identifiers: `for 1 2 3; do` used in zsh-syntax-highlighting main-highlighter
- The multi-variable name-gathering loop accepted only `IDENT`, leaving `2 3` on the line; `expectPeek(DO)` then fired "expected DO, got INT"
- Extend the loop to also accept `INT`, matching the single-name branch that already allows numeric names

Surfaces previously-masked downstream errors in the same file (if-brace `else`, INT-as-IDENT), which are separate issues to tackle in follow-up iterations.

## Test plan
- [x] `go test ./...` green
- [x] `golangci-lint run ./...` clean
- [x] Compat sweep: no regression