### PR TITLE
feat(ZC1502): insert -- before $var args of grep variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 131/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 132/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1008` and `ZC1022` share ZC1013's `let NAME=EXPR` → `(( NAME = EXPR ))` rewrite.
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1413` `hash -t cmd` → `whence -p cmd` (rename + flag swap).
   - `ZC1411` `enable -n NAME` → `disable NAME`.
   - `ZC1448` inserts `-y` after `apt install` / `apt upgrade` / `apt dist-upgrade` / `apt full-upgrade`.
+  - `ZC1502` inserts `-- ` before the first `$var` argument of `grep` / `egrep` / `fgrep` / `rg` / `ag` to block flag injection.
   - `ZC1501` `docker-compose` → `docker compose`.
   - `ZC1512` `service UNIT VERB` → `systemctl VERB UNIT` (rename + arg swap).
   - `ZC1565` `whereis` / `locate` / `mlocate` / `plocate` → `command -v`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **131** |
+| **with auto-fix** | **132** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -515,7 +515,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1499: Style: `docker pull <image>` / `:latest` — unpinned image tag](#zc1499)
 - [ZC1500: Warn on `systemctl edit <unit>` in scripts — requires interactive editor](#zc1500)
 - [ZC1501: Style: `docker-compose` (hyphen) — use `docker compose` (space, built-in plugin)](#zc1501) · auto-fix
-- [ZC1502: Warn on `grep "$var" file` without `--` — flag injection when `$var` starts with `-`](#zc1502)
+- [ZC1502: Warn on `grep "$var" file` without `--` — flag injection when `$var` starts with `-`](#zc1502) · auto-fix
 - [ZC1503: Error on `groupadd -g 0` / `groupmod -g 0` — creates duplicate root group](#zc1503)
 - [ZC1504: Warn on `git push --mirror` — overwrites every remote ref](#zc1504)
 - [ZC1505: Warn on `dpkg --force-confnew` / `--force-confold` — silently overrides /etc changes](#zc1505)
@@ -7000,7 +7000,7 @@ Disable by adding `ZC1501` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1502 — Warn on `grep "$var" file` without `--` — flag injection when `$var` starts with `-`
 
 **Severity:** `warning`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 Without a `--` end-of-flags marker, `grep` (and most POSIX tools) treats any argument that starts with `-` as a flag. If `$var` comes from user input or a fuzzed filename, an attacker can pass `--include=*secret*` or `-f /etc/shadow` and get grep to read paths the script author never intended. Always write `grep -- "$var" file` or use a grep-compatible library with explicit pattern API.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-131%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-132%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 131 of 1000 katas (13.1%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 132 of 1000 katas (13.2%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1604,6 +1604,21 @@ func TestFixIntegration_ZC1293_AlreadyDoubleBracket(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1502_GrepInsertsDashDash(t *testing.T) {
+	src := "grep \"$pat\" file\n"
+	want := "grep -- \"$pat\" file\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1502_AlreadyDashDash(t *testing.T) {
+	src := "grep -- \"$pat\" file\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("already-fixed input should be idempotent, got %q", got)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1502.go
+++ b/pkg/katas/zc1502.go
@@ -17,7 +17,73 @@ func init() {
 			"and get grep to read paths the script author never intended. Always write " +
 			"`grep -- \"$var\" file` or use a grep-compatible library with explicit pattern API.",
 		Check: checkZC1502,
+		Fix:   fixZC1502,
 	})
+}
+
+// fixZC1502 inserts `-- ` before the first variable-shaped argument
+// of a grep / egrep / fgrep / rg / ag invocation that lacks the
+// `--` end-of-options marker. Idempotent — the detector gates on
+// the absence of `--`, so once `-- ` is present a re-run won't
+// re-insert.
+func fixZC1502(node ast.Node, _ Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	if ident.Value != "grep" && ident.Value != "egrep" && ident.Value != "fgrep" &&
+		ident.Value != "rg" && ident.Value != "ag" {
+		return nil
+	}
+	var firstVar ast.Expression
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--" {
+			return nil
+		}
+		if firstVar == nil && (strings.HasPrefix(v, "\"$") || strings.HasPrefix(v, "$")) {
+			firstVar = arg
+		}
+	}
+	if firstVar == nil {
+		return nil
+	}
+	tok := firstVar.TokenLiteralNode()
+	off := LineColToByteOffset(source, tok.Line, tok.Column)
+	if off < 0 {
+		return nil
+	}
+	insLine, insCol := offsetLineColZC1502(source, off)
+	if insLine < 0 {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    insLine,
+		Column:  insCol,
+		Length:  0,
+		Replace: "-- ",
+	}}
+}
+
+func offsetLineColZC1502(source []byte, offset int) (int, int) {
+	if offset < 0 || offset > len(source) {
+		return -1, -1
+	}
+	line := 1
+	col := 1
+	for i := 0; i < offset; i++ {
+		if source[i] == '\n' {
+			line++
+			col = 1
+			continue
+		}
+		col++
+	}
+	return line, col
 }
 
 func checkZC1502(node ast.Node) []Violation {


### PR DESCRIPTION
Inserts `-- ` before the first `$var` argument of `grep` / `egrep` / `fgrep` / `rg` / `ag` invocations that lack the `--` end-of-options marker. Without `--`, an attacker-controlled `$var` starting with `-` becomes a flag and grep can be coerced into reading paths the script author never intended. Idempotent on a re-run because the detector gates on absence of `--`.

Coverage: 131 → 132.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 131 → 132
- [x] ROADMAP coverage: 131 → 132 (13.2%)
- [x] CHANGELOG `[Unreleased]` updated
