### PR TITLE
feat(ZC1512): service UNIT VERB → systemctl VERB UNIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 109/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 110/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
   - `ZC1034` / `ZC1271` `which` → `command -v`.
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1411` `enable -n NAME` → `disable NAME`.
   - `ZC1448` inserts `-y` after `apt install` / `apt upgrade` / `apt dist-upgrade` / `apt full-upgrade`.
   - `ZC1501` `docker-compose` → `docker compose`.
+  - `ZC1512` `service UNIT VERB` → `systemctl VERB UNIT` (rename + arg swap).
   - `ZC1565` `whereis` / `locate` / `mlocate` / `plocate` → `command -v`.
   - `ZC1643` `$(cat FILE)` → `$(<FILE)` inside SimpleCommand argument strings.
   - `ZC1675` `export -f FUNC` → `typeset -fx FUNC`, `export -n VAR` → `typeset +x VAR`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **108** |
+| **with auto-fix** | **109** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -525,7 +525,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1509: Warn on `trap '' TERM` / `trap - TERM` — ignores/resets fatal signal](#zc1509)
 - [ZC1510: Error on `auditctl -e 0` / `auditctl -D` — disables kernel audit logging](#zc1510)
 - [ZC1511: Error on `nmcli ... <wireless/vpn secret>` on command line](#zc1511)
-- [ZC1512: Style: `service <unit> <verb>` — use `systemctl <verb> <unit>` on systemd hosts](#zc1512)
+- [ZC1512: Style: `service <unit> <verb>` — use `systemctl <verb> <unit>` on systemd hosts](#zc1512) · auto-fix
 - [ZC1513: Style: `make install` without `DESTDIR=` — unmanaged system-wide install](#zc1513)
 - [ZC1514: Error on `useradd -p <hash>` / `usermod -p <hash>` — password hash on cmdline](#zc1514)
 - [ZC1515: Warn on `md5sum` / `sha1sum` for integrity check — collision-vulnerable](#zc1515)
@@ -7120,7 +7120,7 @@ Disable by adding `ZC1511` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1512 — Style: `service <unit> <verb>` — use `systemctl <verb> <unit>` on systemd hosts
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `service` is the SysV init compatibility wrapper. On a systemd-managed host (every mainstream distro since ~2016) it translates to `systemctl` anyway, but reverses argument order, loses `--user` scope, ignores unit templating, and can't restart sockets or timers. Prefer `systemctl start|stop|restart|reload <unit>` for consistency across scripts and interactive shells.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-109%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-110%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 109 of 1000 katas (10.9%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 110 of 1000 katas (11.0%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1330,3 +1330,19 @@ func TestFixIntegration_ZC1717_DockerPullStripDct(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
+
+func TestFixIntegration_ZC1512_ServiceToSystemctl(t *testing.T) {
+	src := "service nginx start\n"
+	want := "systemctl start nginx\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1512_RestartVerb(t *testing.T) {
+	src := "service postgresql restart\n"
+	want := "systemctl restart postgresql\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/katas/zc1512.go
+++ b/pkg/katas/zc1512.go
@@ -15,7 +15,70 @@ func init() {
 			"can't restart sockets or timers. Prefer `systemctl start|stop|restart|reload " +
 			"<unit>` for consistency across scripts and interactive shells.",
 		Check: checkZC1512,
+		Fix:   fixZC1512,
 	})
+}
+
+// fixZC1512 rewrites `service UNIT VERB` into `systemctl VERB UNIT`.
+// Three edits per match: rename `service` → `systemctl`, swap the
+// textual contents of the UNIT and VERB positions. Gated to simple
+// Identifier args so the swap stays byte-exact; concat-form units
+// (rare in practice) stay detection-only.
+func fixZC1512(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "service" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	unitIdent, ok := cmd.Arguments[0].(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	verbIdent, ok := cmd.Arguments[1].(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	unitTok := unitIdent.TokenLiteralNode()
+	verbTok := verbIdent.TokenLiteralNode()
+	unitOff := LineColToByteOffset(source, unitTok.Line, unitTok.Column)
+	verbOff := LineColToByteOffset(source, verbTok.Line, verbTok.Column)
+	if unitOff < 0 || verbOff < 0 {
+		return nil
+	}
+	if unitOff+len(unitIdent.Value) > len(source) ||
+		string(source[unitOff:unitOff+len(unitIdent.Value)]) != unitIdent.Value {
+		return nil
+	}
+	if verbOff+len(verbIdent.Value) > len(source) ||
+		string(source[verbOff:verbOff+len(verbIdent.Value)]) != verbIdent.Value {
+		return nil
+	}
+	return []FixEdit{
+		{
+			Line:    v.Line,
+			Column:  v.Column,
+			Length:  len("service"),
+			Replace: "systemctl",
+		},
+		{
+			Line:    unitTok.Line,
+			Column:  unitTok.Column,
+			Length:  len(unitIdent.Value),
+			Replace: verbIdent.Value,
+		},
+		{
+			Line:    verbTok.Line,
+			Column:  verbTok.Column,
+			Length:  len(verbIdent.Value),
+			Replace: unitIdent.Value,
+		},
+	}
 }
 
 func checkZC1512(node ast.Node) []Violation {


### PR DESCRIPTION
`service UNIT VERB` (the SysV init wrapper) collapses to the systemd-native `systemctl VERB UNIT`. Three edits per fire: rename the command name (7→9 bytes), swap the textual contents of the UNIT and VERB positions. Gated to simple `Identifier` arguments so the swap stays byte-exact; concat-form units stay detection-only.

Coverage: 109 → 110.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 109 → 110
- [x] ROADMAP coverage: 109 → 110 (11.0%)
- [x] CHANGELOG `[Unreleased]` updated
