### PR TITLE
feat(ZC1413): hash -t cmd → whence -p cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 115/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 116/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1380` `export HISTIGNORE=…` → `export HISTORY_IGNORE=…`.
   - `ZC1383` `TIMEFORMAT` → `TIMEFMT` inside echo / print / printf string args.
   - `ZC1394` `$BASH` → `$ZSH_NAME` inside echo / print / printf string args.
+  - `ZC1413` `hash -t cmd` → `whence -p cmd` (rename + flag swap).
   - `ZC1411` `enable -n NAME` → `disable NAME`.
   - `ZC1448` inserts `-y` after `apt install` / `apt upgrade` / `apt dist-upgrade` / `apt full-upgrade`.
   - `ZC1501` `docker-compose` → `docker compose`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **114** |
+| **with auto-fix** | **115** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -426,7 +426,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1410: Avoid `compopt` — Bash programmable-completion modifier, not in Zsh](#zc1410)
 - [ZC1411: Use Zsh `disable` instead of Bash `enable -n` to hide builtins](#zc1411) · auto-fix
 - [ZC1412: Avoid `$COMPREPLY` — Bash completion output, use Zsh `compadd`](#zc1412)
-- [ZC1413: Use Zsh `whence -p cmd` instead of `hash -t cmd` for resolved path](#zc1413)
+- [ZC1413: Use Zsh `whence -p cmd` instead of `hash -t cmd` for resolved path](#zc1413) · auto-fix
 - [ZC1414: Beware `hash -d` — Bash deletes from hash table, Zsh defines named directory](#zc1414)
 - [ZC1415: Prefer Zsh `TRAPZERR` function over `trap 'cmd' ERR`](#zc1415)
 - [ZC1416: Prefer Zsh `preexec` hook over `trap 'cmd' DEBUG`](#zc1416)
@@ -5932,7 +5932,7 @@ Disable by adding `ZC1412` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1413 — Use Zsh `whence -p cmd` instead of `hash -t cmd` for resolved path
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 Bash's `hash -t cmd` prints the hashed path for `cmd` (or fails if not hashed). Zsh's `whence -p cmd` prints the PATH-resolved absolute path, whether hashed or not — more reliable and the native Zsh idiom.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-115%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-116%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 115 of 1000 katas (11.5%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 116 of 1000 katas (11.6%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1435,6 +1435,21 @@ func TestFixIntegration_ZC1172_AlreadyDashCapA(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1413_HashTToWhenceP(t *testing.T) {
+	src := "hash -t git\n"
+	want := "whence -p git\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1413_AlreadyWhenceP(t *testing.T) {
+	src := "whence -p git\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("already-fixed input should be idempotent, got %q", got)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1413.go
+++ b/pkg/katas/zc1413.go
@@ -13,7 +13,53 @@ func init() {
 			"hashed). Zsh's `whence -p cmd` prints the PATH-resolved absolute path, whether " +
 			"hashed or not — more reliable and the native Zsh idiom.",
 		Check: checkZC1413,
+		Fix:   fixZC1413,
 	})
+}
+
+// fixZC1413 rewrites `hash -t cmd` to `whence -p cmd`. Two edits per
+// fire: the command name and the `-t` flag. Idempotent — a re-run
+// sees `whence`, not `hash`, so the detector won't fire. Defensive
+// byte-match guards on both edits refuse to insert if the source
+// at the offset doesn't match.
+func fixZC1413(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "hash" {
+		return nil
+	}
+	var dashT ast.Node
+	for _, arg := range cmd.Arguments {
+		if arg.String() == "-t" {
+			dashT = arg
+			break
+		}
+	}
+	if dashT == nil {
+		return nil
+	}
+	cmdOff := LineColToByteOffset(source, v.Line, v.Column)
+	if cmdOff < 0 || cmdOff+len("hash") > len(source) {
+		return nil
+	}
+	if string(source[cmdOff:cmdOff+len("hash")]) != "hash" {
+		return nil
+	}
+	tTok := dashT.TokenLiteralNode()
+	tOff := LineColToByteOffset(source, tTok.Line, tTok.Column)
+	if tOff < 0 || tOff+len("-t") > len(source) {
+		return nil
+	}
+	if string(source[tOff:tOff+len("-t")]) != "-t" {
+		return nil
+	}
+	return []FixEdit{
+		{Line: v.Line, Column: v.Column, Length: len("hash"), Replace: "whence"},
+		{Line: tTok.Line, Column: tTok.Column, Length: len("-t"), Replace: "-p"},
+	}
 }
 
 func checkZC1413(node ast.Node) []Violation {


### PR DESCRIPTION
`hash -t cmd` becomes `whence -p cmd`. Two edits per fire: rename the command and swap the flag letter. `whence -p` resolves through PATH whether or not the command is hashed, which is the more reliable Zsh idiom. Idempotent — a re-run sees `whence`, not `hash`. Defensive byte-match guards on both edits.

Coverage: 115 → 116.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 115 → 116
- [x] ROADMAP coverage: 115 → 116 (11.6%)
- [x] CHANGELOG `[Unreleased]` updated
