### PR TITLE
feat(zc1012): add Fix that inserts `-r` after `read`

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -166,6 +166,29 @@ fi
 	}
 }
 
+func TestFixIntegration_ZC1012_ReadAddR(t *testing.T) {
+	src := "read VAR\n"
+	want := "read -r VAR\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1012_ReadWithFlagsPreserved(t *testing.T) {
+	src := "read -p prompt VAR\n"
+	want := "read -r -p prompt VAR\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1012_ReadDashRLeftAlone(t *testing.T) {
+	src := "read -r VAR\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("already-fixed input should be idempotent, got %q", got)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1012.go
+++ b/pkg/katas/zc1012.go
@@ -14,7 +14,62 @@ func init() {
 			"Use `read -r` to treat backslashes literally, which is usually what you want.",
 		Severity: SeverityStyle,
 		Check:    checkZC1012,
+		Fix:      fixZC1012,
 	})
+}
+
+// fixZC1012 inserts ` -r` directly after the `read` command name.
+// Existing flags are left untouched (`read -p "x" VAR` becomes
+// `read -r -p "x" VAR`) so the fix is order-preserving and idempotent
+// on a second pass (the re-parse will see `-r` and detection won't
+// fire).
+func fixZC1012(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	if cmd.Name.String() != "read" {
+		return nil
+	}
+	nameOffset := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOffset < 0 {
+		return nil
+	}
+	nameLen := IdentLenAt(source, nameOffset)
+	if nameLen != len("read") {
+		return nil
+	}
+	insertAt := nameOffset + nameLen
+	insertLine, insertCol := byteOffsetToLineColZC1012(source, insertAt)
+	if insertLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insertLine,
+		Column:  insertCol,
+		Length:  0,
+		Replace: " -r",
+	}}
+}
+
+// byteOffsetToLineColZC1012 converts a byte offset to a 1-based
+// (line, column). Kept kata-local to avoid exposing a shared helper
+// that the rest of the package does not yet need.
+func byteOffsetToLineColZC1012(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1012(node ast.Node) []Violation {


### PR DESCRIPTION
## Summary

- `read` without `-r` interprets backslashes as escape characters — rarely intended
- ZC1012 already flagged bare `read` calls; this lands the matching auto-fix
- Insertion point is the first byte after the `read` command name; existing flags stay in place

Test matrix:
- `read VAR` → `read -r VAR`
- `read -p prompt VAR` → `read -r -p prompt VAR`
- `read -r VAR` stays unchanged (detection doesn't fire)

## Test plan
- [x] `go test ./...` green (three new integration tests)
- [x] `golangci-lint run ./...` clean