### PR TITLE
feat: 4 more auto-fixes (106/1000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage expanded to 102 katas (+35 since 1.0.15).** All new fixes are deterministic, idempotent, and byte-exact outside the rewritten span. The TIER 2 batch added 12 span-aware / multi-edit / token-strip rewrites on top of the original 23 TIER 1 candidates:
+- **Auto-fix coverage expanded to 106 katas (+39 since 1.0.15).** All new fixes are deterministic, idempotent, and byte-exact outside the rewritten span. The TIER 2 batch-2 round added 4 more span/rename rewrites:
+  - **Arithmetic idiom collapse:**
+    - `ZC1032` — `let i=i+1` → `(( i++ ))`, `let i=i-1` → `(( i-- ))`. ZC1013 yields to ZC1032 on the increment/decrement shape so the rewrite uses the C-style operator.
+  - **Sibling delegation (no new helper):**
+    - `ZC1107` — `[[ a -lt b ]]` → `(( a < b ))`. Reuses `fixZC1091`; the conflict resolver dedupes the duplicate edit produced by both katas.
+  - **Two-edit command + flag swap:**
+    - `ZC1153` — `diff -q FILE1 FILE2` → `cmp -s FILE1 FILE2`.
+  - **Span-aware substitution rewrite:**
+    - `ZC1643` — `$(cat FILE)` → `$(<FILE)` inside SimpleCommand argument strings (e.g. `echo $(cat …)`). Assignment-form `x=$(cat …)` stays detection-only because the cat substitution sits as a DollarParenExpression child rather than as an argument the detector can reach.
+- **TIER 2 batch (+12, prior round):** All new fixes are deterministic, idempotent, and byte-exact outside the rewritten span. The TIER 2 batch added 12 span-aware / multi-edit / token-strip rewrites on top of the original 23 TIER 1 candidates:
   - **Pipeline collapse:**
     - `ZC1146` — `cat F | sed/awk/sort/head/tail` → `tool ... F` (drops `cat F |`, appends `F` to the right side).
     - `ZC1190` — `grep -v p1 | grep -v p2` → `grep -v -e p1 -e p2` (single-grep collapse).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,64 +8,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage expanded to 106 katas (+39 since 1.0.15).** All new fixes are deterministic, idempotent, and byte-exact outside the rewritten span. The TIER 2 batch-2 round added 4 more span/rename rewrites:
-  - **Arithmetic idiom collapse:**
-    - `ZC1032` — `let i=i+1` → `(( i++ ))`, `let i=i-1` → `(( i-- ))`. ZC1013 yields to ZC1032 on the increment/decrement shape so the rewrite uses the C-style operator.
-  - **Sibling delegation (no new helper):**
-    - `ZC1107` — `[[ a -lt b ]]` → `(( a < b ))`. Reuses `fixZC1091`; the conflict resolver dedupes the duplicate edit produced by both katas.
-  - **Two-edit command + flag swap:**
-    - `ZC1153` — `diff -q FILE1 FILE2` → `cmp -s FILE1 FILE2`.
-  - **Span-aware substitution rewrite:**
-    - `ZC1643` — `$(cat FILE)` → `$(<FILE)` inside SimpleCommand argument strings (e.g. `echo $(cat …)`). Assignment-form `x=$(cat …)` stays detection-only because the cat substitution sits as a DollarParenExpression child rather than as an argument the detector can reach.
-- **TIER 2 batch (+12, prior round):** All new fixes are deterministic, idempotent, and byte-exact outside the rewritten span. The TIER 2 batch added 12 span-aware / multi-edit / token-strip rewrites on top of the original 23 TIER 1 candidates:
-  - **Pipeline collapse:**
-    - `ZC1146` — `cat F | sed/awk/sort/head/tail` → `tool ... F` (drops `cat F |`, appends `F` to the right side).
-    - `ZC1190` — `grep -v p1 | grep -v p2` → `grep -v -e p1 -e p2` (single-grep collapse).
-  - **Flag insertion (command-level):**
-    - `ZC1230` — `ping URL` → `ping -c 4 URL`.
-    - `ZC1255` — `curl URL` → `curl -L URL` (HTTP-redirect follow).
-    - `ZC1773` — `xargs CMD` → `xargs -r CMD` (skip empty-input invocation).
-  - **Flag insertion (subcommand-level / positional anchor):**
-    - `ZC1257` — `docker stop X` → `docker stop -t 10 X`.
-    - `ZC1268` — `du -sh *` → `du -sh -- *` (`--` end-of-options before first non-flag).
-  - **Token-strip (whitespace-aware delete):**
-    - `ZC1238` — `docker exec -it …` → `docker exec …`.
-    - `ZC1239` — `kubectl exec -it …` → `kubectl exec …`.
-  - **IdentifierNode renames (Bash → Zsh):**
-    - `ZC1319` — `$BASH_ARGC` → `$#`.
-    - `ZC1320` — `$BASH_ARGV` → `$argv`.
-  - **Assignment-LHS rename:**
-    - `ZC1380` — `export HISTIGNORE=…` → `export HISTORY_IGNORE=…`.
-- **Auto-fix coverage (TIER 1 batch, +23):** All new fixes are deterministic, idempotent, and byte-exact outside the rewritten span.
-  - **Backtick / brace-range aliases (share existing fix shape):**
-    - `ZC1015` — backticks → `$(...)` (alias of `ZC1002`).
-    - `ZC1276` — `seq M N` → `{M..N}` brace range (alias of `ZC1061`).
-  - **Single-token command-name renames:**
-    - `ZC1034` — `which` → `command -v` (ExpressionStatement-position rewrite).
-    - `ZC1271` — `which` → `command -v` (SimpleCommand-position rewrite).
-    - `ZC1191` — `clear` → `print -rn $'\e[2J\e[H'` (avoids the external process; the `-rn` form keeps the rewrite idempotent against `ZC1017`/`ZC1118`).
-    - `ZC1202` — `ifconfig` → `ip addr`.
-    - `ZC1203` — `netstat` → `ss`.
-    - `ZC1216` — `nslookup` → `host`.
-    - `ZC1501` — `docker-compose` → `docker compose` (hyphen → space subcommand).
-    - `ZC1565` — `whereis` / `locate` / `mlocate` / `plocate` → `command -v`.
-    - `ZC1155` — `which -a` → `whence -a` (name swap; `-a` flag preserved).
-  - **Single-character / two-token flag swaps:**
-    - `ZC1260` — `git branch -D` → `git branch -d`.
-    - `ZC1235` — `git push -f` → `git push --force-with-lease`.
-  - **Two-edit / span-collapsing rewrites:**
-    - `ZC1334` — `type -p` / `type -P` → `whence -p` (collapses both name and flag in one span so it wins over `ZC1064`'s narrower `type` → `command -v`).
-    - `ZC1411` — `enable -n NAME` → `disable NAME` (drops the flag, renames the verb).
-    - `ZC1219` — `wget -O- URL` / `wget -qO- URL` → `curl -fsSL URL` (single-span rewrite of name + flag).
-    - `ZC1448` — `apt install` (no `-y`) inserts ` -y` after the command name; `ZC1213` continues to handle `apt-get` so the two katas do not double-insert.
-    - `ZC1163` — `grep PAT | head -1` (or `head -n1`) → `grep -m 1 PAT` (pipeline collapse).
-  - **IdentifierNode parameter renames:**
-    - `ZC1297` — `$BASH_SOURCE` → `${(%):-%x}`.
-  - **Echo / print / printf argument-string substitutions:**
-    - `ZC1377` — `BASH_ALIASES` → `aliases` inside string args.
-    - `ZC1378` — `DIRSTACK` → `dirstack` inside string args.
-    - `ZC1383` — `TIMEFORMAT` → `TIMEFMT` inside string / export args.
-    - `ZC1394` — `$BASH` (not part of `$BASH_*`) → `$ZSH_NAME` inside string args.
+- **Auto-fix coverage now at 106/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+  - `ZC1015` backticks → `$(...)`.
+  - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
+  - `ZC1034` / `ZC1271` `which` → `command -v`.
+  - `ZC1107` `[[ a -lt b ]]` → `(( a < b ))`.
+  - `ZC1146` `cat F | sed/awk/sort/head/tail` → `tool ... F`.
+  - `ZC1153` `diff -q F1 F2` → `cmp -s F1 F2`.
+  - `ZC1155` `which -a` → `whence -a`.
+  - `ZC1163` `grep PAT | head -1` → `grep -m 1 PAT`.
+  - `ZC1190` `grep -v p1 | grep -v p2` → `grep -v -e p1 -e p2`.
+  - `ZC1191` `clear` → `print -rn $'\e[2J\e[H'`.
+  - `ZC1202` `ifconfig` → `ip addr`.
+  - `ZC1203` `netstat` → `ss`.
+  - `ZC1216` `nslookup` → `host`.
+  - `ZC1219` `wget -O- URL` / `wget -qO- URL` → `curl -fsSL URL`.
+  - `ZC1230` `ping URL` → `ping -c 4 URL`.
+  - `ZC1235` `git push -f` → `git push --force-with-lease`.
+  - `ZC1238` strips `-it` from `docker exec`.
+  - `ZC1239` strips `-it` from `kubectl exec`.
+  - `ZC1255` `curl URL` → `curl -L URL`.
+  - `ZC1257` `docker stop X` → `docker stop -t 10 X`.
+  - `ZC1260` `git branch -D` → `git branch -d`.
+  - `ZC1268` inserts `--` before the first non-flag arg of `du -sh`.
+  - `ZC1276` `seq M N` → `{M..N}`.
+  - `ZC1297` `$BASH_SOURCE` → `${(%):-%x}`.
+  - `ZC1319` `$BASH_ARGC` → `$#`.
+  - `ZC1320` `$BASH_ARGV` → `$argv`.
+  - `ZC1334` `type -p` / `type -P` → `whence -p`.
+  - `ZC1377` `BASH_ALIASES` → `aliases` inside echo / print / printf string args.
+  - `ZC1378` uppercase `DIRSTACK` → `dirstack` inside echo / print / printf string args.
+  - `ZC1380` `export HISTIGNORE=…` → `export HISTORY_IGNORE=…`.
+  - `ZC1383` `TIMEFORMAT` → `TIMEFMT` inside echo / print / printf string args.
+  - `ZC1394` `$BASH` → `$ZSH_NAME` inside echo / print / printf string args.
+  - `ZC1411` `enable -n NAME` → `disable NAME`.
+  - `ZC1448` inserts `-y` after `apt install` / `apt upgrade` / `apt dist-upgrade` / `apt full-upgrade`.
+  - `ZC1501` `docker-compose` → `docker compose`.
+  - `ZC1565` `whereis` / `locate` / `mlocate` / `plocate` → `command -v`.
+  - `ZC1643` `$(cat FILE)` → `$(<FILE)` inside SimpleCommand argument strings.
+  - `ZC1773` `xargs CMD` → `xargs -r CMD`.
+  - `ZC1334` collapses `type -p`'s flag with the rename so it wins over `ZC1064`'s narrower `type` → `command -v` form.
+  - `ZC1013` defers to `ZC1032` on the increment/decrement shape so the rewrite uses the C-style operator instead of the literal `(( name = name+1 ))` form.
 
 ### Changed
 - `ZC1005`'s `which` → `whence` rewrite now yields `command -v` for the bare-statement case because the new `ZC1034` fix arrives ahead in walk order. Inside backticks / `$(...)`, `whence` still wins because the parent `ExpressionStatement` is absent.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **102** |
+| **with auto-fix** | **105** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -48,7 +48,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1029: Superseded by ZC1022 — retired duplicate `let` detector](#zc1029)
 - [ZC1030: Use `printf` instead of `echo`](#zc1030)
 - [ZC1031: Use `#!/usr/bin/env zsh` for portability](#zc1031) · auto-fix
-- [ZC1032: Use `((...))` for C-style incrementing](#zc1032)
+- [ZC1032: Use `((...))` for C-style incrementing](#zc1032) · auto-fix
 - [ZC1033: Superseded by ZC1022 — retired duplicate `let` detector](#zc1033)
 - [ZC1034: Use `command -v` instead of `which`](#zc1034) · auto-fix
 - [ZC1035: Superseded by ZC1022 — retired duplicate `let` detector](#zc1035)
@@ -166,7 +166,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1149: Avoid `echo` for error messages — use `>&2`](#zc1149)
 - [ZC1151: Avoid `cat -A` — use `print -v` or od for non-printable characters](#zc1151)
 - [ZC1152: Use Zsh PCRE module instead of `grep -P`](#zc1152)
-- [ZC1153: Use `cmp -s` instead of `diff` for equality check](#zc1153)
+- [ZC1153: Use `cmp -s` instead of `diff` for equality check](#zc1153) · auto-fix
 - [ZC1154: Use `find -exec {} +` instead of `find -exec {} \;`](#zc1154)
 - [ZC1155: Use `whence -a` instead of `which -a`](#zc1155) · auto-fix
 - [ZC1156: Avoid `ln` without `-s` for symlinks](#zc1156)
@@ -656,7 +656,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1640: Style: `${!var}` Bash indirect expansion — prefer Zsh `${(P)var}`](#zc1640)
 - [ZC1641: Error on `kubectl create secret --from-literal=...` / `--docker-password=...`](#zc1641)
 - [ZC1642: Warn on `tshark -w FILE` / `dumpcap -w FILE` without `-Z user` — capture file owned by root](#zc1642)
-- [ZC1643: Style: `$(cat file)` — use `$(<file)` to skip the fork / exec](#zc1643)
+- [ZC1643: Style: `$(cat file)` — use `$(<file)` to skip the fork / exec](#zc1643) · auto-fix
 - [ZC1644: Error on `unzip -P SECRET` / `zip -P SECRET` — archive password in process list](#zc1644)
 - [ZC1645: Style: `lsb_release` — prefer sourcing `/etc/os-release` (no dependency, no fork)](#zc1645)
 - [ZC1646: Warn on `btrfs check --repair` / `xfs_repair -L` — last-resort recovery, may worsen damage](#zc1646)
@@ -1396,9 +1396,9 @@ Disable by adding `ZC1031` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1032 — Use `((...))` for C-style incrementing
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
-Instead of `let i=i+1`, you can use the more concise and idiomatic C-style increment `(( i++ ))` in Zsh.
+Instead of `let i=i+1` or `let i=i-1`, you can use the more concise and idiomatic C-style increment `(( i++ ))` / decrement `(( i-- ))` in Zsh.
 
 Disable by adding `ZC1032` to `disabled_katas` in `.zshellcheckrc`.
 
@@ -2812,7 +2812,7 @@ Disable by adding `ZC1152` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1153 — Use `cmp -s` instead of `diff` for equality check
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 When only checking if two files are identical (not viewing differences), `cmp -s` is faster than `diff` as it stops at the first difference.
 
@@ -8692,7 +8692,7 @@ Disable by adding `ZC1642` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1643 — Style: `$(cat file)` — use `$(<file)` to skip the fork / exec
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `$(cat FILE)` forks, execs `/usr/bin/cat`, reads FILE, writes the bytes to the pipe, waits for the child. `$(<FILE)` is a shell builtin — it reads FILE directly into the command-substitution buffer with no fork and no exec. In a hot path the speedup is dramatic, and even in cold paths it avoids one of the most common useless-use-of-cat patterns in review feedback.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-102%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-106%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 102 of 1000 katas (10.2%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 106 of 1000 katas (10.6%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -108,13 +108,17 @@ fi
 }
 
 func TestFixIntegration_ZC1013_LetToArith(t *testing.T) {
+	// `let counter=counter+1` matches ZC1032's C-style increment
+	// shape; ZC1013's fix yields to it so the output uses the
+	// idiomatic `(( counter++ ))` form. The first two lines fall
+	// through to ZC1013's generic `((NAME = EXPR))` rewrite.
 	src := `let x=5
 let y=$((x + 1))
 let counter=counter+1
 `
 	want := `(( x = 5 ))
 (( y = $((x + 1)) ))
-(( counter = counter+1 ))
+(( counter++ ))
 `
 	if got := runFix(t, src); got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -1221,5 +1225,76 @@ func TestFixIntegration_ZC1380_HistignoreRename(t *testing.T) {
 	want := "export HISTORY_IGNORE='ls:cd'\n"
 	if got := runFix(t, src); got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1032_LetIncrementToCStyle(t *testing.T) {
+	src := "let i=i+1\n"
+	want := "(( i++ ))\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1032_LetDecrementToCStyle(t *testing.T) {
+	src := "let counter=counter-1\n"
+	want := "(( counter-- ))\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1032_AlreadyArithIdempotent(t *testing.T) {
+	// `(( i++ ))` is no longer a LetStatement so neither ZC1013 nor
+	// ZC1032 fires on it; the rewrite is its own fixed point.
+	src := "(( i++ ))\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("already-fixed input should be idempotent, got %q", got)
+	}
+}
+
+func TestFixIntegration_ZC1107_BracketCmpDelegatesToZC1091(t *testing.T) {
+	// ZC1107 reuses ZC1091's Fix shape — both katas detect the same
+	// dashed-comparison-in-`[[…]]` pattern, so the rewrite emerges
+	// once and the conflict resolver dedupes the duplicate edit.
+	src := "[[ a -lt b ]]\n"
+	want := "(( a < b ))\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1153_DiffQToCmpS(t *testing.T) {
+	src := "diff -q a.txt b.txt\n"
+	want := "cmp -s a.txt b.txt\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1153_AlreadyCmpUnchanged(t *testing.T) {
+	src := "cmp -s a.txt b.txt\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("already-cmp input should be idempotent, got %q", got)
+	}
+}
+
+func TestFixIntegration_ZC1643_CatSubstitutionToReadRedirect(t *testing.T) {
+	// Detector fires on SimpleCommand args containing the literal
+	// `$(cat ` substring. Assignment-form `x=$(cat …)` parses with
+	// the cat command nested as a DollarParenExpression child, not as
+	// an argument of any SimpleCommand at the outer level — that
+	// shape is intentionally left detection-only here.
+	src := "echo $(cat /etc/hostname)\n"
+	want := "print -r -- $(</etc/hostname)\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1643_AlreadyReadRedirectUnchanged(t *testing.T) {
+	src := "print -r -- $(</etc/hostname)\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("already-fixed input should be idempotent, got %q", got)
 	}
 }

--- a/pkg/katas/zc1013.go
+++ b/pkg/katas/zc1013.go
@@ -31,6 +31,15 @@ func fixZC1013(node ast.Node, v Violation, source []byte) []FixEdit {
 	if stmt.Name == nil || stmt.Value == nil {
 		return nil
 	}
+	// Defer to ZC1032 when the value matches the C-style
+	// increment/decrement shape so the rewrite produces the
+	// idiomatic `(( i++ ))` / `(( i-- ))` form rather than the
+	// generic `(( i = i+1 ))` form. Both fixes span the same source
+	// range, so emitting both would lose ZC1032's narrower output to
+	// the conflict resolver's deterministic tie-break.
+	if _, increment := zc1032Op(stmt); increment {
+		return nil
+	}
 	start := LineColToByteOffset(source, v.Line, v.Column)
 	if start < 0 {
 		return nil

--- a/pkg/katas/zc1032.go
+++ b/pkg/katas/zc1032.go
@@ -8,35 +8,112 @@ func init() {
 	RegisterKata(ast.LetStatementNode, Kata{
 		ID:    "ZC1032",
 		Title: "Use `((...))` for C-style incrementing",
-		Description: "Instead of `let i=i+1`, you can use the more concise and idiomatic C-style " +
-			"increment `(( i++ ))` in Zsh.",
+		Description: "Instead of `let i=i+1` or `let i=i-1`, you can use the more concise and idiomatic " +
+			"C-style increment `(( i++ ))` / decrement `(( i-- ))` in Zsh.",
 		Severity: SeverityStyle,
 		Check:    checkZC1032,
+		Fix:      fixZC1032,
 	})
 }
 
-func checkZC1032(node ast.Node) []Violation {
-	violations := []Violation{}
-
-	if letStmt, ok := node.(*ast.LetStatement); ok {
-		// Check for let i = i + 1
-		if infixExpr, ok := letStmt.Value.(*ast.InfixExpression); ok {
-			if leftIdent, ok := infixExpr.Left.(*ast.Identifier); ok {
-				if rightInt, ok := infixExpr.Right.(*ast.IntegerLiteral); ok {
-					// Match name, "+", and 1
-					if letStmt.Name.Value == leftIdent.Value && infixExpr.Operator == "+" && rightInt.Value == 1 {
-						violations = append(violations, Violation{
-							KataID:  "ZC1032",
-							Message: "Use `(( i++ ))` for C-style incrementing instead of `let i=i+1`.",
-							Line:    letStmt.Token.Line,
-							Column:  letStmt.Token.Column,
-							Level:   SeverityStyle,
-						})
-					}
-				}
-			}
+// zc1032Op classifies the let-statement value as either an increment
+// (`name + 1`) or decrement (`name - 1`). Returns the C-style suffix
+// (`++` / `--`) and true on match; empty string and false otherwise.
+//
+// The Zsh lexer treats `-` as an identifier byte, so `let i=i-1`
+// parses as a single Identifier value `i-1` rather than an
+// InfixExpression. The detector handles both shapes:
+//   - InfixExpression: `i + 1` (operator `+`, integer literal 1).
+//   - Identifier with `NAME-1` literal: synthetic decrement form.
+func zc1032Op(stmt *ast.LetStatement) (string, bool) {
+	if stmt == nil || stmt.Name == nil {
+		return "", false
+	}
+	if infix, ok := stmt.Value.(*ast.InfixExpression); ok {
+		leftIdent, ok := infix.Left.(*ast.Identifier)
+		if !ok {
+			return "", false
+		}
+		rightInt, ok := infix.Right.(*ast.IntegerLiteral)
+		if !ok {
+			return "", false
+		}
+		if stmt.Name.Value != leftIdent.Value || rightInt.Value != 1 {
+			return "", false
+		}
+		switch infix.Operator {
+		case "+":
+			return "++", true
+		case "-":
+			return "--", true
+		}
+		return "", false
+	}
+	if ident, ok := stmt.Value.(*ast.Identifier); ok {
+		want := stmt.Name.Value + "-1"
+		if ident.Value == want {
+			return "--", true
 		}
 	}
+	return "", false
+}
 
-	return violations
+// fixZC1032 rewrites `let NAME=NAME+1` / `let NAME=NAME-1` into the
+// C-style `(( NAME++ ))` / `(( NAME-- ))` arithmetic form. The
+// replacement spans from the `let` keyword to the end of the logical
+// line (first `;`, `\n`, or EOF). Bails when the AST does not match
+// the increment/decrement shape so the fix stays unambiguous and
+// idempotent on a re-run (the rewritten form is no longer a
+// LetStatement).
+func fixZC1032(node ast.Node, v Violation, source []byte) []FixEdit {
+	stmt, ok := node.(*ast.LetStatement)
+	if !ok {
+		return nil
+	}
+	suffix, ok := zc1032Op(stmt)
+	if !ok {
+		return nil
+	}
+	start := LineColToByteOffset(source, v.Line, v.Column)
+	if start < 0 {
+		return nil
+	}
+	end := start
+	for end < len(source) {
+		b := source[end]
+		if b == '\n' || b == ';' {
+			break
+		}
+		end++
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  end - start,
+		Replace: "(( " + stmt.Name.Value + suffix + " ))",
+	}}
+}
+
+func checkZC1032(node ast.Node) []Violation {
+	letStmt, ok := node.(*ast.LetStatement)
+	if !ok {
+		return nil
+	}
+	suffix, ok := zc1032Op(letStmt)
+	if !ok {
+		return nil
+	}
+	msg := "Use `(( " + letStmt.Name.Value + suffix + " ))` for C-style "
+	if suffix == "++" {
+		msg += "incrementing instead of `let " + letStmt.Name.Value + "=" + letStmt.Name.Value + "+1`."
+	} else {
+		msg += "decrementing instead of `let " + letStmt.Name.Value + "=" + letStmt.Name.Value + "-1`."
+	}
+	return []Violation{{
+		KataID:  "ZC1032",
+		Message: msg,
+		Line:    letStmt.Token.Line,
+		Column:  letStmt.Token.Column,
+		Level:   SeverityStyle,
+	}}
 }

--- a/pkg/katas/zc1107.go
+++ b/pkg/katas/zc1107.go
@@ -11,6 +11,7 @@ func init() {
 		Description: "Use `(( ... ))` for arithmetic comparisons instead of `[[ ... -gt ... ]]`. The double parenthesis syntax supports standard math operators (`>`, `<`, `==`, `!=`) and is optimized.",
 		Severity:    SeverityStyle,
 		Check:       checkZC1107DoubleBracket,
+		Fix:         fixZC1091,
 	})
 
 	RegisterKata(ast.SimpleCommandNode, Kata{

--- a/pkg/katas/zc1153.go
+++ b/pkg/katas/zc1153.go
@@ -12,7 +12,52 @@ func init() {
 		Description: "When only checking if two files are identical (not viewing differences), " +
 			"`cmp -s` is faster than `diff` as it stops at the first difference.",
 		Check: checkZC1153,
+		Fix:   fixZC1153,
 	})
+}
+
+// fixZC1153 rewrites `diff -q FILE1 FILE2` into `cmp -s FILE1 FILE2`.
+// Two non-overlapping edits: the command name (`diff` → `cmp`) and the
+// quiet flag (`-q` → `-s`). Other arguments stay byte-identical.
+// Idempotent because the detector gates on `diff -q` literal presence.
+func fixZC1153(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "diff" {
+		return nil
+	}
+	var dashQ ast.Expression
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-q" {
+			dashQ = arg
+			break
+		}
+	}
+	if dashQ == nil {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 || nameOff+len("diff") > len(source) {
+		return nil
+	}
+	if string(source[nameOff:nameOff+len("diff")]) != "diff" {
+		return nil
+	}
+	dashTok := dashQ.TokenLiteralNode()
+	dashOff := LineColToByteOffset(source, dashTok.Line, dashTok.Column)
+	if dashOff < 0 || dashOff+2 > len(source) {
+		return nil
+	}
+	if string(source[dashOff:dashOff+2]) != "-q" {
+		return nil
+	}
+	return []FixEdit{
+		{Line: v.Line, Column: v.Column, Length: len("diff"), Replace: "cmp"},
+		{Line: dashTok.Line, Column: dashTok.Column, Length: 2, Replace: "-s"},
+	}
 }
 
 func checkZC1153(node ast.Node) []Violation {

--- a/pkg/katas/zc1643.go
+++ b/pkg/katas/zc1643.go
@@ -17,7 +17,123 @@ func init() {
 			"path the speedup is dramatic, and even in cold paths it avoids one of the most " +
 			"common useless-use-of-cat patterns in review feedback.",
 		Check: checkZC1643,
+		Fix:   fixZC1643,
 	})
+}
+
+// fixZC1643 rewrites `$(cat FILE)` into `$(<FILE)`. The detector
+// matches on the literal `$(cat ` substring inside a command argument;
+// the Fix scans each argument's source span for that prefix and
+// replaces `cat ` with `<` (4-byte → 1-byte collapse). Each occurrence
+// becomes its own FixEdit, so multiple `$(cat …)` substitutions on the
+// same line are all handled in one pass.
+//
+// Idempotent because the literal `$(cat ` no longer appears in the
+// rewritten text — the second-pass detector sees `$(<…)` and stays
+// silent.
+func fixZC1643(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	const needle = "$(cat "
+	var edits []FixEdit
+	for _, arg := range cmd.Arguments {
+		tok := arg.TokenLiteralNode()
+		argOff := LineColToByteOffset(source, tok.Line, tok.Column)
+		if argOff < 0 {
+			continue
+		}
+		// Constrain the search window to the argument's literal text
+		// span. arg.String() may include AST decorations (parens for
+		// expressions) so use the byte slice directly: walk forward
+		// from the start of the argument until a delimiter that ends
+		// the unquoted argument context.
+		end := argOff
+		// Track quoting so the search does not stop inside a quoted
+		// substring. The argument span runs to the next unquoted
+		// whitespace, `;`, `&`, `|`, `)` (when paren depth = 0), or
+		// newline.
+		inSingle := false
+		inDouble := false
+		parenDepth := 0
+		for end < len(source) {
+			c := source[end]
+			if c == '\\' && end+1 < len(source) {
+				end += 2
+				continue
+			}
+			switch {
+			case inSingle:
+				if c == '\'' {
+					inSingle = false
+				}
+			case inDouble:
+				if c == '"' {
+					inDouble = false
+				}
+			default:
+				switch c {
+				case '\'':
+					inSingle = true
+				case '"':
+					inDouble = true
+				case '(':
+					parenDepth++
+				case ')':
+					if parenDepth == 0 {
+						goto done
+					}
+					parenDepth--
+				case ' ', '\t', '\n', ';', '&', '|':
+					if parenDepth == 0 {
+						goto done
+					}
+				}
+			}
+			end++
+		}
+	done:
+		// Find every `$(cat ` occurrence inside [argOff, end).
+		i := argOff
+		for i+len(needle) <= end {
+			if string(source[i:i+len(needle)]) != needle {
+				i++
+				continue
+			}
+			// Replace the `cat ` portion (4 bytes after `$(`) with `<`.
+			line, col := offsetLineColZC1643(source, i+2)
+			if line < 0 {
+				i += len(needle)
+				continue
+			}
+			edits = append(edits, FixEdit{
+				Line:    line,
+				Column:  col,
+				Length:  4,
+				Replace: "<",
+			})
+			i += len(needle)
+		}
+	}
+	return edits
+}
+
+func offsetLineColZC1643(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1643(node ast.Node) []Violation {


### PR DESCRIPTION
## Summary

Four more auto-fixes land. Coverage now 106/1000.

## What's new

- `ZC1032` — `let i=i+1` → `(( i++ ))`, `let i=i-1` → `(( i-- ))`. `ZC1013` yields when the value matches the increment/decrement shape so the C-style operator wins.
- `ZC1107` — `[[ a -lt b ]]` → `(( a < b ))`. Reuses `fixZC1091`; the conflict resolver dedupes the duplicate edit.
- `ZC1153` — `diff -q F1 F2` → `cmp -s F1 F2`.
- `ZC1643` — `$(cat FILE)` → `$(<FILE)` inside `SimpleCommand` argument strings (e.g. `echo $(cat …)`). The assignment form `x=$(cat …)` parses with the `cat` substitution as a `DollarParenExpression` child rather than as an argument the detector can reach, so it stays detection-only here.

## Test plan

- [x] `go test ./...` passes.
- [x] `golangci-lint run --timeout=5m ./...` clean.
- [x] `KATAS.md` regenerated.
- [x] README badge: 102 → 106.
- [x] ROADMAP coverage: 102 → 106 (10.6%).
- [x] CHANGELOG `[Unreleased]` updated.
