### PR TITLE
feat(zc1331): rename BASH_REMATCH to match array

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,14 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1331_BashRematchToMatch(t *testing.T) {
+	src := "m=$BASH_REMATCH\n"
+	want := "m=$match\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1300_BashVersionToZsh(t *testing.T) {
 	src := "v=$BASH_VERSION\n"
 	want := "v=$ZSH_VERSION\n"

--- a/pkg/katas/zc1331.go
+++ b/pkg/katas/zc1331.go
@@ -13,7 +13,34 @@ func init() {
 			"regex matches in the `$match` array (and `$MATCH` for the full match) " +
 			"when using `=~` with `setopt BASH_REMATCH` disabled.",
 		Check: checkZC1331,
+		Fix:   fixZC1331,
 	})
+}
+
+// fixZC1331 renames the Bash `$BASH_REMATCH` identifier to the Zsh
+// `$match` regex-capture array.
+func fixZC1331(node ast.Node, v Violation, source []byte) []FixEdit {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "$BASH_REMATCH":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("$BASH_REMATCH"),
+			Replace: "$match",
+		}}
+	case "BASH_REMATCH":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("BASH_REMATCH"),
+			Replace: "match",
+		}}
+	}
+	return nil
 }
 
 func checkZC1331(node ast.Node) []Violation {


### PR DESCRIPTION
Bash holds regex captures in $BASH_REMATCH; Zsh exposes them via $match (array of captures) and $MATCH (full match). Fix renames the identifier at its source position, covering both the dollar-prefixed and bare forms.

Test plan: tests green, lint clean, one integration test.