### PR TITLE
feat(zc1283): rewrite set -o OPT to setopt OPT

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,14 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1283_SetOToSetopt(t *testing.T) {
+	src := "set -o pipefail\n"
+	want := "setopt pipefail\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1288_DeclareToTypeset(t *testing.T) {
 	src := "declare -i counter=0\n"
 	want := "typeset -i counter=0\n"

--- a/pkg/katas/zc1283.go
+++ b/pkg/katas/zc1283.go
@@ -13,7 +13,53 @@ func init() {
 			"options. Using `set -o` / `set +o` is a POSIX compatibility form that is less " +
 			"idiomatic in Zsh scripts.",
 		Check: checkZC1283,
+		Fix:   fixZC1283,
 	})
+}
+
+// fixZC1283 rewrites `set -o OPTION` into `setopt OPTION`. The span
+// covers the `set` command name and the `-o` flag in a single edit;
+// trailing option arguments stay in place.
+func fixZC1283(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "set" {
+		return nil
+	}
+	var dashO ast.Expression
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-o" {
+			dashO = arg
+			break
+		}
+	}
+	if dashO == nil {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 || nameOff+len("set") > len(source) {
+		return nil
+	}
+	if string(source[nameOff:nameOff+len("set")]) != "set" {
+		return nil
+	}
+	dashTok := dashO.TokenLiteralNode()
+	dashOff := LineColToByteOffset(source, dashTok.Line, dashTok.Column)
+	if dashOff < 0 || dashOff+2 > len(source) {
+		return nil
+	}
+	if string(source[dashOff:dashOff+2]) != "-o" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  dashOff + 2 - nameOff,
+		Replace: "setopt",
+	}}
 }
 
 func checkZC1283(node ast.Node) []Violation {


### PR DESCRIPTION
set -o is the POSIX compatibility form for toggling shell options. setopt is the native Zsh builtin. Fix collapses the command name plus -o flag into setopt in a single span edit; the trailing option name stays in place.

Test plan: tests green, lint clean, one integration test.