### PR TITLE
feat(zc1234): insert --rm after docker run subcommand

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -673,6 +673,14 @@ func TestFixIntegration_ZC1227_CurlAddFail(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1234_DockerRunAddRm(t *testing.T) {
+	src := "docker run alpine ls\n"
+	want := "docker run --rm alpine ls\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1234.go
+++ b/pkg/katas/zc1234.go
@@ -12,7 +12,61 @@ func init() {
 		Description: "`docker run` without `--rm` leaves stopped containers behind. " +
 			"Use `--rm` in scripts to automatically clean up after execution.",
 		Check: checkZC1234,
+		Fix:   fixZC1234,
 	})
+}
+
+// fixZC1234 inserts ` --rm` after the `run` subcommand in a
+// `docker run …` invocation. Detector has already verified the shape
+// (docker + run + no --rm + no -d).
+func fixZC1234(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	runArg := cmd.Arguments[0]
+	if runArg.String() != "run" {
+		return nil
+	}
+	tok := runArg.TokenLiteralNode()
+	off := LineColToByteOffset(source, tok.Line, tok.Column)
+	if off < 0 || off+3 > len(source) {
+		return nil
+	}
+	if string(source[off:off+3]) != "run" {
+		return nil
+	}
+	insertAt := off + 3
+	insLine, insCol := offsetLineColZC1234(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " --rm",
+	}}
+}
+
+func offsetLineColZC1234(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1234(node ast.Node) []Violation {


### PR DESCRIPTION
docker run without --rm leaves stopped containers on disk. Fix inserts the auto-remove flag right after the run subcommand so subsequent image/args stay intact. Detector already guards shape (docker + run + no --rm + no -d for detached long-running containers).

Test plan: tests green, lint clean, one integration test.