### PR TITLE
feat(zc1135): strip env prefix from inline var assignments

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -606,6 +606,14 @@ func TestFixIntegration_ZC1171_EchoEscapeToPrint(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1135_EnvStripInline(t *testing.T) {
+	src := "env FOO=bar cmd\n"
+	want := "FOO=bar cmd\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1135.go
+++ b/pkg/katas/zc1135.go
@@ -14,7 +14,40 @@ func init() {
 			"Avoid spawning `env` for simple variable-prefixed command execution.",
 		Severity: SeverityStyle,
 		Check:    checkZC1135,
+		Fix:      fixZC1135,
 	})
+}
+
+// fixZC1135 strips the `env ` prefix from `env VAR=val cmd`. Detector
+// already forbids `env` flags, so the remaining args form a valid
+// inline-assignment command.
+func fixZC1135(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "env" {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 || nameOff+len("env") > len(source) {
+		return nil
+	}
+	if string(source[nameOff:nameOff+len("env")]) != "env" {
+		return nil
+	}
+	// Span covers `env` plus the whitespace that follows it.
+	end := nameOff + len("env")
+	for end < len(source) && (source[end] == ' ' || source[end] == '\t') {
+		end++
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  end - nameOff,
+		Replace: "",
+	}}
 }
 
 func checkZC1135(node ast.Node) []Violation {


### PR DESCRIPTION
Zsh handles inline env assignments natively — env VAR=val cmd and VAR=val cmd are equivalent but the latter avoids the env fork. Fix deletes the env prefix plus its trailing whitespace. Detector already guards env flags (-i clean environment, -u unset, etc.), so only the pure inline-prefix form gets rewritten.

Test plan: tests green, lint clean, one integration test.