### PR TITLE
feat(zc1333): rename TIMEFORMAT to TIMEFMT

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,14 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1333_TimeformatToTimefmt(t *testing.T) {
+	src := "fmt=$TIMEFORMAT\n"
+	want := "fmt=$TIMEFMT\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1331_BashRematchToMatch(t *testing.T) {
 	src := "m=$BASH_REMATCH\n"
 	want := "m=$match\n"

--- a/pkg/katas/zc1333.go
+++ b/pkg/katas/zc1333.go
@@ -12,7 +12,36 @@ func init() {
 		Description: "`$TIMEFORMAT` is the Bash variable for customizing `time` output. " +
 			"Zsh uses `$TIMEFMT` for the same purpose, with different format specifiers.",
 		Check: checkZC1333,
+		Fix:   fixZC1333,
 	})
+}
+
+// fixZC1333 renames the Bash `$TIMEFORMAT` identifier to the Zsh
+// `$TIMEFMT` variable. Format specifiers differ between the two
+// shells; the rename preserves the identifier itself but authors
+// should still review the format string after conversion.
+func fixZC1333(node ast.Node, v Violation, source []byte) []FixEdit {
+	ident, ok := node.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	switch ident.Value {
+	case "$TIMEFORMAT":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("$TIMEFORMAT"),
+			Replace: "$TIMEFMT",
+		}}
+	case "TIMEFORMAT":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("TIMEFORMAT"),
+			Replace: "TIMEFMT",
+		}}
+	}
+	return nil
 }
 
 func checkZC1333(node ast.Node) []Violation {


### PR DESCRIPTION
Bash uses $TIMEFORMAT to customise time output; Zsh uses $TIMEFMT. Fix renames the identifier at its source position, covering both the dollar-prefixed and bare forms. Format-specifier dialect differs between the two shells, so callers should still review the format string after conversion.

Test plan: tests green, lint clean, one integration test.