### PR TITLE
feat(ZC1381): rewrite COMP_* completion vars to Zsh equivalents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 121/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 122/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1374` `$FUNCNEST` → `${#funcstack}` inside echo / print / printf args.
   - `ZC1377` `BASH_ALIASES` → `aliases` inside echo / print / printf string args.
   - `ZC1378` uppercase `DIRSTACK` → `dirstack` inside echo / print / printf string args.
+  - `ZC1381` `$COMP_WORDS` / `$COMP_CWORD` / `$COMP_LINE` / `$COMP_POINT` → `$words` / `$CURRENT` / `$BUFFER` / `$CURSOR` inside echo / print / printf args.
   - `ZC1380` `export HISTIGNORE=…` → `export HISTORY_IGNORE=…`.
   - `ZC1383` `TIMEFORMAT` → `TIMEFMT` inside echo / print / printf string args.
   - `ZC1394` `$BASH` → `$ZSH_NAME` inside echo / print / printf string args.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **120** |
+| **with auto-fix** | **121** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -394,7 +394,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1378: Avoid uppercase `$DIRSTACK` — Zsh uses lowercase `$dirstack`](#zc1378) · auto-fix
 - [ZC1379: Avoid `$PROMPT_COMMAND` — use Zsh `precmd` function](#zc1379)
 - [ZC1380: Avoid `$HISTIGNORE` — use Zsh `$HISTORY_IGNORE`](#zc1380) · auto-fix
-- [ZC1381: Avoid `$COMP_WORDS`/`$COMP_CWORD` — Zsh uses `words`/`$CURRENT`](#zc1381)
+- [ZC1381: Avoid `$COMP_WORDS`/`$COMP_CWORD` — Zsh uses `words`/`$CURRENT`](#zc1381) · auto-fix
 - [ZC1382: Avoid `$READLINE_LINE`/`$READLINE_POINT` — Zsh ZLE uses `$BUFFER`/`$CURSOR`](#zc1382)
 - [ZC1383: Avoid `$TIMEFORMAT` — Zsh uses `$TIMEFMT`](#zc1383) · auto-fix
 - [ZC1384: Avoid `$EXECIGNORE` — Bash-only; Zsh uses completion-system ignore patterns](#zc1384)
@@ -5548,7 +5548,7 @@ Disable by adding `ZC1380` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1381 — Avoid `$COMP_WORDS`/`$COMP_CWORD` — Zsh uses `words`/`$CURRENT`
 
 **Severity:** `error`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 Bash programmable completion reads the partial command via `$COMP_WORDS` (array of tokens) and `$COMP_CWORD` (index of cursor). Zsh's completion system exposes the same via `words` (array) and `$CURRENT` (1-based cursor index). Using the Bash names in Zsh completion functions produces empty expansions.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-121%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-122%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 121 of 1000 katas (12.1%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 122 of 1000 katas (12.2%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1500,6 +1500,28 @@ func TestFixIntegration_ZC1374_FuncnestToFuncstack(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1381_CompWordsToWords(t *testing.T) {
+	src := "print $COMP_WORDS\n"
+	got := runFix(t, src)
+	if !strings.Contains(got, "$words") {
+		t.Errorf("expected $words, got %q", got)
+	}
+	if strings.Contains(got, "COMP_WORDS") {
+		t.Errorf("COMP_WORDS still present, got %q", got)
+	}
+}
+
+func TestFixIntegration_ZC1381_CompCwordToCurrent(t *testing.T) {
+	src := "print $COMP_CWORD\n"
+	got := runFix(t, src)
+	if !strings.Contains(got, "$CURRENT") {
+		t.Errorf("expected $CURRENT, got %q", got)
+	}
+	if strings.Contains(got, "COMP_CWORD") {
+		t.Errorf("COMP_CWORD still present, got %q", got)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1381.go
+++ b/pkg/katas/zc1381.go
@@ -16,7 +16,90 @@ func init() {
 			"exposes the same via `words` (array) and `$CURRENT` (1-based cursor index). Using " +
 			"the Bash names in Zsh completion functions produces empty expansions.",
 		Check: checkZC1381,
+		Fix:   fixZC1381,
 	})
+}
+
+// fixZC1381 rewrites Bash completion variable names inside echo /
+// print / printf args to their Zsh equivalents:
+//
+//	COMP_WORDS  → words
+//	COMP_CWORD  → CURRENT
+//	COMP_LINE   → BUFFER
+//	COMP_POINT  → CURSOR
+//
+// Per-arg byte-anchored scan; one edit per match. Idempotent — a
+// re-run sees the Zsh names, which the detector's substring guard
+// won't match.
+func fixZC1381(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+	mapping := []struct{ old, new string }{
+		{"COMP_WORDS", "words"},
+		{"COMP_CWORD", "CURRENT"},
+		{"COMP_LINE", "BUFFER"},
+		{"COMP_POINT", "CURSOR"},
+	}
+	var edits []FixEdit
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		tok := arg.TokenLiteralNode()
+		off := LineColToByteOffset(source, tok.Line, tok.Column)
+		if off < 0 || off+len(val) > len(source) {
+			continue
+		}
+		if string(source[off:off+len(val)]) != val {
+			continue
+		}
+		for _, m := range mapping {
+			idx := 0
+			for {
+				pos := strings.Index(val[idx:], m.old)
+				if pos < 0 {
+					break
+				}
+				abs := off + idx + pos
+				line, col := offsetLineColZC1381(source, abs)
+				if line < 0 {
+					break
+				}
+				edits = append(edits, FixEdit{
+					Line:    line,
+					Column:  col,
+					Length:  len(m.old),
+					Replace: m.new,
+				})
+				idx += pos + len(m.old)
+			}
+		}
+	}
+	return edits
+}
+
+func offsetLineColZC1381(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1381(node ast.Node) []Violation {


### PR DESCRIPTION
Bash programmable-completion variables become their Zsh equivalents inside echo / print / printf args:

- `COMP_WORDS` → `words`
- `COMP_CWORD` → `CURRENT`
- `COMP_LINE` → `BUFFER`
- `COMP_POINT` → `CURSOR`

Per-arg substring scan, one edit per match. Idempotent on a re-run because the detector's substring guard never matches the Zsh names.

Coverage: 121 → 122.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 121 → 122
- [x] ROADMAP coverage: 121 → 122 (12.2%)
- [x] CHANGELOG `[Unreleased]` updated
