### PR TITLE
feat(ZC1215): cat /etc/{os,lsb}-release → . /etc/{os,lsb}-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 118/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 119/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1203` `netstat` → `ss`.
   - `ZC1216` `nslookup` → `host`.
   - `ZC1219` `wget -O- URL` / `wget -qO- URL` → `curl -fsSL URL`.
+  - `ZC1215` `cat /etc/{os,lsb}-release` → `. /etc/{os,lsb}-release` (single-arg only).
   - `ZC1230` `ping URL` → `ping -c 4 URL`.
   - `ZC1235` `git push -f` → `git push --force-with-lease`.
   - `ZC1238` strips `-it` from `docker exec`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **117** |
+| **with auto-fix** | **118** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -228,7 +228,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1212: Avoid `git add .` — use explicit paths or `git add -p`](#zc1212)
 - [ZC1213: Use `apt-get -y` in scripts for non-interactive installs](#zc1213) · auto-fix
 - [ZC1214: Avoid `su` in scripts — use `sudo -u` for user switching](#zc1214)
-- [ZC1215: Source `/etc/os-release` instead of parsing with `cat`/`grep`](#zc1215)
+- [ZC1215: Source `/etc/os-release` instead of parsing with `cat`/`grep`](#zc1215) · auto-fix
 - [ZC1216: Avoid `nslookup` — use `dig` or `host` for DNS queries](#zc1216) · auto-fix
 - [ZC1217: Avoid `service` command — use `systemctl` on systemd](#zc1217)
 - [ZC1218: Avoid `useradd` without `--shell /sbin/nologin` for service accounts](#zc1218)
@@ -3556,7 +3556,7 @@ Disable by adding `ZC1214` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1215 — Source `/etc/os-release` instead of parsing with `cat`/`grep`
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `/etc/os-release` is designed to be sourced directly. Use `. /etc/os-release` to get variables like `$ID`, `$VERSION_ID` without parsing.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-118%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-119%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 118 of 1000 katas (11.8%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 119 of 1000 katas (11.9%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1473,6 +1473,22 @@ func TestFixIntegration_ZC1095_SeqNToBraceRange(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1215_CatOsReleaseToSource(t *testing.T) {
+	src := "cat /etc/os-release\n"
+	want := ". /etc/os-release\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1215_CatLsbReleaseToSource(t *testing.T) {
+	src := "cat /etc/lsb-release\n"
+	want := ". /etc/lsb-release\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1215.go
+++ b/pkg/katas/zc1215.go
@@ -12,7 +12,44 @@ func init() {
 		Description: "`/etc/os-release` is designed to be sourced directly. " +
 			"Use `. /etc/os-release` to get variables like `$ID`, `$VERSION_ID` without parsing.",
 		Check: checkZC1215,
+		Fix:   fixZC1215,
 	})
+}
+
+// fixZC1215 rewrites `cat /etc/os-release` (or `/etc/lsb-release`) to
+// `. /etc/os-release`. Single-edit replacement of the `cat` command
+// name with the source builtin `.`. Only fires when cat has exactly
+// one argument; piped or multi-file shapes are left alone. Idempotent
+// — a re-run sees `.`, not `cat`. Defensive byte-match guard.
+func fixZC1215(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "cat" {
+		return nil
+	}
+	if len(cmd.Arguments) != 1 {
+		return nil
+	}
+	val := cmd.Arguments[0].String()
+	if val != "/etc/os-release" && val != "/etc/lsb-release" {
+		return nil
+	}
+	off := LineColToByteOffset(source, v.Line, v.Column)
+	if off < 0 || off+len("cat") > len(source) {
+		return nil
+	}
+	if string(source[off:off+len("cat")]) != "cat" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("cat"),
+		Replace: ".",
+	}}
 }
 
 func checkZC1215(node ast.Node) []Violation {


### PR DESCRIPTION
`cat /etc/os-release` and `cat /etc/lsb-release` become `. /etc/os-release` / `. /etc/lsb-release`. The release files are designed to be sourced — sourcing exports `$ID`, `$VERSION_ID`, etc. directly. Single-edit rename of `cat` to `.`. Only fires when `cat` has exactly one argument and that argument is one of the two release files; multi-file or piped shapes are left alone. Idempotent on a re-run.

Coverage: 118 → 119.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 118 → 119
- [x] ROADMAP coverage: 118 → 119 (11.9%)
- [x] CHANGELOG `[Unreleased]` updated
