### PR TITLE
feat(zc1124): replace cat /dev/null with colon builtin for clearing a file

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -519,6 +519,14 @@ func TestFixIntegration_ZC1118_EchoDashNToPrintRN(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1124_CatDevNullTruncate(t *testing.T) {
+	src := "cat /dev/null > file\n"
+	want := ": > file\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1124.go
+++ b/pkg/katas/zc1124.go
@@ -12,7 +12,55 @@ func init() {
 			"Use `: > file` or simply `> file` in Zsh.",
 		Severity: SeverityStyle,
 		Check:    checkZC1124,
+		Fix:      fixZC1124,
 	})
+}
+
+// fixZC1124 replaces the `cat /dev/null` prefix with the `:` builtin.
+// The redirection and anything following stays in place:
+// `cat /dev/null > file` becomes `: > file`. Only fires when
+// `/dev/null` is the first argument — the detector already requires
+// that shape.
+func fixZC1124(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	var devNull ast.Expression
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "/dev/null" {
+			devNull = arg
+			break
+		}
+	}
+	if devNull == nil {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 || nameOff+3 > len(source) {
+		return nil
+	}
+	if string(source[nameOff:nameOff+3]) != "cat" {
+		return nil
+	}
+	argTok := devNull.TokenLiteralNode()
+	argOff := LineColToByteOffset(source, argTok.Line, argTok.Column)
+	if argOff < 0 {
+		return nil
+	}
+	end := argOff + len("/dev/null")
+	if end > len(source) || string(source[argOff:end]) != "/dev/null" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  end - nameOff,
+		Replace: ":",
+	}}
 }
 
 func checkZC1124(node ast.Node) []Violation {


### PR DESCRIPTION
cat /dev/null > file spawns an external process just to empty a file. The colon builtin plus redirection does the same without the process overhead. Fix rewrites the cat /dev/null prefix as a single span, keeping the redirection and the rest of the command intact.

Test plan: tests green, lint clean, one integration test covers the canonical shape.