### PR TITLE
feat(zc1318): rename BASH_CMDS to commands hash

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,14 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1318_BashCmdsToCommands(t *testing.T) {
+	src := "c=$BASH_CMDS\n"
+	want := "c=$commands\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1305_CompWordsToWords(t *testing.T) {
 	src := "w=$COMP_WORDS\n"
 	want := "w=$words\n"

--- a/pkg/katas/zc1318.go
+++ b/pkg/katas/zc1318.go
@@ -13,7 +13,34 @@ func init() {
 			"Zsh provides the `$commands` hash for the same purpose, mapping " +
 			"command names to their full paths.",
 		Check: checkZC1318,
+		Fix:   fixZC1318,
 	})
+}
+
+// fixZC1318 renames the Bash `$BASH_CMDS` identifier to the Zsh
+// `$commands` hash.
+func fixZC1318(node ast.Node, v Violation, source []byte) []FixEdit {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "$BASH_CMDS":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("$BASH_CMDS"),
+			Replace: "$commands",
+		}}
+	case "BASH_CMDS":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("BASH_CMDS"),
+			Replace: "commands",
+		}}
+	}
+	return nil
 }
 
 func checkZC1318(node ast.Node) []Violation {


### PR DESCRIPTION
Bash caches command-path lookups in $BASH_CMDS; Zsh exposes the equivalent via the $commands hash. Fix renames the identifier at its source position, covering both the dollar-prefixed and bare forms.

Test plan: tests green, lint clean, one integration test.