### PR TITLE
feat(zc1031): add Fix that rewrites `#!/bin/zsh` shebang

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -189,6 +189,21 @@ func TestFixIntegration_ZC1012_ReadDashRLeftAlone(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1031_ShebangEnv(t *testing.T) {
+	src := "#!/bin/zsh\nx=1\n"
+	want := "#!/usr/bin/env zsh\nx=1\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1031_AlreadyEnv(t *testing.T) {
+	src := "#!/usr/bin/env zsh\nx=1\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("already-portable shebang should be left alone, got %q", got)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1031.go
+++ b/pkg/katas/zc1031.go
@@ -12,7 +12,27 @@ func init() {
 			"for the `zsh` executable in the user's `PATH`.",
 		Severity: SeverityInfo,
 		Check:    checkZC1031,
+		Fix:      fixZC1031,
 	})
+}
+
+// fixZC1031 rewrites `#!/bin/zsh` to `#!/usr/bin/env zsh` in the
+// shebang line. Span-aware: replaces the whole `#!/bin/zsh` run as a
+// single edit at column 1, line 1.
+func fixZC1031(node ast.Node, v Violation, source []byte) []FixEdit {
+	shebang, ok := node.(*ast.Shebang)
+	if !ok {
+		return nil
+	}
+	if shebang.Path != "#!/bin/zsh" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("#!/bin/zsh"),
+		Replace: "#!/usr/bin/env zsh",
+	}}
 }
 
 func checkZC1031(node ast.Node) []Violation {


### PR DESCRIPTION
## Summary

- ZC1031 advises switching `#!/bin/zsh` to `#!/usr/bin/env zsh` for PATH portability
- This lands the deterministic auto-fix: single replacement at (line 1, column 1)
- Already-portable shebangs untouched (detection only fires on the bare absolute-path form)

## Test plan
- [x] `go test ./...` green
- [x] `golangci-lint run ./...` clean
- [x] Two new integration tests (positive rewrite + idempotent already-portable)