### PR TITLE
feat(zc1051): wrap unquoted rm args in double-quotes

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -243,6 +243,21 @@ func TestFixIntegration_ZC1017_PrintRLeftAlone(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1051_RmUnquotedVar(t *testing.T) {
+	src := "rm $FILE\n"
+	want := `rm "$FILE"` + "\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1051_RmQuotedStaysIdempotent(t *testing.T) {
+	src := `rm "$FILE"` + "\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("quoted input should be idempotent, got %q", got)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1051.go
+++ b/pkg/katas/zc1051.go
@@ -12,7 +12,98 @@ func init() {
 			"Quote the variable (`rm \"$VAR\"`) to ensure safe deletion.",
 		Severity: SeverityWarning,
 		Check:    checkZC1051,
+		Fix:      fixZC1051,
 	})
+}
+
+// fixZC1051 wraps an unquoted `$VAR` argument in double-quotes.
+// Two edits: one `"` before the arg and one after. Arg span is
+// measured from source — we scan forward from the arg's token
+// position until the first unescaped whitespace / delimiter,
+// honouring `{…}` / `[…]` / `(…)` nesting so expansions like
+// `${var[1]}`, `$(cmd)`, `${arr[@]}` stay whole.
+func fixZC1051(_ ast.Node, v Violation, source []byte) []FixEdit {
+	start := LineColToByteOffset(source, v.Line, v.Column)
+	if start < 0 || start >= len(source) {
+		return nil
+	}
+	argLen := unquotedArgLen(source, start)
+	if argLen == 0 {
+		return nil
+	}
+	endLine, endCol := offsetLineColZC1051(source, start+argLen)
+	if endLine < 0 {
+		return nil
+	}
+	return []FixEdit{
+		{Line: v.Line, Column: v.Column, Length: 0, Replace: `"`},
+		{Line: endLine, Column: endCol, Length: 0, Replace: `"`},
+	}
+}
+
+// unquotedArgLen returns the byte length of a shell-word starting
+// at offset. Honours brace / paren / bracket nesting so
+// `${arr[$i]}` and `$(cmd (sub))` stay whole, and stops on the
+// first top-level delimiter.
+func unquotedArgLen(source []byte, offset int) int {
+	if offset < 0 || offset >= len(source) {
+		return 0
+	}
+	n := 0
+	braceDepth := 0
+	parenDepth := 0
+	bracketDepth := 0
+	for offset+n < len(source) {
+		c := source[offset+n]
+		if braceDepth == 0 && parenDepth == 0 && bracketDepth == 0 {
+			switch c {
+			case ' ', '\t', '\n', ';', '|', '&', '>', '<':
+				return n
+			}
+			if c == ')' {
+				return n
+			}
+		}
+		switch c {
+		case '{':
+			braceDepth++
+		case '}':
+			if braceDepth > 0 {
+				braceDepth--
+			}
+		case '(':
+			parenDepth++
+		case ')':
+			if parenDepth > 0 {
+				parenDepth--
+			}
+		case '[':
+			bracketDepth++
+		case ']':
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		}
+		n++
+	}
+	return n
+}
+
+func offsetLineColZC1051(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1051(node ast.Node) []Violation {


### PR DESCRIPTION
Unquoted $VAR passed to rm triggers globbing — if $VAR is "*" the call deletes every file in the current directory. Fix wraps the arg in double-quotes.

Two edits: insert opening quote at arg start, insert closing quote at arg end. Arg span measured from source with brace / paren / bracket nesting honoured so expansions like ${arr[$i]} and $(cmd) stay whole.

Test plan: go test ./... green, golangci-lint clean, two integration tests (positive rewrite + idempotent already-quoted).