### PR TITLE
feat(zc1263): rewrite bare apt to apt-get

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -697,6 +697,14 @@ func TestFixIntegration_ZC1241_XargsAddNullSep(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1263_AptToAptGet(t *testing.T) {
+	src := "apt install curl\n"
+	want := "apt-get install curl\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1263.go
+++ b/pkg/katas/zc1263.go
@@ -12,7 +12,28 @@ func init() {
 		Description: "`apt` is designed for interactive use and its output format may change. " +
 			"`apt-get` has a stable interface suitable for scripts and CI.",
 		Check: checkZC1263,
+		Fix:   fixZC1263,
 	})
+}
+
+// fixZC1263 rewrites `apt` to `apt-get` at the command name position.
+// Arguments stay intact — the two tools accept the same shape for
+// install / upgrade / update / remove.
+func fixZC1263(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "apt" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("apt"),
+		Replace: "apt-get",
+	}}
 }
 
 func checkZC1263(node ast.Node) []Violation {


### PR DESCRIPTION
apt is the interactive frontend; its output format is documented as unstable and may drift between releases. apt-get has the scripting contract. Single-edit command-name rename — subcommands and arguments stay intact because both tools accept the same install / upgrade / update / remove syntax.

Test plan: tests green, lint clean, one integration test.