### PR TITLE
feat(zc1084): single-quote unquoted find globs

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -392,6 +392,21 @@ func TestFixIntegration_ZC1085_AlreadyQuotedUnchanged(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1084_FindGlobQuoted(t *testing.T) {
+	src := "find . -name *.txt\n"
+	want := "find . -name '*.txt'\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1084_FindAlreadyQuotedUnchanged(t *testing.T) {
+	src := "find . -name '*.txt'\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("quoted pattern should be idempotent, got %q", got)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1084.go
+++ b/pkg/katas/zc1084.go
@@ -14,7 +14,49 @@ func init() {
 			"Quote arguments to `-name`, `-path`, etc.",
 		Severity: SeverityWarning,
 		Check:    checkZC1084,
+		Fix:      fixZC1084,
 	})
+}
+
+// fixZC1084 wraps an unquoted `find` glob argument in single-quotes
+// so the shell passes the pattern through verbatim. The violation
+// column already points at the pattern arg start. Span scanning
+// respects `[…]` / `{…}` so character classes and alternations
+// stay whole.
+func fixZC1084(_ ast.Node, v Violation, source []byte) []FixEdit {
+	start := LineColToByteOffset(source, v.Line, v.Column)
+	if start < 0 || start >= len(source) {
+		return nil
+	}
+	argLen := unquotedArgLen(source, start)
+	if argLen == 0 {
+		return nil
+	}
+	endLine, endCol := offsetLineColZC1084(source, start+argLen)
+	if endLine < 0 {
+		return nil
+	}
+	return []FixEdit{
+		{Line: v.Line, Column: v.Column, Length: 0, Replace: `'`},
+		{Line: endLine, Column: endCol, Length: 0, Replace: `'`},
+	}
+}
+
+func offsetLineColZC1084(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1084(node ast.Node) []Violation {


### PR DESCRIPTION
find -name *.txt lets the shell expand the glob before find runs — if files match, find receives the file list instead of the pattern. Fix wraps the pattern arg in single quotes so the pattern reaches find verbatim. Span scanner respects character classes and alternations.

Test plan: tests green, lint clean, two integration tests cover positive rewrite and idempotent already-quoted case.