### PR TITLE
feat(ZC1217): share service rewrite with ZC1512

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 119/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 120/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1216` `nslookup` → `host`.
   - `ZC1219` `wget -O- URL` / `wget -qO- URL` → `curl -fsSL URL`.
   - `ZC1215` `cat /etc/{os,lsb}-release` → `. /etc/{os,lsb}-release` (single-arg only).
+  - `ZC1217` shares the `service UNIT VERB` → `systemctl VERB UNIT` rewrite with ZC1512.
   - `ZC1230` `ping URL` → `ping -c 4 URL`.
   - `ZC1235` `git push -f` → `git push --force-with-lease`.
   - `ZC1238` strips `-it` from `docker exec`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **118** |
+| **with auto-fix** | **119** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -230,7 +230,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1214: Avoid `su` in scripts — use `sudo -u` for user switching](#zc1214)
 - [ZC1215: Source `/etc/os-release` instead of parsing with `cat`/`grep`](#zc1215) · auto-fix
 - [ZC1216: Avoid `nslookup` — use `dig` or `host` for DNS queries](#zc1216) · auto-fix
-- [ZC1217: Avoid `service` command — use `systemctl` on systemd](#zc1217)
+- [ZC1217: Avoid `service` command — use `systemctl` on systemd](#zc1217) · auto-fix
 - [ZC1218: Avoid `useradd` without `--shell /sbin/nologin` for service accounts](#zc1218)
 - [ZC1219: Use `curl -fsSL` instead of `wget -O -` for piped downloads](#zc1219) · auto-fix
 - [ZC1220: Use `chown :group` instead of `chgrp` for group changes](#zc1220)
@@ -3580,7 +3580,7 @@ Disable by adding `ZC1216` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1217 — Avoid `service` command — use `systemctl` on systemd
 
 **Severity:** `info`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `service` is a SysVinit compatibility wrapper. On systemd systems, use `systemctl start/stop/restart/status` directly.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-119%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-120%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 119 of 1000 katas (11.9%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 120 of 1000 katas (12.0%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/katas/zc1217.go
+++ b/pkg/katas/zc1217.go
@@ -12,6 +12,10 @@ func init() {
 		Description: "`service` is a SysVinit compatibility wrapper. " +
 			"On systemd systems, use `systemctl start/stop/restart/status` directly.",
 		Check: checkZC1217,
+		// Reuse the `service UNIT VERB` → `systemctl VERB UNIT` rewrite
+		// from ZC1512. Both detectors fire on the same shape; the
+		// conflict resolver dedupes overlapping edits.
+		Fix: fixZC1512,
 	})
 }
 


### PR DESCRIPTION
ZC1217 (`service` is a SysVinit wrapper) and ZC1512 (`service UNIT VERB` → `systemctl VERB UNIT`) fire on the same shape; wiring ZC1217 to the existing fixZC1512 lets both contribute to the same rewrite. The conflict resolver dedupes overlapping edits.

Coverage: 119 → 120.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 119 → 120
- [x] ROADMAP coverage: 119 → 120 (12.0%)
- [x] CHANGELOG `[Unreleased]` updated
