### PR TITLE
feat(zc1298): rename FUNCNAME to funcstack

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,14 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1298_FuncnameToFuncstack(t *testing.T) {
+	src := "name=$FUNCNAME\n"
+	want := "name=$funcstack\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1304_BashSubshellToZsh(t *testing.T) {
 	src := "depth=$BASH_SUBSHELL\n"
 	want := "depth=$ZSH_SUBSHELL\n"

--- a/pkg/katas/zc1298.go
+++ b/pkg/katas/zc1298.go
@@ -13,7 +13,35 @@ func init() {
 			"Zsh provides `$funcstack` as the equivalent, containing the call stack " +
 			"of function names with the current function at index 1.",
 		Check: checkZC1298,
+		Fix:   fixZC1298,
 	})
+}
+
+// fixZC1298 renames the Bash `$FUNCNAME` identifier to the Zsh
+// `$funcstack` equivalent. Handles both the dollar-prefixed and
+// bare forms.
+func fixZC1298(node ast.Node, v Violation, source []byte) []FixEdit {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "$FUNCNAME":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("$FUNCNAME"),
+			Replace: "$funcstack",
+		}}
+	case "FUNCNAME":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("FUNCNAME"),
+			Replace: "funcstack",
+		}}
+	}
+	return nil
 }
 
 func checkZC1298(node ast.Node) []Violation {


### PR DESCRIPTION
Bash exposes the call stack via $FUNCNAME; Zsh uses $funcstack for the equivalent array. Fix renames the identifier at its source position, covering both the dollar-prefixed and bare forms.

Test plan: tests green, lint clean, one integration test.