### PR TITLE
feat(zc1226): insert -T after dmesg for readable timestamps

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -657,6 +657,14 @@ func TestFixIntegration_ZC1213_AptGetAddYes(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1226_DmesgAddTime(t *testing.T) {
+	src := "dmesg --level err\n"
+	want := "dmesg -T --level err\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1226.go
+++ b/pkg/katas/zc1226.go
@@ -12,7 +12,57 @@ func init() {
 		Description: "`dmesg` without `-T` shows raw kernel timestamps in seconds since boot. " +
 			"Use `-T` for human-readable timestamps or `--time-format=iso` for ISO 8601.",
 		Check: checkZC1226,
+		Fix:   fixZC1226,
 	})
+}
+
+// fixZC1226 inserts ` -T` after the `dmesg` command name. Mirrors
+// other insertion-style fixes (ZC1012 / ZC1017 / ZC1170 / ZC1209).
+func fixZC1226(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "dmesg" {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 {
+		return nil
+	}
+	nameLen := IdentLenAt(source, nameOff)
+	if nameLen != len("dmesg") {
+		return nil
+	}
+	insertAt := nameOff + nameLen
+	insLine, insCol := offsetLineColZC1226(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " -T",
+	}}
+}
+
+func offsetLineColZC1226(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1226(node ast.Node) []Violation {


### PR DESCRIPTION
dmesg without -T emits raw kernel boot-seconds that are hard to correlate with wall-clock events. Fix inserts the human-readable timestamp flag after the command name. Mirrors other insertion-style fixes.

Test plan: tests green, lint clean, one integration test.