### PR TITLE
feat(zc1307): rename Bash DIRSTACK var to Zsh dirstack

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,14 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1307_DirstackLowercase(t *testing.T) {
+	src := "top=$DIRSTACK\n"
+	want := "top=$dirstack\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1301_PipestatusLowercase(t *testing.T) {
 	src := "status=$PIPESTATUS\n"
 	want := "status=$pipestatus\n"

--- a/pkg/katas/zc1307.go
+++ b/pkg/katas/zc1307.go
@@ -12,7 +12,35 @@ func init() {
 		Description: "`$DIRSTACK` is the Bash form of the directory stack array. " +
 			"Zsh uses `$dirstack` (lowercase) for the same purpose.",
 		Check: checkZC1307,
+		Fix:   fixZC1307,
 	})
+}
+
+// fixZC1307 renames the Bash `$DIRSTACK` / `DIRSTACK` identifier to
+// the Zsh lowercase `$dirstack` / `dirstack` form. Mirrors ZC1301's
+// rename pattern.
+func fixZC1307(node ast.Node, v Violation, source []byte) []FixEdit {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "$DIRSTACK":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("$DIRSTACK"),
+			Replace: "$dirstack",
+		}}
+	case "DIRSTACK":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("DIRSTACK"),
+			Replace: "dirstack",
+		}}
+	}
+	return nil
 }
 
 func checkZC1307(node ast.Node) []Violation {


### PR DESCRIPTION
Bash uses $DIRSTACK for the directory stack array; Zsh uses the lowercase $dirstack. Fix renames the identifier at its source position, covering both the dollar-prefixed form and the bare uppercase form. Same shape as ZC1301's pipestatus rename.

Test plan: tests green, lint clean, one integration test.