### PR TITLE
feat(ZC1043): prepend local to unscoped function-body assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 111/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 112/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
+  - `ZC1043` prepends `local ` to unscoped function-body assignments.
   - `ZC1034` / `ZC1271` `which` → `command -v`.
   - `ZC1107` `[[ a -lt b ]]` → `(( a < b ))`.
   - `ZC1146` `cat F | sed/awk/sort/head/tail` → `tool ... F`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **110** |
+| **with auto-fix** | **111** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -59,7 +59,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1040: Use (N) nullglob qualifier for globs in loops](#zc1040) · auto-fix
 - [ZC1041: Do not use variables in printf format string](#zc1041)
 - [ZC1042: Use "$@" to iterate over arguments](#zc1042)
-- [ZC1043: Use `local` for variables in functions](#zc1043)
+- [ZC1043: Use `local` for variables in functions](#zc1043) · auto-fix
 - [ZC1044: Check for unchecked `cd` commands](#zc1044)
 - [ZC1045: Declare and assign separately to avoid masking return values](#zc1045)
 - [ZC1046: Avoid `eval`](#zc1046)
@@ -1528,7 +1528,7 @@ Disable by adding `ZC1042` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1043 — Use `local` for variables in functions
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 Variables defined in functions are global by default in Zsh. Use `local` to scope them to the function.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-111%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-112%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 111 of 1000 katas (11.1%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 112 of 1000 katas (11.2%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1358,3 +1358,30 @@ func TestFixIntegration_ZC1016_ReadSensitive(t *testing.T) {
 		t.Errorf("expected read with a flag and the variable, got %q", got)
 	}
 }
+
+func TestFixIntegration_ZC1043_LocalForFunctionVar(t *testing.T) {
+	src := `foo() {
+  bar=42
+  echo $bar
+}
+`
+	want := `foo() {
+  local bar=42
+  echo $bar
+}
+`
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1043_AlreadyLocal(t *testing.T) {
+	src := `foo() {
+  local bar=42
+  echo $bar
+}
+`
+	if got := runFix(t, src); got != src {
+		t.Errorf("already-local input should be idempotent, got %q", got)
+	}
+}

--- a/pkg/katas/zc1043.go
+++ b/pkg/katas/zc1043.go
@@ -12,7 +12,34 @@ func init() {
 			"Use `local` to scope them to the function.",
 		Severity: SeverityStyle,
 		Check:    checkZC1043,
+		Fix:      fixZC1043,
 	})
+}
+
+// fixZC1043 prepends `local ` to the unscoped assignment the detector
+// flagged. The violation's Line/Column points at the assignment LHS;
+// inserting `local ` there yields `local NAME=value`. On re-run the
+// detector recognises `local …` as a declaration and skips the line,
+// so the rewrite is idempotent.
+func fixZC1043(_ ast.Node, v Violation, source []byte) []FixEdit {
+	off := LineColToByteOffset(source, v.Line, v.Column)
+	if off < 0 || off >= len(source) {
+		return nil
+	}
+	// Defensive idempotency guard: refuse to insert if a declaration
+	// keyword already sits at the violation column.
+	for _, prefix := range []string{"local ", "typeset ", "declare ", "integer ", "float ", "readonly "} {
+		end := off + len(prefix)
+		if end <= len(source) && string(source[off:end]) == prefix {
+			return nil
+		}
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  0,
+		Replace: "local ",
+	}}
 }
 
 func checkZC1043(node ast.Node) []Violation {


### PR DESCRIPTION
Unscoped assignments inside a function body get `local ` prepended at the violation column. After the rewrite, `bar=42` becomes `local bar=42`, which the detector recognises as a declaration on a re-run. Defensive idempotency guard refuses to insert when the line already starts with `local` / `typeset` / `declare` / `integer` / `float` / `readonly`.

Coverage: 111 → 112.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 111 → 112
- [x] ROADMAP coverage: 111 → 112 (11.2%)
- [x] CHANGELOG `[Unreleased]` updated
