### PR TITLE
feat(zc1209): insert --no-pager after systemctl

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -633,6 +633,14 @@ func TestFixIntegration_ZC1170_PopdWithDirAddQuiet(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1209_SystemctlNoPager(t *testing.T) {
+	src := "systemctl status nginx\n"
+	want := "systemctl --no-pager status nginx\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1209.go
+++ b/pkg/katas/zc1209.go
@@ -12,7 +12,58 @@ func init() {
 		Description: "`systemctl` invokes a pager by default which hangs in non-interactive scripts. " +
 			"Use `--no-pager` or pipe to `cat` for reliable script output.",
 		Check: checkZC1209,
+		Fix:   fixZC1209,
 	})
+}
+
+// fixZC1209 inserts ` --no-pager` after the `systemctl` command
+// name so subcommands that emit pager output (status, list-*)
+// behave predictably in scripts.
+func fixZC1209(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "systemctl" {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 {
+		return nil
+	}
+	nameLen := IdentLenAt(source, nameOff)
+	if nameLen != len("systemctl") {
+		return nil
+	}
+	insertAt := nameOff + nameLen
+	insLine, insCol := offsetLineColZC1209(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " --no-pager",
+	}}
+}
+
+func offsetLineColZC1209(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1209(node ast.Node) []Violation {


### PR DESCRIPTION
systemctl invokes a pager by default for status / list-units / list-timers / show, which hangs in non-interactive scripts. Fix inserts --no-pager right after the systemctl command name. Mirrors the ZC1012 / ZC1017 / ZC1170 insertion pattern.

Test plan: tests green, lint clean, one integration test.