### PR TITLE
fix: guard typed-nil *ast.Identifier in 32 katas

### DIFF
--- a/pkg/katas/zc1122.go
+++ b/pkg/katas/zc1122.go
@@ -17,7 +17,7 @@ func init() {
 
 func checkZC1122(node ast.Node) []Violation {
 	ident, ok := node.(*ast.Identifier)
-	if !ok || ident.Value != "whoami" {
+	if !ok || ident == nil || ident.Value != "whoami" {
 		return nil
 	}
 

--- a/pkg/katas/zc1191.go
+++ b/pkg/katas/zc1191.go
@@ -17,7 +17,7 @@ func init() {
 
 func checkZC1191(node ast.Node) []Violation {
 	ident, ok := node.(*ast.Identifier)
-	if !ok || ident.Value != "clear" {
+	if !ok || ident == nil || ident.Value != "clear" {
 		return nil
 	}
 

--- a/pkg/katas/zc1297.go
+++ b/pkg/katas/zc1297.go
@@ -21,6 +21,9 @@ func checkZC1297(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$BASH_SOURCE" && ident.Value != "BASH_SOURCE" {
 		return nil

--- a/pkg/katas/zc1298.go
+++ b/pkg/katas/zc1298.go
@@ -25,6 +25,9 @@ func fixZC1298(node ast.Node, v Violation, source []byte) []FixEdit {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 	switch ident.Value {
 	case "$FUNCNAME":
 		return []FixEdit{{
@@ -47,6 +50,9 @@ func fixZC1298(node ast.Node, v Violation, source []byte) []FixEdit {
 func checkZC1298(node ast.Node) []Violation {
 	ident, ok := node.(*ast.Identifier)
 	if !ok {
+		return nil
+	}
+	if ident == nil {
 		return nil
 	}
 

--- a/pkg/katas/zc1299.go
+++ b/pkg/katas/zc1299.go
@@ -21,6 +21,9 @@ func checkZC1299(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$BASH_LINENO" && ident.Value != "BASH_LINENO" {
 		return nil

--- a/pkg/katas/zc1300.go
+++ b/pkg/katas/zc1300.go
@@ -27,6 +27,9 @@ func fixZC1300(node ast.Node, v Violation, source []byte) []FixEdit {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 	switch ident.Value {
 	case "$BASH_VERSION", "$BASH_VERSINFO":
 		return []FixEdit{{
@@ -49,6 +52,9 @@ func fixZC1300(node ast.Node, v Violation, source []byte) []FixEdit {
 func checkZC1300(node ast.Node) []Violation {
 	ident, ok := node.(*ast.Identifier)
 	if !ok {
+		return nil
+	}
+	if ident == nil {
 		return nil
 	}
 

--- a/pkg/katas/zc1301.go
+++ b/pkg/katas/zc1301.go
@@ -26,6 +26,9 @@ func fixZC1301(node ast.Node, v Violation, source []byte) []FixEdit {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 	switch ident.Value {
 	case "$PIPESTATUS":
 		return []FixEdit{{
@@ -48,6 +51,9 @@ func fixZC1301(node ast.Node, v Violation, source []byte) []FixEdit {
 func checkZC1301(node ast.Node) []Violation {
 	ident, ok := node.(*ast.Identifier)
 	if !ok {
+		return nil
+	}
+	if ident == nil {
 		return nil
 	}
 

--- a/pkg/katas/zc1304.go
+++ b/pkg/katas/zc1304.go
@@ -24,6 +24,9 @@ func fixZC1304(node ast.Node, v Violation, source []byte) []FixEdit {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 	switch ident.Value {
 	case "$BASH_SUBSHELL":
 		return []FixEdit{{
@@ -46,6 +49,9 @@ func fixZC1304(node ast.Node, v Violation, source []byte) []FixEdit {
 func checkZC1304(node ast.Node) []Violation {
 	ident, ok := node.(*ast.Identifier)
 	if !ok {
+		return nil
+	}
+	if ident == nil {
 		return nil
 	}
 

--- a/pkg/katas/zc1305.go
+++ b/pkg/katas/zc1305.go
@@ -24,6 +24,9 @@ func fixZC1305(node ast.Node, v Violation, source []byte) []FixEdit {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 	switch ident.Value {
 	case "$COMP_WORDS":
 		return []FixEdit{{
@@ -46,6 +49,9 @@ func fixZC1305(node ast.Node, v Violation, source []byte) []FixEdit {
 func checkZC1305(node ast.Node) []Violation {
 	ident, ok := node.(*ast.Identifier)
 	if !ok {
+		return nil
+	}
+	if ident == nil {
 		return nil
 	}
 

--- a/pkg/katas/zc1306.go
+++ b/pkg/katas/zc1306.go
@@ -23,6 +23,9 @@ func fixZC1306(node ast.Node, v Violation, source []byte) []FixEdit {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 	switch ident.Value {
 	case "$COMP_CWORD":
 		return []FixEdit{{
@@ -45,6 +48,9 @@ func fixZC1306(node ast.Node, v Violation, source []byte) []FixEdit {
 func checkZC1306(node ast.Node) []Violation {
 	ident, ok := node.(*ast.Identifier)
 	if !ok {
+		return nil
+	}
+	if ident == nil {
 		return nil
 	}
 

--- a/pkg/katas/zc1307.go
+++ b/pkg/katas/zc1307.go
@@ -24,6 +24,9 @@ func fixZC1307(node ast.Node, v Violation, source []byte) []FixEdit {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 	switch ident.Value {
 	case "$DIRSTACK":
 		return []FixEdit{{
@@ -46,6 +49,9 @@ func fixZC1307(node ast.Node, v Violation, source []byte) []FixEdit {
 func checkZC1307(node ast.Node) []Violation {
 	ident, ok := node.(*ast.Identifier)
 	if !ok {
+		return nil
+	}
+	if ident == nil {
 		return nil
 	}
 

--- a/pkg/katas/zc1308.go
+++ b/pkg/katas/zc1308.go
@@ -23,6 +23,9 @@ func fixZC1308(node ast.Node, v Violation, source []byte) []FixEdit {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 	switch ident.Value {
 	case "$COMP_LINE":
 		return []FixEdit{{
@@ -45,6 +48,9 @@ func fixZC1308(node ast.Node, v Violation, source []byte) []FixEdit {
 func checkZC1308(node ast.Node) []Violation {
 	ident, ok := node.(*ast.Identifier)
 	if !ok {
+		return nil
+	}
+	if ident == nil {
 		return nil
 	}
 

--- a/pkg/katas/zc1309.go
+++ b/pkg/katas/zc1309.go
@@ -21,6 +21,9 @@ func checkZC1309(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$BASH_COMMAND" && ident.Value != "BASH_COMMAND" {
 		return nil

--- a/pkg/katas/zc1310.go
+++ b/pkg/katas/zc1310.go
@@ -20,6 +20,9 @@ func checkZC1310(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$BASH_EXECUTION_STRING" && ident.Value != "BASH_EXECUTION_STRING" {
 		return nil

--- a/pkg/katas/zc1313.go
+++ b/pkg/katas/zc1313.go
@@ -23,6 +23,9 @@ func fixZC1313(node ast.Node, v Violation, source []byte) []FixEdit {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 	switch ident.Value {
 	case "$BASH_ALIASES":
 		return []FixEdit{{
@@ -45,6 +48,9 @@ func fixZC1313(node ast.Node, v Violation, source []byte) []FixEdit {
 func checkZC1313(node ast.Node) []Violation {
 	ident, ok := node.(*ast.Identifier)
 	if !ok {
+		return nil
+	}
+	if ident == nil {
 		return nil
 	}
 

--- a/pkg/katas/zc1314.go
+++ b/pkg/katas/zc1314.go
@@ -20,6 +20,9 @@ func checkZC1314(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$BASH_LOADABLES_PATH" && ident.Value != "BASH_LOADABLES_PATH" {
 		return nil

--- a/pkg/katas/zc1315.go
+++ b/pkg/katas/zc1315.go
@@ -20,6 +20,9 @@ func checkZC1315(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$BASH_COMPAT" && ident.Value != "BASH_COMPAT" {
 		return nil

--- a/pkg/katas/zc1317.go
+++ b/pkg/katas/zc1317.go
@@ -21,6 +21,9 @@ func checkZC1317(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$BASH_ENV" && ident.Value != "BASH_ENV" {
 		return nil

--- a/pkg/katas/zc1318.go
+++ b/pkg/katas/zc1318.go
@@ -24,6 +24,9 @@ func fixZC1318(node ast.Node, v Violation, source []byte) []FixEdit {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 	switch ident.Value {
 	case "$BASH_CMDS":
 		return []FixEdit{{
@@ -46,6 +49,9 @@ func fixZC1318(node ast.Node, v Violation, source []byte) []FixEdit {
 func checkZC1318(node ast.Node) []Violation {
 	ident, ok := node.(*ast.Identifier)
 	if !ok {
+		return nil
+	}
+	if ident == nil {
 		return nil
 	}
 

--- a/pkg/katas/zc1319.go
+++ b/pkg/katas/zc1319.go
@@ -20,6 +20,9 @@ func checkZC1319(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$BASH_ARGC" && ident.Value != "BASH_ARGC" {
 		return nil

--- a/pkg/katas/zc1320.go
+++ b/pkg/katas/zc1320.go
@@ -20,6 +20,9 @@ func checkZC1320(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$BASH_ARGV" && ident.Value != "BASH_ARGV" {
 		return nil

--- a/pkg/katas/zc1321.go
+++ b/pkg/katas/zc1321.go
@@ -21,6 +21,9 @@ func checkZC1321(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$BASH_XTRACEFD" && ident.Value != "BASH_XTRACEFD" {
 		return nil

--- a/pkg/katas/zc1322.go
+++ b/pkg/katas/zc1322.go
@@ -21,6 +21,9 @@ func checkZC1322(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$COPROC" && ident.Value != "COPROC" {
 		return nil

--- a/pkg/katas/zc1324.go
+++ b/pkg/katas/zc1324.go
@@ -20,6 +20,9 @@ func checkZC1324(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$PROMPT_COMMAND" && ident.Value != "PROMPT_COMMAND" {
 		return nil

--- a/pkg/katas/zc1325.go
+++ b/pkg/katas/zc1325.go
@@ -20,6 +20,9 @@ func checkZC1325(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$PS0" && ident.Value != "PS0" {
 		return nil

--- a/pkg/katas/zc1326.go
+++ b/pkg/katas/zc1326.go
@@ -21,6 +21,9 @@ func checkZC1326(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$HISTTIMEFORMAT" && ident.Value != "HISTTIMEFORMAT" {
 		return nil

--- a/pkg/katas/zc1328.go
+++ b/pkg/katas/zc1328.go
@@ -21,6 +21,9 @@ func checkZC1328(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$HISTCONTROL" && ident.Value != "HISTCONTROL" {
 		return nil

--- a/pkg/katas/zc1329.go
+++ b/pkg/katas/zc1329.go
@@ -21,6 +21,9 @@ func checkZC1329(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$HISTIGNORE" && ident.Value != "HISTIGNORE" {
 		return nil

--- a/pkg/katas/zc1330.go
+++ b/pkg/katas/zc1330.go
@@ -21,6 +21,9 @@ func checkZC1330(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$INPUTRC" && ident.Value != "INPUTRC" {
 		return nil

--- a/pkg/katas/zc1331.go
+++ b/pkg/katas/zc1331.go
@@ -24,6 +24,9 @@ func fixZC1331(node ast.Node, v Violation, source []byte) []FixEdit {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 	switch ident.Value {
 	case "$BASH_REMATCH":
 		return []FixEdit{{
@@ -46,6 +49,9 @@ func fixZC1331(node ast.Node, v Violation, source []byte) []FixEdit {
 func checkZC1331(node ast.Node) []Violation {
 	ident, ok := node.(*ast.Identifier)
 	if !ok {
+		return nil
+	}
+	if ident == nil {
 		return nil
 	}
 

--- a/pkg/katas/zc1332.go
+++ b/pkg/katas/zc1332.go
@@ -21,6 +21,9 @@ func checkZC1332(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 
 	if ident.Value != "$GLOBIGNORE" && ident.Value != "GLOBIGNORE" {
 		return nil

--- a/pkg/katas/zc1333.go
+++ b/pkg/katas/zc1333.go
@@ -25,6 +25,9 @@ func fixZC1333(node ast.Node, v Violation, source []byte) []FixEdit {
 	if !ok {
 		return nil
 	}
+	if ident == nil {
+		return nil
+	}
 	switch ident.Value {
 	case "$TIMEFORMAT":
 		return []FixEdit{{
@@ -47,6 +50,9 @@ func fixZC1333(node ast.Node, v Violation, source []byte) []FixEdit {
 func checkZC1333(node ast.Node) []Violation {
 	ident, ok := node.(*ast.Identifier)
 	if !ok {
+		return nil
+	}
+	if ident == nil {
 		return nil
 	}
 


### PR DESCRIPTION
Closes #1233, #1232.

Every kata whose Check starts with `ident, ok := node.(*ast.Identifier)` panicked on a typed-nil interface: the type assertion returned `ok=true, ident=nil` and the subsequent `ident.Value` read landed on a nil receiver.

## Katas patched

ZC1122, ZC1191, ZC1297, ZC1298, ZC1299, ZC1300, ZC1301, ZC1304, ZC1305, ZC1306, ZC1307, ZC1308, ZC1309, ZC1310, ZC1313, ZC1314, ZC1315, ZC1317, ZC1318, ZC1319, ZC1320, ZC1321, ZC1322, ZC1324, ZC1325, ZC1326, ZC1328, ZC1329, ZC1330, ZC1331, ZC1332, ZC1333.

## Two shapes patched

**Single-line guard:**

```go
// before
if !ok || ident.Value != "…" {
// after
if !ok || ident == nil || ident.Value != "…" {
```

**Split guard:**

```go
// before
ident, ok := node.(*ast.Identifier)
if !ok {
    return nil
}
// … later …
if ident.Value != "…" {
// after — inserted immediately after the !ok block
if ident == nil {
    return nil
}
```

## Integration-scan impact

Clears panics on `omz/plugins/jsontools`, `omz/plugins/keychain`, `omz/plugins/virtualenvwrapper`, `omz/themes/jnrowe.zsh-theme`, plus antidote test fixtures. ZC1054 / ZC1004 / ZC1191 follow-ups still outstanding — tracked separately.

## Test plan

- [x] `go test ./...` green
- [x] `golangci-lint run ./...` clean
- [x] Post-patch integration scan on `omz/plugins/jsontools` yields normal violations instead of panic.