### PR TITLE
feat(zc1144): rewrite trap numeric signals to canonical names

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -566,6 +566,22 @@ func TestFixIntegration_ZC1140_HashToCommandV(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1144_TrapSignalNumberToName(t *testing.T) {
+	src := "trap 'cleanup' 15\n"
+	want := "trap 'cleanup' TERM\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1144_MultipleSignalsRewritten(t *testing.T) {
+	src := "trap 'cleanup' 2 15\n"
+	want := "trap 'cleanup' INT TERM\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1144.go
+++ b/pkg/katas/zc1144.go
@@ -12,7 +12,82 @@ func init() {
 		Description: "Signal numbers vary across platforms. Use signal names like " +
 			"`SIGTERM`, `SIGINT`, `EXIT` instead of numeric values for portability.",
 		Check: checkZC1144,
+		Fix:   fixZC1144,
 	})
+}
+
+// zc1144SignalNames maps POSIX signal numbers to their canonical
+// names. Numbers above 31 (realtime signals) aren't included because
+// their names vary across platforms and are rarely used with `trap`.
+var zc1144SignalNames = map[string]string{
+	"1":  "HUP",
+	"2":  "INT",
+	"3":  "QUIT",
+	"4":  "ILL",
+	"5":  "TRAP",
+	"6":  "ABRT",
+	"7":  "BUS",
+	"8":  "FPE",
+	"9":  "KILL",
+	"10": "USR1",
+	"11": "SEGV",
+	"12": "USR2",
+	"13": "PIPE",
+	"14": "ALRM",
+	"15": "TERM",
+	"17": "CHLD",
+	"18": "CONT",
+	"19": "STOP",
+	"20": "TSTP",
+	"21": "TTIN",
+	"22": "TTOU",
+	"23": "URG",
+	"24": "XCPU",
+	"25": "XFSZ",
+	"26": "VTALRM",
+	"27": "PROF",
+	"28": "WINCH",
+	"29": "IO",
+	"30": "PWR",
+	"31": "SYS",
+}
+
+// fixZC1144 replaces numeric signal arguments in a `trap` call with
+// their canonical names. Each numeric arg becomes a separate edit at
+// that arg's position. Unknown numbers stay untouched.
+func fixZC1144(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "trap" {
+		return nil
+	}
+	var edits []FixEdit
+	for i := 1; i < len(cmd.Arguments); i++ {
+		arg := cmd.Arguments[i]
+		val := arg.String()
+		name, ok := zc1144SignalNames[val]
+		if !ok {
+			continue
+		}
+		tok := arg.TokenLiteralNode()
+		off := LineColToByteOffset(source, tok.Line, tok.Column)
+		if off < 0 || off+len(val) > len(source) {
+			continue
+		}
+		if string(source[off:off+len(val)]) != val {
+			continue
+		}
+		edits = append(edits, FixEdit{
+			Line:    tok.Line,
+			Column:  tok.Column,
+			Length:  len(val),
+			Replace: name,
+		})
+	}
+	return edits
 }
 
 func checkZC1144(node ast.Node) []Violation {


### PR DESCRIPTION
Signal numbers vary across platforms — 9 is portable for KILL but much of the range (10, 12, 17+) differs between BSD and Linux. Fix maps POSIX signal numbers 1..31 to their canonical names and rewrites each numeric argument in a trap call. Multiple signals in one invocation all get rewritten.

Test plan: tests green, lint clean, two integration tests cover single and multiple signal rewrites.