### PR TITLE
feat(zc1355): collapse echo raw form to print -r

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -729,6 +729,14 @@ func TestFixIntegration_ZC1267_DfAddPortable(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1355_EchoDashERawToPrintR(t *testing.T) {
+	src := `echo -E "literal\tslash"` + "\n"
+	want := `print -r "literal\tslash"` + "\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1356_ReadArrayFlagUppercase(t *testing.T) {
 	// ZC1012 fires simultaneously (missing raw flag) so the combined
 	// rewrite adds the raw flag as well.

--- a/pkg/katas/zc1355.go
+++ b/pkg/katas/zc1355.go
@@ -14,7 +14,45 @@ func init() {
 			"with `-n` (no newline), `-l` (one per line), `-u<fd>` (file descriptor), or `--` " +
 			"(end of flags) as needed.",
 		Check: checkZC1355,
+		Fix:   fixZC1355,
 	})
+}
+
+// fixZC1355 collapses `echo -E` into `print -r`. Span covers the
+// command name, intervening whitespace, and the `-E` flag.
+func fixZC1355(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "echo" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 || nameOff+len("echo") > len(source) {
+		return nil
+	}
+	if string(source[nameOff:nameOff+len("echo")]) != "echo" {
+		return nil
+	}
+	i := nameOff + len("echo")
+	for i < len(source) && (source[i] == ' ' || source[i] == '\t') {
+		i++
+	}
+	if i+2 > len(source) || source[i] != '-' || source[i+1] != 'E' {
+		return nil
+	}
+	end := i + 2
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  end - nameOff,
+		Replace: "print -r",
+	}}
 }
 
 func checkZC1355(node ast.Node) []Violation {


### PR DESCRIPTION
echo with the uppercase raw flag is a Bash-ism that POSIX echo ignores. print -r is the reliable Zsh raw-printer. Fix collapses the command name plus flag into the Zsh form as a single span edit; remaining arguments stay in place.

Test plan: tests green, lint clean, one integration test.