### PR TITLE
feat(zc1078): quote $@ / $* when passed as arguments

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -407,6 +407,29 @@ func TestFixIntegration_ZC1084_FindAlreadyQuotedUnchanged(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1078_QuoteDollarAt(t *testing.T) {
+	src := "cmd $@\n"
+	want := `cmd "$@"` + "\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1078_QuoteDollarStar(t *testing.T) {
+	src := "cmd $*\n"
+	want := `cmd "$*"` + "\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1078_AlreadyQuotedUnchanged(t *testing.T) {
+	src := `cmd "$@"` + "\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("quoted input should be idempotent, got %q", got)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1078.go
+++ b/pkg/katas/zc1078.go
@@ -12,7 +12,46 @@ func init() {
 			"Use `\"$@\"` to preserve the original argument grouping, or `\"$*\"` to join them into a single string.",
 		Severity: SeverityWarning,
 		Check:    checkZC1078,
+		Fix:      fixZC1078,
 	})
+}
+
+// fixZC1078 wraps an unquoted `$@` / `$*` argument in double-quotes.
+// Both tokens are exactly two bytes; the two-edit insertion always
+// surrounds the same 2-byte run.
+func fixZC1078(_ ast.Node, v Violation, source []byte) []FixEdit {
+	start := LineColToByteOffset(source, v.Line, v.Column)
+	if start < 0 || start+2 > len(source) {
+		return nil
+	}
+	if source[start] != '$' || (source[start+1] != '@' && source[start+1] != '*') {
+		return nil
+	}
+	endLine, endCol := offsetLineColZC1078(source, start+2)
+	if endLine < 0 {
+		return nil
+	}
+	return []FixEdit{
+		{Line: v.Line, Column: v.Column, Length: 0, Replace: `"`},
+		{Line: endLine, Column: endCol, Length: 0, Replace: `"`},
+	}
+}
+
+func offsetLineColZC1078(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1078(node ast.Node) []Violation {


### PR DESCRIPTION
Unquoted $@ and $* split arguments by IFS. Quoting preserves the original structure (or joins into one string for $*). Fixed-width two-byte token; two-edit wrap around the position.

Test plan: tests green, lint clean, three integration tests cover $@, $*, and already-quoted idempotence.