### PR TITLE
feat(zc1313): rename BASH_ALIASES to aliases hash

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,14 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1313_BashAliasesToAliases(t *testing.T) {
+	src := "a=$BASH_ALIASES\n"
+	want := "a=$aliases\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1318_BashCmdsToCommands(t *testing.T) {
 	src := "c=$BASH_CMDS\n"
 	want := "c=$commands\n"

--- a/pkg/katas/zc1313.go
+++ b/pkg/katas/zc1313.go
@@ -12,7 +12,34 @@ func init() {
 		Description: "`$BASH_ALIASES` is a Bash associative array of defined aliases. " +
 			"Zsh provides the `aliases` associative array for the same purpose.",
 		Check: checkZC1313,
+		Fix:   fixZC1313,
 	})
+}
+
+// fixZC1313 renames the Bash `$BASH_ALIASES` identifier to the Zsh
+// `$aliases` associative array.
+func fixZC1313(node ast.Node, v Violation, source []byte) []FixEdit {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "$BASH_ALIASES":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("$BASH_ALIASES"),
+			Replace: "$aliases",
+		}}
+	case "BASH_ALIASES":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("BASH_ALIASES"),
+			Replace: "aliases",
+		}}
+	}
+	return nil
 }
 
 func checkZC1313(node ast.Node) []Violation {


### PR DESCRIPTION
Bash exposes defined aliases via $BASH_ALIASES; Zsh uses the $aliases associative array. Fix renames the identifier at its source position, covering both the dollar-prefixed and bare forms.

Test plan: tests green, lint clean, one integration test.