### PR TITLE
feat(zc1265): insert --now after systemctl enable

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,14 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1265_SystemctlEnableNow(t *testing.T) {
+	src := "systemctl enable nginx\n"
+	want := "systemctl enable --now nginx\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1283_SetOToSetopt(t *testing.T) {
 	src := "set -o pipefail\n"
 	want := "setopt pipefail\n"

--- a/pkg/katas/zc1265.go
+++ b/pkg/katas/zc1265.go
@@ -12,7 +12,68 @@ func init() {
 		Description: "`systemctl enable` without `--now` only enables on next boot. " +
 			"Use `--now` to enable and immediately start the service.",
 		Check: checkZC1265,
+		Fix:   fixZC1265,
 	})
+}
+
+// fixZC1265 inserts ` --now` after the `enable` subcommand in a
+// `systemctl enable …` invocation. Same subcommand-level insertion
+// pattern as ZC1234's docker-run --rm.
+func fixZC1265(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "systemctl" {
+		return nil
+	}
+	var enableArg ast.Expression
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "enable" {
+			enableArg = arg
+			break
+		}
+	}
+	if enableArg == nil {
+		return nil
+	}
+	tok := enableArg.TokenLiteralNode()
+	off := LineColToByteOffset(source, tok.Line, tok.Column)
+	if off < 0 || off+len("enable") > len(source) {
+		return nil
+	}
+	if string(source[off:off+len("enable")]) != "enable" {
+		return nil
+	}
+	insertAt := off + len("enable")
+	insLine, insCol := offsetLineColZC1265(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " --now",
+	}}
+}
+
+func offsetLineColZC1265(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1265(node ast.Node) []Violation {


### PR DESCRIPTION
systemctl enable without --now only arms the service for next boot. Fix inserts --now right after the enable subcommand so the service starts immediately too. Subcommand-level insertion pattern (same shape as ZC1234 / ZC1253).

Test plan: tests green, lint clean, one integration test.