### PR TITLE
feat(zc1227): insert fail flag after curl for HTTP errors

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -665,6 +665,14 @@ func TestFixIntegration_ZC1226_DmesgAddTime(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1227_CurlAddFail(t *testing.T) {
+	src := "curl https://example.com/data\n"
+	want := "curl -f https://example.com/data\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1227.go
+++ b/pkg/katas/zc1227.go
@@ -12,7 +12,58 @@ func init() {
 		Description: "`curl` without `-f` silently returns error pages (404, 500) as success. " +
 			"Use `-f` or `--fail` to return exit code 22 on HTTP errors.",
 		Check: checkZC1227,
+		Fix:   fixZC1227,
 	})
+}
+
+// fixZC1227 inserts ` -f` after the `curl` command name so HTTP
+// errors translate into a non-zero exit code. Detector guards the
+// shape (URL arg present, no existing -f/-fsSL/etc.).
+func fixZC1227(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "curl" {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 {
+		return nil
+	}
+	nameLen := IdentLenAt(source, nameOff)
+	if nameLen != len("curl") {
+		return nil
+	}
+	insertAt := nameOff + nameLen
+	insLine, insCol := offsetLineColZC1227(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " -f",
+	}}
+}
+
+func offsetLineColZC1227(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1227(node ast.Node) []Violation {


### PR DESCRIPTION
curl without the fail flag silently returns HTTP error pages (404, 500) as success. Fix inserts the relevant short flag after the command name. Detector already gates on URL arg presence and absence of existing fail-form flags.

Test plan: tests green, lint clean, one integration test.