### PR TITLE
feat(zc1267): insert -P flag after df for portable output

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -721,6 +721,14 @@ func TestFixIntegration_ZC1253_DockerBuildNoCache(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
+	src := "df -h /\n"
+	want := "df -P -h /\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1267.go
+++ b/pkg/katas/zc1267.go
@@ -12,7 +12,58 @@ func init() {
 		Description: "`df -h` output format varies across systems and locales. " +
 			"Use `df -P` for single-line, fixed-format output safe for script parsing.",
 		Check: checkZC1267,
+		Fix:   fixZC1267,
 	})
+}
+
+// fixZC1267 inserts ` -P` after the `df` command name. Detector
+// narrows to `df -h` (script-unsafe), so only that shape is
+// rewritten.
+func fixZC1267(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "df" {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 {
+		return nil
+	}
+	nameLen := IdentLenAt(source, nameOff)
+	if nameLen != len("df") {
+		return nil
+	}
+	insertAt := nameOff + nameLen
+	insLine, insCol := offsetLineColZC1267(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " -P",
+	}}
+}
+
+func offsetLineColZC1267(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1267(node ast.Node) []Violation {


### PR DESCRIPTION
df -h output format varies across systems and locales and can split long device names across lines. Fix inserts the POSIX-portable flag after the command name. Detector narrows to df -h so only script-unsafe invocations get rewritten.

Test plan: tests green, lint clean, one integration test.