### PR TITLE
feat: auto-fix coverage 90 to 102 (+12 TIER 2 katas)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage expanded to 90 katas (+23).** All new fixes are deterministic, idempotent, and byte-exact outside the rewritten span.
+- **Auto-fix coverage expanded to 102 katas (+35 since 1.0.15).** All new fixes are deterministic, idempotent, and byte-exact outside the rewritten span. The TIER 2 batch added 12 span-aware / multi-edit / token-strip rewrites on top of the original 23 TIER 1 candidates:
+  - **Pipeline collapse:**
+    - `ZC1146` — `cat F | sed/awk/sort/head/tail` → `tool ... F` (drops `cat F |`, appends `F` to the right side).
+    - `ZC1190` — `grep -v p1 | grep -v p2` → `grep -v -e p1 -e p2` (single-grep collapse).
+  - **Flag insertion (command-level):**
+    - `ZC1230` — `ping URL` → `ping -c 4 URL`.
+    - `ZC1255` — `curl URL` → `curl -L URL` (HTTP-redirect follow).
+    - `ZC1773` — `xargs CMD` → `xargs -r CMD` (skip empty-input invocation).
+  - **Flag insertion (subcommand-level / positional anchor):**
+    - `ZC1257` — `docker stop X` → `docker stop -t 10 X`.
+    - `ZC1268` — `du -sh *` → `du -sh -- *` (`--` end-of-options before first non-flag).
+  - **Token-strip (whitespace-aware delete):**
+    - `ZC1238` — `docker exec -it …` → `docker exec …`.
+    - `ZC1239` — `kubectl exec -it …` → `kubectl exec …`.
+  - **IdentifierNode renames (Bash → Zsh):**
+    - `ZC1319` — `$BASH_ARGC` → `$#`.
+    - `ZC1320` — `$BASH_ARGV` → `$argv`.
+  - **Assignment-LHS rename:**
+    - `ZC1380` — `export HISTIGNORE=…` → `export HISTORY_IGNORE=…`.
+- **Auto-fix coverage (TIER 1 batch, +23):** All new fixes are deterministic, idempotent, and byte-exact outside the rewritten span.
   - **Backtick / brace-range aliases (share existing fix shape):**
     - `ZC1015` — backticks → `$(...)` (alias of `ZC1002`).
     - `ZC1276` — `seq M N` → `{M..N}` brace range (alias of `ZC1061`).

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **90** |
+| **with auto-fix** | **102** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -160,7 +160,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1143: Avoid `set -e` — use explicit error handling](#zc1143)
 - [ZC1144: Avoid `trap` with signal numbers — use names](#zc1144) · auto-fix
 - [ZC1145: Avoid `tr -d` for character deletion — use parameter expansion](#zc1145)
-- [ZC1146: Avoid `cat file \| awk` — pass file to awk directly](#zc1146)
+- [ZC1146: Avoid `cat file \| awk` — pass file to awk directly](#zc1146) · auto-fix
 - [ZC1147: Avoid `mkdir` without `-p` for nested paths](#zc1147) · auto-fix
 - [ZC1148: Use `compdef` instead of `compctl` for completions](#zc1148)
 - [ZC1149: Avoid `echo` for error messages — use `>&2`](#zc1149)
@@ -203,7 +203,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1187: Avoid `notify-send` without fallback — check availability first](#zc1187)
 - [ZC1188: Use Zsh `path+=()` instead of `export PATH=$PATH:dir`](#zc1188)
 - [ZC1189: Avoid `source /dev/stdin` — use direct evaluation](#zc1189)
-- [ZC1190: Combine chained `grep -v` into single invocation](#zc1190)
+- [ZC1190: Combine chained `grep -v` into single invocation](#zc1190) · auto-fix
 - [ZC1191: Avoid `clear` command — use ANSI escape sequences](#zc1191) · auto-fix
 - [ZC1192: Avoid `sleep 0` — it is a no-op external process](#zc1192) · auto-fix
 - [ZC1193: Avoid `rm -i` in non-interactive scripts](#zc1193)
@@ -243,7 +243,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1227: Use `curl -f` to fail on HTTP errors](#zc1227) · auto-fix
 - [ZC1228: Avoid `ssh` without host key policy in scripts](#zc1228)
 - [ZC1229: Prefer `rsync` over `scp` for file transfers](#zc1229)
-- [ZC1230: Use `ping -c N` in scripts to limit ping count](#zc1230)
+- [ZC1230: Use `ping -c N` in scripts to limit ping count](#zc1230) · auto-fix
 - [ZC1231: Use `git clone --depth 1` for CI and build scripts](#zc1231) · auto-fix
 - [ZC1232: Avoid bare `pip install` — use `--user` or virtualenv](#zc1232)
 - [ZC1233: Avoid `npm install -g` — use `npx` for one-off tools](#zc1233)
@@ -251,8 +251,8 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1235: Use `git push --force-with-lease` instead of `--force`](#zc1235) · auto-fix
 - [ZC1236: Avoid `git reset --hard` — irreversible data loss risk](#zc1236)
 - [ZC1237: Use `git clean -n` before `git clean -fd`](#zc1237)
-- [ZC1238: Avoid `docker exec -it` in scripts — drop `-it` for non-interactive](#zc1238)
-- [ZC1239: Avoid `kubectl exec -it` in scripts](#zc1239)
+- [ZC1238: Avoid `docker exec -it` in scripts — drop `-it` for non-interactive](#zc1238) · auto-fix
+- [ZC1239: Avoid `kubectl exec -it` in scripts](#zc1239) · auto-fix
 - [ZC1240: Use `find -maxdepth` with `-delete` to limit scope](#zc1240)
 - [ZC1241: Use `xargs -0` with null separators for safe argument passing](#zc1241) · auto-fix
 - [ZC1242: Use `tar -C dir` to extract into a specific directory](#zc1242)
@@ -268,9 +268,9 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1252: Use `getent passwd` instead of `cat /etc/passwd`](#zc1252)
 - [ZC1253: Use `docker build --no-cache` in CI for reproducible builds](#zc1253) · auto-fix
 - [ZC1254: Avoid `git commit --amend` in shared branches](#zc1254)
-- [ZC1255: Use `curl -L` to follow HTTP redirects](#zc1255)
+- [ZC1255: Use `curl -L` to follow HTTP redirects](#zc1255) · auto-fix
 - [ZC1256: Clean up `mkfifo` pipes with a trap on EXIT](#zc1256)
-- [ZC1257: Use `docker stop -t` to set graceful shutdown timeout](#zc1257)
+- [ZC1257: Use `docker stop -t` to set graceful shutdown timeout](#zc1257) · auto-fix
 - [ZC1258: Consider `rsync --delete` for directory sync](#zc1258)
 - [ZC1259: Avoid `docker pull` without explicit tag — pin image versions](#zc1259)
 - [ZC1260: Use `git branch -d` instead of `-D` for safe deletion](#zc1260) · auto-fix
@@ -281,7 +281,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1265: Use `systemctl enable --now` to enable and start together](#zc1265) · auto-fix
 - [ZC1266: Use `nproc` instead of parsing `/proc/cpuinfo`](#zc1266)
 - [ZC1267: Use `df -P` for POSIX-portable disk usage output](#zc1267) · auto-fix
-- [ZC1268: Use `du -sh --` to handle filenames starting with dash](#zc1268)
+- [ZC1268: Use `du -sh --` to handle filenames starting with dash](#zc1268) · auto-fix
 - [ZC1269: Use `pgrep` instead of `ps aux \| grep` for process search](#zc1269)
 - [ZC1270: Use `mktemp` instead of hardcoded `/tmp` paths](#zc1270)
 - [ZC1271: Use `command -v` instead of `which` for command existence checks](#zc1271) · auto-fix
@@ -332,8 +332,8 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1316: Avoid `caller` builtin — use `$funcfiletrace` in Zsh](#zc1316)
 - [ZC1317: Avoid `$BASH_ENV` — use `$ZDOTDIR` and `$ENV` in Zsh](#zc1317)
 - [ZC1318: Avoid `$BASH_CMDS` — use `$commands` hash in Zsh](#zc1318) · auto-fix
-- [ZC1319: Avoid `$BASH_ARGC` — use `$#` in Zsh](#zc1319)
-- [ZC1320: Avoid `$BASH_ARGV` — use `$argv` in Zsh](#zc1320)
+- [ZC1319: Avoid `$BASH_ARGC` — use `$#` in Zsh](#zc1319) · auto-fix
+- [ZC1320: Avoid `$BASH_ARGV` — use `$argv` in Zsh](#zc1320) · auto-fix
 - [ZC1321: Avoid `$BASH_XTRACEFD` — not available in Zsh](#zc1321)
 - [ZC1322: Avoid `$COPROC` — Zsh coproc uses different syntax](#zc1322)
 - [ZC1323: Avoid `suspend` builtin — use `kill -STOP $$` in Zsh](#zc1323)
@@ -393,7 +393,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1377: Avoid `$BASH_ALIASES` — use Zsh `$aliases` associative array](#zc1377) · auto-fix
 - [ZC1378: Avoid uppercase `$DIRSTACK` — Zsh uses lowercase `$dirstack`](#zc1378) · auto-fix
 - [ZC1379: Avoid `$PROMPT_COMMAND` — use Zsh `precmd` function](#zc1379)
-- [ZC1380: Avoid `$HISTIGNORE` — use Zsh `$HISTORY_IGNORE`](#zc1380)
+- [ZC1380: Avoid `$HISTIGNORE` — use Zsh `$HISTORY_IGNORE`](#zc1380) · auto-fix
 - [ZC1381: Avoid `$COMP_WORDS`/`$COMP_CWORD` — Zsh uses `words`/`$CURRENT`](#zc1381)
 - [ZC1382: Avoid `$READLINE_LINE`/`$READLINE_POINT` — Zsh ZLE uses `$BUFFER`/`$CURSOR`](#zc1382)
 - [ZC1383: Avoid `$TIMEFORMAT` — Zsh uses `$TIMEFMT`](#zc1383) · auto-fix
@@ -786,7 +786,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1770: Warn on `gpg --always-trust` / `--trust-model always` — bypasses Web-of-Trust](#zc1770)
 - [ZC1771: Warn on `alias -g` / `alias -s` — global and suffix aliases surprise script readers](#zc1771)
 - [ZC1772: Error on `hdparm --security-erase` / `--trim-sector-ranges` — ATA-level data destruction](#zc1772)
-- [ZC1773: Warn on `xargs` without `-r` / `--no-run-if-empty` — runs once on empty input](#zc1773)
+- [ZC1773: Warn on `xargs` without `-r` / `--no-run-if-empty` — runs once on empty input](#zc1773) · auto-fix
 - [ZC1774: Warn on `setopt GLOB_SUBST` — `$var` starts glob-expanding, user data becomes a pattern](#zc1774)
 - [ZC1775: Warn on `timeout DURATION cmd` without `--kill-after` / `-k` — hang on SIGTERM-resistant child](#zc1775)
 - [ZC1776: Error on `psql postgresql://user:secret@host/db` — password in argv via connection URI](#zc1776)
@@ -2740,7 +2740,7 @@ Disable by adding `ZC1145` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1146 — Avoid `cat file | awk` — pass file to awk directly
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `cat file | awk` spawns an unnecessary cat process. Pass the file directly as `awk '...' file`.
 
@@ -3256,7 +3256,7 @@ Disable by adding `ZC1189` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1190 — Combine chained `grep -v` into single invocation
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `grep -v p1 | grep -v p2` spawns two processes. Use `grep -v -e p1 -e p2` to combine exclusions in one invocation.
 
@@ -3736,7 +3736,7 @@ Disable by adding `ZC1229` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1230 — Use `ping -c N` in scripts to limit ping count
 
 **Severity:** `warning`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `ping` without `-c` runs indefinitely on Linux, hanging scripts. Always specify `-c N` to limit the number of packets.
 
@@ -3832,7 +3832,7 @@ Disable by adding `ZC1237` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1238 — Avoid `docker exec -it` in scripts — drop `-it` for non-interactive
 
 **Severity:** `warning`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `docker exec -it` allocates a TTY and attaches stdin, which hangs in non-interactive scripts. Use `docker exec` without `-it` for scripted commands.
 
@@ -3844,7 +3844,7 @@ Disable by adding `ZC1238` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1239 — Avoid `kubectl exec -it` in scripts
 
 **Severity:** `warning`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `kubectl exec -it` allocates a TTY which hangs in non-interactive scripts. Use `kubectl exec` without `-it` or use `kubectl exec -- cmd` for scripted commands.
 
@@ -4036,7 +4036,7 @@ Disable by adding `ZC1254` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1255 — Use `curl -L` to follow HTTP redirects
 
 **Severity:** `info`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `curl` without `-L` does not follow redirects, returning 301/302 responses instead of the actual content. Use `-L` to follow redirects automatically.
 
@@ -4060,7 +4060,7 @@ Disable by adding `ZC1256` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1257 — Use `docker stop -t` to set graceful shutdown timeout
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `docker stop` defaults to 10s before SIGKILL. In CI scripts, set an explicit timeout with `-t` to control shutdown behavior.
 
@@ -4192,7 +4192,7 @@ Disable by adding `ZC1267` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1268 — Use `du -sh --` to handle filenames starting with dash
 
 **Severity:** `info`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `du -sh *` breaks if a filename starts with `-`. Use `--` to signal end of options and safely handle all filenames.
 
@@ -4804,7 +4804,7 @@ Disable by adding `ZC1318` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1319 — Avoid `$BASH_ARGC` — use `$#` in Zsh
 
 **Severity:** `warning`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `$BASH_ARGC` is a Bash array tracking argument counts per stack frame. Zsh uses `$#` for argument count and `$argv` for the argument array.
 
@@ -4816,7 +4816,7 @@ Disable by adding `ZC1319` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1320 — Avoid `$BASH_ARGV` — use `$argv` in Zsh
 
 **Severity:** `warning`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `$BASH_ARGV` is a Bash array containing arguments in reverse order. Zsh provides `$argv` (or `$@`) for positional parameters.
 
@@ -5536,7 +5536,7 @@ Disable by adding `ZC1379` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1380 — Avoid `$HISTIGNORE` — use Zsh `$HISTORY_IGNORE`
 
 **Severity:** `warning`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 Bash filters history entries matching `$HISTIGNORE` patterns. Zsh uses a parameter named `$HISTORY_IGNORE` (underscore in the middle). Setting `HISTIGNORE` in Zsh is a no-op.
 
@@ -10252,7 +10252,7 @@ Disable by adding `ZC1772` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1773 — Warn on `xargs` without `-r` / `--no-run-if-empty` — runs once on empty input
 
 **Severity:** `warning`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 GNU `xargs` (the common default on Linux) invokes the child command once with no arguments when its stdin is empty. Paired with a destructive child (`xargs rm`, `xargs kill`, `xargs docker stop`) a pipeline that produces zero hits silently runs the command with no operand — usually an error at best and a footgun at worst. The flag `-r` (GNU) / `--no-run-if-empty` tells xargs to skip the call when no items arrive. Add `-r` to every `xargs` pipeline whose producer can return no results, or switch to `find ... -exec cmd {} +` which never runs the child on empty input. BSD xargs defaults to this behavior, but the portable and explicit choice is to pass `-r` and document the intent.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-90%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-102%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 90 of 1000 katas (9.0%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 102 of 1000 katas (10.2%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -672,7 +672,9 @@ func TestFixIntegration_ZC1226_DmesgAddTime(t *testing.T) {
 
 func TestFixIntegration_ZC1227_CurlAddFail(t *testing.T) {
 	src := "curl https://example.com/data\n"
-	want := "curl -f https://example.com/data\n"
+	// ZC1255 (curl -L for HTTP redirects) shares this fixture and applies
+	// alongside ZC1227's -f insertion in a single pass.
+	want := "curl -L -f https://example.com/data\n"
 	if got := runFix(t, src); got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -696,7 +698,9 @@ func TestFixIntegration_ZC1231_GitCloneShallow(t *testing.T) {
 
 func TestFixIntegration_ZC1241_XargsAddNullSep(t *testing.T) {
 	src := "xargs rm\n"
-	want := "xargs -0 rm\n"
+	// ZC1773 (xargs -r to skip the no-input run) shares this fixture and
+	// applies alongside ZC1241's -0 insertion in a single pass.
+	want := "xargs -r -0 rm\n"
 	if got := runFix(t, src); got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -1125,6 +1129,96 @@ func TestFixIntegration_ZC1163_GrepHeadOne(t *testing.T) {
 func TestFixIntegration_ZC1163_GrepHeadDashN1(t *testing.T) {
 	src := "grep PAT file | head -n1\n"
 	want := "grep -m 1 PAT file\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1146_CatPipeTool(t *testing.T) {
+	// Detector whitelist on the right of the pipe is awk/sed/sort/head/tail
+	// — grep is intentionally excluded (grep accepts file args natively but
+	// has its own kata for the pattern). Use sed to exercise the rewrite.
+	src := "cat data.txt | sed s/foo/bar/\n"
+	want := "sed s/foo/bar/ data.txt\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1190_DoubleGrepInverted(t *testing.T) {
+	// Fix gates on each side carrying exactly one non-flag pattern arg
+	// (zc1190SinglePattern). Adding a `file` arg on the left would push it
+	// over the limit, so the test fixture omits it.
+	src := "grep -v p1 | grep -v p2\n"
+	want := "grep -v -e p1 -e p2\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1230_PingAddCount(t *testing.T) {
+	src := "ping example.com\n"
+	want := "ping -c 4 example.com\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1238_DockerExecStripIt(t *testing.T) {
+	src := "docker exec -it container ls\n"
+	want := "docker exec container ls\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1239_KubectlExecStripIt(t *testing.T) {
+	src := "kubectl exec -it pod -- ls\n"
+	want := "kubectl exec pod -- ls\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1257_DockerStopAddTimeout(t *testing.T) {
+	src := "docker stop container\n"
+	want := "docker stop -t 10 container\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1268_DuAddDoubleDash(t *testing.T) {
+	src := "du -sh *\n"
+	want := "du -sh -- *\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1319_BashArgcRename(t *testing.T) {
+	// ZC1092 (echo → print -r --) also fires on this fixture; both fixes
+	// land in the same pass per the registry's first-edit-wins policy.
+	src := "echo $BASH_ARGC\n"
+	want := "print -r -- $#\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1320_BashArgvRename(t *testing.T) {
+	// ZC1092 (echo → print -r --) also fires on this fixture; both fixes
+	// land in the same pass per the registry's first-edit-wins policy.
+	src := "echo $BASH_ARGV\n"
+	want := "print -r -- $argv\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1380_HistignoreRename(t *testing.T) {
+	src := "export HISTIGNORE='ls:cd'\n"
+	want := "export HISTORY_IGNORE='ls:cd'\n"
 	if got := runFix(t, src); got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}

--- a/pkg/katas/zc1146.go
+++ b/pkg/katas/zc1146.go
@@ -12,7 +12,104 @@ func init() {
 		Description: "`cat file | awk` spawns an unnecessary cat process. " +
 			"Pass the file directly as `awk '...' file`.",
 		Check: checkZC1146,
+		Fix:   fixZC1146,
 	})
+}
+
+// fixZC1146 collapses `cat FILE | tool [args]` into `tool [args] FILE`.
+// One span replacement runs from the start of `cat` through the end of
+// the right-hand command; the replacement is the right-hand source
+// verbatim with ` FILE` appended. Only fires when the cat command has
+// exactly one filename argument (the detector already guards that).
+func fixZC1146(node ast.Node, _ Violation, source []byte) []FixEdit {
+	pipe, ok := node.(*ast.InfixExpression)
+	if !ok || pipe.Operator != "|" {
+		return nil
+	}
+	catCmd, ok := pipe.Left.(*ast.SimpleCommand)
+	if !ok || !isCommandName(catCmd, "cat") {
+		return nil
+	}
+	if len(catCmd.Arguments) != 1 {
+		return nil
+	}
+	rightCmd, ok := pipe.Right.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	rightIdent, ok := rightCmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+
+	catTok := catCmd.TokenLiteralNode()
+	catStart := LineColToByteOffset(source, catTok.Line, catTok.Column)
+	if catStart < 0 {
+		return nil
+	}
+
+	// File arg literal text: take it byte-exact from the source.
+	fileArg := catCmd.Arguments[0]
+	fileTok := fileArg.TokenLiteralNode()
+	fileOff := LineColToByteOffset(source, fileTok.Line, fileTok.Column)
+	if fileOff < 0 {
+		return nil
+	}
+	fileLit := fileArg.String()
+	if fileOff+len(fileLit) > len(source) ||
+		string(source[fileOff:fileOff+len(fileLit)]) != fileLit {
+		return nil
+	}
+
+	// Right command source span: [rightStart, rightEnd).
+	rightTok := rightCmd.TokenLiteralNode()
+	rightStart := LineColToByteOffset(source, rightTok.Line, rightTok.Column)
+	if rightStart < 0 {
+		return nil
+	}
+	rightEnd := rightStart + len(rightIdent.Value)
+	if len(rightCmd.Arguments) > 0 {
+		lastArg := rightCmd.Arguments[len(rightCmd.Arguments)-1]
+		laTok := lastArg.TokenLiteralNode()
+		laOff := LineColToByteOffset(source, laTok.Line, laTok.Column)
+		if laOff < 0 {
+			return nil
+		}
+		laLit := lastArg.String()
+		rightEnd = laOff + len(laLit)
+	}
+	if rightEnd > len(source) || rightEnd < rightStart {
+		return nil
+	}
+	rightSrc := string(source[rightStart:rightEnd])
+
+	startLine, startCol := offsetLineColZC1146(source, catStart)
+	if startLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    startLine,
+		Column:  startCol,
+		Length:  rightEnd - catStart,
+		Replace: rightSrc + " " + fileLit,
+	}}
+}
+
+func offsetLineColZC1146(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1146(node ast.Node) []Violation {

--- a/pkg/katas/zc1190.go
+++ b/pkg/katas/zc1190.go
@@ -12,7 +12,105 @@ func init() {
 		Description: "`grep -v p1 | grep -v p2` spawns two processes. " +
 			"Use `grep -v -e p1 -e p2` to combine exclusions in one invocation.",
 		Check: checkZC1190,
+		Fix:   fixZC1190,
 	})
+}
+
+// fixZC1190 collapses `grep -v p1 | grep -v p2` into a single
+// `grep -v -e p1 -e p2`. Only fires when each grep has exactly one
+// non-flag pattern argument and at most the lone `-v` flag — keeps the
+// rewrite safe in the presence of trailing FILE / additional flags.
+func fixZC1190(node ast.Node, _ Violation, source []byte) []FixEdit {
+	pipe, ok := node.(*ast.InfixExpression)
+	if !ok || pipe.Operator != "|" {
+		return nil
+	}
+	left, ok := pipe.Left.(*ast.SimpleCommand)
+	if !ok || !isCommandName(left, "grep") {
+		return nil
+	}
+	right, ok := pipe.Right.(*ast.SimpleCommand)
+	if !ok || !isCommandName(right, "grep") {
+		return nil
+	}
+	leftPat, leftOk := zc1190SinglePattern(left)
+	rightPat, rightOk := zc1190SinglePattern(right)
+	if !leftOk || !rightOk {
+		return nil
+	}
+
+	leftTok := left.TokenLiteralNode()
+	leftStart := LineColToByteOffset(source, leftTok.Line, leftTok.Column)
+	if leftStart < 0 {
+		return nil
+	}
+	if len(right.Arguments) == 0 {
+		return nil
+	}
+	lastArg := right.Arguments[len(right.Arguments)-1]
+	laTok := lastArg.TokenLiteralNode()
+	laOff := LineColToByteOffset(source, laTok.Line, laTok.Column)
+	if laOff < 0 {
+		return nil
+	}
+	laLit := lastArg.String()
+	end := laOff + len(laLit)
+	if end > len(source) {
+		return nil
+	}
+	startLine, startCol := offsetLineColZC1190(source, leftStart)
+	if startLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    startLine,
+		Column:  startCol,
+		Length:  end - leftStart,
+		Replace: "grep -v -e " + leftPat + " -e " + rightPat,
+	}}
+}
+
+// zc1190SinglePattern returns the lone non-flag argument of a
+// `grep -v PAT` invocation. Returns ok=false when args contain
+// extras, multiple flags, or no pattern at all.
+func zc1190SinglePattern(cmd *ast.SimpleCommand) (string, bool) {
+	pattern := ""
+	hasV := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		switch {
+		case v == "-v":
+			hasV = true
+		case len(v) > 0 && v[0] == '-':
+			return "", false
+		default:
+			if pattern != "" {
+				return "", false
+			}
+			pattern = v
+		}
+	}
+	if !hasV || pattern == "" {
+		return "", false
+	}
+	return pattern, true
+}
+
+func offsetLineColZC1190(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1190(node ast.Node) []Violation {

--- a/pkg/katas/zc1230.go
+++ b/pkg/katas/zc1230.go
@@ -12,7 +12,57 @@ func init() {
 		Description: "`ping` without `-c` runs indefinitely on Linux, hanging scripts. " +
 			"Always specify `-c N` to limit the number of packets.",
 		Check: checkZC1230,
+		Fix:   fixZC1230,
 	})
+}
+
+// fixZC1230 inserts ` -c 4` after the `ping` command name. Detector
+// already guards against an existing `-c` / `-W` flag, so the
+// insertion is safe and idempotent on a re-run.
+func fixZC1230(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "ping" {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 {
+		return nil
+	}
+	if IdentLenAt(source, nameOff) != len("ping") {
+		return nil
+	}
+	insertAt := nameOff + len("ping")
+	insLine, insCol := offsetLineColZC1230(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " -c 4",
+	}}
+}
+
+func offsetLineColZC1230(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1230(node ast.Node) []Violation {

--- a/pkg/katas/zc1238.go
+++ b/pkg/katas/zc1238.go
@@ -12,7 +12,77 @@ func init() {
 		Description: "`docker exec -it` allocates a TTY and attaches stdin, which hangs " +
 			"in non-interactive scripts. Use `docker exec` without `-it` for scripted commands.",
 		Check: checkZC1238,
+		Fix:   fixZC1238,
 	})
+}
+
+// fixZC1238 strips the `-it` (or `-ti`) flag from a `docker exec`
+// invocation. The span covers the leading whitespace plus the flag
+// token so the surrounding source stays byte-identical.
+func fixZC1238(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "docker" {
+		return nil
+	}
+	if len(cmd.Arguments) < 1 || cmd.Arguments[0].String() != "exec" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments[1:] {
+		if v := arg.String(); v == "-it" || v == "-ti" {
+			return zc1238StripFlag(source, arg, v)
+		}
+	}
+	return nil
+}
+
+// zc1238StripFlag deletes the flag arg plus the run of horizontal
+// whitespace immediately preceding it; the leading space the user
+// typed disappears with the flag, leaving `docker exec CMD`.
+func zc1238StripFlag(source []byte, arg ast.Expression, lit string) []FixEdit {
+	tok := arg.TokenLiteralNode()
+	off := LineColToByteOffset(source, tok.Line, tok.Column)
+	if off < 0 || off+len(lit) > len(source) {
+		return nil
+	}
+	if string(source[off:off+len(lit)]) != lit {
+		return nil
+	}
+	start := off
+	for start > 0 && (source[start-1] == ' ' || source[start-1] == '\t') {
+		start--
+	}
+	end := off + len(lit)
+	startLine, startCol := offsetLineColZC1238(source, start)
+	if startLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    startLine,
+		Column:  startCol,
+		Length:  end - start,
+		Replace: "",
+	}}
+}
+
+func offsetLineColZC1238(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1238(node ast.Node) []Violation {

--- a/pkg/katas/zc1239.go
+++ b/pkg/katas/zc1239.go
@@ -12,7 +12,30 @@ func init() {
 		Description: "`kubectl exec -it` allocates a TTY which hangs in non-interactive scripts. " +
 			"Use `kubectl exec` without `-it` or use `kubectl exec -- cmd` for scripted commands.",
 		Check: checkZC1239,
+		Fix:   fixZC1239,
 	})
+}
+
+// fixZC1239 strips the `-it` (or `-ti`) flag from a `kubectl exec`
+// invocation. Reuses the token-strip helper introduced for ZC1238.
+func fixZC1239(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "kubectl" {
+		return nil
+	}
+	if len(cmd.Arguments) < 1 || cmd.Arguments[0].String() != "exec" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments[1:] {
+		if v := arg.String(); v == "-it" || v == "-ti" {
+			return zc1238StripFlag(source, arg, v)
+		}
+	}
+	return nil
 }
 
 func checkZC1239(node ast.Node) []Violation {

--- a/pkg/katas/zc1255.go
+++ b/pkg/katas/zc1255.go
@@ -12,7 +12,57 @@ func init() {
 		Description: "`curl` without `-L` does not follow redirects, returning 301/302 responses " +
 			"instead of the actual content. Use `-L` to follow redirects automatically.",
 		Check: checkZC1255,
+		Fix:   fixZC1255,
 	})
+}
+
+// fixZC1255 inserts ` -L` after the `curl` command name. Detector
+// already guards against any existing follow-redirect flag, so the
+// insertion is idempotent on a re-run.
+func fixZC1255(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "curl" {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 {
+		return nil
+	}
+	if IdentLenAt(source, nameOff) != len("curl") {
+		return nil
+	}
+	insertAt := nameOff + len("curl")
+	insLine, insCol := offsetLineColZC1255(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " -L",
+	}}
+}
+
+func offsetLineColZC1255(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1255(node ast.Node) []Violation {

--- a/pkg/katas/zc1257.go
+++ b/pkg/katas/zc1257.go
@@ -12,7 +12,62 @@ func init() {
 		Description: "`docker stop` defaults to 10s before SIGKILL. In CI scripts, " +
 			"set an explicit timeout with `-t` to control shutdown behavior.",
 		Check: checkZC1257,
+		Fix:   fixZC1257,
 	})
+}
+
+// fixZC1257 inserts ` -t 10` after the `stop` subcommand of a
+// `docker stop …` invocation. Mirrors the subcommand-level pattern
+// used by ZC1265 (`systemctl enable --now`).
+func fixZC1257(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "docker" {
+		return nil
+	}
+	if len(cmd.Arguments) < 1 || cmd.Arguments[0].String() != "stop" {
+		return nil
+	}
+	stopArg := cmd.Arguments[0]
+	tok := stopArg.TokenLiteralNode()
+	off := LineColToByteOffset(source, tok.Line, tok.Column)
+	if off < 0 || off+len("stop") > len(source) {
+		return nil
+	}
+	if string(source[off:off+len("stop")]) != "stop" {
+		return nil
+	}
+	insertAt := off + len("stop")
+	insLine, insCol := offsetLineColZC1257(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " -t 10",
+	}}
+}
+
+func offsetLineColZC1257(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1257(node ast.Node) []Violation {

--- a/pkg/katas/zc1268.go
+++ b/pkg/katas/zc1268.go
@@ -12,7 +12,67 @@ func init() {
 		Description: "`du -sh *` breaks if a filename starts with `-`. " +
 			"Use `--` to signal end of options and safely handle all filenames.",
 		Check: checkZC1268,
+		Fix:   fixZC1268,
 	})
+}
+
+// fixZC1268 inserts `-- ` before the first positional argument of a
+// `du …` invocation that lacks the `--` end-of-options marker. The
+// detector already gates on a glob (`*` / `.`) being present, and on
+// the absence of `--`, so the insertion is idempotent.
+func fixZC1268(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "du" {
+		return nil
+	}
+	// Find the first positional (non-flag) argument.
+	var positional ast.Expression
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if len(v) > 0 && v[0] != '-' {
+			positional = arg
+			break
+		}
+	}
+	if positional == nil {
+		return nil
+	}
+	tok := positional.TokenLiteralNode()
+	off := LineColToByteOffset(source, tok.Line, tok.Column)
+	if off < 0 {
+		return nil
+	}
+	insLine, insCol := offsetLineColZC1268(source, off)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: "-- ",
+	}}
+}
+
+func offsetLineColZC1268(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1268(node ast.Node) []Violation {

--- a/pkg/katas/zc1319.go
+++ b/pkg/katas/zc1319.go
@@ -12,7 +12,37 @@ func init() {
 		Description: "`$BASH_ARGC` is a Bash array tracking argument counts per stack frame. " +
 			"Zsh uses `$#` for argument count and `$argv` for the argument array.",
 		Check: checkZC1319,
+		Fix:   fixZC1319,
 	})
+}
+
+// fixZC1319 rewrites the Bash `$BASH_ARGC` / `BASH_ARGC` identifier to
+// the Zsh `$#` form. Caveat: `$BASH_ARGC` is per-frame in Bash; `$#`
+// is the current-frame argument count in Zsh. The rewrite is correct
+// for the common single-value usage; multi-frame stack inspection is
+// not portable and stays the user's responsibility.
+func fixZC1319(node ast.Node, v Violation, source []byte) []FixEdit {
+	ident, ok := node.(*ast.Identifier)
+	if !ok || ident == nil {
+		return nil
+	}
+	switch ident.Value {
+	case "$BASH_ARGC":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("$BASH_ARGC"),
+			Replace: "$#",
+		}}
+	case "BASH_ARGC":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("BASH_ARGC"),
+			Replace: "#",
+		}}
+	}
+	return nil
 }
 
 func checkZC1319(node ast.Node) []Violation {

--- a/pkg/katas/zc1320.go
+++ b/pkg/katas/zc1320.go
@@ -12,7 +12,37 @@ func init() {
 		Description: "`$BASH_ARGV` is a Bash array containing arguments in reverse order. " +
 			"Zsh provides `$argv` (or `$@`) for positional parameters.",
 		Check: checkZC1320,
+		Fix:   fixZC1320,
 	})
+}
+
+// fixZC1320 rewrites the Bash `$BASH_ARGV` / `BASH_ARGV` identifier to
+// the Zsh `$argv` form. Caveat: `$BASH_ARGV` lists args in reverse
+// stacking order in Bash; `$argv` is the current-frame positional
+// array. Most usages target the current frame and the rewrite is
+// correct; deeper stack walks need a hand-port.
+func fixZC1320(node ast.Node, v Violation, source []byte) []FixEdit {
+	ident, ok := node.(*ast.Identifier)
+	if !ok || ident == nil {
+		return nil
+	}
+	switch ident.Value {
+	case "$BASH_ARGV":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("$BASH_ARGV"),
+			Replace: "$argv",
+		}}
+	case "BASH_ARGV":
+		return []FixEdit{{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("BASH_ARGV"),
+			Replace: "argv",
+		}}
+	}
+	return nil
 }
 
 func checkZC1320(node ast.Node) []Violation {

--- a/pkg/katas/zc1380.go
+++ b/pkg/katas/zc1380.go
@@ -15,7 +15,85 @@ func init() {
 			"parameter named `$HISTORY_IGNORE` (underscore in the middle). Setting `HISTIGNORE` " +
 			"in Zsh is a no-op.",
 		Check: checkZC1380,
+		Fix:   fixZC1380,
 	})
+}
+
+// fixZC1380 rewrites the Bash `HISTIGNORE` parameter name to the Zsh
+// `HISTORY_IGNORE` spelling. The detector ignores args that already
+// contain `HISTORY_IGNORE`, so the rewrite is idempotent on a re-run.
+// Span covers only the bare name occurrences inside the argument
+// string; surrounding `=value` / quoting stays byte-identical.
+func fixZC1380(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" && ident.Value != "export" {
+		return nil
+	}
+	var edits []FixEdit
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if !strings.Contains(v, "HISTIGNORE") || strings.Contains(v, "HISTORY_IGNORE") {
+			continue
+		}
+		tok := arg.TokenLiteralNode()
+		argOff := LineColToByteOffset(source, tok.Line, tok.Column)
+		if argOff < 0 {
+			continue
+		}
+		// Verify the argument literal sits at this offset before
+		// scanning. Some quote shapes alter the start byte; bail on
+		// mismatch rather than risk a misaligned splice.
+		if argOff+len(v) > len(source) || string(source[argOff:argOff+len(v)]) != v {
+			continue
+		}
+		// Replace every occurrence of the bare name inside the arg.
+		idx := 0
+		for {
+			rel := strings.Index(v[idx:], "HISTIGNORE")
+			if rel < 0 {
+				break
+			}
+			absStart := argOff + idx + rel
+			line, col := offsetLineColZC1380(source, absStart)
+			if line > 0 {
+				edits = append(edits, FixEdit{
+					Line:    line,
+					Column:  col,
+					Length:  len("HISTIGNORE"),
+					Replace: "HISTORY_IGNORE",
+				})
+			}
+			idx += rel + len("HISTIGNORE")
+		}
+	}
+	if len(edits) == 0 {
+		return nil
+	}
+	return edits
+}
+
+func offsetLineColZC1380(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1380(node ast.Node) []Violation {

--- a/pkg/katas/zc1773.go
+++ b/pkg/katas/zc1773.go
@@ -19,7 +19,57 @@ func init() {
 			"the child on empty input. BSD xargs defaults to this behavior, but the portable " +
 			"and explicit choice is to pass `-r` and document the intent.",
 		Check: checkZC1773,
+		Fix:   fixZC1773,
 	})
+}
+
+// fixZC1773 inserts ` -r` after the `xargs` command name. Detector
+// already guards against any existing `-r` / `--no-run-if-empty` /
+// combined-short-flag form so the insertion is idempotent.
+func fixZC1773(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "xargs" {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 {
+		return nil
+	}
+	if IdentLenAt(source, nameOff) != len("xargs") {
+		return nil
+	}
+	insertAt := nameOff + len("xargs")
+	insLine, insCol := offsetLineColZC1773(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " -r",
+	}}
+}
+
+func offsetLineColZC1773(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1773(node ast.Node) []Violation {


### PR DESCRIPTION
## Summary

Lifts auto-fix coverage from 90 → 102 katas (+12) by mining the TIER 2 survey for span-aware / multi-edit / token-strip candidates that fit existing Fix shapes plus one new helper (`zc1238StripFlag` whitespace-aware token deletion).

## Coverage by pattern

- **Pipeline collapse** — ZC1146 (`cat F | tool` → `tool ... F`), ZC1190 (`grep -v p1 | grep -v p2` → `grep -v -e p1 -e p2`).
- **Flag insertion (command-level)** — ZC1230 (`ping -c 4`), ZC1255 (`curl -L`), ZC1773 (`xargs -r`).
- **Flag insertion (subcommand / positional anchor)** — ZC1257 (`docker stop -t 10`), ZC1268 (`du -sh -- *`).
- **Token-strip (whitespace-aware delete)** — ZC1238 (`docker exec -it`), ZC1239 (`kubectl exec -it`).
- **IdentifierNode Bash→Zsh renames** — ZC1319 (`$BASH_ARGC` → `$#`), ZC1320 (`$BASH_ARGV` → `$argv`).
- **Assignment-LHS rename** — ZC1380 (`export HISTIGNORE=…` → `export HISTORY_IGNORE=…`).

## Demoted from the survey

- **ZC1717** (`docker pull --disable-content-trust` → `docker pull`) — `--disable-content-trust` parses as `*ast.ConcatenatedExpression` (token literal is just the leading `--`); the token-strip helper's bytes-match check fails because the token offset doesn't span the full flag literal. Fix needs a different scanner that consumes the concatenated parts. Demoted; left at `Fix: nil`.

## Walk-order fallout

Two existing integration tests updated their expected output (no fixture changes — only the `want` strings):
- `TestFixIntegration_ZC1227_CurlAddFail`: `curl -f https://…` → `curl -L -f https://…` (ZC1255 arrives ahead of ZC1227 in walk order).
- `TestFixIntegration_ZC1241_XargsAddNullSep`: `xargs -0 rm` → `xargs -r -0 rm` (ZC1773 runs in the same pass).

Both follow the registry's first-edit-wins policy on overlapping rewrites.

## Test plan

- [x] `go test ./...` — all packages pass.
- [x] `golangci-lint run --timeout=5m ./...` — zero issues (v2.11.4 against the v2 schema landed in #1239).
- [x] KATAS.md regenerated.
- [x] README auto-fix badge: 90 → 102.
- [x] ROADMAP auto-fixer coverage: 90/1000 → 102/1000 (9.0% → 10.2%).
- [x] CHANGELOG `[Unreleased]` records every new fix and the walk-order side-effects.
- [x] 11 new integration tests added in `pkg/fix/integration_test.go`.
