### PR TITLE
feat(zc1253): insert --no-cache after docker build subcommand

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -713,6 +713,14 @@ func TestFixIntegration_ZC1264_YumToDnf(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1253_DockerBuildNoCache(t *testing.T) {
+	src := "docker build -t app .\n"
+	want := "docker build --no-cache -t app .\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1253.go
+++ b/pkg/katas/zc1253.go
@@ -12,7 +12,60 @@ func init() {
 		Description: "`docker build` uses layer caching which can mask dependency changes. " +
 			"Use `--no-cache` in CI pipelines to ensure fully reproducible builds.",
 		Check: checkZC1253,
+		Fix:   fixZC1253,
 	})
+}
+
+// fixZC1253 inserts ` --no-cache` after the `build` subcommand in
+// `docker build …`. Mirrors ZC1234's subcommand-level insertion.
+func fixZC1253(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	subArg := cmd.Arguments[0]
+	if subArg.String() != "build" {
+		return nil
+	}
+	tok := subArg.TokenLiteralNode()
+	off := LineColToByteOffset(source, tok.Line, tok.Column)
+	if off < 0 || off+5 > len(source) {
+		return nil
+	}
+	if string(source[off:off+5]) != "build" {
+		return nil
+	}
+	insertAt := off + 5
+	insLine, insCol := offsetLineColZC1253(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " --no-cache",
+	}}
+}
+
+func offsetLineColZC1253(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1253(node ast.Node) []Violation {


### PR DESCRIPTION
docker build uses layer caching which can mask dependency changes in CI. Fix inserts --no-cache right after the build subcommand to guarantee reproducible builds. Mirrors ZC1234's subcommand-level insertion pattern.

Test plan: tests green, lint clean, one integration test.