### PR TITLE
feat(zc1356): uppercase read array flag for Zsh semantics

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,16 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1356_ReadArrayFlagUppercase(t *testing.T) {
+	// ZC1012 fires simultaneously (missing raw flag) so the combined
+	// rewrite adds the raw flag as well.
+	src := "read -a arr\n"
+	want := "read -r -A arr\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1333_TimeformatToTimefmt(t *testing.T) {
 	src := "fmt=$TIMEFORMAT\n"
 	want := "fmt=$TIMEFMT\n"

--- a/pkg/katas/zc1356.go
+++ b/pkg/katas/zc1356.go
@@ -13,7 +13,41 @@ func init() {
 			"(lowercase) for the same thing. In Zsh, `read -a` assigns a flag to a scalar " +
 			"variable — not what Bash users expect. Use `-A` for portable-Zsh behavior.",
 		Check: checkZC1356,
+		Fix:   fixZC1356,
 	})
+}
+
+// fixZC1356 rewrites the Bash-flavoured `read -a` flag to the
+// uppercase `-A` that Zsh uses for array reads.
+func fixZC1356(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "read" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		if arg.String() != "-a" {
+			continue
+		}
+		tok := arg.TokenLiteralNode()
+		off := LineColToByteOffset(source, tok.Line, tok.Column)
+		if off < 0 || off+2 > len(source) {
+			return nil
+		}
+		if string(source[off:off+2]) != "-a" {
+			return nil
+		}
+		return []FixEdit{{
+			Line:    tok.Line,
+			Column:  tok.Column,
+			Length:  2,
+			Replace: "-A",
+		}}
+	}
+	return nil
 }
 
 func checkZC1356(node ast.Node) []Violation {


### PR DESCRIPTION
Bash uses lowercase array flag with read; Zsh uses uppercase for the same intent. Bash's lowercase variant in Zsh actually assigns a shell flag to a scalar variable, which is almost never the author's intent. Fix swaps the lowercase arg to uppercase at its source position.

Test plan: tests green, lint clean, one integration test. ZC1012's raw-flag insertion fires on the same invocation so the combined rewrite adds the raw flag too — test asserts the combined output.