### PR TITLE
feat(zc1171): rewrite echo escape form to print

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -598,6 +598,14 @@ func TestFixIntegration_ZC1162_CpCapitalRToArchive(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1171_EchoEscapeToPrint(t *testing.T) {
+	src := `echo -e "line1\nline2"` + "\n"
+	want := `print "line1\nline2"` + "\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1171.go
+++ b/pkg/katas/zc1171.go
@@ -12,7 +12,46 @@ func init() {
 		Description: "`echo -e` behavior varies across shells and platforms. " +
 			"In Zsh, `print` natively interprets escape sequences and is more reliable.",
 		Check: checkZC1171,
+		Fix:   fixZC1171,
 	})
+}
+
+// fixZC1171 collapses `echo -e` into `print`. Span covers the
+// command name, intervening whitespace, and the `-e` flag; remaining
+// arguments stay in place.
+func fixZC1171(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "echo" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 || nameOff+len("echo") > len(source) {
+		return nil
+	}
+	if string(source[nameOff:nameOff+len("echo")]) != "echo" {
+		return nil
+	}
+	i := nameOff + len("echo")
+	for i < len(source) && (source[i] == ' ' || source[i] == '\t') {
+		i++
+	}
+	if i+2 > len(source) || source[i] != '-' || source[i+1] != 'e' {
+		return nil
+	}
+	end := i + 2
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  end - nameOff,
+		Replace: "print",
+	}}
 }
 
 func checkZC1171(node ast.Node) []Violation {


### PR DESCRIPTION
echo escape-flag behaviour varies across shells. print natively interprets escape sequences in Zsh. Fix collapses the command name, whitespace, and flag into a single print token; remaining arguments stay in place.

Test plan: tests green, lint clean, one integration test covers the rewrite.