### PR TITLE
feat(zc1300): rename BASH_VERSION / BASH_VERSINFO to ZSH_VERSION

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,14 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1300_BashVersionToZsh(t *testing.T) {
+	src := "v=$BASH_VERSION\n"
+	want := "v=$ZSH_VERSION\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1313_BashAliasesToAliases(t *testing.T) {
 	src := "a=$BASH_ALIASES\n"
 	want := "a=$aliases\n"

--- a/pkg/katas/zc1300.go
+++ b/pkg/katas/zc1300.go
@@ -13,7 +13,37 @@ func init() {
 			"In Zsh, use `$ZSH_VERSION` (string) or `${(s:.:)ZSH_VERSION}` to split " +
 			"it into components for version comparison.",
 		Check: checkZC1300,
+		Fix:   fixZC1300,
 	})
+}
+
+// fixZC1300 renames `$BASH_VERSION` / `$BASH_VERSINFO` to the Zsh
+// equivalent `$ZSH_VERSION`. The lossy case (BASH_VERSINFO is an
+// array, ZSH_VERSION is a string) is the best single-token swap
+// available; callers that need components can split the string with
+// the `${(s:.:)ZSH_VERSION}` flag.
+func fixZC1300(node ast.Node, v Violation, source []byte) []FixEdit {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "$BASH_VERSION", "$BASH_VERSINFO":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len(ident.Value),
+			Replace: "$ZSH_VERSION",
+		}}
+	case "BASH_VERSION", "BASH_VERSINFO":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len(ident.Value),
+			Replace: "ZSH_VERSION",
+		}}
+	}
+	return nil
 }
 
 func checkZC1300(node ast.Node) []Violation {


### PR DESCRIPTION
Bash exposes shell version via $BASH_VERSION (string) and $BASH_VERSINFO (array). Zsh exposes it via $ZSH_VERSION (string). Fix renames either Bash form to the Zsh equivalent. The array-to-string conversion is lossy; callers that need components can split the result with ${(s:.:)ZSH_VERSION}.

Test plan: tests green, lint clean, one integration test.