### PR TITLE
feat(zc1064): rewrite type to command -v

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -313,6 +313,14 @@ func TestFixIntegration_ZC1073_MultipleDollarsAllDropped(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1064_TypeToCommandV(t *testing.T) {
+	src := "type git\n"
+	want := "command -v git\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1064.go
+++ b/pkg/katas/zc1064.go
@@ -12,7 +12,27 @@ func init() {
 			"`command -v` is quieter and standard.",
 		Severity: SeverityInfo,
 		Check:    checkZC1064,
+		Fix:      fixZC1064,
 	})
+}
+
+// fixZC1064 rewrites `type` to `command -v` at the command name
+// position. Single replacement — arguments stay untouched.
+func fixZC1064(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "type" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("type"),
+		Replace: "command -v",
+	}}
 }
 
 func checkZC1064(node ast.Node) []Violation {


### PR DESCRIPTION
type output format varies across shells; command -v is POSIX and quieter for existence checks. Single-edit command-name replacement.

Test plan: go test ./... green, golangci-lint clean, one integration test.