### PR TITLE
feat(zc1128): rewrite touch file to empty redirect

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -527,6 +527,21 @@ func TestFixIntegration_ZC1124_CatDevNullTruncate(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1128_TouchToEmptyRedirect(t *testing.T) {
+	src := "touch file\n"
+	want := "> file\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1128_TouchWithFlagsUnchanged(t *testing.T) {
+	src := "touch -t 202504240000 file\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("flagged touch should stay, got %q", got)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1128.go
+++ b/pkg/katas/zc1128.go
@@ -12,7 +12,34 @@ func init() {
 			"spawning `touch`. Use `touch` only when you need to update timestamps.",
 		Severity: SeverityStyle,
 		Check:    checkZC1128,
+		Fix:      fixZC1128,
 	})
+}
+
+// fixZC1128 rewrites `touch file` into `> file`. Detector already
+// guards against flagged forms (timestamp updates) and multi-arg
+// invocations, so the fix covers only the single-file case.
+func fixZC1128(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	if len(cmd.Arguments) != 1 {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 || nameOff+len("touch") > len(source) {
+		return nil
+	}
+	if string(source[nameOff:nameOff+len("touch")]) != "touch" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("touch"),
+		Replace: ">",
+	}}
 }
 
 func checkZC1128(node ast.Node) []Violation {


### PR DESCRIPTION
Creating an empty file via touch spawns an external process; a bare redirection does the same without the fork. Single-edit command-name replacement: touch becomes >. Detector already guards flagged forms (timestamp updates) and multi-arg invocations, so the fix covers only the single-file creation case.

Test plan: tests green, lint clean, two integration tests cover the rewrite and the flagged-form skip.