### PR TITLE
feat: rename Bash completion COMP_* vars to Zsh equivalents

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,30 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1305_CompWordsToWords(t *testing.T) {
+	src := "w=$COMP_WORDS\n"
+	want := "w=$words\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1306_CompCwordToCurrent(t *testing.T) {
+	src := "c=$COMP_CWORD\n"
+	want := "c=$CURRENT\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1308_CompLineToBuffer(t *testing.T) {
+	src := "b=$COMP_LINE\n"
+	want := "b=$BUFFER\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1298_FuncnameToFuncstack(t *testing.T) {
 	src := "name=$FUNCNAME\n"
 	want := "name=$funcstack\n"

--- a/pkg/katas/zc1305.go
+++ b/pkg/katas/zc1305.go
@@ -12,7 +12,35 @@ func init() {
 		Description: "`$COMP_WORDS` is a Bash completion variable containing the words on " +
 			"the command line. Zsh completion uses `$words` array for the same purpose.",
 		Check: checkZC1305,
+		Fix:   fixZC1305,
 	})
+}
+
+// fixZC1305 renames the Bash `$COMP_WORDS` identifier to the Zsh
+// `$words` completion array. Handles both dollar-prefixed and bare
+// forms.
+func fixZC1305(node ast.Node, v Violation, source []byte) []FixEdit {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "$COMP_WORDS":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("$COMP_WORDS"),
+			Replace: "$words",
+		}}
+	case "COMP_WORDS":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("COMP_WORDS"),
+			Replace: "words",
+		}}
+	}
+	return nil
 }
 
 func checkZC1305(node ast.Node) []Violation {

--- a/pkg/katas/zc1306.go
+++ b/pkg/katas/zc1306.go
@@ -12,7 +12,34 @@ func init() {
 		Description: "`$COMP_CWORD` is a Bash completion variable for the current cursor " +
 			"word index. Zsh completion uses `$CURRENT` for the same purpose.",
 		Check: checkZC1306,
+		Fix:   fixZC1306,
 	})
+}
+
+// fixZC1306 renames the Bash `$COMP_CWORD` identifier to the Zsh
+// `$CURRENT` completion variable.
+func fixZC1306(node ast.Node, v Violation, source []byte) []FixEdit {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "$COMP_CWORD":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("$COMP_CWORD"),
+			Replace: "$CURRENT",
+		}}
+	case "COMP_CWORD":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("COMP_CWORD"),
+			Replace: "CURRENT",
+		}}
+	}
+	return nil
 }
 
 func checkZC1306(node ast.Node) []Violation {

--- a/pkg/katas/zc1308.go
+++ b/pkg/katas/zc1308.go
@@ -12,7 +12,34 @@ func init() {
 		Description: "`$COMP_LINE` is a Bash completion variable containing the full command " +
 			"line. Zsh completion uses `$BUFFER` for the current command line content.",
 		Check: checkZC1308,
+		Fix:   fixZC1308,
 	})
+}
+
+// fixZC1308 renames the Bash `$COMP_LINE` identifier to the Zsh
+// `$BUFFER` completion variable.
+func fixZC1308(node ast.Node, v Violation, source []byte) []FixEdit {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "$COMP_LINE":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("$COMP_LINE"),
+			Replace: "$BUFFER",
+		}}
+	case "COMP_LINE":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("COMP_LINE"),
+			Replace: "BUFFER",
+		}}
+	}
+	return nil
 }
 
 func checkZC1308(node ast.Node) []Violation {


### PR DESCRIPTION
Three Bash completion variables have direct Zsh equivalents. One PR covers them all because the rewrite logic is identical — only the name pairs differ.

- COMP_WORDS becomes words (array of words on the command line)
- COMP_CWORD becomes CURRENT (current cursor word index)
- COMP_LINE becomes BUFFER (full command line content)

Each fix handles both the dollar-prefixed and bare forms.

Test plan: tests green, lint clean, three integration tests.