### PR TITLE
feat(zc1170): insert -q after pushd / popd

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -614,6 +614,25 @@ func TestFixIntegration_ZC1135_EnvStripInline(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1170_PushdAddQuiet(t *testing.T) {
+	src := "pushd /tmp\n"
+	want := "pushd -q /tmp\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1170_PopdWithDirAddQuiet(t *testing.T) {
+	// Bare `popd` parses as Identifier (not SimpleCommand) so the
+	// detector doesn't fire on it; giving popd an argument routes
+	// through SimpleCommand where the detector lives.
+	src := "popd /tmp\n"
+	want := "popd -q /tmp\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1170.go
+++ b/pkg/katas/zc1170.go
@@ -12,7 +12,57 @@ func init() {
 		Description: "`pushd` and `popd` print the directory stack by default, cluttering output. " +
 			"Use `-q` flag to suppress output in scripts.",
 		Check: checkZC1170,
+		Fix:   fixZC1170,
 	})
+}
+
+// fixZC1170 inserts ` -q` after `pushd` or `popd` so the directory
+// stack output is suppressed in scripts.
+func fixZC1170(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || (ident.Value != "pushd" && ident.Value != "popd") {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 {
+		return nil
+	}
+	nameLen := IdentLenAt(source, nameOff)
+	if nameLen != len(ident.Value) {
+		return nil
+	}
+	insertAt := nameOff + nameLen
+	insLine, insCol := offsetLineColZC1170(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " -q",
+	}}
+}
+
+func offsetLineColZC1170(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1170(node ast.Node) []Violation {


### PR DESCRIPTION
pushd and popd print the directory stack on every call, which clutters script output. Fix inserts -q after the command name to suppress that output. Mirrors the ZC1012 / ZC1017 insertion pattern.

Test plan: tests green, lint clean, two integration tests cover pushd and popd.