### PR TITLE
feat(ZC1675): export -f / -n → typeset -fx / +x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 106/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 107/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
   - `ZC1034` / `ZC1271` `which` → `command -v`.
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1501` `docker-compose` → `docker compose`.
   - `ZC1565` `whereis` / `locate` / `mlocate` / `plocate` → `command -v`.
   - `ZC1643` `$(cat FILE)` → `$(<FILE)` inside SimpleCommand argument strings.
+  - `ZC1675` `export -f FUNC` → `typeset -fx FUNC`, `export -n VAR` → `typeset +x VAR`.
   - `ZC1773` `xargs CMD` → `xargs -r CMD`.
   - `ZC1334` collapses `type -p`'s flag with the rename so it wins over `ZC1064`'s narrower `type` → `command -v` form.
   - `ZC1013` defers to `ZC1032` on the increment/decrement shape so the rewrite uses the C-style operator instead of the literal `(( name = name+1 ))` form.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **105** |
+| **with auto-fix** | **106** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -688,7 +688,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1672: Info: `chcon` writes an ephemeral SELinux label — next `restorecon` wipes it](#zc1672)
 - [ZC1673: Style: `stty -echo` around `read` — prefer Zsh `read -s`](#zc1673)
 - [ZC1674: Warn on `docker/podman run --oom-kill-disable` or `--oom-score-adj <= -500`](#zc1674)
-- [ZC1675: Avoid Bash-only `export -f` / `export -n` — use Zsh `typeset -fx` / `typeset +x`](#zc1675)
+- [ZC1675: Avoid Bash-only `export -f` / `export -n` — use Zsh `typeset -fx` / `typeset +x`](#zc1675) · auto-fix
 - [ZC1676: Warn on `helm rollback --force` — recreates in-flight resources, corrupts rolling updates](#zc1676)
 - [ZC1677: Warn on `trap 'set -x' DEBUG` — xtrace on every command leaks secrets](#zc1677)
 - [ZC1678: Error on `borg init --encryption=none` — unencrypted backup repository](#zc1678)
@@ -9076,7 +9076,7 @@ Disable by adding `ZC1674` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1675 — Avoid Bash-only `export -f` / `export -n` — use Zsh `typeset -fx` / `typeset +x`
 
 **Severity:** `info`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `export -f FUNC` (export a function to child processes) and `export -n VAR` (strip the export flag while keeping the value) are Bash-only. Zsh's `export` ignores `-f` entirely and prints usage for `-n`, so scripts that depend on either silently break under Zsh. The Zsh equivalents are `typeset -fx FUNC` for function export (parameter-passing via `$FUNCTIONS` in a subshell) and `typeset +x VAR` to drop the export flag. Functions that must cross a subshell are usually better handled by `autoload -Uz` from an `fpath` directory than by serialisation.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-106%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-107%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 106 of 1000 katas (10.6%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 107 of 1000 katas (10.7%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1298,3 +1298,19 @@ func TestFixIntegration_ZC1643_AlreadyReadRedirectUnchanged(t *testing.T) {
 		t.Errorf("already-fixed input should be idempotent, got %q", got)
 	}
 }
+
+func TestFixIntegration_ZC1675_ExportFunctionFlag(t *testing.T) {
+	src := "export -f my_helper\n"
+	want := "typeset -fx my_helper\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1675_ExportStripFlag(t *testing.T) {
+	src := "export -n PATH\n"
+	want := "typeset +x PATH\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/katas/zc1675.go
+++ b/pkg/katas/zc1675.go
@@ -18,7 +18,63 @@ func init() {
 			"cross a subshell are usually better handled by `autoload -Uz` from an `fpath` " +
 			"directory than by serialisation.",
 		Check: checkZC1675,
+		Fix:   fixZC1675,
 	})
+}
+
+// fixZC1675 collapses `export -f` and `export -n` into the Zsh
+// equivalents `typeset -fx` and `typeset +x`. Single edit spans the
+// command name + flag together, mirroring fixZC1283's `set -o OPT`
+// → `setopt OPT` collapse.
+func fixZC1675(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "export" {
+		return nil
+	}
+	var flag ast.Expression
+	var replace string
+	for _, arg := range cmd.Arguments {
+		switch arg.String() {
+		case "-f":
+			flag = arg
+			replace = "typeset -fx"
+		case "-n":
+			flag = arg
+			replace = "typeset +x"
+		}
+		if flag != nil {
+			break
+		}
+	}
+	if flag == nil {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 || nameOff+len("export") > len(source) {
+		return nil
+	}
+	if string(source[nameOff:nameOff+len("export")]) != "export" {
+		return nil
+	}
+	flagTok := flag.TokenLiteralNode()
+	flagOff := LineColToByteOffset(source, flagTok.Line, flagTok.Column)
+	if flagOff < 0 || flagOff+2 > len(source) {
+		return nil
+	}
+	flagLit := string(source[flagOff : flagOff+2])
+	if flagLit != "-f" && flagLit != "-n" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  flagOff + 2 - nameOff,
+		Replace: replace,
+	}}
 }
 
 func checkZC1675(node ast.Node) []Violation {


### PR DESCRIPTION
Bash-only `export -f FUNC` collapses to `typeset -fx FUNC`, and `export -n VAR` collapses to `typeset +x VAR`. Single-edit span rewrite mirroring `fixZC1283`'s `set -o OPT` → `setopt OPT` shape. Detector is unchanged.

Coverage: 106 → 107.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 106 → 107
- [x] ROADMAP coverage: 106 → 107 (10.7%)
- [x] CHANGELOG `[Unreleased]` updated
