### PR TITLE
feat(ZC1591): printf '%s\n' "${array[@]}" → print -l -r --

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 132/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 133/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1008` and `ZC1022` share ZC1013's `let NAME=EXPR` → `(( NAME = EXPR ))` rewrite.
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1501` `docker-compose` → `docker compose`.
   - `ZC1512` `service UNIT VERB` → `systemctl VERB UNIT` (rename + arg swap).
   - `ZC1565` `whereis` / `locate` / `mlocate` / `plocate` → `command -v`.
+  - `ZC1591` `printf '%s\n' "${array[@]}"` → `print -l -r -- "${array[@]}"`.
   - `ZC1637` `readonly NAME=value` → `typeset -r NAME=value`.
   - `ZC1643` `$(cat FILE)` → `$(<FILE)` inside SimpleCommand argument strings.
   - `ZC1675` `export -f FUNC` → `typeset -fx FUNC`, `export -n VAR` → `typeset +x VAR`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **132** |
+| **with auto-fix** | **133** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -604,7 +604,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1588: Error on `nsenter --target 1` — joins host init namespaces (container escape)](#zc1588)
 - [ZC1589: Warn on `trap 'set -x' ERR/RETURN/EXIT/ZERR` — trace hook leaks env to stderr](#zc1589)
 - [ZC1590: Error on `sshpass -p SECRET` — password in process list and history](#zc1590)
-- [ZC1591: Style: use Zsh `print -l` / `${(F)array}` instead of `printf '%s\n' "${array\[@\]}"`](#zc1591)
+- [ZC1591: Style: use Zsh `print -l` / `${(F)array}` instead of `printf '%s\n' "${array\[@\]}"`](#zc1591) · auto-fix
 - [ZC1592: Warn on `faillock --reset` / `pam_tally2 -r` — clears failed-auth counter](#zc1592)
 - [ZC1593: Error on `blkdiscard` — issues TRIM/DISCARD across the whole device (data loss)](#zc1593)
 - [ZC1594: Warn on `docker/podman run --security-opt=systempaths=unconfined` — unhides host kernel knobs](#zc1594)
@@ -8068,7 +8068,7 @@ Disable by adding `ZC1590` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1591 — Style: use Zsh `print -l` / `${(F)array}` instead of `printf '%s\n' "${array[@]}"`
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `printf '%s\n' "${array[@]}"` is the Bash-idiomatic way to print one element per line. Zsh has `print -l -r -- "${array[@]}"` (one element per line, raw, sentinel-safe) and the parameter-expansion flag `${(F)array}` (newline-join, fine for `$(...)`). Both are shorter than the printf incantation and avoid format-string surprises if the array ever contains a literal `%`.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-132%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-133%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 132 of 1000 katas (13.2%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 133 of 1000 katas (13.3%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1619,6 +1619,14 @@ func TestFixIntegration_ZC1502_AlreadyDashDash(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1591_PrintfArrayToPrintL(t *testing.T) {
+	src := "printf '%s\\n' \"${arr[@]}\"\n"
+	want := "print -l -r -- \"${arr[@]}\"\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1591.go
+++ b/pkg/katas/zc1591.go
@@ -17,7 +17,55 @@ func init() {
 			"fine for `$(...)`). Both are shorter than the printf incantation and avoid format-" +
 			"string surprises if the array ever contains a literal `%`.",
 		Check: checkZC1591,
+		Fix:   fixZC1591,
 	})
+}
+
+// fixZC1591 rewrites `printf '%s\n' "${array[@]}"` (or `printf '%s'
+// "${array[@]}"`) to `print -l -r -- "${array[@]}"`. Single span
+// replacement covers the `printf` command name and the format
+// argument; subsequent args (the array expansion) pass through
+// unchanged. Idempotent — a re-run sees `print`, not `printf`.
+func fixZC1591(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "printf" {
+		return nil
+	}
+	if len(cmd.Arguments) < 2 {
+		return nil
+	}
+	formatArg := cmd.Arguments[0]
+	formatVal := formatArg.String()
+	trimmed := strings.Trim(formatVal, "'\"")
+	if trimmed != `%s\n` && trimmed != "%s" {
+		return nil
+	}
+	cmdOff := LineColToByteOffset(source, v.Line, v.Column)
+	if cmdOff < 0 || cmdOff+len("printf") > len(source) {
+		return nil
+	}
+	if string(source[cmdOff:cmdOff+len("printf")]) != "printf" {
+		return nil
+	}
+	formatTok := formatArg.TokenLiteralNode()
+	formatOff := LineColToByteOffset(source, formatTok.Line, formatTok.Column)
+	if formatOff < 0 || formatOff+len(formatVal) > len(source) {
+		return nil
+	}
+	if string(source[formatOff:formatOff+len(formatVal)]) != formatVal {
+		return nil
+	}
+	end := formatOff + len(formatVal)
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  end - cmdOff,
+		Replace: "print -l -r --",
+	}}
 }
 
 func checkZC1591(node ast.Node) []Violation {


### PR DESCRIPTION
`printf '%s\n' "${array[@]}"` becomes `print -l -r -- "${array[@]}"`. Single span replacement covers the `printf` command name and the format argument; the array expansion passes through unchanged. Only fires on the literal `'%s\n'` or `'%s'` format with an array-shaped second argument. Idempotent on a re-run because the cmd name is now `print`.

Coverage: 132 → 133.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 132 → 133
- [x] ROADMAP coverage: 132 → 133 (13.3%)
- [x] CHANGELOG `[Unreleased]` updated
