### PR TITLE
feat(ZC1382): rewrite READLINE_* vars to Zsh ZLE equivalents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 122/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 123/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1377` `BASH_ALIASES` → `aliases` inside echo / print / printf string args.
   - `ZC1378` uppercase `DIRSTACK` → `dirstack` inside echo / print / printf string args.
   - `ZC1381` `$COMP_WORDS` / `$COMP_CWORD` / `$COMP_LINE` / `$COMP_POINT` → `$words` / `$CURRENT` / `$BUFFER` / `$CURSOR` inside echo / print / printf args.
+  - `ZC1382` `$READLINE_LINE` / `$READLINE_POINT` / `$READLINE_MARK` → `$BUFFER` / `$CURSOR` / `$MARK` inside echo / print / printf args.
   - `ZC1380` `export HISTIGNORE=…` → `export HISTORY_IGNORE=…`.
   - `ZC1383` `TIMEFORMAT` → `TIMEFMT` inside echo / print / printf string args.
   - `ZC1394` `$BASH` → `$ZSH_NAME` inside echo / print / printf string args.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **121** |
+| **with auto-fix** | **122** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -395,7 +395,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1379: Avoid `$PROMPT_COMMAND` — use Zsh `precmd` function](#zc1379)
 - [ZC1380: Avoid `$HISTIGNORE` — use Zsh `$HISTORY_IGNORE`](#zc1380) · auto-fix
 - [ZC1381: Avoid `$COMP_WORDS`/`$COMP_CWORD` — Zsh uses `words`/`$CURRENT`](#zc1381) · auto-fix
-- [ZC1382: Avoid `$READLINE_LINE`/`$READLINE_POINT` — Zsh ZLE uses `$BUFFER`/`$CURSOR`](#zc1382)
+- [ZC1382: Avoid `$READLINE_LINE`/`$READLINE_POINT` — Zsh ZLE uses `$BUFFER`/`$CURSOR`](#zc1382) · auto-fix
 - [ZC1383: Avoid `$TIMEFORMAT` — Zsh uses `$TIMEFMT`](#zc1383) · auto-fix
 - [ZC1384: Avoid `$EXECIGNORE` — Bash-only; Zsh uses completion-system ignore patterns](#zc1384)
 - [ZC1385: Avoid `$PS0` — Bash-only; Zsh uses `preexec` hook](#zc1385)
@@ -5560,7 +5560,7 @@ Disable by adding `ZC1381` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1382 — Avoid `$READLINE_LINE`/`$READLINE_POINT` — Zsh ZLE uses `$BUFFER`/`$CURSOR`
 
 **Severity:** `error`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 Bash readline exposes the current input line as `$READLINE_LINE` and cursor offset as `$READLINE_POINT` inside `bind -x` handlers. Zsh's Line Editor (ZLE) uses `$BUFFER` (line text) and `$CURSOR` (1-based column) inside widget functions. The Bash names are unset in Zsh.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-122%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-123%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 122 of 1000 katas (12.2%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 123 of 1000 katas (12.3%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1522,6 +1522,28 @@ func TestFixIntegration_ZC1381_CompCwordToCurrent(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1382_ReadlineLineToBuffer(t *testing.T) {
+	src := "print $READLINE_LINE\n"
+	got := runFix(t, src)
+	if !strings.Contains(got, "$BUFFER") {
+		t.Errorf("expected $BUFFER, got %q", got)
+	}
+	if strings.Contains(got, "READLINE_LINE") {
+		t.Errorf("READLINE_LINE still present, got %q", got)
+	}
+}
+
+func TestFixIntegration_ZC1382_ReadlinePointToCursor(t *testing.T) {
+	src := "print $READLINE_POINT\n"
+	got := runFix(t, src)
+	if !strings.Contains(got, "$CURSOR") {
+		t.Errorf("expected $CURSOR, got %q", got)
+	}
+	if strings.Contains(got, "READLINE_POINT") {
+		t.Errorf("READLINE_POINT still present, got %q", got)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1382.go
+++ b/pkg/katas/zc1382.go
@@ -16,7 +16,88 @@ func init() {
 			"`$BUFFER` (line text) and `$CURSOR` (1-based column) inside widget functions. The " +
 			"Bash names are unset in Zsh.",
 		Check: checkZC1382,
+		Fix:   fixZC1382,
 	})
+}
+
+// fixZC1382 rewrites Bash readline variable names inside echo /
+// print / printf args to their Zsh ZLE equivalents:
+//
+//	READLINE_LINE   → BUFFER
+//	READLINE_POINT  → CURSOR
+//	READLINE_MARK   → MARK
+//
+// Per-arg byte-anchored scan; one edit per match. Idempotent — a
+// re-run sees the Zsh names, which the detector's substring guard
+// won't match.
+func fixZC1382(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+	mapping := []struct{ old, new string }{
+		{"READLINE_LINE", "BUFFER"},
+		{"READLINE_POINT", "CURSOR"},
+		{"READLINE_MARK", "MARK"},
+	}
+	var edits []FixEdit
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		tok := arg.TokenLiteralNode()
+		off := LineColToByteOffset(source, tok.Line, tok.Column)
+		if off < 0 || off+len(val) > len(source) {
+			continue
+		}
+		if string(source[off:off+len(val)]) != val {
+			continue
+		}
+		for _, m := range mapping {
+			idx := 0
+			for {
+				pos := strings.Index(val[idx:], m.old)
+				if pos < 0 {
+					break
+				}
+				abs := off + idx + pos
+				line, col := offsetLineColZC1382(source, abs)
+				if line < 0 {
+					break
+				}
+				edits = append(edits, FixEdit{
+					Line:    line,
+					Column:  col,
+					Length:  len(m.old),
+					Replace: m.new,
+				})
+				idx += pos + len(m.old)
+			}
+		}
+	}
+	return edits
+}
+
+func offsetLineColZC1382(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1382(node ast.Node) []Violation {


### PR DESCRIPTION
Bash readline-handler variables become their Zsh ZLE equivalents inside echo / print / printf args:

- `READLINE_LINE`  → `BUFFER`
- `READLINE_POINT` → `CURSOR`
- `READLINE_MARK`  → `MARK`

Per-arg substring scan, one edit per match. Idempotent on a re-run because the detector's substring guard never matches the Zsh names.

Coverage: 122 → 123.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 122 → 123
- [x] ROADMAP coverage: 122 → 123 (12.3%)
- [x] CHANGELOG `[Unreleased]` updated
