### PR TITLE
feat(zc1210): insert --no-pager after journalctl

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -641,6 +641,14 @@ func TestFixIntegration_ZC1209_SystemctlNoPager(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1210_JournalctlNoPager(t *testing.T) {
+	src := "journalctl -u nginx\n"
+	want := "journalctl --no-pager -u nginx\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1210.go
+++ b/pkg/katas/zc1210.go
@@ -12,7 +12,58 @@ func init() {
 		Description: "`journalctl` invokes a pager by default which hangs in non-interactive scripts. " +
 			"Use `--no-pager` for reliable script output.",
 		Check: checkZC1210,
+		Fix:   fixZC1210,
 	})
+}
+
+// fixZC1210 inserts ` --no-pager` after the `journalctl` command
+// name, preventing the pager from hanging in non-interactive runs.
+// Mirrors ZC1209's insertion for `systemctl`.
+func fixZC1210(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "journalctl" {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 {
+		return nil
+	}
+	nameLen := IdentLenAt(source, nameOff)
+	if nameLen != len("journalctl") {
+		return nil
+	}
+	insertAt := nameOff + nameLen
+	insLine, insCol := offsetLineColZC1210(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " --no-pager",
+	}}
+}
+
+func offsetLineColZC1210(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1210(node ast.Node) []Violation {


### PR DESCRIPTION
journalctl invokes a pager by default which hangs in non-interactive scripts. Fix inserts --no-pager right after the command name. Mirrors ZC1209's systemctl insertion.

Test plan: tests green, lint clean, one integration test.