### PR TITLE
feat(zc1147): insert -p flag after mkdir for nested paths

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -542,6 +542,22 @@ func TestFixIntegration_ZC1128_TouchWithFlagsUnchanged(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1147_MkdirAddParentFlag(t *testing.T) {
+	src := "mkdir a/b/c\n"
+	want := "mkdir -p a/b/c\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1147_FlatPathUnchanged(t *testing.T) {
+	// Detector only fires on nested paths; flat mkdir stays.
+	src := "mkdir foo\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("flat mkdir should stay, got %q", got)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1147.go
+++ b/pkg/katas/zc1147.go
@@ -12,7 +12,58 @@ func init() {
 		Description: "Using `mkdir` without `-p` fails if parent directories don't exist. " +
 			"Use `mkdir -p` to create the full path safely.",
 		Check: checkZC1147,
+		Fix:   fixZC1147,
 	})
+}
+
+// fixZC1147 inserts ` -p` after the `mkdir` command name so nested
+// paths survive missing intermediates. Detector already gates on
+// absence of `-p` and presence of a nested path.
+func fixZC1147(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "mkdir" {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 {
+		return nil
+	}
+	nameLen := IdentLenAt(source, nameOff)
+	if nameLen != len("mkdir") {
+		return nil
+	}
+	insertAt := nameOff + nameLen
+	insLine, insCol := offsetLineColZC1147(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " -p",
+	}}
+}
+
+func offsetLineColZC1147(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1147(node ast.Node) []Violation {


### PR DESCRIPTION
mkdir without -p fails when parent directories are missing. Fix inserts the parent-creating flag after the command name so nested paths create intermediates automatically. Detector already gates on both the absence of -p and the presence of a nested path, so the fix stays narrow.

Test plan: tests green, lint clean, two integration tests cover the nested-path rewrite and the flat-path skip.