### PR TITLE
feat(zc1192): replace sleep 0 with colon builtin

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,14 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1192_SleepZeroToColon(t *testing.T) {
+	src := "sleep 0\n"
+	want := ":\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_SecondPass_ResolvesInner(t *testing.T) {
 	src := "result=`which git`\n"
 	first := runFix(t, src)

--- a/pkg/katas/zc1192.go
+++ b/pkg/katas/zc1192.go
@@ -12,7 +12,43 @@ func init() {
 		Description: "`sleep 0` spawns an external process that does nothing. " +
 			"Remove it or use `:` if an explicit no-op is needed.",
 		Check: checkZC1192,
+		Fix:   fixZC1192,
 	})
+}
+
+// fixZC1192 rewrites the no-op `sleep 0` invocation into `:`, the
+// builtin no-op. Span covers the command name through the `0` arg.
+func fixZC1192(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	if len(cmd.Arguments) != 1 {
+		return nil
+	}
+	zeroArg := cmd.Arguments[0]
+	if zeroArg.String() != "0" {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 || nameOff+len("sleep") > len(source) {
+		return nil
+	}
+	if string(source[nameOff:nameOff+len("sleep")]) != "sleep" {
+		return nil
+	}
+	argTok := zeroArg.TokenLiteralNode()
+	argOff := LineColToByteOffset(source, argTok.Line, argTok.Column)
+	if argOff < 0 || argOff+1 > len(source) || source[argOff] != '0' {
+		return nil
+	}
+	end := argOff + 1
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  end - nameOff,
+		Replace: ":",
+	}}
 }
 
 func checkZC1192(node ast.Node) []Violation {


### PR DESCRIPTION
sleep 0 spawns an external process that does nothing. Colon is the zsh builtin no-op equivalent. Fix replaces the span from sleep through the zero arg with a single colon. Detector already gates on exactly one arg equal to zero.

Test plan: tests green, lint clean, one integration test.