### PR TITLE
feat(zc1304): rename BASH_SUBSHELL to ZSH_SUBSHELL

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,14 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1304_BashSubshellToZsh(t *testing.T) {
+	src := "depth=$BASH_SUBSHELL\n"
+	want := "depth=$ZSH_SUBSHELL\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1307_DirstackLowercase(t *testing.T) {
 	src := "top=$DIRSTACK\n"
 	want := "top=$dirstack\n"

--- a/pkg/katas/zc1304.go
+++ b/pkg/katas/zc1304.go
@@ -12,7 +12,35 @@ func init() {
 		Description: "`$BASH_SUBSHELL` tracks subshell nesting depth in Bash. " +
 			"Zsh provides `$ZSH_SUBSHELL` as the native equivalent.",
 		Check: checkZC1304,
+		Fix:   fixZC1304,
 	})
+}
+
+// fixZC1304 renames the Bash `$BASH_SUBSHELL` identifier to the Zsh
+// `$ZSH_SUBSHELL` equivalent. Handles both the dollar-prefixed and
+// bare forms.
+func fixZC1304(node ast.Node, v Violation, source []byte) []FixEdit {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "$BASH_SUBSHELL":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("$BASH_SUBSHELL"),
+			Replace: "$ZSH_SUBSHELL",
+		}}
+	case "BASH_SUBSHELL":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("BASH_SUBSHELL"),
+			Replace: "ZSH_SUBSHELL",
+		}}
+	}
+	return nil
 }
 
 func checkZC1304(node ast.Node) []Violation {


### PR DESCRIPTION
Bash exposes subshell nesting depth via $BASH_SUBSHELL; Zsh provides $ZSH_SUBSHELL as the native equivalent. Fix renames the identifier at its source position, covering both the dollar-prefixed and bare forms.

Test plan: tests green, lint clean, one integration test.