### PR TITLE
feat(zc1301): rename Bash PIPESTATUS var to Zsh pipestatus

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,14 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1301_PipestatusLowercase(t *testing.T) {
+	src := "status=$PIPESTATUS\n"
+	want := "status=$pipestatus\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1265_SystemctlEnableNow(t *testing.T) {
 	src := "systemctl enable nginx\n"
 	want := "systemctl enable --now nginx\n"

--- a/pkg/katas/zc1301.go
+++ b/pkg/katas/zc1301.go
@@ -13,7 +13,36 @@ func init() {
 			"pipeline. Zsh uses `$pipestatus` (lowercase) for the same purpose. " +
 			"The uppercase form is undefined in Zsh.",
 		Check: checkZC1301,
+		Fix:   fixZC1301,
 	})
+}
+
+// fixZC1301 rewrites the uppercase Bash `$PIPESTATUS` / `PIPESTATUS`
+// identifier to the lowercase Zsh `$pipestatus` / `pipestatus`
+// form. Span covers only the name itself — subscripts and surrounding
+// context stay in place.
+func fixZC1301(node ast.Node, v Violation, source []byte) []FixEdit {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "$PIPESTATUS":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("$PIPESTATUS"),
+			Replace: "$pipestatus",
+		}}
+	case "PIPESTATUS":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("PIPESTATUS"),
+			Replace: "pipestatus",
+		}}
+	}
+	return nil
 }
 
 func checkZC1301(node ast.Node) []Violation {


### PR DESCRIPTION
Bash uses $PIPESTATUS for the pipeline exit-code array; Zsh uses the lowercase $pipestatus. Fix renames the identifier at its source position, covering both the dollar-prefixed form and the bare uppercase form. Array subscripts inside a braced reference aren't reached because the parser wraps those in ArrayAccess — a follow-up can extend detection there.

Test plan: tests green, lint clean, one integration test.