### PR TITLE
feat(ZC1273): grep PAT FILE /dev/null → grep -q PAT FILE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 107/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 108/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
   - `ZC1034` / `ZC1271` `which` → `command -v`.
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1257` `docker stop X` → `docker stop -t 10 X`.
   - `ZC1260` `git branch -D` → `git branch -d`.
   - `ZC1268` inserts `--` before the first non-flag arg of `du -sh`.
+  - `ZC1273` `grep PAT FILE /dev/null` → `grep -q PAT FILE` (insert `-q`, drop `/dev/null`).
   - `ZC1276` `seq M N` → `{M..N}`.
   - `ZC1297` `$BASH_SOURCE` → `${(%):-%x}`.
   - `ZC1319` `$BASH_ARGC` → `$#`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **106** |
+| **with auto-fix** | **107** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -286,7 +286,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1270: Use `mktemp` instead of hardcoded `/tmp` paths](#zc1270)
 - [ZC1271: Use `command -v` instead of `which` for command existence checks](#zc1271) · auto-fix
 - [ZC1272: Use `install -m` instead of separate `cp` and `chmod`](#zc1272)
-- [ZC1273: Use `grep -q` instead of redirecting grep output to `/dev/null`](#zc1273)
+- [ZC1273: Use `grep -q` instead of redirecting grep output to `/dev/null`](#zc1273) · auto-fix
 - [ZC1274: Use Zsh `${var:t}` instead of `basename`](#zc1274)
 - [ZC1275: Use Zsh `${var:h}` instead of `dirname`](#zc1275)
 - [ZC1276: Use Zsh `{start..end}` instead of `seq`](#zc1276) · auto-fix
@@ -4252,7 +4252,7 @@ Disable by adding `ZC1272` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1273 — Use `grep -q` instead of redirecting grep output to `/dev/null`
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `grep -q` suppresses output and exits on first match, which is faster and more idiomatic than piping or redirecting to `/dev/null`.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-107%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-108%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 107 of 1000 katas (10.7%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 108 of 1000 katas (10.8%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1314,3 +1314,11 @@ func TestFixIntegration_ZC1675_ExportStripFlag(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
+
+func TestFixIntegration_ZC1273_GrepDevNullToDashQ(t *testing.T) {
+	src := "grep PAT file /dev/null\n"
+	want := "grep -q PAT file\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/katas/zc1273.go
+++ b/pkg/katas/zc1273.go
@@ -12,7 +12,69 @@ func init() {
 		Description: "`grep -q` suppresses output and exits on first match, which is faster and more " +
 			"idiomatic than piping or redirecting to `/dev/null`.",
 		Check: checkZC1273,
+		Fix:   fixZC1273,
 	})
+}
+
+// fixZC1273 inserts ` -q` after `grep` and strips the trailing
+// `/dev/null` argument (including its leading whitespace). Two edits;
+// the detector already gates on the absence of `-q`, so the rewrite
+// is idempotent on a re-run.
+func fixZC1273(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "grep" {
+		return nil
+	}
+	var devNull ast.Expression
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "/dev/null" {
+			devNull = arg
+			break
+		}
+	}
+	if devNull == nil {
+		return nil
+	}
+	nameOff := LineColToByteOffset(source, v.Line, v.Column)
+	if nameOff < 0 || IdentLenAt(source, nameOff) != len("grep") {
+		return nil
+	}
+	insertAt := nameOff + len("grep")
+	insLine, insCol := offsetLineColZC1273(source, insertAt)
+	if insLine < 0 {
+		return nil
+	}
+	stripEdits := zc1238StripFlag(source, devNull, "/dev/null")
+	if stripEdits == nil {
+		return nil
+	}
+	return append([]FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: " -q",
+	}}, stripEdits...)
+}
+
+func offsetLineColZC1273(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1273(node ast.Node) []Violation {


### PR DESCRIPTION
`grep PAT FILE /dev/null` (the silent-grep-via-redirect pattern) collapses to `grep -q PAT FILE`. The fix inserts ` -q` after the command name and strips the trailing `/dev/null` argument with its leading whitespace; reuses the whitespace-aware token-strip helper from ZC1238. Detector unchanged.

Coverage: 107 → 108.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 107 → 108
- [x] ROADMAP coverage: 107 → 108 (10.8%)
- [x] CHANGELOG `[Unreleased]` updated
