### PR TITLE
feat(ZC1095): seq N → {1..N}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 117/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 118/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
   - `ZC1043` prepends `local ` to unscoped function-body assignments.
+  - `ZC1095` `seq N` → `{1..N}` (reuses the ZC1061 brace-expansion rewrite).
   - `ZC1034` / `ZC1271` `which` → `command -v`.
   - `ZC1107` `[[ a -lt b ]]` → `(( a < b ))`.
   - `ZC1146` `cat F | sed/awk/sort/head/tail` → `tool ... F`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **116** |
+| **with auto-fix** | **117** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -111,7 +111,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1092: Prefer `print` or `printf` over `echo` in Zsh](#zc1092) · auto-fix
 - [ZC1093: Superseded by ZC1038 — retired duplicate](#zc1093)
 - [ZC1094: Use parameter expansion instead of `sed` for simple substitutions](#zc1094)
-- [ZC1095: Use `repeat N` for simple repetition](#zc1095)
+- [ZC1095: Use `repeat N` for simple repetition](#zc1095) · auto-fix
 - [ZC1096: Warn on `bc` for simple arithmetic](#zc1096)
 - [ZC1097: Declare loop variables as `local` in functions](#zc1097)
 - [ZC1098: Use `(q)` flag for quoting variables in eval](#zc1098)
@@ -2152,7 +2152,7 @@ Disable by adding `ZC1094` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1095 — Use `repeat N` for simple repetition
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 Zsh provides `repeat N do ... done` for running a block a fixed number of times. It is cleaner than `for i in {1..N}` or C-style for loops when the iterator variable is unused.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-117%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-118%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 117 of 1000 katas (11.7%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 118 of 1000 katas (11.8%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1465,6 +1465,14 @@ func TestFixIntegration_ZC1279_AlreadyRealpath(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1095_SeqNToBraceRange(t *testing.T) {
+	src := "seq 5\n"
+	want := "{1..5}\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1095.go
+++ b/pkg/katas/zc1095.go
@@ -12,6 +12,11 @@ func init() {
 			"It is cleaner than `for i in {1..N}` or C-style for loops when the iterator variable is unused.",
 		Severity: SeverityStyle,
 		Check:    checkZC1095,
+		// Reuse the seq → {start..end} rewrite from ZC1061. The detector
+		// here fires on a single-numeric-arg `seq N`, which fixZC1061
+		// rewrites to `{1..N}` — exactly the brace expansion this kata
+		// suggests for `for i in {1..N}`.
+		Fix: fixZC1061,
 	})
 }
 


### PR DESCRIPTION
`seq N` becomes `{1..N}`. Reuses the shared `seq` rewrite that already powers ZC1061 and ZC1276 for `seq M N` and `seq M S N`. The detector here only fires on a single-numeric-arg shape, which the shared rewrite already maps to `{1..N}` — so wiring it up was a one-line change. Idempotent on a re-run.

Coverage: 117 → 118.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 117 → 118
- [x] ROADMAP coverage: 117 → 118 (11.8%)
- [x] CHANGELOG `[Unreleased]` updated
