### PR TITLE
feat(ZC1022): share let rewrite with ZC1013

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 126/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 127/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
+  - `ZC1022` shares ZC1013's `let NAME=EXPR` → `(( NAME = EXPR ))` rewrite.
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
   - `ZC1043` prepends `local ` to unscoped function-body assignments.
   - `ZC1053` inserts `-q` after `grep` / `egrep` / `fgrep` / `zgrep` when used in an `if` or `while` condition.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **125** |
+| **with auto-fix** | **126** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -38,7 +38,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1019: Superseded by ZC1005 — retired duplicate](#zc1019)
 - [ZC1020: Use `\[\[ ... \]\]` for tests instead of `test`](#zc1020)
 - [ZC1021: Use symbolic permissions with `chmod` instead of octal](#zc1021)
-- [ZC1022: Use `$((...))` for arithmetic expansion](#zc1022)
+- [ZC1022: Use `$((...))` for arithmetic expansion](#zc1022) · auto-fix
 - [ZC1023: Superseded by ZC1022 — retired duplicate `let` detector](#zc1023)
 - [ZC1024: Superseded by ZC1022 — retired duplicate `let` detector](#zc1024)
 - [ZC1025: Superseded by ZC1022 — retired duplicate `let` detector](#zc1025)
@@ -1276,7 +1276,7 @@ Disable by adding `ZC1021` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1022 — Use `$((...))` for arithmetic expansion
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 The `$((...))` syntax is the modern, recommended way to perform arithmetic expansion. It is more readable and can be nested easily, unlike `let`.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-126%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-127%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 126 of 1000 katas (12.6%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 127 of 1000 katas (12.7%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/katas/zc1022.go
+++ b/pkg/katas/zc1022.go
@@ -12,6 +12,11 @@ func init() {
 			"It is more readable and can be nested easily, unlike `let`.",
 		Severity: SeverityStyle,
 		Check:    checkZC1022,
+		// Reuse ZC1013's `let NAME=EXPR` → `(( NAME = EXPR ))` rewrite.
+		// For a standalone arithmetic statement the `(( ))` command
+		// form is the right shape; the `$((...))` text in the message
+		// reads as the broader "use Zsh arithmetic" recommendation.
+		Fix: fixZC1013,
 	})
 }
 


### PR DESCRIPTION
ZC1022 (`use $((...))` for arithmetic) and ZC1013 (`use $((...))` for let) fire on the same `let NAME=EXPR` shape. Wiring ZC1022 to the existing fixZC1013 lets both detectors emit the same `(( NAME = EXPR ))` rewrite. The conflict resolver dedupes overlapping edits.

Coverage: 126 → 127.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 126 → 127
- [x] ROADMAP coverage: 126 → 127 (12.7%)
- [x] CHANGELOG `[Unreleased]` updated
