### PR TITLE
feat(zc1062,zc1063): rewrite egrep/fgrep to grep -E/-F

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -258,6 +258,22 @@ func TestFixIntegration_ZC1051_RmQuotedStaysIdempotent(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1062_EgrepToGrepE(t *testing.T) {
+	src := "egrep pattern file\n"
+	want := "grep -E pattern file\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1063_FgrepToGrepF(t *testing.T) {
+	src := "fgrep pattern file\n"
+	want := "grep -F pattern file\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1062.go
+++ b/pkg/katas/zc1062.go
@@ -11,7 +11,27 @@ func init() {
 		Description: "`egrep` is deprecated. Use `grep -E` instead.",
 		Severity:    SeverityInfo,
 		Check:       checkZC1062,
+		Fix:         fixZC1062,
 	})
+}
+
+// fixZC1062 rewrites `egrep` to `grep -E` at the command name
+// position. Single replacement — arguments stay untouched.
+func fixZC1062(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "egrep" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("egrep"),
+		Replace: "grep -E",
+	}}
 }
 
 func checkZC1062(node ast.Node) []Violation {

--- a/pkg/katas/zc1063.go
+++ b/pkg/katas/zc1063.go
@@ -11,7 +11,27 @@ func init() {
 		Description: "`fgrep` is deprecated. Use `grep -F` instead.",
 		Severity:    SeverityInfo,
 		Check:       checkZC1063,
+		Fix:         fixZC1063,
 	})
+}
+
+// fixZC1063 rewrites `fgrep` to `grep -F` at the command name
+// position. Single replacement — arguments stay untouched.
+func fixZC1063(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "fgrep" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("fgrep"),
+		Replace: "grep -F",
+	}}
 }
 
 func checkZC1063(node ast.Node) []Violation {


### PR DESCRIPTION
Two deprecated command aliases with the same shape, fixed in one PR because the rewrite logic is identical. egrep / fgrep are deprecated per upstream grep; the canonical modern forms are grep -E / grep -F. Single-edit command-name replacement.

Test plan: go test ./... green, golangci-lint clean, two new integration tests.