### PR TITLE
fix(zc1043): guard nil assign.Right in local-hint message

### DIFF
--- a/pkg/katas/katatests/zc1043_test.go
+++ b/pkg/katas/katatests/zc1043_test.go
@@ -30,6 +30,22 @@ func TestZC1043(t *testing.T) {
 			input:    "myfunc() { local x=1; }",
 			expected: []katas.Violation{},
 		},
+		{
+			// Regression for #1229 — empty-RHS assignment must not
+			// panic during message build. Hint still emitted with an
+			// empty RHS rendered in the template.
+			name:  "empty-RHS assignment does not panic",
+			input: "myfunc() { empty= }",
+			expected: []katas.Violation{
+				{
+					KataID: "ZC1043",
+					Message: "Variable 'empty' is assigned without 'local'. It will be global. " +
+						"Use `local empty=`.",
+					Line:   1,
+					Column: 12,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/zc1043.go
+++ b/pkg/katas/zc1043.go
@@ -59,10 +59,18 @@ func checkZC1043(node ast.Node) []Violation {
 			if assign, ok := exprStmt.Expression.(*ast.InfixExpression); ok && assign.Operator == "=" {
 				if ident, ok := assign.Left.(*ast.Identifier); ok {
 					if !locals[ident.Value] {
+						// Empty RHS (`VAR=` at end of line) is valid Zsh
+						// and the parser records it with Right == nil.
+						// Fall back to an empty string so the message
+						// builder doesn't deref nil.
+						rhs := ""
+						if assign.Right != nil {
+							rhs = assign.Right.String()
+						}
 						violations = append(violations, Violation{
 							KataID: "ZC1043",
 							Message: "Variable '" + ident.Value + "' is assigned without 'local'. It will be global. " +
-								"Use `local " + ident.Value + "=" + assign.Right.String() + "`.",
+								"Use `local " + ident.Value + "=" + rhs + "`.",
 							Line:   ident.Token.Line,
 							Column: ident.Token.Column,
 							Level:  SeverityStyle,


### PR DESCRIPTION
Closes #1229.

Empty-RHS assignments (`VAR=` at end of line) are valid Zsh and the parser records them with `Right == nil`. The violation message template dereferenced `assign.Right.String()` without a nil check, crashing the linter. Surfaced via integration scan against antidote.zsh.

Fallback to an empty string so the hint still renders as `local VAR=` instead of panicking.

Regression test added.

Test plan: tests green, lint clean.