### PR TITLE
feat(ZC1172): read -a ARR → read -A ARR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 114/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 115/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1153` `diff -q F1 F2` → `cmp -s F1 F2`.
   - `ZC1155` `which -a` → `whence -a`.
   - `ZC1163` `grep PAT | head -1` → `grep -m 1 PAT`.
+  - `ZC1172` `read -a ARR` → `read -A ARR` (Zsh array form).
   - `ZC1190` `grep -v p1 | grep -v p2` → `grep -v -e p1 -e p2`.
   - `ZC1191` `clear` → `print -rn $'\e[2J\e[H'`.
   - `ZC1202` `ifconfig` → `ip addr`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **113** |
+| **with auto-fix** | **114** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -185,7 +185,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1169: Avoid `install` for simple copy+chmod — use `cp` then `chmod`](#zc1169)
 - [ZC1170: Avoid `pushd`/`popd` without `-q` flag](#zc1170) · auto-fix
 - [ZC1171: Use `print` instead of `echo -e` for escape sequences](#zc1171) · auto-fix
-- [ZC1172: Use `read -A` instead of Bash `read -a` for arrays](#zc1172)
+- [ZC1172: Use `read -A` instead of Bash `read -a` for arrays](#zc1172) · auto-fix
 - [ZC1173: Avoid `column` command — use Zsh `print -C` for columnar output](#zc1173)
 - [ZC1174: Use Zsh `${(j:delim:)}` instead of `paste -sd`](#zc1174)
 - [ZC1175: Avoid `tput` for simple ANSI colors — use Zsh `%F{color}`](#zc1175)
@@ -3040,7 +3040,7 @@ Disable by adding `ZC1171` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1172 — Use `read -A` instead of Bash `read -a` for arrays
 
 **Severity:** `info`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 Bash uses `read -a` to read into an array, but Zsh uses `read -A`. Using `-a` in Zsh reads into a scalar, not an array.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-114%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-115%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 114 of 1000 katas (11.4%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 115 of 1000 katas (11.5%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1418,6 +1418,23 @@ func TestFixIntegration_ZC1252_CatShadowToGetent(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1172_ReadDashAToDashCapA(t *testing.T) {
+	src := "read -a arr\n"
+	want := "read -r -A arr\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1172_AlreadyDashCapA(t *testing.T) {
+	src := "read -A arr\n"
+	want := "read -r -A arr\n"
+	// ZC1012 still inserts -r; the -a/-A swap is the no-op part.
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1172.go
+++ b/pkg/katas/zc1172.go
@@ -12,7 +12,44 @@ func init() {
 		Description: "Bash uses `read -a` to read into an array, but Zsh uses `read -A`. " +
 			"Using `-a` in Zsh reads into a scalar, not an array.",
 		Check: checkZC1172,
+		Fix:   fixZC1172,
 	})
+}
+
+// fixZC1172 swaps the lowercase `-a` flag for the uppercase `-A` Zsh
+// equivalent. Single-byte replacement at the argument's column.
+// Idempotent: a re-run sees `-A`, not `-a`, so the detector won't
+// fire. Defensive byte-match guard refuses to insert unless the
+// source at the offset is literally `-a`.
+func fixZC1172(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "read" {
+		return nil
+	}
+	for _, arg := range cmd.Arguments {
+		if arg.String() != "-a" {
+			continue
+		}
+		tok := arg.TokenLiteralNode()
+		off := LineColToByteOffset(source, tok.Line, tok.Column)
+		if off < 0 || off+2 > len(source) {
+			return nil
+		}
+		if string(source[off:off+2]) != "-a" {
+			return nil
+		}
+		return []FixEdit{{
+			Line:    tok.Line,
+			Column:  tok.Column,
+			Length:  2,
+			Replace: "-A",
+		}}
+	}
+	return nil
 }
 
 func checkZC1172(node ast.Node) []Violation {


### PR DESCRIPTION
`read -a ARR` becomes `read -A ARR`. Single-byte flag swap at the argument's column — Bash uses lowercase `-a` to read into an array, Zsh uses uppercase `-A`. Idempotent on a re-run because the detector keys on `-a` literal.

Coverage: 114 → 115.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 114 → 115
- [x] ROADMAP coverage: 114 → 115 (11.5%)
- [x] CHANGELOG `[Unreleased]` updated
