### PR TITLE
feat(zc1061): rewrite seq to brace range expansion

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -321,6 +321,37 @@ func TestFixIntegration_ZC1064_TypeToCommandV(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1061_SeqSingleArg(t *testing.T) {
+	src := "for i in $(seq 5); do :; done\n"
+	want := "for i in $({1..5}); do :; done\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1061_SeqTwoArgs(t *testing.T) {
+	src := "for i in $(seq 3 8); do :; done\n"
+	want := "for i in $({3..8}); do :; done\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1061_SeqThreeArgs(t *testing.T) {
+	src := "for i in $(seq 1 2 10); do :; done\n"
+	want := "for i in $({1..10..2}); do :; done\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1061_SeqVariableArgsSkipped(t *testing.T) {
+	src := "seq $N\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("variable arg should be left alone, got %q", got)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1061.go
+++ b/pkg/katas/zc1061.go
@@ -11,7 +11,77 @@ func init() {
 		Description: "Using `seq` creates an external process. Zsh supports integer range expansion natively: `{1..10}`.",
 		Severity:    SeverityStyle,
 		Check:       checkZC1061,
+		Fix:         fixZC1061,
 	})
+}
+
+// fixZC1061 rewrites `seq M` / `seq M N` / `seq M S N` with integer
+// literal arguments into Zsh's brace range expansion `{M..N}` or
+// `{M..N..S}`. Forms with `-s sep` separator, variable arguments,
+// or floats are left alone because the rewrite semantics differ.
+func fixZC1061(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "seq" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || len(cmd.Arguments) > 3 {
+		return nil
+	}
+	nums := make([]string, 0, len(cmd.Arguments))
+	for _, arg := range cmd.Arguments {
+		s := arg.String()
+		if !isAllDigits(s) {
+			return nil
+		}
+		nums = append(nums, s)
+	}
+	var rng string
+	switch len(nums) {
+	case 1:
+		rng = "{1.." + nums[0] + "}"
+	case 2:
+		rng = "{" + nums[0] + ".." + nums[1] + "}"
+	case 3:
+		rng = "{" + nums[0] + ".." + nums[2] + ".." + nums[1] + "}"
+	}
+	// Replace from the `seq` command name through the last argument
+	// so the whole invocation becomes a single brace expansion.
+	start := LineColToByteOffset(source, v.Line, v.Column)
+	if start < 0 {
+		return nil
+	}
+	lastArg := cmd.Arguments[len(cmd.Arguments)-1]
+	lastTok := lastArg.TokenLiteralNode()
+	lastOff := LineColToByteOffset(source, lastTok.Line, lastTok.Column)
+	if lastOff < 0 {
+		return nil
+	}
+	end := lastOff + len(lastTok.Literal)
+	if end <= start {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  end - start,
+		Replace: rng,
+	}}
+}
+
+func isAllDigits(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func checkZC1061(node ast.Node) []Violation {


### PR DESCRIPTION
seq spawns an external process; Zsh brace range {m..n} is built-in. Fix covers three canonical forms with integer literal arguments: single arg N becomes {1..N}, two args M N becomes {M..N}, three args M S N becomes {M..N..S}. Variable args, floats, or flag variants (like -s) are left alone because the rewrite semantics differ.

Test plan: go test ./... green, golangci-lint clean, four integration tests cover each arity plus the variable-arg skip.