### PR TITLE
feat(zc1231): insert --depth 1 after git clone subcommand

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -681,6 +681,14 @@ func TestFixIntegration_ZC1234_DockerRunAddRm(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1231_GitCloneShallow(t *testing.T) {
+	src := "git clone https://github.com/x/y\n"
+	want := "git clone --depth 1 https://github.com/x/y\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1231.go
+++ b/pkg/katas/zc1231.go
@@ -12,7 +12,61 @@ func init() {
 		Description: "`git clone` without `--depth` downloads the entire history. " +
 			"Use `--depth 1` in CI/build scripts where only the latest commit is needed.",
 		Check: checkZC1231,
+		Fix:   fixZC1231,
 	})
+}
+
+// fixZC1231 inserts ` --depth 1` after the `clone` subcommand in
+// `git clone …`. Mirrors ZC1234's subcommand-level insertion for
+// docker run --rm.
+func fixZC1231(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	cloneArg := cmd.Arguments[0]
+	if cloneArg.String() != "clone" {
+		return nil
+	}
+	tok := cloneArg.TokenLiteralNode()
+	off := LineColToByteOffset(source, tok.Line, tok.Column)
+	if off < 0 || off+5 > len(source) {
+		return nil
+	}
+	if string(source[off:off+5]) != "clone" {
+		return nil
+	}
+	insertAt := off + 5
+	insLine, insCol := offsetLineColZC1231(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " --depth 1",
+	}}
+}
+
+func offsetLineColZC1231(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1231(node ast.Node) []Violation {


### PR DESCRIPTION
Full git clones download the entire history, which wastes time and disk in CI or build contexts. Fix inserts shallow flags after the clone subcommand. Detector already guards against existing --depth / --shallow-since / --single-branch flags.

Test plan: tests green, lint clean, one integration test.