### PR TITLE
feat(zc1288): rewrite declare to typeset

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,14 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1288_DeclareToTypeset(t *testing.T) {
+	src := "declare -i counter=0\n"
+	want := "typeset -i counter=0\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1192_SleepZeroToColon(t *testing.T) {
 	src := "sleep 0\n"
 	want := ":\n"

--- a/pkg/katas/zc1288.go
+++ b/pkg/katas/zc1288.go
@@ -13,7 +13,24 @@ func init() {
 			"`declare` is a Bash compatibility alias. Using `typeset` is more idiomatic " +
 			"and signals that the script is Zsh-native.",
 		Check: checkZC1288,
+		Fix:   fixZC1288,
 	})
+}
+
+// fixZC1288 rewrites the `declare` keyword to `typeset`. Arguments,
+// flags and assignments carry over unchanged because the two
+// builtins share the same Zsh interface.
+func fixZC1288(node ast.Node, v Violation, source []byte) []FixEdit {
+	decl, ok := node.(*ast.DeclarationStatement)
+	if !ok || decl.Command != "declare" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("declare"),
+		Replace: "typeset",
+	}}
 }
 
 func checkZC1288(node ast.Node) []Violation {


### PR DESCRIPTION
typeset is the native Zsh builtin. declare is a Bash compatibility alias. Fix swaps the keyword at the declaration statement position; flags and assignments carry over.

Test plan: tests green, lint clean, one integration test.