### PR TITLE
feat(ZC1685): sleep infinity → exec tail -f /dev/null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 134/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 135/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1008` and `ZC1022` share ZC1013's `let NAME=EXPR` → `(( NAME = EXPR ))` rewrite.
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ZC1637` `readonly NAME=value` → `typeset -r NAME=value`.
   - `ZC1643` `$(cat FILE)` → `$(<FILE)` inside SimpleCommand argument strings.
   - `ZC1675` `export -f FUNC` → `typeset -fx FUNC`, `export -n VAR` → `typeset +x VAR`.
+  - `ZC1685` `sleep infinity` → `exec tail -f /dev/null`.
   - `ZC1717` strips `--disable-content-trust` from `docker pull` / `push` / `build` / `create` / `run`.
   - `ZC1773` `xargs CMD` → `xargs -r CMD`.
   - `ZC1334` collapses `type -p`'s flag with the rename so it wins over `ZC1064`'s narrower `type` → `command -v` form.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **134** |
+| **with auto-fix** | **135** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -698,7 +698,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1682: Error on `npm install --unsafe-perm` — npm lifecycle scripts keep root privileges](#zc1682)
 - [ZC1683: Error on `npm/yarn/pnpm config set registry http://...` — plaintext package index](#zc1683)
 - [ZC1684: Error on `redis-cli -a PASSWORD` — authentication password in process list](#zc1684)
-- [ZC1685: Info: `sleep infinity` — container keep-alive pattern that ignores SIGTERM](#zc1685)
+- [ZC1685: Info: `sleep infinity` — container keep-alive pattern that ignores SIGTERM](#zc1685) · auto-fix
 - [ZC1686: Warn on `compinit -C` / `compinit -u` — skips / ignores `$fpath` integrity checks](#zc1686)
 - [ZC1687: Warn on `snap install --classic` / `--devmode` — weakens snap confinement](#zc1687)
 - [ZC1688: Warn on `aws s3 sync --delete` — destination objects deleted when source diverges](#zc1688)
@@ -9196,7 +9196,7 @@ Disable by adding `ZC1684` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1685 — Info: `sleep infinity` — container keep-alive pattern that ignores SIGTERM
 
 **Severity:** `info`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 `sleep infinity` is most often used as a container or systemd-unit keep-alive. Problem: GNU `sleep` does not install a SIGTERM handler, so when `docker stop` / `systemctl stop` sends SIGTERM the process sits unresponsive until the grace period expires and SIGKILL lands. The orchestrator reports a hung stop, logs look wrong, and any cleanup registered on signal handlers in a wrapping shell never runs. Replace with `exec tail -f /dev/null` (signal-handles cleanly) or front with `tini` / `dumb-init` when PID 1 must stay.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-134%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-135%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 134 of 1000 katas (13.4%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 135 of 1000 katas (13.5%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1651,6 +1651,14 @@ func TestFixIntegration_ZC1201_RloginToSsh(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1685_SleepInfinityToExecTail(t *testing.T) {
+	src := "sleep infinity\n"
+	want := "exec tail -f /dev/null\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1685.go
+++ b/pkg/katas/zc1685.go
@@ -17,7 +17,48 @@ func init() {
 			"a wrapping shell never runs. Replace with `exec tail -f /dev/null` (signal-" +
 			"handles cleanly) or front with `tini` / `dumb-init` when PID 1 must stay.",
 		Check: checkZC1685,
+		Fix:   fixZC1685,
 	})
+}
+
+// fixZC1685 rewrites `sleep infinity` to `exec tail -f /dev/null`.
+// Single span replacement covers both tokens. Idempotent — a re-run
+// sees `exec`, not `sleep`, so the detector won't fire. Defensive
+// byte-match guards on both anchors.
+func fixZC1685(node ast.Node, v Violation, source []byte) []FixEdit {
+	cmd, ok := node.(*ast.SimpleCommand)
+	if !ok {
+		return nil
+	}
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok || ident.Value != "sleep" {
+		return nil
+	}
+	if len(cmd.Arguments) != 1 || cmd.Arguments[0].String() != "infinity" {
+		return nil
+	}
+	cmdOff := LineColToByteOffset(source, v.Line, v.Column)
+	if cmdOff < 0 || cmdOff+len("sleep") > len(source) {
+		return nil
+	}
+	if string(source[cmdOff:cmdOff+len("sleep")]) != "sleep" {
+		return nil
+	}
+	argTok := cmd.Arguments[0].TokenLiteralNode()
+	argOff := LineColToByteOffset(source, argTok.Line, argTok.Column)
+	if argOff < 0 || argOff+len("infinity") > len(source) {
+		return nil
+	}
+	if string(source[argOff:argOff+len("infinity")]) != "infinity" {
+		return nil
+	}
+	end := argOff + len("infinity")
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  end - cmdOff,
+		Replace: "exec tail -f /dev/null",
+	}}
 }
 
 func checkZC1685(node ast.Node) []Violation {


### PR DESCRIPTION
`sleep infinity` becomes `exec tail -f /dev/null`. Single span replacement covers both tokens. The new form handles SIGTERM cleanly so `docker stop` / `systemctl stop` doesn't hang until the SIGKILL grace period expires. Idempotent on a re-run because the cmd name becomes `exec`.

Coverage: 134 → 135.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 134 → 135
- [x] ROADMAP coverage: 134 → 135 (13.5%)
- [x] CHANGELOG `[Unreleased]` updated
