### PR TITLE
feat(zc1162): rewrite cp recursive flag to archive mode

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -582,6 +582,22 @@ func TestFixIntegration_ZC1144_MultipleSignalsRewritten(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1162_CpRecursiveToArchive(t *testing.T) {
+	src := "cp -r src dest\n"
+	want := "cp -a src dest\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1162_CpCapitalRToArchive(t *testing.T) {
+	src := "cp -R src dest\n"
+	want := "cp -a src dest\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1162.go
+++ b/pkg/katas/zc1162.go
@@ -12,7 +12,42 @@ func init() {
 		Description: "`cp -r` copies recursively but may not preserve permissions, timestamps, " +
 			"or symlinks. Use `cp -a` (archive mode) to preserve all attributes.",
 		Check: checkZC1162,
+		Fix:   fixZC1162,
 	})
+}
+
+// fixZC1162 rewrites `cp -r` / `cp -R` to `cp -a`. Single-edit
+// replacement of the recursive flag; surrounding args stay put.
+func fixZC1162(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cp" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val != "-r" && val != "-R" {
+			continue
+		}
+		tok := arg.TokenLiteralNode()
+		off := LineColToByteOffset(source, tok.Line, tok.Column)
+		if off < 0 || off+2 > len(source) {
+			return nil
+		}
+		if string(source[off:off+2]) != val {
+			return nil
+		}
+		return []FixEdit{{
+			Line:    tok.Line,
+			Column:  tok.Column,
+			Length:  2,
+			Replace: "-a",
+		}}
+	}
+	return nil
 }
 
 func checkZC1162(node ast.Node) []Violation {


### PR DESCRIPTION
cp recursive flag copies contents but drops permissions, timestamps, and symlinks unless combined with additional flags. cp archive mode preserves all attributes. Fix swaps the flag token to keep the command compact.

Test plan: tests green, lint clean, two integration tests cover lowercase and uppercase recursive forms.