### PR TITLE
feat(ZC1201): rsh/rlogin → ssh, rcp → scp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 133/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 134/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1008` and `ZC1022` share ZC1013's `let NAME=EXPR` → `(( NAME = EXPR ))` rewrite.
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1172` `read -a ARR` → `read -A ARR` (Zsh array form).
   - `ZC1190` `grep -v p1 | grep -v p2` → `grep -v -e p1 -e p2`.
   - `ZC1191` `clear` → `print -rn $'\e[2J\e[H'`.
+  - `ZC1201` `rsh`/`rlogin` → `ssh`, `rcp` → `scp`.
   - `ZC1202` `ifconfig` → `ip addr`.
   - `ZC1203` `netstat` → `ss`.
   - `ZC1216` `nslookup` → `host`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **133** |
+| **with auto-fix** | **134** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -214,7 +214,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1198: Avoid interactive editors in scripts](#zc1198)
 - [ZC1199: Avoid `telnet` in scripts — use `curl` or `zsh/net/tcp`](#zc1199)
 - [ZC1200: Avoid `ftp` — use `sftp` or `curl` for secure transfers](#zc1200)
-- [ZC1201: Avoid `rsh`/`rlogin`/`rcp` — use `ssh`/`scp`](#zc1201)
+- [ZC1201: Avoid `rsh`/`rlogin`/`rcp` — use `ssh`/`scp`](#zc1201) · auto-fix
 - [ZC1202: Avoid `ifconfig` — use `ip` for network configuration](#zc1202) · auto-fix
 - [ZC1203: Avoid `netstat` — use `ss` for socket statistics](#zc1203) · auto-fix
 - [ZC1204: Avoid `route` — use `ip route` for routing](#zc1204)
@@ -3388,7 +3388,7 @@ Disable by adding `ZC1200` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1201 — Avoid `rsh`/`rlogin`/`rcp` — use `ssh`/`scp`
 
 **Severity:** `warning`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `rsh`, `rlogin`, and `rcp` are insecure legacy protocols. Use `ssh`, `scp`, or `rsync` over SSH for encrypted remote operations.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-133%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-134%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 133 of 1000 katas (13.3%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 134 of 1000 katas (13.4%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1627,6 +1627,30 @@ func TestFixIntegration_ZC1591_PrintfArrayToPrintL(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1201_RshToSsh(t *testing.T) {
+	src := "rsh host command\n"
+	want := "ssh host command\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1201_RcpToScp(t *testing.T) {
+	src := "rcp src dst\n"
+	want := "scp src dst\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixIntegration_ZC1201_RloginToSsh(t *testing.T) {
+	src := "rlogin host\n"
+	want := "ssh host\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1201.go
+++ b/pkg/katas/zc1201.go
@@ -12,7 +12,47 @@ func init() {
 		Description: "`rsh`, `rlogin`, and `rcp` are insecure legacy protocols. " +
 			"Use `ssh`, `scp`, or `rsync` over SSH for encrypted remote operations.",
 		Check: checkZC1201,
+		Fix:   fixZC1201,
 	})
+}
+
+// fixZC1201 rewrites the legacy `rsh` / `rlogin` / `rcp` command
+// names to `ssh` / `ssh` / `scp` respectively. Single-edit
+// replacement at the violation column. Argument syntax is
+// compatible (host + optional command for rsh/rlogin/ssh; src dst
+// for rcp/scp). Idempotent — a re-run sees `ssh` or `scp`, not
+// the legacy names.
+func fixZC1201(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return nil
+	}
+	var replacement string
+	switch ident.Value {
+	case "rsh", "rlogin":
+		replacement = "ssh"
+	case "rcp":
+		replacement = "scp"
+	default:
+		return nil
+	}
+	off := LineColToByteOffset(source, v.Line, v.Column)
+	if off < 0 || off+len(ident.Value) > len(source) {
+		return nil
+	}
+	if string(source[off:off+len(ident.Value)]) != ident.Value {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len(ident.Value),
+		Replace: replacement,
+	}}
 }
 
 func checkZC1201(node ast.Node) []Violation {


### PR DESCRIPTION
Legacy r-tools become their SSH-suite equivalents:

- `rsh` → `ssh`
- `rlogin` → `ssh`
- `rcp` → `scp`

Single-edit command-name replacement at the violation column. Argument syntax matches between rsh/ssh (host + optional command) and rcp/scp (src dst), so positional args pass through. Idempotent on a re-run.

Coverage: 133 → 134.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 133 → 134
- [x] ROADMAP coverage: 133 → 134 (13.4%)
- [x] CHANGELOG `[Unreleased]` updated
