### PR TITLE
feat(zc1091): rewrite bracket numeric compare to arithmetic

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -460,6 +460,31 @@ func TestFixIntegration_ZC1040_AlreadyQualifiedUnchanged(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1091_BracketCmpToArith(t *testing.T) {
+	src := "[[ x -lt 10 ]]\n"
+	want := "(( x < 10 ))\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1091_GeBracketCmp(t *testing.T) {
+	src := "[[ a -ge b ]]\n"
+	want := "(( a >= b ))\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1091_MultipleOpsLeftAlone(t *testing.T) {
+	// Ambiguous: two comparison operators — fix yields to avoid
+	// corrupting the expression.
+	src := "[[ a -lt b && c -gt d ]]\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("multi-op bracket should be left alone, got %q", got)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1091.go
+++ b/pkg/katas/zc1091.go
@@ -13,7 +13,112 @@ func init() {
 			"It is cleaner and strictly numeric.",
 		Severity: SeverityStyle,
 		Check:    checkZC1091,
+		Fix:      fixZC1091,
 	})
+}
+
+// fixZC1091 rewrites a bracket conditional that uses dashed
+// comparison operators into arithmetic form. Example:
+// `[[ x -lt 10 ]]` → `(( x < 10 ))`. Only fires when exactly one
+// recognised operator appears inside the brackets to keep the
+// rewrite unambiguous.
+func fixZC1091(node ast.Node, v Violation, source []byte) []FixEdit {
+	dbe, ok := node.(*ast.DoubleBracketExpression)
+	if !ok {
+		return nil
+	}
+	openLine := dbe.Token.Line
+	openCol := dbe.Token.Column
+	openOff := LineColToByteOffset(source, openLine, openCol)
+	if openOff < 0 {
+		return nil
+	}
+	// The lexer stamps `[[` at the second bracket (two-char fusion).
+	// Step back one column when needed so the edit covers the whole
+	// opener.
+	if openOff > 0 && source[openOff] == '[' && source[openOff-1] == '[' {
+		openOff--
+		openCol--
+	}
+	if openOff+2 > len(source) || source[openOff] != '[' || source[openOff+1] != '[' {
+		return nil
+	}
+	closeOff := findDoubleBracketClose(source, openOff+2)
+	if closeOff < 0 {
+		return nil
+	}
+	// Find the single `-eq`/etc. operator token and replace.
+	var opTok ast.Expression
+	var opStr string
+	opCount := 0
+	for _, el := range dbe.Elements {
+		if infix, ok := el.(*ast.InfixExpression); ok {
+			if repl, found := arithCmpReplacements[infix.Operator]; found {
+				opTok = el
+				opStr = infix.Operator
+				_ = repl
+				opCount++
+			}
+		}
+	}
+	if opCount != 1 || opTok == nil {
+		return nil
+	}
+	// opTok points at the infix expression; its TokenLiteralNode is
+	// the operator token (e.g. `-eq`). Row/col is already 1-based.
+	infix := opTok.(*ast.InfixExpression)
+	opLine := infix.Token.Line
+	opCol := infix.Token.Column
+	closeLine, closeCol := offsetLineColZC1091(source, closeOff)
+	if closeLine < 0 {
+		return nil
+	}
+	return []FixEdit{
+		{Line: openLine, Column: openCol, Length: 2, Replace: "(("},
+		{Line: opLine, Column: opCol, Length: len(opStr), Replace: arithCmpReplacements[opStr]},
+		{Line: closeLine, Column: closeCol, Length: 2, Replace: "))"},
+	}
+}
+
+// findDoubleBracketClose scans source for the matching `]]` that
+// closes the `[[` just before `start`. Honours `[…]` nesting so
+// character classes like `[:alnum:]` don't trip the scan.
+func findDoubleBracketClose(source []byte, start int) int {
+	depth := 0
+	for i := start; i < len(source)-1; i++ {
+		switch source[i] {
+		case '\\':
+			i++
+		case '[':
+			depth++
+		case ']':
+			if depth > 0 {
+				depth--
+				continue
+			}
+			if source[i+1] == ']' {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func offsetLineColZC1091(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1091(node ast.Node) []Violation {


### PR DESCRIPTION
Bracket conditionals with dashed comparison operators should use the arithmetic context. Fix covers the same op map as ZC1003 but applies inside bracket conditionals instead of POSIX test form. Rewrite replaces opener, operator, and closer in three edits.

Yields when more than one comparison op appears inside the brackets — that case is ambiguous to auto-fix.

Test plan: tests green, lint clean, three integration tests cover single-op rewrite, operator variant, and multi-op skip.