### PR TITLE
feat(zc1079): quote unquoted RHS in bracket equality tests

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -352,6 +352,21 @@ func TestFixIntegration_ZC1061_SeqVariableArgsSkipped(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1079_QuoteRhsInBrackets(t *testing.T) {
+	src := `[[ $x == $y ]]` + "\n"
+	want := `[[ $x == "$y" ]]` + "\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1079_AlreadyQuotedRhsUnchanged(t *testing.T) {
+	src := `[[ $x == "$y" ]]` + "\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("quoted RHS should be idempotent, got %q", got)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1079.go
+++ b/pkg/katas/zc1079.go
@@ -12,7 +12,74 @@ func init() {
 			"are treated as patterns (globbing). If you intend to compare strings literally, quote the variable.",
 		Severity: SeverityWarning,
 		Check:    checkZC1079,
+		Fix:      fixZC1079,
 	})
+}
+
+// fixZC1079 wraps an unquoted RHS variable reference inside `[[ … ]]`
+// with double-quotes. Two edits: one `"` before the RHS token, one
+// after. RHS span is measured from source so `${arr[$i]}` and
+// `${var:-default}` stay whole. When the sibling LHS is an empty
+// string literal, ZC1055's `-z` / `-n` rewrite takes priority and
+// this fix no-ops to avoid overlapping edits.
+func fixZC1079(node ast.Node, v Violation, source []byte) []FixEdit {
+	if dbe, ok := node.(*ast.DoubleBracketExpression); ok {
+		for _, el := range dbe.Elements {
+			infix, ok := el.(*ast.InfixExpression)
+			if !ok {
+				continue
+			}
+			if infix.Operator != "==" && infix.Operator != "=" && infix.Operator != "!=" {
+				continue
+			}
+			if isEmptyStringLiteral(infix.Left) || isEmptyStringLiteral(infix.Right) {
+				// ZC1055 owns this rewrite; skip.
+				return nil
+			}
+		}
+	}
+	start := LineColToByteOffset(source, v.Line, v.Column)
+	if start < 0 || start >= len(source) {
+		return nil
+	}
+	argLen := unquotedArgLen(source, start)
+	if argLen == 0 {
+		return nil
+	}
+	endOff := start + argLen
+	endLine, endCol := offsetLineColZC1079(source, endOff)
+	if endLine < 0 {
+		return nil
+	}
+	return []FixEdit{
+		{Line: v.Line, Column: v.Column, Length: 0, Replace: `"`},
+		{Line: endLine, Column: endCol, Length: 0, Replace: `"`},
+	}
+}
+
+func isEmptyStringLiteral(n ast.Node) bool {
+	str, ok := n.(*ast.StringLiteral)
+	if !ok {
+		return false
+	}
+	return str.Value == `""` || str.Value == `''`
+}
+
+func offsetLineColZC1079(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1079(node ast.Node) []Violation {


### PR DESCRIPTION
Inside bracket conditionals, unquoted variables on the RHS of equality operators are treated as glob patterns. Quote them to force literal string comparison. Two-edit fix inserts surrounding double quotes around the RHS span, honouring brace / bracket / paren nesting so expansions like array subscripts stay whole.

Yields to ZC1055 when the sibling LHS is an empty string literal — that case is owned by the empty-string rewrite to avoid overlapping edits.

Test plan: tests green, lint clean, two integration tests cover positive rewrite and idempotent already-quoted RHS.