### PR TITLE
feat(zc1241): insert null-separator flag after xargs

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -689,6 +689,14 @@ func TestFixIntegration_ZC1231_GitCloneShallow(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1241_XargsAddNullSep(t *testing.T) {
+	src := "xargs rm\n"
+	want := "xargs -0 rm\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1241.go
+++ b/pkg/katas/zc1241.go
@@ -12,7 +12,58 @@ func init() {
 		Description: "`xargs` without `-0` splits on whitespace, breaking on filenames with spaces. " +
 			"Use `xargs -0` paired with `find -print0` for safe handling.",
 		Check: checkZC1241,
+		Fix:   fixZC1241,
 	})
+}
+
+// fixZC1241 inserts ` -0` after the `xargs` command name so
+// null-terminated input from `find -print0` is consumed safely.
+// Detector gates on `xargs rm` without `-0`.
+func fixZC1241(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "xargs" {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 {
+		return nil
+	}
+	nameLen := IdentLenAt(source, nameOff)
+	if nameLen != len("xargs") {
+		return nil
+	}
+	insertAt := nameOff + nameLen
+	insLine, insCol := offsetLineColZC1241(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " -0",
+	}}
+}
+
+func offsetLineColZC1241(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1241(node ast.Node) []Violation {


### PR DESCRIPTION
xargs without the null-separator flag splits on whitespace, so filenames with spaces or newlines get corrupted. Fix inserts the flag after the command name. Detector gates on 'xargs rm' specifically to narrow the rewrite to the highest-risk shape.

Test plan: tests green, lint clean, one integration test.