### PR TITLE
feat(ZC1053): insert -q after grep in if/while conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 125/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 126/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
   - `ZC1043` prepends `local ` to unscoped function-body assignments.
+  - `ZC1053` inserts `-q` after `grep` / `egrep` / `fgrep` / `zgrep` when used in an `if` or `while` condition.
   - `ZC1095` `seq N` → `{1..N}` (reuses the ZC1061 brace-expansion rewrite).
   - `ZC1034` / `ZC1271` `which` → `command -v`.
   - `ZC1107` `[[ a -lt b ]]` → `(( a < b ))`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **124** |
+| **with auto-fix** | **125** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -69,7 +69,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1050: Avoid iterating over `ls` output](#zc1050)
 - [ZC1051: Quote variables in `rm` to avoid globbing](#zc1051) · auto-fix
 - [ZC1052: Avoid `sed -i` for portability](#zc1052)
-- [ZC1053: Silence `grep` output in conditions](#zc1053)
+- [ZC1053: Silence `grep` output in conditions](#zc1053) · auto-fix
 - [ZC1054: Use POSIX classes in regex/glob](#zc1054)
 - [ZC1055: Use `\[\[ -n/-z \]\]` for empty string checks](#zc1055) · auto-fix
 - [ZC1056: Avoid `$((...))` as a statement](#zc1056)
@@ -1648,7 +1648,7 @@ Disable by adding `ZC1052` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1053 — Silence `grep` output in conditions
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 Using `grep` in a condition prints matches to stdout. Use `grep -q` (or `> /dev/null`) to silence output if you only care about the exit code.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-125%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-126%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 125 of 1000 katas (12.5%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 126 of 1000 katas (12.6%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1566,6 +1566,29 @@ func TestFixIntegration_ZC1403_HistfilesizeToSavehist(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1053_GrepInIfAddsQ(t *testing.T) {
+	src := "if grep PAT FILE; then :; fi\n"
+	want := "if grep -q PAT FILE; then :; fi\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1053_GrepInWhileAddsQ(t *testing.T) {
+	src := "while grep PAT FILE; do :; done\n"
+	want := "while grep -q PAT FILE; do :; done\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1053_AlreadyQuiet(t *testing.T) {
+	src := "if grep -q PAT FILE; then :; fi\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("already-quiet input should be idempotent, got %q", got)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1053.go
+++ b/pkg/katas/zc1053.go
@@ -14,6 +14,7 @@ func init() {
 			"Use `grep -q` (or `> /dev/null`) to silence output if you only care about the exit code.",
 		Severity: SeverityStyle,
 		Check:    checkZC1053,
+		Fix:      fixZC1053,
 	})
 	RegisterKata(ast.WhileLoopStatementNode, Kata{
 		ID:    "ZC1053",
@@ -22,7 +23,71 @@ func init() {
 			"Use `grep -q` (or `> /dev/null`) to silence output if you only care about the exit code.",
 		Severity: SeverityStyle,
 		Check:    checkZC1053,
+		Fix:      fixZC1053,
 	})
+}
+
+// fixZC1053 inserts ` -q` directly after the grep / egrep / fgrep /
+// zgrep command name reported at the violation column. Idempotent —
+// once `-q` is present the detector's hasQuiet check short-circuits
+// and the kata no longer fires. Defensive byte-match guard refuses
+// to insert unless the source at the offset is one of the recognised
+// grep variants followed by whitespace.
+func fixZC1053(_ ast.Node, v Violation, source []byte) []FixEdit {
+	off := LineColToByteOffset(source, v.Line, v.Column)
+	if off < 0 {
+		return nil
+	}
+	var name string
+	for _, n := range []string{"grep", "egrep", "fgrep", "zgrep"} {
+		end := off + len(n)
+		if end > len(source) {
+			continue
+		}
+		if string(source[off:end]) != n {
+			continue
+		}
+		// Boundary: next byte must be whitespace, newline, or end of file.
+		if end < len(source) {
+			c := source[end]
+			if c != ' ' && c != '\t' && c != '\n' {
+				continue
+			}
+		}
+		name = n
+		break
+	}
+	if name == "" {
+		return nil
+	}
+	insertAt := off + len(name)
+	line, col := offsetLineColZC1053(source, insertAt)
+	if line < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    line,
+		Column:  col,
+		Length:  0,
+		Replace: " -q",
+	}}
+}
+
+func offsetLineColZC1053(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1053(node ast.Node) []Violation {


### PR DESCRIPTION
`if grep PAT FILE; then ...` becomes `if grep -q PAT FILE; then ...`. Same for `while` conditions and the `egrep` / `fgrep` / `zgrep` aliases. Single ` -q` insertion after the command name reported at the violation column. Idempotent — once `-q` is present the detector's hasQuiet check short-circuits. Defensive byte-match guard refuses to insert unless the source at the offset is one of the recognised grep variants followed by whitespace.

Coverage: 125 → 126.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 125 → 126
- [x] ROADMAP coverage: 125 → 126 (12.6%)
- [x] CHANGELOG `[Unreleased]` updated
