### PR TITLE
feat(zc1140): rewrite hash cmd to command -v cmd

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -558,6 +558,14 @@ func TestFixIntegration_ZC1147_FlatPathUnchanged(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1140_HashToCommandV(t *testing.T) {
+	src := "hash git\n"
+	want := "command -v git\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1140.go
+++ b/pkg/katas/zc1140.go
@@ -14,7 +14,28 @@ func init() {
 			"poor error messages. Use `command -v cmd` for cleaner checks in Zsh.",
 		Severity: SeverityStyle,
 		Check:    checkZC1140,
+		Fix:      fixZC1140,
 	})
+}
+
+// fixZC1140 rewrites `hash cmd` to `command -v cmd`. Single-edit
+// command-name replacement — arguments stay intact. Detector gates
+// on flagged forms like `hash -r`, so those stay as-is.
+func fixZC1140(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "hash" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("hash"),
+		Replace: "command -v",
+	}}
 }
 
 func checkZC1140(node ast.Node) []Violation {


### PR DESCRIPTION
hash cmd works as a POSIX existence check but the error messaging is poor. command -v cmd provides cleaner semantics in Zsh. Fix swaps the command name in a single edit; detector already guards flagged forms like hash -r.

Test plan: tests green, lint clean, one integration test.