### PR TITLE
feat(zc1086): rewrite function keyword form to paren-syntax

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -274,6 +274,29 @@ func TestFixIntegration_ZC1063_FgrepToGrepF(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1086_FunctionKeywordBareBody(t *testing.T) {
+	src := "function foo { body }\n"
+	want := "foo() { body }\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1086_FunctionKeywordWithParens(t *testing.T) {
+	src := "function foo() { body }\n"
+	want := "foo() { body }\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1086_NoFunctionKeywordUnchanged(t *testing.T) {
+	src := "foo() { body }\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("plain form should be idempotent, got %q", got)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1086.go
+++ b/pkg/katas/zc1086.go
@@ -12,6 +12,7 @@ func init() {
 			"Using `func() { ... }` is more portable and consistent.",
 		Severity: SeverityStyle,
 		Check:    checkZC1086,
+		Fix:      fixZC1086,
 	})
 	RegisterKata(ast.FunctionLiteralNode, Kata{
 		ID:    "ZC1086",
@@ -20,7 +21,93 @@ func init() {
 			"Using `func() { ... }` is more portable and consistent.",
 		Severity: SeverityStyle,
 		Check:    checkZC1086,
+		Fix:      fixZC1086,
 	})
+}
+
+// fixZC1086 rewrites `function name [()] { body }` to the portable
+// `name() { body }` form. Deletes the `function ` prefix and, when
+// the source doesn't already carry `()` after the name, inserts it.
+func fixZC1086(node ast.Node, v Violation, source []byte) []FixEdit {
+	var name string
+	switch n := node.(type) {
+	case *ast.FunctionLiteral:
+		if n.TokenLiteral() != "function" || n.Name == nil {
+			return nil
+		}
+		name = n.Name.Value
+	case *ast.FunctionDefinition:
+		if n.TokenLiteral() != "function" || n.Name == nil {
+			return nil
+		}
+		name = n.Name.Value
+	default:
+		return nil
+	}
+	if name == "" {
+		return nil
+	}
+	kwOffset := LineColToByteOffset(source, v.Line, v.Column)
+	if kwOffset < 0 || kwOffset+len("function ") > len(source) {
+		return nil
+	}
+	if string(source[kwOffset:kwOffset+len("function")]) != "function" {
+		return nil
+	}
+	// Delete `function` + the whitespace run that follows, up to the
+	// name start. Find the name's byte position by scanning forward
+	// past the whitespace.
+	i := kwOffset + len("function")
+	for i < len(source) && (source[i] == ' ' || source[i] == '\t') {
+		i++
+	}
+	if i+len(name) > len(source) || string(source[i:i+len(name)]) != name {
+		return nil
+	}
+	edits := []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  i - kwOffset,
+		Replace: "",
+	}}
+	// After the name, check whether `()` already follows. Skip any
+	// whitespace between name and peek byte; Zsh allows
+	// `function foo ()` with a space.
+	after := i + len(name)
+	j := after
+	for j < len(source) && (source[j] == ' ' || source[j] == '\t') {
+		j++
+	}
+	if j >= len(source) || source[j] != '(' {
+		afterLine, afterCol := offsetLineColZC1086(source, after)
+		if afterLine < 0 {
+			return nil
+		}
+		edits = append(edits, FixEdit{
+			Line:    afterLine,
+			Column:  afterCol,
+			Length:  0,
+			Replace: "()",
+		})
+	}
+	return edits
+}
+
+func offsetLineColZC1086(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1086(node ast.Node) []Violation {


### PR DESCRIPTION
Zsh's function keyword form is non-POSIX. ZC1086 recommends the portable paren-less syntax. The fix deletes the function prefix and, when needed, inserts empty parens after the name to stay consistent with the canonical shape.

Handles both FunctionLiteral (function foo { body }) and FunctionDefinition (function foo() { body }) node shapes.

Test plan: go test ./... green, golangci-lint clean, three integration tests cover bare-body rewrite, explicit-parens rewrite, and plain-form idempotence.