### PR TITLE
feat(zc1118): rewrite echo no-newline form to print -rn

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -63,12 +63,14 @@ func TestFixIntegration_ZC1092_Echo(t *testing.T) {
 	}
 }
 
-func TestFixIntegration_EchoFlag_LeftAlone(t *testing.T) {
-	// ZC1092 Fix skips flagged forms — `echo -n` translates to a
-	// different print invocation than `print -r --`.
+func TestFixIntegration_EchoFlag_HandledByZC1118(t *testing.T) {
+	// ZC1092 skips flagged `echo` because `print -r --` is the wrong
+	// rewrite for `-n`. ZC1118 picks it up and rewrites to the
+	// matching `print -rn` form instead.
 	src := "echo -n keep\n"
-	if got := runFix(t, src); got != src {
-		t.Errorf("flagged echo should not be auto-fixed, got %q", got)
+	want := "print -rn keep\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }
 
@@ -506,6 +508,14 @@ func TestFixIntegration_ZC1126_UniqCountUnchanged(t *testing.T) {
 	src := "sort | uniq -c\n"
 	if got := runFix(t, src); got != src {
 		t.Errorf("uniq with flags should be left alone, got %q", got)
+	}
+}
+
+func TestFixIntegration_ZC1118_EchoDashNToPrintRN(t *testing.T) {
+	src := "echo -n hello\n"
+	want := "print -rn hello\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }
 

--- a/pkg/katas/zc1118.go
+++ b/pkg/katas/zc1118.go
@@ -12,7 +12,47 @@ func init() {
 			"In Zsh, `print -rn` is the reliable way to output text without a trailing newline.",
 		Severity: SeverityStyle,
 		Check:    checkZC1118,
+		Fix:      fixZC1118,
 	})
+}
+
+// fixZC1118 collapses `echo -n` (with any whitespace between) into
+// `print -rn`. Spans the `echo` name, intervening whitespace, and
+// the `-n` flag in a single edit; remaining arguments stay in place.
+func fixZC1118(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "echo" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 || nameOff+len("echo") > len(source) {
+		return nil
+	}
+	if string(source[nameOff:nameOff+len("echo")]) != "echo" {
+		return nil
+	}
+	// Walk forward past whitespace, then expect `-n`.
+	i := nameOff + len("echo")
+	for i < len(source) && (source[i] == ' ' || source[i] == '\t') {
+		i++
+	}
+	if i+2 > len(source) || source[i] != '-' || source[i+1] != 'n' {
+		return nil
+	}
+	end := i + 2
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  end - nameOff,
+		Replace: "print -rn",
+	}}
 }
 
 func checkZC1118(node ast.Node) []Violation {


### PR DESCRIPTION
echo no-newline flag behaviour varies across shells. print -rn is the reliable Zsh idiom. Fix collapses the echo + no-newline-flag prefix into print -rn as a single span edit; remaining arguments stay intact. ZC1092 already skips flagged echo, so this now picks up the case that was previously detection-only.

One pre-existing test updated to match the combined fix behaviour.

Test plan: tests green, lint clean, one new integration test.