### PR TITLE
feat(ZC1637): readonly NAME=value → typeset -r NAME=value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 112/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 113/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1501` `docker-compose` → `docker compose`.
   - `ZC1512` `service UNIT VERB` → `systemctl VERB UNIT` (rename + arg swap).
   - `ZC1565` `whereis` / `locate` / `mlocate` / `plocate` → `command -v`.
+  - `ZC1637` `readonly NAME=value` → `typeset -r NAME=value`.
   - `ZC1643` `$(cat FILE)` → `$(<FILE)` inside SimpleCommand argument strings.
   - `ZC1675` `export -f FUNC` → `typeset -fx FUNC`, `export -n VAR` → `typeset +x VAR`.
   - `ZC1717` strips `--disable-content-trust` from `docker pull` / `push` / `build` / `create` / `run`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **111** |
+| **with auto-fix** | **112** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -650,7 +650,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1634: Warn on `umask NNN` that fails to mask world-write — mask-inversion footgun](#zc1634)
 - [ZC1635: Error on `mysql -pSECRET` / `--password=SECRET` — password in process list](#zc1635)
 - [ZC1636: Warn on `virsh destroy DOMAIN` — force-stops VM (no graceful shutdown)](#zc1636)
-- [ZC1637: Style: prefer Zsh `typeset -r NAME=value` over POSIX `readonly NAME=value`](#zc1637)
+- [ZC1637: Style: prefer Zsh `typeset -r NAME=value` over POSIX `readonly NAME=value`](#zc1637) · auto-fix
 - [ZC1638: Error on `docker/podman build --build-arg SECRET=VALUE` — secret baked into image layer](#zc1638)
 - [ZC1639: Error on `curl -H 'Authorization: ...'` — credential header in process list](#zc1639)
 - [ZC1640: Style: `${!var}` Bash indirect expansion — prefer Zsh `${(P)var}`](#zc1640)
@@ -8620,7 +8620,7 @@ Disable by adding `ZC1636` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1637 — Style: prefer Zsh `typeset -r NAME=value` over POSIX `readonly NAME=value`
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 Both `readonly NAME` and `typeset -r NAME` create a read-only parameter. In Zsh the idiomatic form is `typeset -r` — it composes with other typeset flags (`-ir` for readonly integer, `-xr` for readonly export, `-gr` to pin a readonly global from inside a function). `readonly` works but reads as a Bash / POSIX-ism in a Zsh codebase.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-112%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-113%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 112 of 1000 katas (11.2%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 113 of 1000 katas (11.3%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1385,3 +1385,11 @@ func TestFixIntegration_ZC1043_AlreadyLocal(t *testing.T) {
 		t.Errorf("already-local input should be idempotent, got %q", got)
 	}
 }
+
+func TestFixIntegration_ZC1637_ReadonlyToTypesetR(t *testing.T) {
+	src := "readonly MAX=100\n"
+	want := "typeset -r MAX=100\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/katas/zc1637.go
+++ b/pkg/katas/zc1637.go
@@ -15,7 +15,36 @@ func init() {
 			"global from inside a function). `readonly` works but reads as a Bash / POSIX-ism " +
 			"in a Zsh codebase.",
 		Check: checkZC1637,
+		Fix:   fixZC1637,
 	})
+}
+
+// fixZC1637 rewrites the `readonly` command name to `typeset -r`.
+// Single-edit replacement at the violation column. Detector gates on
+// the bare command name match, so the rewrite is idempotent on a
+// re-run (the new line starts with `typeset` not `readonly`).
+func fixZC1637(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "readonly" {
+		return nil
+	}
+	off := LineColToByteOffset(source, v.Line, v.Column)
+	if off < 0 || off+len("readonly") > len(source) {
+		return nil
+	}
+	if string(source[off:off+len("readonly")]) != "readonly" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("readonly"),
+		Replace: "typeset -r",
+	}}
 }
 
 func checkZC1637(node ast.Node) []Violation {


### PR DESCRIPTION
`readonly NAME=value` becomes `typeset -r NAME=value`. Single-edit replacement at the command name. The detector gates on the bare `readonly` token, so the rewrite is idempotent — a re-run sees `typeset` and does nothing. A defensive byte-match guard refuses to insert if the source at the offset isn't literally `readonly`.

Coverage: 112 → 113.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 112 → 113
- [x] ROADMAP coverage: 112 → 113 (11.3%)
- [x] CHANGELOG `[Unreleased]` updated
