### PR TITLE
feat(ZC1404): $BASH_CMDS → $commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 123/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 124/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1380` `export HISTIGNORE=…` → `export HISTORY_IGNORE=…`.
   - `ZC1383` `TIMEFORMAT` → `TIMEFMT` inside echo / print / printf string args.
   - `ZC1394` `$BASH` → `$ZSH_NAME` inside echo / print / printf string args.
+  - `ZC1404` `$BASH_CMDS` → `$commands` inside echo / print / printf string args.
   - `ZC1413` `hash -t cmd` → `whence -p cmd` (rename + flag swap).
   - `ZC1411` `enable -n NAME` → `disable NAME`.
   - `ZC1448` inserts `-y` after `apt install` / `apt upgrade` / `apt dist-upgrade` / `apt full-upgrade`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **122** |
+| **with auto-fix** | **123** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -417,7 +417,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1401: Prefer Zsh `$VENDOR` over parsing `$MACHTYPE` for vendor detection](#zc1401)
 - [ZC1402: Avoid `date -d @seconds` — use Zsh `strftime` for epoch formatting](#zc1402)
 - [ZC1403: Setting `$HISTFILESIZE` alone is incomplete in Zsh — pair with `$SAVEHIST`](#zc1403)
-- [ZC1404: Avoid `$BASH_CMDS` — Bash-specific hash-table mirror, use Zsh `$commands`](#zc1404)
+- [ZC1404: Avoid `$BASH_CMDS` — Bash-specific hash-table mirror, use Zsh `$commands`](#zc1404) · auto-fix
 - [ZC1405: Avoid `env -u VAR cmd` — use Zsh `(unset VAR; cmd)` subshell](#zc1405)
 - [ZC1406: Prefer Zsh `zargs -P N` autoload over `xargs -P N` for parallel execution](#zc1406)
 - [ZC1407: Avoid `/dev/tcp/...` — use Zsh `zsh/net/tcp` module](#zc1407)
@@ -5824,7 +5824,7 @@ Disable by adding `ZC1403` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1404 — Avoid `$BASH_CMDS` — Bash-specific hash-table mirror, use Zsh `$commands`
 
 **Severity:** `warning`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 Bash's `$BASH_CMDS` associative array mirrors the hash-table of command names→paths. Zsh exposes the same via `$commands` (assoc array from `zsh/parameter`). `$BASH_CMDS` is unset in Zsh.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-123%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-124%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 123 of 1000 katas (12.3%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 124 of 1000 katas (12.4%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1544,6 +1544,17 @@ func TestFixIntegration_ZC1382_ReadlinePointToCursor(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1404_BashCmdsToCommands(t *testing.T) {
+	src := "print $BASH_CMDS\n"
+	got := runFix(t, src)
+	if !strings.Contains(got, "$commands") {
+		t.Errorf("expected $commands, got %q", got)
+	}
+	if strings.Contains(got, "BASH_CMDS") {
+		t.Errorf("BASH_CMDS still present, got %q", got)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1404.go
+++ b/pkg/katas/zc1404.go
@@ -15,7 +15,77 @@ func init() {
 			"names→paths. Zsh exposes the same via `$commands` (assoc array from " +
 			"`zsh/parameter`). `$BASH_CMDS` is unset in Zsh.",
 		Check: checkZC1404,
+		Fix:   fixZC1404,
 	})
+}
+
+// fixZC1404 rewrites `BASH_CMDS` → `commands` inside echo / print /
+// printf args. Per-arg substring scan; one edit per match.
+// Idempotent — a re-run sees `commands`, which the detector's
+// substring guard won't match.
+func fixZC1404(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "echo" && ident.Value != "print" && ident.Value != "printf" {
+		return nil
+	}
+	const oldName = "BASH_CMDS"
+	const newName = "commands"
+	var edits []FixEdit
+	for _, arg := range cmd.Arguments {
+		val := arg.String()
+		tok := arg.TokenLiteralNode()
+		off := LineColToByteOffset(source, tok.Line, tok.Column)
+		if off < 0 || off+len(val) > len(source) {
+			continue
+		}
+		if string(source[off:off+len(val)]) != val {
+			continue
+		}
+		idx := 0
+		for {
+			pos := strings.Index(val[idx:], oldName)
+			if pos < 0 {
+				break
+			}
+			abs := off + idx + pos
+			line, col := offsetLineColZC1404(source, abs)
+			if line < 0 {
+				break
+			}
+			edits = append(edits, FixEdit{
+				Line:    line,
+				Column:  col,
+				Length:  len(oldName),
+				Replace: newName,
+			})
+			idx += pos + len(oldName)
+		}
+	}
+	return edits
+}
+
+func offsetLineColZC1404(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1404(node ast.Node) []Violation {


### PR DESCRIPTION
`$BASH_CMDS` becomes `$commands` inside echo / print / printf args. Bash's `$BASH_CMDS` mirrors the command-name→path hash table; Zsh exposes the same as `$commands` (assoc array from `zsh/parameter`). Per-arg substring scan, one edit per match. Idempotent on a re-run.

Coverage: 123 → 124.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 123 → 124
- [x] ROADMAP coverage: 123 → 124 (12.4%)
- [x] CHANGELOG `[Unreleased]` updated
