### PR TITLE
feat(zc1017): add Fix that inserts raw flag after print

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -228,6 +228,21 @@ func TestFixIntegration_ZC1055_LeftEmpty(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1017_PrintAddR(t *testing.T) {
+	src := `print "hello"` + "\n"
+	want := `print -r "hello"` + "\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1017_PrintRLeftAlone(t *testing.T) {
+	src := `print -r "hello"` + "\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("already-fixed input should be idempotent, got %q", got)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1017.go
+++ b/pkg/katas/zc1017.go
@@ -14,7 +14,60 @@ func init() {
 			"To print a string literally, use the `-r` option.",
 		Severity: SeverityStyle,
 		Check:    checkZC1017,
+		Fix:      fixZC1017,
 	})
+}
+
+// fixZC1017 inserts ` -r` directly after the `print` command name.
+// Existing flags are left in place, mirroring ZC1012's `read -r`
+// insertion: `print "x"` becomes `print -r "x"`, `print -n "x"`
+// becomes `print -r -n "x"`. Idempotent on a second pass — once
+// `-r` appears among the flags the detector no longer fires.
+func fixZC1017(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	name, ok := cmd.Name.(*ast.Identifier)
+	if !ok || name.Value != "print" {
+		return nil
+	}
+	nameOffset := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOffset < 0 {
+		return nil
+	}
+	nameLen := IdentLenAt(source, nameOffset)
+	if nameLen != len("print") {
+		return nil
+	}
+	insertAt := nameOffset + nameLen
+	insLine, insCol := byteOffsetToLineColZC1017(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " -r",
+	}}
+}
+
+func byteOffsetToLineColZC1017(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1017(node ast.Node) []Violation {


### PR DESCRIPTION
Mirrors ZC1012's insertion pattern. print without raw flag may interpret backslash escapes; the fix inserts the flag right after the command name, preserving any existing flags. Idempotent on re-run once the flag is present.

Test plan: go test ./... green, golangci-lint clean, two integration tests.