### PR TITLE
feat(zc1126): collapse sort pipe uniq into sort -u

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -485,6 +485,30 @@ func TestFixIntegration_ZC1091_MultipleOpsLeftAlone(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1126_SortPipeUniq(t *testing.T) {
+	src := "sort file | uniq\n"
+	want := "sort -u file\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1126_SortNoArgsPipeUniq(t *testing.T) {
+	src := "sort | uniq\n"
+	want := "sort -u\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1126_UniqCountUnchanged(t *testing.T) {
+	// ZC1126 detector skips `uniq -c` etc; fix also stays silent.
+	src := "sort | uniq -c\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("uniq with flags should be left alone, got %q", got)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1126.go
+++ b/pkg/katas/zc1126.go
@@ -12,7 +12,87 @@ func init() {
 			"Use `sort -u` to deduplicate sorted output efficiently.",
 		Severity: SeverityStyle,
 		Check:    checkZC1126,
+		Fix:      fixZC1126,
 	})
+}
+
+// fixZC1126 collapses `sort ... | uniq` into `sort -u ...`. Uses a
+// single span-replacement from just after the `sort` command name
+// through the end of `uniq`, rewriting the region to ` -u` +
+// whatever sort args sit between the name and the pipe. Only fires
+// when `uniq` has no flags (ZC1126's detector already guards that).
+func fixZC1126(node ast.Node, v Violation, source []byte) []FixEdit {
+	pipe, ok := node.(*ast.InfixExpression)
+	if !ok || pipe.Operator != "|" {
+		return nil
+	}
+	sortCmd, ok := pipe.Left.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	uniqCmd, ok := pipe.Right.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	sortTok := sortCmd.TokenLiteralNode()
+	sortNameOff := LineColToByteOffset(source, sortTok.Line, sortTok.Column)
+	if sortNameOff < 0 {
+		return nil
+	}
+	sortNameLen := IdentLenAt(source, sortNameOff)
+	if sortNameLen == 0 {
+		return nil
+	}
+	spanStart := sortNameOff + sortNameLen
+
+	// Find the pipe byte and walk back past trailing whitespace.
+	pipeOff := LineColToByteOffset(source, pipe.Token.Line, pipe.Token.Column)
+	if pipeOff < 0 || source[pipeOff] != '|' {
+		return nil
+	}
+	argsEnd := pipeOff
+	for argsEnd > spanStart && (source[argsEnd-1] == ' ' || source[argsEnd-1] == '\t') {
+		argsEnd--
+	}
+	middle := string(source[spanStart:argsEnd])
+
+	// End of uniq: the identifier itself; detector forbids flags.
+	uniqTok := uniqCmd.TokenLiteralNode()
+	uniqOff := LineColToByteOffset(source, uniqTok.Line, uniqTok.Column)
+	uniqLen := IdentLenAt(source, uniqOff)
+	if uniqOff < 0 || uniqLen == 0 {
+		return nil
+	}
+	spanEnd := uniqOff + uniqLen
+
+	replace := " -u" + middle
+	startLine, startCol := offsetLineColZC1126(source, spanStart)
+	if startLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    startLine,
+		Column:  startCol,
+		Length:  spanEnd - spanStart,
+		Replace: replace,
+	}}
+}
+
+func offsetLineColZC1126(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1126(node ast.Node) []Violation {


### PR DESCRIPTION
sort | uniq spawns two processes when sort -u does the same in one. Fix rewrites the region from just after the sort command name through the end of uniq as a single span, preserving whatever args sit between sort and the pipe.

Detector already guards against uniq flags like -c / -d — those cases stay detection-only because the semantics diverge from sort -u.

Test plan: tests green, lint clean, three integration tests cover args, no-args, and flagged-uniq skip.