### PR TITLE
feat(zc1085): quote unquoted expansions in for loop items

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -322,8 +322,10 @@ func TestFixIntegration_ZC1064_TypeToCommandV(t *testing.T) {
 }
 
 func TestFixIntegration_ZC1061_SeqSingleArg(t *testing.T) {
+	// ZC1085 also fires and wraps the for-loop item in quotes; the
+	// combined output shows both rewrites applied in one pass.
 	src := "for i in $(seq 5); do :; done\n"
-	want := "for i in $({1..5}); do :; done\n"
+	want := `for i in "$({1..5})"; do :; done` + "\n"
 	if got := runFix(t, src); got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -331,7 +333,7 @@ func TestFixIntegration_ZC1061_SeqSingleArg(t *testing.T) {
 
 func TestFixIntegration_ZC1061_SeqTwoArgs(t *testing.T) {
 	src := "for i in $(seq 3 8); do :; done\n"
-	want := "for i in $({3..8}); do :; done\n"
+	want := `for i in "$({3..8})"; do :; done` + "\n"
 	if got := runFix(t, src); got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -339,7 +341,7 @@ func TestFixIntegration_ZC1061_SeqTwoArgs(t *testing.T) {
 
 func TestFixIntegration_ZC1061_SeqThreeArgs(t *testing.T) {
 	src := "for i in $(seq 1 2 10); do :; done\n"
-	want := "for i in $({1..10..2}); do :; done\n"
+	want := `for i in "$({1..10..2})"; do :; done` + "\n"
 	if got := runFix(t, src); got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -364,6 +366,29 @@ func TestFixIntegration_ZC1079_AlreadyQuotedRhsUnchanged(t *testing.T) {
 	src := `[[ $x == "$y" ]]` + "\n"
 	if got := runFix(t, src); got != src {
 		t.Errorf("quoted RHS should be idempotent, got %q", got)
+	}
+}
+
+func TestFixIntegration_ZC1085_QuoteForLoopExpansion(t *testing.T) {
+	src := "for f in $files; do :; done\n"
+	want := `for f in "$files"; do :; done` + "\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1085_ArrayExpansionQuoted(t *testing.T) {
+	src := "for f in ${files[@]}; do :; done\n"
+	want := `for f in "${files[@]}"; do :; done` + "\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1085_AlreadyQuotedUnchanged(t *testing.T) {
+	src := `for f in "$files"; do :; done` + "\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("quoted input should be idempotent, got %q", got)
 	}
 }
 

--- a/pkg/katas/zc1085.go
+++ b/pkg/katas/zc1085.go
@@ -12,7 +12,48 @@ func init() {
 			"This often leads to iterating over words instead of lines or array elements. Quote the expansion to preserve structure.",
 		Severity: SeverityWarning,
 		Check:    checkZC1085,
+		Fix:      fixZC1085,
 	})
+}
+
+// fixZC1085 wraps an unquoted expansion in a `for` loop item list
+// with double-quotes. Two-edit insertion at the span start and end.
+// Span uses the shared unquotedArgLen scanner so `${arr[@]}`,
+// `$(cmd args)`, `${var:-default}` all stay whole.
+func fixZC1085(_ ast.Node, v Violation, source []byte) []FixEdit {
+	start := LineColToByteOffset(source, v.Line, v.Column)
+	if start < 0 || start >= len(source) {
+		return nil
+	}
+	argLen := unquotedArgLen(source, start)
+	if argLen == 0 {
+		return nil
+	}
+	endLine, endCol := offsetLineColZC1085(source, start+argLen)
+	if endLine < 0 {
+		return nil
+	}
+	return []FixEdit{
+		{Line: v.Line, Column: v.Column, Length: 0, Replace: `"`},
+		{Line: endLine, Column: endCol, Length: 0, Replace: `"`},
+	}
+}
+
+func offsetLineColZC1085(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1085(node ast.Node) []Violation {


### PR DESCRIPTION
Unquoted variable expansions in for loops get split by IFS. Fix wraps each unquoted item in double quotes, honouring brace / bracket / paren nesting via the shared source-span scanner. Three ZC1061 tests updated to reflect the combined multi-kata rewrite (seq arg becomes brace range and the whole substitution gets quoted in one pass).

Test plan: tests green, lint clean, three new integration tests cover variable expansion, array expansion, and already-quoted idempotence.