### PR TITLE
feat(zc1076): insert -Uz after autoload

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -430,6 +430,21 @@ func TestFixIntegration_ZC1078_AlreadyQuotedUnchanged(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1076_AutoloadAddUZ(t *testing.T) {
+	src := "autoload compinit\n"
+	want := "autoload -Uz compinit\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1076_AutoloadWithUZUnchanged(t *testing.T) {
+	src := "autoload -Uz compinit\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("already-flagged autoload should be idempotent, got %q", got)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1076.go
+++ b/pkg/katas/zc1076.go
@@ -14,7 +14,57 @@ func init() {
 			"`-U` prevents alias expansion, and `-z` ensures Zsh style autoloading.",
 		Severity: SeverityStyle,
 		Check:    checkZC1076,
+		Fix:      fixZC1076,
 	})
+}
+
+// fixZC1076 inserts ` -Uz` after the `autoload` command name. Only
+// fires when neither `U` nor `z` are already present; the detector
+// already gates on that. Idempotent on re-run once both flags exist.
+func fixZC1076(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	if cmd.Name.String() != "autoload" {
+		return nil
+	}
+	nameOffset := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOffset < 0 {
+		return nil
+	}
+	nameLen := IdentLenAt(source, nameOffset)
+	if nameLen != len("autoload") {
+		return nil
+	}
+	insertAt := nameOffset + nameLen
+	insLine, insCol := offsetLineColZC1076(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " -Uz",
+	}}
+}
+
+func offsetLineColZC1076(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1076(node ast.Node) []Violation {


### PR DESCRIPTION
autoload without -Uz picks up whatever default the calling environment has. The canonical zsh idiom is autoload -Uz: -U prevents alias expansion in the loaded body and -z selects zsh function style. Fix inserts the flags right after the command name, preserving any trailing arguments.

Test plan: tests green, lint clean, two integration tests cover insertion and idempotence.