### PR TITLE
feat(ZC1293): test EXPR… → [[ EXPR… ]]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 128/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 129/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1008` and `ZC1022` share ZC1013's `let NAME=EXPR` → `(( NAME = EXPR ))` rewrite.
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1268` inserts `--` before the first non-flag arg of `du -sh`.
   - `ZC1273` `grep PAT FILE /dev/null` → `grep -q PAT FILE` (insert `-q`, drop `/dev/null`).
   - `ZC1276` `seq M N` → `{M..N}`.
+  - `ZC1293` `test EXPR…` → `[[ EXPR… ]]`.
   - `ZC1279` `readlink -f PATH` → `realpath PATH` when `-f` is the first argument.
   - `ZC1297` `$BASH_SOURCE` → `${(%):-%x}`.
   - `ZC1319` `$BASH_ARGC` → `$#`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **127** |
+| **with auto-fix** | **128** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -306,7 +306,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1290: Use Zsh `${(n)array}` for numeric sorting instead of `sort -n`](#zc1290)
 - [ZC1291: Use Zsh `${(O)array}` for reverse sorting instead of `sort -r`](#zc1291)
 - [ZC1292: Use Zsh `${var//old/new}` instead of `tr` for character translation](#zc1292)
-- [ZC1293: Use `\[\[ \]\]` instead of `test` command in Zsh](#zc1293)
+- [ZC1293: Use `\[\[ \]\]` instead of `test` command in Zsh](#zc1293) · auto-fix
 - [ZC1294: Use `bindkey` instead of `bind` for key bindings in Zsh](#zc1294)
 - [ZC1295: Use `vared` instead of `read -e` for interactive editing in Zsh](#zc1295)
 - [ZC1296: Avoid `shopt` in Zsh — use `setopt`/`unsetopt` instead](#zc1296)
@@ -4492,7 +4492,7 @@ Disable by adding `ZC1292` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1293 — Use `[[ ]]` instead of `test` command in Zsh
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 Zsh `[[ ]]` provides a more powerful conditional expression syntax than the `test` command. It supports pattern matching, regex, and does not require quoting of variable expansions to prevent word splitting.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-128%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-129%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 128 of 1000 katas (12.8%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 129 of 1000 katas (12.9%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1589,6 +1589,21 @@ func TestFixIntegration_ZC1053_AlreadyQuiet(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1293_TestToDoubleBracket(t *testing.T) {
+	src := "test -f /etc/passwd\n"
+	want := "[[ -f /etc/passwd ]]\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1293_AlreadyDoubleBracket(t *testing.T) {
+	src := "[[ -f /etc/passwd ]]\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("already-fixed input should be idempotent, got %q", got)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1293.go
+++ b/pkg/katas/zc1293.go
@@ -13,7 +13,70 @@ func init() {
 			"the `test` command. It supports pattern matching, regex, and does not require " +
 			"quoting of variable expansions to prevent word splitting.",
 		Check: checkZC1293,
+		Fix:   fixZC1293,
 	})
+}
+
+// fixZC1293 rewrites `test EXPR…` into `[[ EXPR… ]]`. Two edits:
+// the `test` command name becomes `[[`; ` ]]` is appended after the
+// last argument's source span. Bails when there are no arguments
+// (a bare `test` is invalid anyway). Idempotent — a re-run sees
+// `[[ ... ]]`, not `test`.
+func fixZC1293(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "test" {
+		return nil
+	}
+	if len(cmd.Arguments) == 0 {
+		return nil
+	}
+	cmdOff := LineColToByteOffset(source, v.Line, v.Column)
+	if cmdOff < 0 || cmdOff+len("test") > len(source) {
+		return nil
+	}
+	if string(source[cmdOff:cmdOff+len("test")]) != "test" {
+		return nil
+	}
+	lastArg := cmd.Arguments[len(cmd.Arguments)-1]
+	lastTok := lastArg.TokenLiteralNode()
+	lastOff := LineColToByteOffset(source, lastTok.Line, lastTok.Column)
+	if lastOff < 0 {
+		return nil
+	}
+	lastVal := lastArg.String()
+	lastEnd := lastOff + len(lastVal)
+	if lastEnd > len(source) {
+		return nil
+	}
+	endLine, endCol := offsetLineColZC1293(source, lastEnd)
+	if endLine < 0 {
+		return nil
+	}
+	return []FixEdit{
+		{Line: v.Line, Column: v.Column, Length: len("test"), Replace: "[["},
+		{Line: endLine, Column: endCol, Length: 0, Replace: " ]]"},
+	}
+}
+
+func offsetLineColZC1293(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1293(node ast.Node) []Violation {


### PR DESCRIPTION
`test EXPR…` becomes `[[ EXPR… ]]`. Two edits: the `test` command name is replaced with `[[`, and ` ]]` is appended after the last argument's source span. Bails on a bare `test` with no arguments. Idempotent on a re-run because the detector keys on the `test` command name.

Coverage: 128 → 129.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 128 → 129
- [x] ROADMAP coverage: 128 → 129 (12.9%)
- [x] CHANGELOG `[Unreleased]` updated
