### PR TITLE
feat(ZC1252): cat /etc/{passwd,group,shadow} → getent {passwd,group,shadow}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 113/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 114/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1235` `git push -f` → `git push --force-with-lease`.
   - `ZC1238` strips `-it` from `docker exec`.
   - `ZC1239` strips `-it` from `kubectl exec`.
+  - `ZC1252` `cat /etc/{passwd,group,shadow}` → `getent {passwd,group,shadow}`.
   - `ZC1255` `curl URL` → `curl -L URL`.
   - `ZC1257` `docker stop X` → `docker stop -t 10 X`.
   - `ZC1260` `git branch -D` → `git branch -d`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **112** |
+| **with auto-fix** | **113** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -265,7 +265,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1249: Use `ssh-keygen -f` to specify key file in scripts](#zc1249)
 - [ZC1250: Use `gpg --batch` in scripts for non-interactive operation](#zc1250)
 - [ZC1251: Use `mount -o noexec,nosuid` for untrusted media](#zc1251)
-- [ZC1252: Use `getent passwd` instead of `cat /etc/passwd`](#zc1252)
+- [ZC1252: Use `getent passwd` instead of `cat /etc/passwd`](#zc1252) · auto-fix
 - [ZC1253: Use `docker build --no-cache` in CI for reproducible builds](#zc1253) · auto-fix
 - [ZC1254: Avoid `git commit --amend` in shared branches](#zc1254)
 - [ZC1255: Use `curl -L` to follow HTTP redirects](#zc1255) · auto-fix
@@ -4000,7 +4000,7 @@ Disable by adding `ZC1251` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1252 — Use `getent passwd` instead of `cat /etc/passwd`
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `cat /etc/passwd` misses users from LDAP, NIS, or SSSD sources. `getent passwd` queries NSS and returns all configured user databases.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-113%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-114%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 113 of 1000 katas (11.3%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 114 of 1000 katas (11.4%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1393,3 +1393,39 @@ func TestFixIntegration_ZC1637_ReadonlyToTypesetR(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
+
+func TestFixIntegration_ZC1252_CatPasswdToGetent(t *testing.T) {
+	src := "cat /etc/passwd\n"
+	want := "getent passwd\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1252_CatGroupToGetent(t *testing.T) {
+	src := "cat /etc/group\n"
+	want := "getent group\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1252_CatShadowToGetent(t *testing.T) {
+	src := "cat /etc/shadow\n"
+	want := "getent shadow\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
+	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
+	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would
+	// also fire on the lhs SimpleCommand, but the conflict resolver
+	// keeps the parent-pipe edit emitted first in walk order.
+	src := "cat /etc/group | head\n"
+	want := "head /etc/group\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/katas/zc1252.go
+++ b/pkg/katas/zc1252.go
@@ -12,7 +12,61 @@ func init() {
 		Description: "`cat /etc/passwd` misses users from LDAP, NIS, or SSSD sources. " +
 			"`getent passwd` queries NSS and returns all configured user databases.",
 		Check: checkZC1252,
+		Fix:   fixZC1252,
 	})
+}
+
+// fixZC1252 rewrites `cat /etc/{passwd,group,shadow}` to
+// `getent {passwd,group,shadow}`. Two edits per fire: the command
+// name and the file argument. Only fires when the cat command has
+// exactly one argument; piped or multi-file shapes are left alone
+// (ZC1146 handles `cat FILE | tool`, and multi-file `cat` doesn't
+// translate cleanly to `getent`). Idempotent: a re-run sees `getent`,
+// not `cat`, so the detector won't fire.
+func fixZC1252(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cat" {
+		return nil
+	}
+	if len(cmd.Arguments) != 1 {
+		return nil
+	}
+	arg := cmd.Arguments[0]
+	val := arg.String()
+	var dbName string
+	switch val {
+	case "/etc/passwd":
+		dbName = "passwd"
+	case "/etc/group":
+		dbName = "group"
+	case "/etc/shadow":
+		dbName = "shadow"
+	default:
+		return nil
+	}
+	catOff := LineColToByteOffset(source, v.Line, v.Column)
+	if catOff < 0 || catOff+len("cat") > len(source) {
+		return nil
+	}
+	if string(source[catOff:catOff+len("cat")]) != "cat" {
+		return nil
+	}
+	argTok := arg.TokenLiteralNode()
+	argOff := LineColToByteOffset(source, argTok.Line, argTok.Column)
+	if argOff < 0 || argOff+len(val) > len(source) {
+		return nil
+	}
+	if string(source[argOff:argOff+len(val)]) != val {
+		return nil
+	}
+	return []FixEdit{
+		{Line: v.Line, Column: v.Column, Length: len("cat"), Replace: "getent"},
+		{Line: argTok.Line, Column: argTok.Column, Length: len(val), Replace: dbName},
+	}
 }
 
 func checkZC1252(node ast.Node) []Violation {


### PR DESCRIPTION
`cat /etc/passwd` becomes `getent passwd` (and the same for `/etc/group`, `/etc/shadow`). Two edits per fire: rename the command and trim the file argument to its NSS database name. Only fires when `cat` has exactly one argument — multi-file `cat` and piped shapes are left alone, and ZC1146 already handles `cat FILE | tool`. Defensive byte-match guards on both edits.

Idempotent: a re-run sees `getent`, not `cat`, so the detector won't re-fire.

Coverage: 113 → 114.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 113 → 114
- [x] ROADMAP coverage: 113 → 114 (11.4%)
- [x] CHANGELOG `[Unreleased]` updated
