### PR TITLE
feat(ZC1717): strip --disable-content-trust from docker pull/push/build/create/run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 108/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 109/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
   - `ZC1034` / `ZC1271` `which` → `command -v`.
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1565` `whereis` / `locate` / `mlocate` / `plocate` → `command -v`.
   - `ZC1643` `$(cat FILE)` → `$(<FILE)` inside SimpleCommand argument strings.
   - `ZC1675` `export -f FUNC` → `typeset -fx FUNC`, `export -n VAR` → `typeset +x VAR`.
+  - `ZC1717` strips `--disable-content-trust` from `docker pull` / `push` / `build` / `create` / `run`.
   - `ZC1773` `xargs CMD` → `xargs -r CMD`.
   - `ZC1334` collapses `type -p`'s flag with the rename so it wins over `ZC1064`'s narrower `type` → `command -v` form.
   - `ZC1013` defers to `ZC1032` on the increment/decrement shape so the rewrite uses the C-style operator instead of the literal `(( name = name+1 ))` form.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **107** |
+| **with auto-fix** | **108** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -730,7 +730,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1714: Error on `gh repo delete --yes` / `gh release delete --yes` — bypassed confirmation](#zc1714)
 - [ZC1715: Error on `read -p "prompt"` — Zsh `-p` reads from coprocess, not a prompt](#zc1715)
 - [ZC1716: Use Zsh `$CPUTYPE` / `$MACHTYPE` instead of `uname -m` / `-p`](#zc1716)
-- [ZC1717: Warn on `docker pull/push --disable-content-trust` — bypasses image signature checks](#zc1717)
+- [ZC1717: Warn on `docker pull/push --disable-content-trust` — bypasses image signature checks](#zc1717) · auto-fix
 - [ZC1718: Error on `gh secret set --body SECRET` / `-b SECRET` — secret in process list](#zc1718)
 - [ZC1719: Warn on `git filter-branch` — deprecated since Git 2.24, use `git filter-repo`](#zc1719)
 - [ZC1720: Use Zsh `$COLUMNS` / `$LINES` instead of `tput cols` / `tput lines`](#zc1720)
@@ -9580,7 +9580,7 @@ Disable by adding `ZC1716` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1717 — Warn on `docker pull/push --disable-content-trust` — bypasses image signature checks
 
 **Severity:** `warning`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 When `DOCKER_CONTENT_TRUST=1` is enforced on a host (or set via `/etc/docker/daemon.json`), Docker rejects unsigned image pulls and signs every push. The `--disable-content-trust` flag overrides that per command: a `pull` accepts a replaced or unsigned image into local storage, a `push` lands an unsigned tag in the registry where downstream pulls cannot verify provenance. Drop the flag and sign the artifact (`docker trust sign IMAGE:TAG`) instead, or scope the bypass with a tight Notary signer policy.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-108%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-109%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 108 of 1000 katas (10.8%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 109 of 1000 katas (10.9%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1322,3 +1322,11 @@ func TestFixIntegration_ZC1273_GrepDevNullToDashQ(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
+
+func TestFixIntegration_ZC1717_DockerPullStripDct(t *testing.T) {
+	src := "docker pull --disable-content-trust alpine\n"
+	want := "docker pull alpine\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/katas/zc1717.go
+++ b/pkg/katas/zc1717.go
@@ -17,7 +17,99 @@ func init() {
 			"sign the artifact (`docker trust sign IMAGE:TAG`) instead, or scope the bypass " +
 			"with a tight Notary signer policy.",
 		Check: checkZC1717,
+		Fix:   fixZC1717,
 	})
+}
+
+// fixZC1717 strips the `--disable-content-trust` flag from a `docker
+// {pull,push,build,create,run}` invocation. The argument parses as a
+// ConcatenatedExpression whose token literal is just the leading `--`,
+// so the whitespace-aware token-strip helper from ZC1238 can't span
+// the full literal on its own. Scan the source forward from the
+// argument's start offset for the literal flag bytes and delete the
+// span (plus the leading whitespace, so the surrounding source stays
+// byte-identical).
+func fixZC1717(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "docker" {
+		return nil
+	}
+	const flag = "--disable-content-trust"
+	sawSub := false
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if !sawSub {
+			switch v {
+			case "pull", "push", "build", "create", "run":
+				sawSub = true
+				continue
+			}
+		}
+		if !sawSub || v != flag {
+			continue
+		}
+		tok := arg.TokenLiteralNode()
+		anchor := LineColToByteOffset(source, tok.Line, tok.Column)
+		if anchor < 0 {
+			return nil
+		}
+		// The lexer reports `--` as a separate token, then the rest
+		// of the flag is concatenated into a ConcatenatedExpression.
+		// The token's column lands on the second `-` for the
+		// `DASHDASH` token type, so search a 2-byte window around the
+		// anchor for the full flag literal in source bytes.
+		off := -1
+		for _, delta := range []int{-1, 0, 1} {
+			cand := anchor + delta
+			if cand < 0 || cand+len(flag) > len(source) {
+				continue
+			}
+			if string(source[cand:cand+len(flag)]) == flag {
+				off = cand
+				break
+			}
+		}
+		if off < 0 {
+			return nil
+		}
+		start := off
+		for start > 0 && (source[start-1] == ' ' || source[start-1] == '\t') {
+			start--
+		}
+		end := off + len(flag)
+		startLine, startCol := offsetLineColZC1717(source, start)
+		if startLine < 0 {
+			return nil
+		}
+		return []FixEdit{{
+			Line:    startLine,
+			Column:  startCol,
+			Length:  end - start,
+			Replace: "",
+		}}
+	}
+	return nil
+}
+
+func offsetLineColZC1717(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1717(node ast.Node) []Violation {


### PR DESCRIPTION
`docker pull --disable-content-trust IMAGE` (and the `push` / `build` / `create` / `run` variants) drops the flag and leaves `docker {sub} IMAGE`. The detector previously demoted this kata because `--disable-content-trust` parses as a `ConcatenatedExpression` whose token literal is just the leading `--`; the new fix searches a 2-byte window around the token offset for the full literal in source bytes, then deletes the span plus its leading whitespace.

Coverage: 108 → 109.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 108 → 109
- [x] ROADMAP coverage: 108 → 109 (10.9%)
- [x] CHANGELOG `[Unreleased]` updated
