### PR TITLE
feat(zc1073): drop unnecessary dollar prefix inside (( ))

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -297,6 +297,22 @@ func TestFixIntegration_ZC1086_NoFunctionKeywordUnchanged(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1073_DropDollarInArith(t *testing.T) {
+	src := "(( $x > 0 ))\n"
+	want := "(( x > 0 ))\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1073_MultipleDollarsAllDropped(t *testing.T) {
+	src := "(( $a + $b ))\n"
+	want := "(( a + b ))\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1073.go
+++ b/pkg/katas/zc1073.go
@@ -11,7 +11,25 @@ func init() {
 		Description: "Variables in `((...))` do not need `$` prefix. Use `(( var > 0 ))` instead of `(( $var > 0 ))`.",
 		Severity:    SeverityStyle,
 		Check:       checkZC1073,
+		Fix:         fixZC1073,
 	})
+}
+
+// fixZC1073 deletes the leading `$` from a variable used inside
+// `(( … ))`. The violation coordinates already point at the `$`
+// byte, so a single zero-replacement edit removes it. A second pass
+// won't re-trigger because the identifier no longer carries `$`.
+func fixZC1073(_ ast.Node, v Violation, source []byte) []FixEdit {
+	off := LineColToByteOffset(source, v.Line, v.Column)
+	if off < 0 || off >= len(source) || source[off] != '$' {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  1,
+		Replace: "",
+	}}
 }
 
 func checkZC1073(node ast.Node) []Violation {


### PR DESCRIPTION
Zsh arithmetic context (( ... )) does name-resolution on bare identifiers — the leading dollar is redundant and noise. Fix deletes the single byte at the violation column. Idempotent once removed.

Test plan: go test ./... green, golangci-lint clean, two integration tests cover single and multiple occurrences.