### PR TITLE
fix(zc1068): guard nil Name on anonymous function definitions

### DIFF
--- a/pkg/katas/katatests/zc1068_test.go
+++ b/pkg/katas/katatests/zc1068_test.go
@@ -50,6 +50,12 @@ func TestZC1068(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Regression for #1225 — anonymous function must not panic.
+			name:     "anonymous function is safe",
+			input:    `() { echo hi } "$@"`,
+			expected: []katas.Violation{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/zc1068.go
+++ b/pkg/katas/zc1068.go
@@ -24,10 +24,16 @@ func checkZC1068(node ast.Node) []Violation {
 
 	switch n := node.(type) {
 	case *ast.FunctionDefinition:
+		if n.Name == nil {
+			return nil
+		}
 		name = n.Name.Value
 		tokenLine = n.Token.Line
 		tokenCol = n.Token.Column
 	case *ast.FunctionLiteral:
+		if n.Name == nil {
+			return nil
+		}
 		name = n.Name.Value
 		tokenLine = n.Token.Line
 		tokenCol = n.Token.Column


### PR DESCRIPTION
Closes #1225.

Anonymous function nodes (`() { … }`) have `Name == nil`. `checkZC1068` dereferenced `n.Name.Value` without a nil check, hard-crashing the whole linter. Surfaced via integration scan against the antidote repo.

Fix: return early from both switch branches when Name is nil.

Regression test covers the shape.

Test plan: tests green, lint clean.