### PR TITLE
feat(ZC1069): local → typeset at file scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 135/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 136/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1008` and `ZC1022` share ZC1013's `let NAME=EXPR` → `(( NAME = EXPR ))` rewrite.
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
   - `ZC1043` prepends `local ` to unscoped function-body assignments.
   - `ZC1053` inserts `-q` after `grep` / `egrep` / `fgrep` / `zgrep` when used in an `if` or `while` condition.
+  - `ZC1069` rewrites `local` to `typeset` when used at file scope (outside any function).
   - `ZC1095` `seq N` → `{1..N}` (reuses the ZC1061 brace-expansion rewrite).
   - `ZC1034` / `ZC1271` `which` → `command -v`.
   - `ZC1107` `[[ a -lt b ]]` → `(( a < b ))`.

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **135** |
+| **with auto-fix** | **136** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -85,7 +85,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1066: Avoid iterating over `cat` output](#zc1066)
 - [ZC1067: Separate `export` and assignment to avoid masking return codes](#zc1067)
 - [ZC1068: Use `add-zsh-hook` instead of defining hook functions directly](#zc1068)
-- [ZC1069: Avoid `local` outside of functions](#zc1069)
+- [ZC1069: Avoid `local` outside of functions](#zc1069) · auto-fix
 - [ZC1070: Use `builtin` or `command` to avoid infinite recursion in wrapper functions](#zc1070)
 - [ZC1071: Use `+=` for appending to arrays](#zc1071)
 - [ZC1072: Use `awk` instead of `grep \| awk`](#zc1072)
@@ -1840,7 +1840,7 @@ Disable by adding `ZC1068` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1069 — Avoid `local` outside of functions
 
 **Severity:** `info`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 The `local` builtin can only be used inside functions. Using it in the global scope causes an error.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-135%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-136%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 135 of 1000 katas (13.5%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 136 of 1000 katas (13.6%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1659,6 +1659,14 @@ func TestFixIntegration_ZC1685_SleepInfinityToExecTail(t *testing.T) {
 	}
 }
 
+func TestFixIntegration_ZC1069_LocalToTypesetAtFileScope(t *testing.T) {
+	src := "local x=1\n"
+	want := "typeset x=1\n"
+	if got := runFix(t, src); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
 func TestFixIntegration_ZC1252_PipedCatHandledByZC1146(t *testing.T) {
 	// `cat /etc/group | head` lets ZC1146 win the overlap and collapse
 	// the pipe into `head /etc/group`. ZC1252's two-edit rewrite would

--- a/pkg/katas/zc1069.go
+++ b/pkg/katas/zc1069.go
@@ -12,7 +12,29 @@ func init() {
 			"Using it in the global scope causes an error.",
 		Severity: SeverityInfo,
 		Check:    checkZC1069,
+		Fix:      fixZC1069,
 	})
+}
+
+// fixZC1069 rewrites `local` to `typeset` when used at file scope.
+// `typeset` works in both function and global contexts, so the
+// rewrite is safe wherever the detector fires. Single-edit name
+// swap at the violation column. Idempotent — a re-run sees
+// `typeset`, not `local`. Defensive byte-match guard.
+func fixZC1069(_ ast.Node, v Violation, source []byte) []FixEdit {
+	off := LineColToByteOffset(source, v.Line, v.Column)
+	if off < 0 || off+len("local") > len(source) {
+		return nil
+	}
+	if string(source[off:off+len("local")]) != "local" {
+		return nil
+	}
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  len("local"),
+		Replace: "typeset",
+	}}
 }
 
 func checkZC1069(node ast.Node) []Violation {


### PR DESCRIPTION
`local` at file scope becomes `typeset`. Single-edit name swap at the violation column. `typeset` works in both function and global contexts, so the rewrite is safe wherever the file-scope `local` detector fires. Idempotent on a re-run.

Coverage: 135 → 136.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 135 → 136
- [x] ROADMAP coverage: 135 → 136 (13.6%)
- [x] CHANGELOG `[Unreleased]` updated
