### PR TITLE
feat(ZC1374): $FUNCNEST → ${#funcstack}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 120/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 121/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1319` `$BASH_ARGC` → `$#`.
   - `ZC1320` `$BASH_ARGV` → `$argv`.
   - `ZC1334` `type -p` / `type -P` → `whence -p`.
+  - `ZC1374` `$FUNCNEST` → `${#funcstack}` inside echo / print / printf args.
   - `ZC1377` `BASH_ALIASES` → `aliases` inside echo / print / printf string args.
   - `ZC1378` uppercase `DIRSTACK` → `dirstack` inside echo / print / printf string args.
   - `ZC1380` `export HISTIGNORE=…` → `export HISTORY_IGNORE=…`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **119** |
+| **with auto-fix** | **120** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -387,7 +387,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1371: Use Zsh array `:t` modifier instead of `basename -a` for bulk path stripping](#zc1371)
 - [ZC1372: Use Zsh `zmv` autoload function instead of `rename`/`rename.ul`](#zc1372)
 - [ZC1373: Use Zsh `${(0)var}` flag for NUL-split parsing instead of `env -0`](#zc1373)
-- [ZC1374: Avoid `$FUNCNEST` — Zsh uses `$FUNCNEST` as a limit, not a depth indicator](#zc1374)
+- [ZC1374: Avoid `$FUNCNEST` — Zsh uses `$FUNCNEST` as a limit, not a depth indicator](#zc1374) · auto-fix
 - [ZC1375: Use `\[\[ -t fd \]\]` instead of `tty -s` for tty-check](#zc1375)
 - [ZC1376: Avoid `BASH_XTRACEFD` — use Zsh `exec {fd}>file` + `setopt XTRACE`](#zc1376)
 - [ZC1377: Avoid `$BASH_ALIASES` — use Zsh `$aliases` associative array](#zc1377) · auto-fix
@@ -5464,7 +5464,7 @@ Disable by adding `ZC1373` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1374 — Avoid `$FUNCNEST` — Zsh uses `$FUNCNEST` as a limit, not a depth indicator
 
 **Severity:** `warning`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 Bash's `$FUNCNEST` is both a writable limit and (implicitly) the current depth-query vehicle. Zsh's `$FUNCNEST` is only the limit — to read the current depth use `${#funcstack}`. Reading `$FUNCNEST` expecting depth returns the limit, not the current depth.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-120%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-121%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 120 of 1000 katas (12.0%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 121 of 1000 katas (12.1%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1489,6 +1489,17 @@ func TestFixIntegration_ZC1215_CatLsbReleaseToSource(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1374_FuncnestToFuncstack(t *testing.T) {
+	src := "print $FUNCNEST\n"
+	got := runFix(t, src)
+	if !strings.Contains(got, "${#funcstack}") {
+		t.Errorf("expected fix to insert ${#funcstack}, got %q", got)
+	}
+	if strings.Contains(got, "$FUNCNEST") {
+		t.Errorf("expected fix to remove $FUNCNEST, got %q", got)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1374.go
+++ b/pkg/katas/zc1374.go
@@ -14,7 +14,48 @@ func init() {
 			"use `${#funcstack}`. Reading `$FUNCNEST` expecting depth returns the limit, not " +
 			"the current depth.",
 		Check: checkZC1374,
+		Fix:   fixZC1374,
 	})
+}
+
+// fixZC1374 rewrites `$FUNCNEST` / `${FUNCNEST}` arguments to
+// `${#funcstack}` inside echo / print / printf calls. One edit per
+// matching arg. Idempotent — a re-run sees `${#funcstack}`, which
+// the detector's exact-match guard won't match.
+func fixZC1374(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+	var edits []FixEdit
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		if val != "$FUNCNEST" && val != "${FUNCNEST}" {
+			continue
+		}
+		tok := arg.TokenLiteralNode()
+		off := LineColToByteOffset(source, tok.Line, tok.Column)
+		if off < 0 || off+len(val) > len(source) {
+			continue
+		}
+		if string(source[off:off+len(val)]) != val {
+			continue
+		}
+		edits = append(edits, FixEdit{
+			Line:    tok.Line,
+			Column:  tok.Column,
+			Length:  len(val),
+			Replace: "${#funcstack}",
+		})
+	}
+	return edits
 }
 
 func checkZC1374(node ast.Node) []Violation {


### PR DESCRIPTION
`$FUNCNEST` becomes `${#funcstack}` inside echo / print / printf args. In Zsh, `$FUNCNEST` is the configured limit, not the current nesting depth — `${#funcstack}` reports the depth. Single arg replacement at the variable expansion's column. Only the bare `$FUNCNEST` form is rewritten because the parser splits `${FUNCNEST}` into a different node shape that the existing detector already declines to match. Idempotent on a re-run.

Coverage: 120 → 121.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 120 → 121
- [x] ROADMAP coverage: 120 → 121 (12.1%)
- [x] CHANGELOG `[Unreleased]` updated
