### PR TITLE
feat(zc1264): rewrite yum to dnf

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -705,6 +705,14 @@ func TestFixIntegration_ZC1263_AptToAptGet(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1264_YumToDnf(t *testing.T) {
+	src := "yum install httpd\n"
+	want := "dnf install httpd\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1264.go
+++ b/pkg/katas/zc1264.go
@@ -12,7 +12,27 @@ func init() {
 		Description: "`yum` is deprecated on Fedora 22+ and RHEL 8+. " +
 			"`dnf` is the modern replacement with better dependency resolution.",
 		Check: checkZC1264,
+		Fix:   fixZC1264,
 	})
+}
+
+// fixZC1264 rewrites `yum` to `dnf`. dnf is broadly compatible with
+// yum's CLI surface so arguments carry over unchanged.
+func fixZC1264(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "yum" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("yum"),
+		Replace: "dnf",
+	}}
 }
 
 func checkZC1264(node ast.Node) []Violation {


### PR DESCRIPTION
yum is deprecated on Fedora 22+ and RHEL 8+. dnf has broadly-compatible CLI so arguments carry over unchanged. Single-edit command-name rename.

Test plan: tests green, lint clean, one integration test.