### PR TITLE
fix(zc1070): guard nil Name / Body / cmd.Name during body walk

### DIFF
--- a/pkg/katas/katatests/zc1070_test.go
+++ b/pkg/katas/katatests/zc1070_test.go
@@ -79,6 +79,13 @@ func TestZC1070(t *testing.T) {
 			input:    `fib() { fib $(($1-1)); }`,
 			expected: []katas.Violation{}, // Should NOT warn for generic recursion?
 		},
+		{
+			// Regression for #1226 — anonymous function (nil Name) must
+			// not panic even when the check walks its body.
+			name:     "anonymous function is safe",
+			input:    `() { cd /tmp } "$@"`,
+			expected: []katas.Violation{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/zc1070.go
+++ b/pkg/katas/zc1070.go
@@ -21,6 +21,9 @@ func checkZC1070(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if funcDef.Name == nil || funcDef.Body == nil {
+		return nil
+	}
 
 	name := funcDef.Name.String()
 
@@ -51,6 +54,9 @@ func checkZC1070(node ast.Node) []Violation {
 		}
 
 		if cmd, ok := n.(*ast.SimpleCommand); ok {
+			if cmd.Name == nil {
+				return true
+			}
 			cmdName := cmd.Name.String()
 			if cmdName == name {
 				// Found self-call.


### PR DESCRIPTION
Closes #1226.

Three separate un-guarded dereferences in the ZC1070 recursive-wrapper check, all reached via anonymous functions and malformed bodies the parser recovered from:

- `funcDef.Name.String()` when Name is nil.
- `ast.Walk(funcDef.Body, …)` when Body is nil.
- `cmd.Name.String()` when a SimpleCommand has nil Name.

Each path now returns early (or skips the subtree) instead of panicking. Surfaced via integration scan against antidote.zsh after #1227 fixed the preceding panic in ZC1068.

Regression test covers the anonymous-function shape.

Test plan: tests green, lint clean.