### PR TITLE
fix(ast): reject typed-nil Node in Walk to stop downstream panics

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/afadesigns/zshellcheck/pkg/token"
@@ -647,6 +648,15 @@ type WalkFn func(node Node) bool
 // It calls the walkFn for each node.
 func Walk(node Node, f WalkFn) {
 	if node == nil {
+		return
+	}
+	// Guard against typed-nil interface values: a Node interface can
+	// hold a concrete type descriptor with a nil pointer underneath,
+	// which does not compare equal to nil. Descending into such a
+	// value hands every kata switch arm a nil receiver, so fields
+	// like Identifier.Value or SimpleCommand.Name panic immediately.
+	// Reflect is the cheapest reliable check for this case.
+	if v := reflect.ValueOf(node); v.Kind() == reflect.Ptr && v.IsNil() {
 		return
 	}
 


### PR DESCRIPTION
Closes #1237.

Walk's existing `node == nil` check only rejected untyped interface-nil. A Node interface value that holds a concrete pointer type with a nil underlying pointer passes the check, descends into the type switch, and the downstream kata switch arm picks it up as the concrete type. Every Check that reads a field on that nil receiver panics.

## Fix

Add a `reflect.ValueOf(node).IsNil()` check immediately after the interface-nil guard at the top of Walk:

```go
if v := reflect.ValueOf(node); v.Kind() == reflect.Ptr && v.IsNil() {
    return
}
```

This closes the class of bug at the walker level. Individual katas remain responsible for nil-guarding sub-node fields; no kata ever sees a typed-nil node again.

## Integration impact

Clears the last panic in the baseline scan (`testdata/external-corpora/prezto/init.zsh` via ZC1004). PRs #1234 and #1236 hardened specific katas; this fix addresses the root cause that fed them.

## Test plan

- [x] `go test ./...` green
- [x] `golangci-lint run ./...` clean
- [x] Post-fix scan on prezto/init.zsh yields normal violations instead of panic.