### PR TITLE
feat(ZC1279): readlink -f PATH → realpath PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 116/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 117/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1268` inserts `--` before the first non-flag arg of `du -sh`.
   - `ZC1273` `grep PAT FILE /dev/null` → `grep -q PAT FILE` (insert `-q`, drop `/dev/null`).
   - `ZC1276` `seq M N` → `{M..N}`.
+  - `ZC1279` `readlink -f PATH` → `realpath PATH` when `-f` is the first argument.
   - `ZC1297` `$BASH_SOURCE` → `${(%):-%x}`.
   - `ZC1319` `$BASH_ARGC` → `$#`.
   - `ZC1320` `$BASH_ARGV` → `$argv`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **115** |
+| **with auto-fix** | **116** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -292,7 +292,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1276: Use Zsh `{start..end}` instead of `seq`](#zc1276) · auto-fix
 - [ZC1277: Superseded by ZC1108 — retired duplicate](#zc1277)
 - [ZC1278: Superseded by ZC1009 — retired duplicate](#zc1278)
-- [ZC1279: Use `realpath` instead of `readlink -f` for canonical paths](#zc1279)
+- [ZC1279: Use `realpath` instead of `readlink -f` for canonical paths](#zc1279) · auto-fix
 - [ZC1280: Use `Zsh ${var:e}` instead of shell expansion to extract file extension](#zc1280)
 - [ZC1281: Use `sort -u` instead of `sort \| uniq` for deduplication](#zc1281)
 - [ZC1282: Use Zsh `${var:r}` instead of `sed` to remove file extension](#zc1282)
@@ -4324,7 +4324,7 @@ Disable by adding `ZC1278` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1279 — Use `realpath` instead of `readlink -f` for canonical paths
 
 **Severity:** `info`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `readlink -f` is not portable across all platforms (notably macOS). Use `realpath` which is POSIX-standard and available on modern systems.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-116%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-117%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 116 of 1000 katas (11.6%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 117 of 1000 katas (11.7%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1450,6 +1450,21 @@ func TestFixIntegration_ZC1413_AlreadyWhenceP(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1279_ReadlinkFToRealpath(t *testing.T) {
+	src := "readlink -f /usr/bin/zsh\n"
+	want := "realpath /usr/bin/zsh\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1279_AlreadyRealpath(t *testing.T) {
+	src := "realpath /usr/bin/zsh\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("already-fixed input should be idempotent, got %q", got)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1279.go
+++ b/pkg/katas/zc1279.go
@@ -12,7 +12,50 @@ func init() {
 		Description: "`readlink -f` is not portable across all platforms (notably macOS). " +
 			"Use `realpath` which is POSIX-standard and available on modern systems.",
 		Check: checkZC1279,
+		Fix:   fixZC1279,
 	})
+}
+
+// fixZC1279 collapses `readlink -f` to `realpath` when `-f` is the
+// first argument. Single span replacement from the start of
+// `readlink` through the end of `-f`. Only fires when `-f` is the
+// first argument; other shapes (`readlink -n -f`, `readlink path -f`)
+// are left alone to avoid clobbering unrelated flags. Idempotent —
+// a re-run sees `realpath`, not `readlink`. Defensive byte-match
+// guards on both anchors.
+func fixZC1279(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "readlink" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 || cmd.Arguments[0].String() != "-f" {
+		return nil
+	}
+	cmdOff := LineColToByteOffset(source, v.Line, v.Column)
+	if cmdOff < 0 || cmdOff+len("readlink") > len(source) {
+		return nil
+	}
+	if string(source[cmdOff:cmdOff+len("readlink")]) != "readlink" {
+		return nil
+	}
+	fTok := cmd.Arguments[0].TokenLiteralNode()
+	fOff := LineColToByteOffset(source, fTok.Line, fTok.Column)
+	if fOff < 0 || fOff+len("-f") > len(source) {
+		return nil
+	}
+	if string(source[fOff:fOff+len("-f")]) != "-f" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  fOff + len("-f") - cmdOff,
+		Replace: "realpath",
+	}}
 }
 
 func checkZC1279(node ast.Node) []Violation {


### PR DESCRIPTION
`readlink -f PATH` becomes `realpath PATH`. Single span replacement covers the command name and the `-f` flag together. Only fires when `-f` is the first argument — `readlink -n -f` or `readlink path -f` would clobber unrelated tokens, so those shapes are left alone. Idempotent: a re-run sees `realpath`, not `readlink`.

Coverage: 116 → 117.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 116 → 117
- [x] ROADMAP coverage: 116 → 117 (11.7%)
- [x] CHANGELOG `[Unreleased]` updated
