### PR TITLE
feat(ZC1037): share echo rewrite with ZC1092

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Auto-fix coverage now at 136/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
+- **Auto-fix coverage now at 137/1000 katas.** New rewrites since 1.0.15, every one deterministic and idempotent on a re-run:
   - `ZC1015` backticks → `$(...)`.
   - `ZC1016` inserts `-s` after `read` when the variable looks sensitive (`password`, `secret`, `token`, …).
   - `ZC1008` and `ZC1022` share ZC1013's `let NAME=EXPR` → `(( NAME = EXPR ))` rewrite.
   - `ZC1032` `let i=i+1` → `(( i++ ))` (and `i-1` → `i--`).
+  - `ZC1037` shares ZC1092's `echo` → `print -r --` rewrite.
   - `ZC1043` prepends `local ` to unscoped function-body assignments.
   - `ZC1053` inserts `-q` after `grep` / `egrep` / `fgrep` / `zgrep` when used in an `if` or `while` condition.
   - `ZC1069` rewrites `local` to `typeset` when used at file scope (outside any function).

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **136** |
+| **with auto-fix** | **137** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -53,7 +53,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1034: Use `command -v` instead of `which`](#zc1034) · auto-fix
 - [ZC1035: Superseded by ZC1022 — retired duplicate `let` detector](#zc1035)
 - [ZC1036: Prefer `\[\[ ... \]\]` over `test` command](#zc1036) · auto-fix
-- [ZC1037: Use 'print -r --' for variable expansion](#zc1037)
+- [ZC1037: Use 'print -r --' for variable expansion](#zc1037) · auto-fix
 - [ZC1038: Avoid useless use of cat](#zc1038)
 - [ZC1039: Avoid `rm` with root path](#zc1039)
 - [ZC1040: Use (N) nullglob qualifier for globs in loops](#zc1040) · auto-fix
@@ -1456,7 +1456,7 @@ Disable by adding `ZC1036` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1037 — Use 'print -r --' for variable expansion
 
 **Severity:** `style`  
-**Auto-fix:** `no`
+**Auto-fix:** `yes`
 
 Using 'echo' to print strings containing variables can lead to unexpected behavior if the variable contains special characters or flags. A safer, more reliable alternative is 'print -r --'.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Static analysis and auto-fix for the setopts, hooks, and globs Bash never learne
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
-[![Auto-fix](https://img.shields.io/badge/auto--fix-136%20katas-2ea44f)](KATAS.md)
+[![Auto-fix](https://img.shields.io/badge/auto--fix-137%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)
 [![codecov](https://codecov.io/gh/afadesigns/zshellcheck/graph/badge.svg)](https://codecov.io/gh/afadesigns/zshellcheck)
 [![Scorecard](https://api.securityscorecards.dev/projects/github.com/afadesigns/zshellcheck/badge)](https://securityscorecards.dev/viewer/?uri=github.com/afadesigns/zshellcheck)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Our mission is to provide the most comprehensive, fast, and reliable tooling for
 - [ ] **Language Server Protocol (LSP)**: Build an official LSP implementation to support VS Code, Neovim, and other editors natively with inline diagnostics and "Quick Fix" actions.
 - [x] **Auto-Fixer core** (v1.0.14+): `-fix`, `-diff`, `-dry-run` flags applying deterministic per-kata rewrites.
   The set of fix-enabled katas grows with each release.
-- [ ] **Auto-Fixer coverage**: 136 of 1000 katas (13.6%) ship a deterministic rewrite as of the latest tag.
+- [ ] **Auto-Fixer coverage**: 137 of 1000 katas (13.7%) ship a deterministic rewrite as of the latest tag.
   Expansion continues per release; the structural ceiling is the subset of detections that admit a context-free, idempotent, byte-exact rewrite — many advisory or context-dependent detections will remain detection-only.
 - [ ] **Plugin System**: Allow users to write their own custom checks in Lua or Wasm.
 - [ ] **Distribution channels** — broaden install paths beyond `./install.sh`, `go install`, and the signed Releases archive:

--- a/pkg/katas/zc1037.go
+++ b/pkg/katas/zc1037.go
@@ -16,6 +16,11 @@ func init() {
 			"is 'print -r --'.",
 		Severity: SeverityStyle,
 		Check:    checkZC1037,
+		// Reuse ZC1092's `echo` → `print -r --` rewrite. The detector
+		// here is a stricter subset (only fires when echo prints a
+		// variable expansion) but the rewrite is identical; the
+		// conflict resolver dedupes overlapping edits.
+		Fix: fixZC1092,
 	})
 }
 


### PR DESCRIPTION
ZC1037 (echo with variable expansion in args) is a stricter subset of ZC1092's general echo detector. Wiring ZC1037 to the existing fixZC1092 lets both contribute the same `print -r --` rewrite. The conflict resolver dedupes overlapping span replacements.

Coverage: 136 → 137.

- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] `KATAS.md` regenerated
- [x] README badge: 136 → 137
- [x] ROADMAP coverage: 136 → 137 (13.7%)
- [x] CHANGELOG `[Unreleased]` updated
