### PR TITLE
feat(ZC1008): share let rewrite with ZC1013/ZC1022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 127/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 128/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
-  - `ZC1022` shares ZC1013's `let NAME=EXPR` → `(( NAME = EXPR ))` rewrite.
+  - `ZC1008` and `ZC1022` share ZC1013's `let NAME=EXPR` → `(( NAME = EXPR ))` rewrite.
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
   - `ZC1043` prepends `local ` to unscoped function-body assignments.
   - `ZC1053` inserts `-q` after `grep` / `egrep` / `fgrep` / `zgrep` when used in an `if` or `while` condition.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **126** |
+| **with auto-fix** | **127** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -24,7 +24,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1005: Use whence instead of which](#zc1005) · auto-fix
 - [ZC1006: Prefer \[\[ over test for tests](#zc1006)
 - [ZC1007: Avoid using `chmod 777`](#zc1007)
-- [ZC1008: Use `\$(())` for arithmetic operations](#zc1008)
+- [ZC1008: Use `\$(())` for arithmetic operations](#zc1008) · auto-fix
 - [ZC1009: Use `((...))` for C-style arithmetic](#zc1009)
 - [ZC1010: Use \[\[ ... \]\] instead of \[ ... \]](#zc1010) · auto-fix
 - [ZC1011: Use `git` porcelain commands instead of plumbing commands](#zc1011)
@@ -1108,7 +1108,7 @@ Disable by adding `ZC1007` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1008 — Use `\$(())` for arithmetic operations
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 The `let` command is a shell builtin, but the `\$(())` syntax is more portable and generally preferred for arithmetic operations in Zsh. It's also more powerful as it can be used in more contexts.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-127%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-128%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 127 of 1000 katas (12.7%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 128 of 1000 katas (12.8%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/katas/zc1008.go
+++ b/pkg/katas/zc1008.go
@@ -13,6 +13,11 @@ func init() {
 			"can be used in more contexts.",
 		Severity: SeverityStyle,
 		Check:    checkZC1008,
+		// Reuse ZC1013's `let NAME=EXPR` → `(( NAME = EXPR ))` rewrite.
+		// All three of ZC1008, ZC1013, ZC1022 fire on the same `let`
+		// shape and want the same arithmetic-command form; the
+		// conflict resolver dedupes overlapping edits.
+		Fix: fixZC1013,
 	})
 }
 


### PR DESCRIPTION
ZC1008 (use `$(())` for arithmetic) joins ZC1013 / ZC1022 in firing on the same `let NAME=EXPR` shape. Wiring it to the existing fixZC1013 lets all three contribute to the same `(( NAME = EXPR ))` rewrite. The conflict resolver dedupes overlapping edits.

Coverage: 127 → 128.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 127 → 128
- [x] ROADMAP coverage: 127 → 128 (12.8%)
- [x] CHANGELOG `[Unreleased]` updated
