### PR TITLE
refactor(katas): drop cyclomatic complexity below gocyclo floor (batch 1/N)

### DIFF
--- a/pkg/katas/fixutil.go
+++ b/pkg/katas/fixutil.go
@@ -79,3 +79,40 @@ func FlagArgPosition(cmd *ast.SimpleCommand, needles map[string]bool) (int, int)
 	}
 	return cmd.Token.Line, cmd.Token.Column
 }
+
+// HasArgFlag reports whether any cmd argument stringifies to a key
+// present in flags. Replaces the recurring `for arg ... if v == "-x" ||
+// v == "-y" || ...` chains that drive kata cyclomatic complexity above
+// the gocyclo threshold.
+func HasArgFlag(cmd *ast.SimpleCommand, flags map[string]struct{}) bool {
+	for _, arg := range cmd.Arguments {
+		if _, hit := flags[arg.String()]; hit {
+			return true
+		}
+	}
+	return false
+}
+
+// ArgValueAfter returns the stringified argument that immediately
+// follows the first argument matching key, or the empty string when
+// the key is absent or sits at the tail. Used by katas that match
+// `--bind 0.0.0.0` style options.
+func ArgValueAfter(cmd *ast.SimpleCommand, key string) string {
+	for i, arg := range cmd.Arguments {
+		if arg.String() == key && i+1 < len(cmd.Arguments) {
+			return cmd.Arguments[i+1].String()
+		}
+	}
+	return ""
+}
+
+// CommandIdentifier returns the head identifier value of cmd, or "" if
+// the head is not an identifier. Wraps the common type-assertion guard
+// at the top of every Check function.
+func CommandIdentifier(cmd *ast.SimpleCommand) string {
+	ident, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return ""
+	}
+	return ident.Value
+}

--- a/pkg/katas/zc1010.go
+++ b/pkg/katas/zc1010.go
@@ -54,46 +54,77 @@ func fixZC1010(node ast.Node, v Violation, source []byte) []FixEdit {
 // double-quoted strings, and `${…}` braces are respected so the scan
 // doesn't match `]` inside `"$arr[idx]"`.
 func findTestCloseBracket(source []byte, open int) int {
-	inSingle := false
-	inDouble := false
-	braceDepth := 0
+	st := bracketScan{}
 	for i := open + 1; i < len(source); i++ {
-		c := source[i]
-		switch {
-		case inSingle:
-			if c == '\'' {
-				inSingle = false
-			}
-		case inDouble:
-			if c == '\\' && i+1 < len(source) {
-				i++
-				continue
-			}
-			if c == '"' {
-				inDouble = false
-			}
-		default:
-			switch c {
-			case '\'':
-				inSingle = true
-			case '"':
-				inDouble = true
-			case '{':
-				braceDepth++
-			case '}':
-				if braceDepth > 0 {
-					braceDepth--
-				}
-			case '\n', ';':
-				return -1
-			case ']':
-				if braceDepth == 0 {
-					return i
-				}
-			}
+		if next, ok := st.advance(source, i); ok {
+			i = next
+			continue
+		}
+		if st.closedAt(source, i) {
+			return i
+		}
+		if st.terminated(source, i) {
+			return -1
 		}
 	}
 	return -1
+}
+
+type bracketScan struct {
+	inSingle, inDouble bool
+	braceDepth         int
+}
+
+// advance returns (newIndex, true) when the byte at i drives the scanner
+// forward past quoted/escaped material without further classification.
+func (s *bracketScan) advance(source []byte, i int) (int, bool) {
+	c := source[i]
+	switch {
+	case s.inSingle:
+		if c == '\'' {
+			s.inSingle = false
+		}
+		return i, true
+	case s.inDouble:
+		if c == '\\' && i+1 < len(source) {
+			return i + 1, true
+		}
+		if c == '"' {
+			s.inDouble = false
+		}
+		return i, true
+	}
+	return i, false
+}
+
+// closedAt reports whether the unquoted byte at i is the matching `]`.
+// Side effect: classifies opening / closing braces to track depth.
+func (s *bracketScan) closedAt(source []byte, i int) bool {
+	switch source[i] {
+	case '\'':
+		s.inSingle = true
+	case '"':
+		s.inDouble = true
+	case '{':
+		s.braceDepth++
+	case '}':
+		if s.braceDepth > 0 {
+			s.braceDepth--
+		}
+	case ']':
+		if s.braceDepth == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *bracketScan) terminated(source []byte, i int) bool {
+	if s.inSingle || s.inDouble {
+		return false
+	}
+	c := source[i]
+	return c == '\n' || c == ';'
 }
 
 // offsetToEdit builds a FixEdit whose Line/Column correspond to the

--- a/pkg/katas/zc1045.go
+++ b/pkg/katas/zc1045.go
@@ -94,37 +94,43 @@ func hasCommandSubstitutionAssignment(arg ast.Expression) bool {
 
 func isCommandSubstitution(node ast.Node) bool {
 	switch n := node.(type) {
-	case *ast.CommandSubstitution:
-		return true
-	case *ast.DollarParenExpression:
+	case *ast.CommandSubstitution, *ast.DollarParenExpression:
 		return true
 	case *ast.ConcatenatedExpression:
-		// Recursively check parts? e.g. `var="foo $(cmd)"`
-		for _, p := range n.Parts {
-			if isCommandSubstitution(p) {
+		return zc1045ConcatHasSub(n)
+	case *ast.StringLiteral:
+		return zc1045StringHasSub(n.Value)
+	}
+	return false
+}
+
+func zc1045ConcatHasSub(n *ast.ConcatenatedExpression) bool {
+	for _, p := range n.Parts {
+		if isCommandSubstitution(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// zc1045StringHasSub scans a double-quoted string literal for embedded
+// `$(...)` or backtick command substitutions, ignoring backslash-
+// escaped bytes.
+func zc1045StringHasSub(val string) bool {
+	if len(val) < 2 || val[0] != '"' || val[len(val)-1] != '"' {
+		return false
+	}
+	for i := 0; i < len(val); i++ {
+		switch val[i] {
+		case '\\':
+			i++
+		case '`':
+			return true
+		case '$':
+			if i+1 < len(val) && val[i+1] == '(' {
 				return true
 			}
 		}
-	case *ast.StringLiteral:
-		// Check for interpolation in double-quoted strings
-		val := n.Value
-		if len(val) >= 2 && val[0] == '"' && val[len(val)-1] == '"' {
-			// Scan for $(...) or `...`
-			// Simple heuristic: unescaped $ followed by ( or unescaped `
-			for i := 0; i < len(val); i++ {
-				if val[i] == '\\' {
-					i++ // skip next
-					continue
-				}
-				if val[i] == '`' {
-					return true
-				}
-				if val[i] == '$' && i+1 < len(val) && val[i+1] == '(' {
-					return true
-				}
-			}
-		}
-		return false
 	}
 	return false
 }

--- a/pkg/katas/zc1053.go
+++ b/pkg/katas/zc1053.go
@@ -119,51 +119,45 @@ func walkZC1053(node ast.Node, isSilenced bool, violations *[]Violation) {
 	if node == nil {
 		return
 	}
-
 	switch n := node.(type) {
 	case *ast.BlockStatement:
 		for _, stmt := range n.Statements {
-			// In a block (condition), usually all statements execute, but only the last one's exit code
-			// matters for the condition?
-			// No, `if cmd1; cmd2; then`. Both execute. `cmd1` prints. `cmd2` prints.
-			// Should we check ALL commands in condition?
-			// Yes, because `grep` printing in a condition is usually unwanted noise.
 			walkZC1053(stmt, isSilenced, violations)
 		}
 	case *ast.ExpressionStatement:
 		walkZC1053(n.Expression, isSilenced, violations)
 	case *ast.InfixExpression:
-		if n.Operator == "|" {
-			// Left side of pipe is silenced (stdout goes to pipe)
-			walkZC1053(n.Left, true, violations)
-			// Right side inherits current silence state
-			walkZC1053(n.Right, isSilenced, violations)
-		} else {
-			// &&, || etc. inherit state
-			walkZC1053(n.Left, isSilenced, violations)
-			walkZC1053(n.Right, isSilenced, violations)
-		}
+		zc1053WalkInfix(n, isSilenced, violations)
 	case *ast.PrefixExpression:
 		if n.Operator == "!" {
 			walkZC1053(n.Right, isSilenced, violations)
 		}
 	case *ast.Redirection:
-		// Check if redirection silences stdout
-		newSilenced := isSilenced
-		if n.Operator == ">" || n.Operator == ">>" || n.Operator == "&>" {
-			// Check if Right is /dev/null
-			if isDevNull(n.Right) {
-				newSilenced = true
-			}
-		}
-		walkZC1053(n.Left, newSilenced, violations)
+		walkZC1053(n.Left, isSilenced || zc1053SilencesStdout(n), violations)
 	case *ast.SimpleCommand:
 		checkCommandZC1053(n, isSilenced, violations)
 	case *ast.GroupedExpression:
 		walkZC1053(n.Expression, isSilenced, violations)
-		// case *ast.Subshell:
-		// Handled by BlockStatement
 	}
+}
+
+func zc1053WalkInfix(n *ast.InfixExpression, isSilenced bool, violations *[]Violation) {
+	if n.Operator == "|" {
+		// Left side of pipe is silenced (stdout goes to pipe).
+		walkZC1053(n.Left, true, violations)
+		walkZC1053(n.Right, isSilenced, violations)
+		return
+	}
+	walkZC1053(n.Left, isSilenced, violations)
+	walkZC1053(n.Right, isSilenced, violations)
+}
+
+func zc1053SilencesStdout(n *ast.Redirection) bool {
+	switch n.Operator {
+	case ">", ">>", "&>":
+		return isDevNull(n.Right)
+	}
+	return false
 }
 
 func checkCommandZC1053(cmd *ast.SimpleCommand, isSilenced bool, violations *[]Violation) {

--- a/pkg/katas/zc1077.go
+++ b/pkg/katas/zc1077.go
@@ -26,67 +26,63 @@ func init() {
 }
 
 func checkZC1077(node ast.Node) []Violation {
-	var command ast.Node
+	rightCmd, ok := zc1077TrPipeline(node)
+	if !ok || len(rightCmd.Arguments) < 2 {
+		return nil
+	}
+	arg1 := rightCmd.Arguments[0].String()
+	arg2 := rightCmd.Arguments[1].String()
 
+	if zc1077IsUpperPair(arg1, arg2) {
+		return zc1077Hit(node, "u", "uppercase")
+	}
+	if zc1077IsLowerPair(arg1, arg2) {
+		return zc1077Hit(node, "l", "lowercase")
+	}
+	return nil
+}
+
+// zc1077TrPipeline returns the right-hand `tr` command of a `cmd | tr`
+// pipeline embedded in either a backtick or `$()` substitution.
+func zc1077TrPipeline(node ast.Node) (*ast.SimpleCommand, bool) {
+	var command ast.Node
 	switch n := node.(type) {
 	case *ast.CommandSubstitution:
 		command = n.Command
 	case *ast.DollarParenExpression:
 		command = n.Command
 	default:
-		return nil
+		return nil, false
 	}
-
-	// Check for pipeline: echo $var | tr ...
 	infix, ok := command.(*ast.InfixExpression)
 	if !ok || infix.Operator != "|" {
-		return nil
+		return nil, false
 	}
-
-	// Right side must be `tr`
 	rightCmd, ok := infix.Right.(*ast.SimpleCommand)
 	if !ok || rightCmd.Name.String() != "tr" {
-		return nil
+		return nil, false
 	}
+	return rightCmd, true
+}
 
-	// Check arguments of tr
-	if len(rightCmd.Arguments) < 2 {
-		return nil
-	}
+func zc1077IsUpperPair(a, b string) bool {
+	return (checkTrPattern(a, "a-z") && checkTrPattern(b, "A-Z")) ||
+		(checkTrPattern(a, "[:lower:]") && checkTrPattern(b, "[:upper:]"))
+}
 
-	arg1 := rightCmd.Arguments[0].String()
-	arg2 := rightCmd.Arguments[1].String()
+func zc1077IsLowerPair(a, b string) bool {
+	return (checkTrPattern(a, "A-Z") && checkTrPattern(b, "a-z")) ||
+		(checkTrPattern(a, "[:upper:]") && checkTrPattern(b, "[:lower:]"))
+}
 
-	// Check for 'a-z' 'A-Z' or similar patterns
-	// We check both quoted and unquoted versions roughly
-	isUpper := checkTrPattern(arg1, "a-z") && checkTrPattern(arg2, "A-Z")
-	isLower := checkTrPattern(arg1, "A-Z") && checkTrPattern(arg2, "a-z")
-
-	// Also check POSIX classes
-	isUpperPosix := checkTrPattern(arg1, "[:lower:]") && checkTrPattern(arg2, "[:upper:]")
-	isLowerPosix := checkTrPattern(arg1, "[:upper:]") && checkTrPattern(arg2, "[:lower:]")
-
-	if isUpper || isUpperPosix {
-		return []Violation{{
-			KataID:  "ZC1077",
-			Message: "Use `${var:u}` instead of `tr` for uppercase conversion. It is faster and built-in.",
-			Line:    node.TokenLiteralNode().Line,
-			Column:  node.TokenLiteralNode().Column,
-			Level:   SeverityStyle,
-		}}
-	}
-
-	if isLower || isLowerPosix {
-		return []Violation{{
-			KataID:  "ZC1077",
-			Message: "Use `${var:l}` instead of `tr` for lowercase conversion. It is faster and built-in.",
-			Line:    node.TokenLiteralNode().Line,
-			Column:  node.TokenLiteralNode().Column,
-			Level:   SeverityStyle,
-		}}
-	}
-
-	return nil
+func zc1077Hit(node ast.Node, flag, label string) []Violation {
+	return []Violation{{
+		KataID:  "ZC1077",
+		Message: "Use `${var:" + flag + "}` instead of `tr` for " + label + " conversion. It is faster and built-in.",
+		Line:    node.TokenLiteralNode().Line,
+		Column:  node.TokenLiteralNode().Column,
+		Level:   SeverityStyle,
+	}}
 }
 
 func checkTrPattern(arg, pattern string) bool {

--- a/pkg/katas/zc1091.go
+++ b/pkg/katas/zc1091.go
@@ -24,62 +24,67 @@ func init() {
 // `[[ x -lt 10 ]]` → `(( x < 10 ))`. Only fires when exactly one
 // recognised operator appears inside the brackets to keep the
 // rewrite unambiguous.
-func fixZC1091(node ast.Node, v Violation, source []byte) []FixEdit {
+func fixZC1091(node ast.Node, _ Violation, source []byte) []FixEdit {
 	dbe, ok := node.(*ast.DoubleBracketExpression)
 	if !ok {
 		return nil
 	}
-	openLine := dbe.Token.Line
-	openCol := dbe.Token.Column
-	openOff := LineColToByteOffset(source, openLine, openCol)
-	if openOff < 0 {
-		return nil
-	}
-	// The lexer stamps `[[` at the second bracket (two-char fusion).
-	// Step back one column when needed so the edit covers the whole
-	// opener.
-	if openOff > 0 && source[openOff] == '[' && source[openOff-1] == '[' {
-		openOff--
-		openCol--
-	}
-	if openOff+2 > len(source) || source[openOff] != '[' || source[openOff+1] != '[' {
+	openOff, openLine, openCol, ok := zc1091OpenBracket(source, dbe)
+	if !ok {
 		return nil
 	}
 	closeOff := findDoubleBracketClose(source, openOff+2)
 	if closeOff < 0 {
 		return nil
 	}
-	// Find the single `-eq`/etc. operator token and replace.
-	var opTok ast.Expression
-	var opStr string
-	opCount := 0
-	for _, el := range dbe.Elements {
-		if infix, ok := el.(*ast.InfixExpression); ok {
-			if repl, found := arithCmpReplacements[infix.Operator]; found {
-				opTok = el
-				opStr = infix.Operator
-				_ = repl
-				opCount++
-			}
-		}
-	}
-	if opCount != 1 || opTok == nil {
+	infix, ok := zc1091SingleArithOp(dbe)
+	if !ok {
 		return nil
 	}
-	// opTok points at the infix expression; its TokenLiteralNode is
-	// the operator token (e.g. `-eq`). Row/col is already 1-based.
-	infix := opTok.(*ast.InfixExpression)
-	opLine := infix.Token.Line
-	opCol := infix.Token.Column
 	closeLine, closeCol := offsetLineColZC1091(source, closeOff)
 	if closeLine < 0 {
 		return nil
 	}
 	return []FixEdit{
 		{Line: openLine, Column: openCol, Length: 2, Replace: "(("},
-		{Line: opLine, Column: opCol, Length: len(opStr), Replace: arithCmpReplacements[opStr]},
+		{Line: infix.Token.Line, Column: infix.Token.Column, Length: len(infix.Operator), Replace: arithCmpReplacements[infix.Operator]},
 		{Line: closeLine, Column: closeCol, Length: 2, Replace: "))"},
 	}
+}
+
+func zc1091OpenBracket(source []byte, dbe *ast.DoubleBracketExpression) (off, line, col int, ok bool) {
+	line = dbe.Token.Line
+	col = dbe.Token.Column
+	off = LineColToByteOffset(source, line, col)
+	if off < 0 {
+		return 0, 0, 0, false
+	}
+	if off > 0 && source[off] == '[' && source[off-1] == '[' {
+		off--
+		col--
+	}
+	if off+2 > len(source) || source[off] != '[' || source[off+1] != '[' {
+		return 0, 0, 0, false
+	}
+	return off, line, col, true
+}
+
+func zc1091SingleArithOp(dbe *ast.DoubleBracketExpression) (*ast.InfixExpression, bool) {
+	var found *ast.InfixExpression
+	for _, el := range dbe.Elements {
+		infix, ok := el.(*ast.InfixExpression)
+		if !ok {
+			continue
+		}
+		if _, hit := arithCmpReplacements[infix.Operator]; !hit {
+			continue
+		}
+		if found != nil {
+			return nil, false
+		}
+		found = infix
+	}
+	return found, found != nil
 }
 
 // findDoubleBracketClose scans source for the matching `]]` that

--- a/pkg/katas/zc1146.go
+++ b/pkg/katas/zc1146.go
@@ -4,6 +4,7 @@ package katas
 
 import (
 	"github.com/afadesigns/zshellcheck/pkg/ast"
+	"github.com/afadesigns/zshellcheck/pkg/token"
 )
 
 func init() {
@@ -24,67 +25,26 @@ func init() {
 // verbatim with ` FILE` appended. Only fires when the cat command has
 // exactly one filename argument (the detector already guards that).
 func fixZC1146(node ast.Node, _ Violation, source []byte) []FixEdit {
-	pipe, ok := node.(*ast.InfixExpression)
-	if !ok || pipe.Operator != "|" {
-		return nil
-	}
-	catCmd, ok := pipe.Left.(*ast.SimpleCommand)
-	if !ok || !isCommandName(catCmd, "cat") {
-		return nil
-	}
-	if len(catCmd.Arguments) != 1 {
-		return nil
-	}
-	rightCmd, ok := pipe.Right.(*ast.SimpleCommand)
+	_, catCmd, rightCmd, _, ok := zc1146Pipe(node)
 	if !ok {
 		return nil
 	}
-	rightIdent, ok := rightCmd.Name.(*ast.Identifier)
+	catStart, ok := zc1146Offset(source, catCmd.TokenLiteralNode())
 	if !ok {
 		return nil
 	}
-
-	catTok := catCmd.TokenLiteralNode()
-	catStart := LineColToByteOffset(source, catTok.Line, catTok.Column)
-	if catStart < 0 {
+	fileLit, _, ok := zc1146ArgSlice(source, catCmd.Arguments[0])
+	if !ok {
 		return nil
 	}
-
-	// File arg literal text: take it byte-exact from the source.
-	fileArg := catCmd.Arguments[0]
-	fileTok := fileArg.TokenLiteralNode()
-	fileOff := LineColToByteOffset(source, fileTok.Line, fileTok.Column)
-	if fileOff < 0 {
+	rightStart, ok := zc1146Offset(source, rightCmd.TokenLiteralNode())
+	if !ok {
 		return nil
 	}
-	fileLit := fileArg.String()
-	if fileOff+len(fileLit) > len(source) ||
-		string(source[fileOff:fileOff+len(fileLit)]) != fileLit {
+	rightEnd, ok := zc1146RightEnd(source, rightCmd, rightStart)
+	if !ok {
 		return nil
 	}
-
-	// Right command source span: [rightStart, rightEnd).
-	rightTok := rightCmd.TokenLiteralNode()
-	rightStart := LineColToByteOffset(source, rightTok.Line, rightTok.Column)
-	if rightStart < 0 {
-		return nil
-	}
-	rightEnd := rightStart + len(rightIdent.Value)
-	if len(rightCmd.Arguments) > 0 {
-		lastArg := rightCmd.Arguments[len(rightCmd.Arguments)-1]
-		laTok := lastArg.TokenLiteralNode()
-		laOff := LineColToByteOffset(source, laTok.Line, laTok.Column)
-		if laOff < 0 {
-			return nil
-		}
-		laLit := lastArg.String()
-		rightEnd = laOff + len(laLit)
-	}
-	if rightEnd > len(source) || rightEnd < rightStart {
-		return nil
-	}
-	rightSrc := string(source[rightStart:rightEnd])
-
 	startLine, startCol := offsetLineColZC1146(source, catStart)
 	if startLine < 0 {
 		return nil
@@ -93,8 +53,49 @@ func fixZC1146(node ast.Node, _ Violation, source []byte) []FixEdit {
 		Line:    startLine,
 		Column:  startCol,
 		Length:  rightEnd - catStart,
-		Replace: rightSrc + " " + fileLit,
+		Replace: string(source[rightStart:rightEnd]) + " " + fileLit,
 	}}
+}
+
+func zc1146Offset(source []byte, tok token.Token) (int, bool) {
+	off := LineColToByteOffset(source, tok.Line, tok.Column)
+	return off, off >= 0
+}
+
+// zc1146ArgSlice returns the literal text of arg as it appears in
+// source plus the offset, or ok=false when the AST coordinates do not
+// line up with the source bytes.
+func zc1146ArgSlice(source []byte, arg ast.Expression) (lit string, off int, ok bool) {
+	tok := arg.TokenLiteralNode()
+	off, ok = zc1146Offset(source, tok)
+	if !ok {
+		return "", 0, false
+	}
+	lit = arg.String()
+	if off+len(lit) > len(source) || string(source[off:off+len(lit)]) != lit {
+		return "", 0, false
+	}
+	return lit, off, true
+}
+
+func zc1146RightEnd(source []byte, rightCmd *ast.SimpleCommand, rightStart int) (int, bool) {
+	rightIdent, ok := rightCmd.Name.(*ast.Identifier)
+	if !ok {
+		return 0, false
+	}
+	end := rightStart + len(rightIdent.Value)
+	if n := len(rightCmd.Arguments); n > 0 {
+		lastArg := rightCmd.Arguments[n-1]
+		laOff, ok := zc1146Offset(source, lastArg.TokenLiteralNode())
+		if !ok {
+			return 0, false
+		}
+		end = laOff + len(lastArg.String())
+	}
+	if end > len(source) || end < rightStart {
+		return 0, false
+	}
+	return end, true
 }
 
 func offsetLineColZC1146(source []byte, offset int) (int, int) {
@@ -114,48 +115,53 @@ func offsetLineColZC1146(source []byte, offset int) (int, int) {
 	return line, col
 }
 
+var zc1146FileTakers = map[string]struct{}{
+	"awk":  {},
+	"sed":  {},
+	"sort": {},
+	"head": {},
+	"tail": {},
+}
+
 func checkZC1146(node ast.Node) []Violation {
-	pipe, ok := node.(*ast.InfixExpression)
-	if !ok || pipe.Operator != "|" {
-		return nil
-	}
-
-	catCmd, ok := pipe.Left.(*ast.SimpleCommand)
-	if !ok || !isCommandName(catCmd, "cat") {
-		return nil
-	}
-
-	// cat must have exactly one file argument and no flags
-	if len(catCmd.Arguments) != 1 {
-		return nil
-	}
-	for _, arg := range catCmd.Arguments {
-		if len(arg.String()) > 0 && arg.String()[0] == '-' {
-			return nil
-		}
-	}
-
-	// Right side must be awk/sed/sort or similar
-	rightCmd, ok := pipe.Right.(*ast.SimpleCommand)
+	pipe, _, _, name, ok := zc1146Pipe(node)
 	if !ok {
 		return nil
 	}
-	rightIdent, ok := rightCmd.Name.(*ast.Identifier)
-	if !ok {
+	if _, hit := zc1146FileTakers[name]; !hit {
 		return nil
 	}
+	return []Violation{{
+		KataID: "ZC1146",
+		Message: "Pass the file directly to `" + name + "` instead of `cat file | " + name + "`. " +
+			"Most text-processing tools accept file arguments.",
+		Line:   pipe.TokenLiteralNode().Line,
+		Column: pipe.TokenLiteralNode().Column,
+		Level:  SeverityStyle,
+	}}
+}
 
-	name := rightIdent.Value
-	if name == "awk" || name == "sed" || name == "sort" || name == "head" || name == "tail" {
-		return []Violation{{
-			KataID: "ZC1146",
-			Message: "Pass the file directly to `" + name + "` instead of `cat file | " + name + "`. " +
-				"Most text-processing tools accept file arguments.",
-			Line:   pipe.TokenLiteralNode().Line,
-			Column: pipe.TokenLiteralNode().Column,
-			Level:  SeverityStyle,
-		}}
+// zc1146Pipe destructures `cat FILE | NAME [args]` into its parts and
+// reports whether the cat side is well-formed (single non-flag arg).
+func zc1146Pipe(node ast.Node) (pipe *ast.InfixExpression, catCmd, rightCmd *ast.SimpleCommand, name string, ok bool) {
+	pipe, isPipe := node.(*ast.InfixExpression)
+	if !isPipe || pipe.Operator != "|" {
+		return nil, nil, nil, "", false
 	}
-
-	return nil
+	catCmd, isCat := pipe.Left.(*ast.SimpleCommand)
+	if !isCat || !isCommandName(catCmd, "cat") || len(catCmd.Arguments) != 1 {
+		return nil, nil, nil, "", false
+	}
+	if first := catCmd.Arguments[0].String(); first != "" && first[0] == '-' {
+		return nil, nil, nil, "", false
+	}
+	rightCmd, isRight := pipe.Right.(*ast.SimpleCommand)
+	if !isRight {
+		return nil, nil, nil, "", false
+	}
+	rightIdent, isIdent := rightCmd.Name.(*ast.Identifier)
+	if !isIdent {
+		return nil, nil, nil, "", false
+	}
+	return pipe, catCmd, rightCmd, rightIdent.Value, true
 }

--- a/pkg/katas/zc1464.go
+++ b/pkg/katas/zc1464.go
@@ -20,39 +20,61 @@ func init() {
 	})
 }
 
+var (
+	zc1464FirewallNames = map[string]struct{}{"iptables": {}, "ip6tables": {}, "nft": {}}
+	zc1464FlushFlags    = map[string]struct{}{"-F": {}, "--flush": {}}
+	zc1464PolicyFlags   = map[string]struct{}{"-P": {}, "--policy": {}}
+	zc1464OpenChains    = map[string]struct{}{"INPUT": {}, "FORWARD": {}}
+)
+
 func checkZC1464(node ast.Node) []Violation {
 	cmd, ok := node.(*ast.SimpleCommand)
 	if !ok {
 		return nil
 	}
-
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok {
+	if _, hit := zc1464FirewallNames[CommandIdentifier(cmd)]; !hit {
 		return nil
 	}
-	if ident.Value != "iptables" && ident.Value != "ip6tables" && ident.Value != "nft" {
-		return nil
+	args := zc1464StringArgs(cmd)
+	if zc1464FlushHit(args) {
+		return violateZC1464(cmd, "flushing all firewall rules")
 	}
-
-	args := make([]string, 0, len(cmd.Arguments))
-	for _, arg := range cmd.Arguments {
-		args = append(args, arg.String())
-	}
-
-	// Catch: `iptables -F` (no chain) — flushes everything
-	// Catch: `iptables -P INPUT ACCEPT` / `-P FORWARD ACCEPT`
-	for i, a := range args {
-		if a == "-F" || a == "--flush" {
-			return violateZC1464(cmd, "flushing all firewall rules")
-		}
-		if (a == "-P" || a == "--policy") && i+2 < len(args) && args[i+2] == "ACCEPT" {
-			chain := args[i+1]
-			if chain == "INPUT" || chain == "FORWARD" {
-				return violateZC1464(cmd, "default-ACCEPT policy on "+chain+" chain")
-			}
-		}
+	if chain := zc1464AcceptPolicy(args); chain != "" {
+		return violateZC1464(cmd, "default-ACCEPT policy on "+chain+" chain")
 	}
 	return nil
+}
+
+func zc1464StringArgs(cmd *ast.SimpleCommand) []string {
+	out := make([]string, 0, len(cmd.Arguments))
+	for _, arg := range cmd.Arguments {
+		out = append(out, arg.String())
+	}
+	return out
+}
+
+func zc1464FlushHit(args []string) bool {
+	for _, a := range args {
+		if _, hit := zc1464FlushFlags[a]; hit {
+			return true
+		}
+	}
+	return false
+}
+
+func zc1464AcceptPolicy(args []string) string {
+	for i, a := range args {
+		if _, hit := zc1464PolicyFlags[a]; !hit {
+			continue
+		}
+		if i+2 >= len(args) || args[i+2] != "ACCEPT" {
+			continue
+		}
+		if _, hit := zc1464OpenChains[args[i+1]]; hit {
+			return args[i+1]
+		}
+	}
+	return ""
 }
 
 func violateZC1464(cmd *ast.SimpleCommand, what string) []Violation {

--- a/pkg/katas/zc1481.go
+++ b/pkg/katas/zc1481.go
@@ -22,40 +22,54 @@ func init() {
 	})
 }
 
+var (
+	zc1481UnsetVars  = map[string]struct{}{"HISTFILE": {}, "HISTSIZE": {}, "SAVEHIST": {}, "HISTCMD": {}}
+	zc1481EmptyHist  = map[string]struct{}{"": {}, "/dev/null": {}, "''": {}, `""`: {}}
+	zc1481ZeroAssign = map[string]struct{}{"HISTSIZE=0": {}, "SAVEHIST=0": {}}
+)
+
 func checkZC1481(node ast.Node) []Violation {
 	cmd, ok := node.(*ast.SimpleCommand)
 	if !ok {
 		return nil
 	}
-
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok {
-		return nil
-	}
-
-	switch ident.Value {
+	switch CommandIdentifier(cmd) {
 	case "unset":
-		for _, arg := range cmd.Arguments {
-			v := arg.String()
-			if v == "HISTFILE" || v == "HISTSIZE" || v == "SAVEHIST" || v == "HISTCMD" {
-				return zc1481Violation(cmd, "unset "+v)
-			}
+		if hit := zc1481UnsetHit(cmd); hit != "" {
+			return zc1481Violation(cmd, "unset "+hit)
 		}
 	case "export", "typeset":
-		for _, arg := range cmd.Arguments {
-			v := arg.String()
-			if strings.HasPrefix(v, "HISTFILE=") {
-				val := strings.TrimPrefix(v, "HISTFILE=")
-				if val == "" || val == "/dev/null" || val == "''" || val == `""` {
-					return zc1481Violation(cmd, v)
-				}
-			}
-			if v == "HISTSIZE=0" || v == "SAVEHIST=0" {
-				return zc1481Violation(cmd, v)
-			}
+		if hit := zc1481AssignHit(cmd); hit != "" {
+			return zc1481Violation(cmd, hit)
 		}
 	}
 	return nil
+}
+
+func zc1481UnsetHit(cmd *ast.SimpleCommand) string {
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if _, hit := zc1481UnsetVars[v]; hit {
+			return v
+		}
+	}
+	return ""
+}
+
+func zc1481AssignHit(cmd *ast.SimpleCommand) string {
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if strings.HasPrefix(v, "HISTFILE=") {
+			val := strings.TrimPrefix(v, "HISTFILE=")
+			if _, hit := zc1481EmptyHist[val]; hit {
+				return v
+			}
+		}
+		if _, hit := zc1481ZeroAssign[v]; hit {
+			return v
+		}
+	}
+	return ""
 }
 
 func zc1481Violation(cmd *ast.SimpleCommand, what string) []Violation {

--- a/pkg/katas/zc1498.go
+++ b/pkg/katas/zc1498.go
@@ -23,52 +23,51 @@ func init() {
 	})
 }
 
+var zc1498Roots = map[string]struct{}{"/": {}, "/root": {}, "/boot": {}}
+
 func checkZC1498(node ast.Node) []Violation {
 	cmd, ok := node.(*ast.SimpleCommand)
-	if !ok {
+	if !ok || CommandIdentifier(cmd) != "mount" {
 		return nil
 	}
-
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok {
+	args := zc1464StringArgs(cmd)
+	hasRemount, hasRW := zc1498RemountFlags(args)
+	target := zc1498SystemTarget(args)
+	if !hasRemount || !hasRW || target == "" {
 		return nil
 	}
-	if ident.Value != "mount" {
-		return nil
-	}
+	return []Violation{{
+		KataID: "ZC1498",
+		Message: "`mount -o remount,rw " + target + "` makes a read-only system path " +
+			"writable — use ostree / systemd-sysext or fix /etc/fstab.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}
 
-	args := make([]string, 0, len(cmd.Arguments))
-	for _, a := range cmd.Arguments {
-		args = append(args, a.String())
-	}
-
-	var hasRemount, hasRW bool
-	var target string
+func zc1498RemountFlags(args []string) (hasRemount, hasRW bool) {
 	for i, a := range args {
-		if a == "-o" && i+1 < len(args) {
-			opts := strings.Split(args[i+1], ",")
-			for _, o := range opts {
-				if o == "remount" {
-					hasRemount = true
-				}
-				if o == "rw" {
-					hasRW = true
-				}
+		if a != "-o" || i+1 >= len(args) {
+			continue
+		}
+		for _, o := range strings.Split(args[i+1], ",") {
+			switch o {
+			case "remount":
+				hasRemount = true
+			case "rw":
+				hasRW = true
 			}
 		}
-		if (a == "/" || a == "/root" || a == "/boot") && !strings.HasPrefix(a, "-") {
-			target = a
+	}
+	return
+}
+
+func zc1498SystemTarget(args []string) string {
+	for _, a := range args {
+		if _, hit := zc1498Roots[a]; hit && !strings.HasPrefix(a, "-") {
+			return a
 		}
 	}
-	if hasRemount && hasRW && target != "" {
-		return []Violation{{
-			KataID: "ZC1498",
-			Message: "`mount -o remount,rw " + target + "` makes a read-only system path " +
-				"writable — use ostree / systemd-sysext or fix /etc/fstab.",
-			Line:   cmd.Token.Line,
-			Column: cmd.Token.Column,
-			Level:  SeverityWarning,
-		}}
-	}
-	return nil
+	return ""
 }

--- a/pkg/katas/zc1502.go
+++ b/pkg/katas/zc1502.go
@@ -30,27 +30,10 @@ func init() {
 // re-insert.
 func fixZC1502(node ast.Node, _ Violation, source []byte) []FixEdit {
 	cmd, ok := node.(*ast.SimpleCommand)
-	if !ok {
+	if !ok || !zc1502IsGrepFamily(cmd) {
 		return nil
 	}
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok {
-		return nil
-	}
-	if ident.Value != "grep" && ident.Value != "egrep" && ident.Value != "fgrep" &&
-		ident.Value != "rg" && ident.Value != "ag" {
-		return nil
-	}
-	var firstVar ast.Expression
-	for _, arg := range cmd.Arguments {
-		v := arg.String()
-		if v == "--" {
-			return nil
-		}
-		if firstVar == nil && (strings.HasPrefix(v, "\"$") || strings.HasPrefix(v, "$")) {
-			firstVar = arg
-		}
-	}
+	firstVar := zc1502FirstVarArg(cmd)
 	if firstVar == nil {
 		return nil
 	}
@@ -63,12 +46,30 @@ func fixZC1502(node ast.Node, _ Violation, source []byte) []FixEdit {
 	if insLine < 0 {
 		return nil
 	}
-	return []FixEdit{{
-		Line:    insLine,
-		Column:  insCol,
-		Length:  0,
-		Replace: "-- ",
-	}}
+	return []FixEdit{{Line: insLine, Column: insCol, Length: 0, Replace: "-- "}}
+}
+
+var zc1502GrepFamily = map[string]struct{}{
+	"grep": {}, "egrep": {}, "fgrep": {}, "rg": {}, "ag": {},
+}
+
+func zc1502IsGrepFamily(cmd *ast.SimpleCommand) bool {
+	_, hit := zc1502GrepFamily[CommandIdentifier(cmd)]
+	return hit
+}
+
+func zc1502FirstVarArg(cmd *ast.SimpleCommand) ast.Expression {
+	var first ast.Expression
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--" {
+			return nil
+		}
+		if first == nil && (strings.HasPrefix(v, "\"$") || strings.HasPrefix(v, "$")) {
+			first = arg
+		}
+	}
+	return first
 }
 
 func offsetLineColZC1502(source []byte, offset int) (int, int) {
@@ -90,39 +91,16 @@ func offsetLineColZC1502(source []byte, offset int) (int, int) {
 
 func checkZC1502(node ast.Node) []Violation {
 	cmd, ok := node.(*ast.SimpleCommand)
-	if !ok {
+	if !ok || !zc1502IsGrepFamily(cmd) {
 		return nil
 	}
-
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok {
-		return nil
-	}
-	if ident.Value != "grep" && ident.Value != "egrep" && ident.Value != "fgrep" &&
-		ident.Value != "rg" && ident.Value != "ag" {
-		return nil
-	}
-
-	hasDashDash := false
-	firstVarArg := ""
-	for _, arg := range cmd.Arguments {
-		v := arg.String()
-		if v == "--" {
-			hasDashDash = true
-			break
-		}
-		// First variable-like pattern argument (no surrounding single quote means interpolation)
-		if firstVarArg == "" && (strings.HasPrefix(v, "\"$") || strings.HasPrefix(v, "$")) {
-			firstVarArg = v
-		}
-	}
-
-	if firstVarArg == "" || hasDashDash {
+	firstVar := zc1502FirstVarArg(cmd)
+	if firstVar == nil {
 		return nil
 	}
 	return []Violation{{
 		KataID: "ZC1502",
-		Message: "Variable `" + firstVarArg + "` used as pattern without `--` end-of-flags " +
+		Message: "Variable `" + firstVar.String() + "` used as pattern without `--` end-of-flags " +
 			"marker — attacker-controlled leading `-` becomes a flag. Write `grep -- \"$var\"`.",
 		Line:   cmd.Token.Line,
 		Column: cmd.Token.Column,

--- a/pkg/katas/zc1538.go
+++ b/pkg/katas/zc1538.go
@@ -21,36 +21,39 @@ func init() {
 	})
 }
 
+var zc1538ZfsRecursiveFlags = map[string]struct{}{
+	"-r": {}, "-R": {}, "-rR": {}, "-Rr": {}, "-rf": {}, "-fr": {},
+}
+
 func checkZC1538(node ast.Node) []Violation {
 	cmd, ok := node.(*ast.SimpleCommand)
 	if !ok {
 		return nil
 	}
-
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok {
-		return nil
-	}
-
-	if ident.Value == "zpool" && len(cmd.Arguments) >= 2 &&
-		cmd.Arguments[0].String() == "destroy" {
-		for _, arg := range cmd.Arguments[1:] {
-			if arg.String() == "-f" {
-				return zc1538Violation(cmd, "zpool destroy -f")
-			}
+	switch CommandIdentifier(cmd) {
+	case "zpool":
+		if zc1538DestroyFlag(cmd, map[string]struct{}{"-f": {}}) != "" {
+			return zc1538Violation(cmd, "zpool destroy -f")
 		}
-	}
-	if ident.Value == "zfs" && len(cmd.Arguments) >= 2 &&
-		cmd.Arguments[0].String() == "destroy" {
-		for _, arg := range cmd.Arguments[1:] {
-			v := arg.String()
-			if v == "-r" || v == "-R" || v == "-rR" || v == "-Rr" ||
-				v == "-rf" || v == "-fr" {
-				return zc1538Violation(cmd, "zfs destroy "+v)
-			}
+	case "zfs":
+		if hit := zc1538DestroyFlag(cmd, zc1538ZfsRecursiveFlags); hit != "" {
+			return zc1538Violation(cmd, "zfs destroy "+hit)
 		}
 	}
 	return nil
+}
+
+func zc1538DestroyFlag(cmd *ast.SimpleCommand, flags map[string]struct{}) string {
+	if len(cmd.Arguments) < 2 || cmd.Arguments[0].String() != "destroy" {
+		return ""
+	}
+	for _, arg := range cmd.Arguments[1:] {
+		v := arg.String()
+		if _, hit := flags[v]; hit {
+			return v
+		}
+	}
+	return ""
 }
 
 func zc1538Violation(cmd *ast.SimpleCommand, what string) []Violation {

--- a/pkg/katas/zc1553.go
+++ b/pkg/katas/zc1553.go
@@ -24,51 +24,47 @@ func init() {
 
 func checkZC1553(node ast.Node) []Violation {
 	cmd, ok := node.(*ast.SimpleCommand)
-	if !ok {
+	if !ok || CommandIdentifier(cmd) != "tr" {
 		return nil
 	}
+	from, to := zc1553TrSets(cmd)
+	if !zc1553IsCasePair(from, to) {
+		return nil
+	}
+	return []Violation{{
+		KataID: "ZC1553",
+		Message: "`tr` for case conversion — use Zsh `${(U)var}` / `${(L)var}` to avoid " +
+			"the fork/exec and portability hazard.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityStyle,
+	}}
+}
 
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok {
-		return nil
-	}
-	if ident.Value != "tr" {
-		return nil
-	}
-
-	args := make([]string, 0, len(cmd.Arguments))
+func zc1553TrSets(cmd *ast.SimpleCommand) (from, to string) {
 	for _, a := range cmd.Arguments {
-		args = append(args, strings.Trim(a.String(), "'\""))
-	}
-
-	// Need at least the from/to sets.
-	if len(args) < 2 {
-		return nil
-	}
-	var from, to string
-	for _, a := range args {
-		if strings.HasPrefix(a, "-") {
+		v := strings.Trim(a.String(), "'\"")
+		if strings.HasPrefix(v, "-") {
 			continue
 		}
 		if from == "" {
-			from = a
-		} else if to == "" {
-			to = a
-			break
+			from = v
+			continue
+		}
+		if to == "" {
+			to = v
+			return
 		}
 	}
+	return
+}
 
-	isUpper := func(s string) bool { return s == "[:upper:]" || s == "A-Z" }
-	isLower := func(s string) bool { return s == "[:lower:]" || s == "a-z" }
-	if (isLower(from) && isUpper(to)) || (isUpper(from) && isLower(to)) {
-		return []Violation{{
-			KataID: "ZC1553",
-			Message: "`tr` for case conversion — use Zsh `${(U)var}` / `${(L)var}` to avoid " +
-				"the fork/exec and portability hazard.",
-			Line:   cmd.Token.Line,
-			Column: cmd.Token.Column,
-			Level:  SeverityStyle,
-		}}
+func zc1553IsCasePair(from, to string) bool {
+	upper := from == "[:upper:]" || from == "A-Z"
+	lower := from == "[:lower:]" || from == "a-z"
+	if !upper && !lower {
+		return false
 	}
-	return nil
+	other := to == "[:upper:]" || to == "A-Z" || to == "[:lower:]" || to == "a-z"
+	return other && upper != (to == "[:upper:]" || to == "A-Z")
 }

--- a/pkg/katas/zc1606.go
+++ b/pkg/katas/zc1606.go
@@ -21,51 +21,57 @@ func init() {
 	})
 }
 
+var zc1606Names = map[string]struct{}{"mkdir": {}, "install": {}}
+
 func checkZC1606(node ast.Node) []Violation {
 	cmd, ok := node.(*ast.SimpleCommand)
 	if !ok {
 		return nil
 	}
-
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok {
+	name := CommandIdentifier(cmd)
+	if _, hit := zc1606Names[name]; !hit {
 		return nil
 	}
-	if ident.Value != "mkdir" && ident.Value != "install" {
+	mode := zc1606WorldWriteMode(cmd)
+	if mode == "" {
 		return nil
 	}
+	return []Violation{{
+		KataID: "ZC1606",
+		Message: "`" + name + " -m " + mode + "` creates a world-writable path " +
+			"without the sticky bit — TOCTOU symlink-attack ground. Use `-m 700` / " +
+			"`-m 750`, or `-m 1777` if a shared sticky dir is actually needed.",
+		Line:   cmd.Token.Line,
+		Column: cmd.Token.Column,
+		Level:  SeverityWarning,
+	}}
+}
 
+func zc1606WorldWriteMode(cmd *ast.SimpleCommand) string {
 	for i := 0; i+1 < len(cmd.Arguments); i++ {
 		if cmd.Arguments[i].String() != "-m" {
 			continue
 		}
 		mode := cmd.Arguments[i+1].String()
-		if len(mode) != 3 {
-			continue
+		if zc1606IsWorldWritable(mode) {
+			return mode
 		}
-		allOctal := true
-		for _, c := range mode {
-			if c < '0' || c > '7' {
-				allOctal = false
-				break
-			}
-		}
-		if !allOctal {
-			continue
-		}
-		last := mode[2]
-		if last != '2' && last != '3' && last != '6' && last != '7' {
-			continue
-		}
-		return []Violation{{
-			KataID: "ZC1606",
-			Message: "`" + ident.Value + " -m " + mode + "` creates a world-writable path " +
-				"without the sticky bit — TOCTOU symlink-attack ground. Use `-m 700` / " +
-				"`-m 750`, or `-m 1777` if a shared sticky dir is actually needed.",
-			Line:   cmd.Token.Line,
-			Column: cmd.Token.Column,
-			Level:  SeverityWarning,
-		}}
 	}
-	return nil
+	return ""
+}
+
+func zc1606IsWorldWritable(mode string) bool {
+	if len(mode) != 3 {
+		return false
+	}
+	for _, c := range mode {
+		if c < '0' || c > '7' {
+			return false
+		}
+	}
+	switch mode[2] {
+	case '2', '3', '6', '7':
+		return true
+	}
+	return false
 }

--- a/pkg/katas/zc1634.go
+++ b/pkg/katas/zc1634.go
@@ -23,36 +23,11 @@ func init() {
 
 func checkZC1634(node ast.Node) []Violation {
 	cmd, ok := node.(*ast.SimpleCommand)
-	if !ok {
+	if !ok || CommandIdentifier(cmd) != "umask" || len(cmd.Arguments) != 1 {
 		return nil
 	}
-
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok {
-		return nil
-	}
-	if ident.Value != "umask" {
-		return nil
-	}
-	if len(cmd.Arguments) != 1 {
-		return nil
-	}
-
 	v := cmd.Arguments[0].String()
-	// Exclude forms already flagged by ZC1195 / ZC1516.
-	if v == "0" || v == "00" || v == "000" || v == "0000" {
-		return nil
-	}
-	if len(v) < 3 || len(v) > 4 {
-		return nil
-	}
-	for _, c := range v {
-		if c < '0' || c > '7' {
-			return nil
-		}
-	}
-	last := v[len(v)-1]
-	if last != '0' && last != '1' && last != '4' && last != '5' {
+	if !zc1634UmaskMissesWorldWrite(v) {
 		return nil
 	}
 	return []Violation{{
@@ -64,4 +39,25 @@ func checkZC1634(node ast.Node) []Violation {
 		Column: cmd.Token.Column,
 		Level:  SeverityWarning,
 	}}
+}
+
+var zc1634AllZero = map[string]struct{}{"0": {}, "00": {}, "000": {}, "0000": {}}
+
+func zc1634UmaskMissesWorldWrite(v string) bool {
+	if _, hit := zc1634AllZero[v]; hit {
+		return false
+	}
+	if len(v) < 3 || len(v) > 4 {
+		return false
+	}
+	for _, c := range v {
+		if c < '0' || c > '7' {
+			return false
+		}
+	}
+	switch v[len(v)-1] {
+	case '0', '1', '4', '5':
+		return true
+	}
+	return false
 }

--- a/pkg/katas/zc1675.go
+++ b/pkg/katas/zc1675.go
@@ -28,47 +28,26 @@ func init() {
 // equivalents `typeset -fx` and `typeset +x`. Single edit spans the
 // command name + flag together, mirroring fixZC1283's `set -o OPT`
 // → `setopt OPT` collapse.
+var zc1675FlagReplace = map[string]string{
+	"-f": "typeset -fx",
+	"-n": "typeset +x",
+}
+
 func fixZC1675(node ast.Node, v Violation, source []byte) []FixEdit {
 	cmd, ok := node.(*ast.SimpleCommand)
-	if !ok {
+	if !ok || CommandIdentifier(cmd) != "export" {
 		return nil
 	}
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok || ident.Value != "export" {
-		return nil
-	}
-	var flag ast.Expression
-	var replace string
-	for _, arg := range cmd.Arguments {
-		switch arg.String() {
-		case "-f":
-			flag = arg
-			replace = "typeset -fx"
-		case "-n":
-			flag = arg
-			replace = "typeset +x"
-		}
-		if flag != nil {
-			break
-		}
-	}
+	flag, replace := zc1675FindFlag(cmd)
 	if flag == nil {
 		return nil
 	}
-	nameOff := LineColToByteOffset(source, v.Line, v.Column)
-	if nameOff < 0 || nameOff+len("export") > len(source) {
+	nameOff, ok := zc1675ExportOffset(source, v)
+	if !ok {
 		return nil
 	}
-	if string(source[nameOff:nameOff+len("export")]) != "export" {
-		return nil
-	}
-	flagTok := flag.TokenLiteralNode()
-	flagOff := LineColToByteOffset(source, flagTok.Line, flagTok.Column)
-	if flagOff < 0 || flagOff+2 > len(source) {
-		return nil
-	}
-	flagLit := string(source[flagOff : flagOff+2])
-	if flagLit != "-f" && flagLit != "-n" {
+	flagOff, ok := zc1675FlagOffset(source, flag)
+	if !ok {
 		return nil
 	}
 	return []FixEdit{{
@@ -77,6 +56,39 @@ func fixZC1675(node ast.Node, v Violation, source []byte) []FixEdit {
 		Length:  flagOff + 2 - nameOff,
 		Replace: replace,
 	}}
+}
+
+func zc1675FindFlag(cmd *ast.SimpleCommand) (ast.Expression, string) {
+	for _, arg := range cmd.Arguments {
+		if r, hit := zc1675FlagReplace[arg.String()]; hit {
+			return arg, r
+		}
+	}
+	return nil, ""
+}
+
+func zc1675ExportOffset(source []byte, v Violation) (int, bool) {
+	off := LineColToByteOffset(source, v.Line, v.Column)
+	if off < 0 || off+len("export") > len(source) {
+		return 0, false
+	}
+	if string(source[off:off+len("export")]) != "export" {
+		return 0, false
+	}
+	return off, true
+}
+
+func zc1675FlagOffset(source []byte, flag ast.Expression) (int, bool) {
+	tok := flag.TokenLiteralNode()
+	off := LineColToByteOffset(source, tok.Line, tok.Column)
+	if off < 0 || off+2 > len(source) {
+		return 0, false
+	}
+	lit := string(source[off : off+2])
+	if lit != "-f" && lit != "-n" {
+		return 0, false
+	}
+	return off, true
 }
 
 func checkZC1675(node ast.Node) []Violation {

--- a/pkg/katas/zc1800.go
+++ b/pkg/katas/zc1800.go
@@ -26,33 +26,10 @@ func init() {
 
 func checkZC1800(node ast.Node) []Violation {
 	cmd, ok := node.(*ast.SimpleCommand)
-	if !ok {
+	if !ok || CommandIdentifier(cmd) != "pg_ctl" {
 		return nil
 	}
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok || ident.Value != "pg_ctl" {
-		return nil
-	}
-	hasStop := false
-	hasImmediate := false
-	for i, arg := range cmd.Arguments {
-		v := arg.String()
-		if v == "stop" || v == "restart" {
-			hasStop = true
-		}
-		if v == "-m" && i+1 < len(cmd.Arguments) {
-			if cmd.Arguments[i+1].String() == "immediate" {
-				hasImmediate = true
-			}
-		}
-		if strings.HasPrefix(v, "-m") && len(v) > 2 && v[2:] == "immediate" {
-			hasImmediate = true
-		}
-		if v == "--mode=immediate" {
-			hasImmediate = true
-		}
-	}
-	if !hasStop || !hasImmediate {
+	if !zc1800StopOrRestart(cmd) || !zc1800ImmediateMode(cmd) {
 		return nil
 	}
 	return []Violation{{
@@ -64,4 +41,30 @@ func checkZC1800(node ast.Node) []Violation {
 		Column: cmd.Token.Column,
 		Level:  SeverityWarning,
 	}}
+}
+
+func zc1800StopOrRestart(cmd *ast.SimpleCommand) bool {
+	for _, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "stop" || v == "restart" {
+			return true
+		}
+	}
+	return false
+}
+
+func zc1800ImmediateMode(cmd *ast.SimpleCommand) bool {
+	for i, arg := range cmd.Arguments {
+		v := arg.String()
+		if v == "--mode=immediate" {
+			return true
+		}
+		if v == "-m" && i+1 < len(cmd.Arguments) && cmd.Arguments[i+1].String() == "immediate" {
+			return true
+		}
+		if strings.HasPrefix(v, "-m") && len(v) > 2 && v[2:] == "immediate" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/katas/zc1806.go
+++ b/pkg/katas/zc1806.go
@@ -24,28 +24,12 @@ func init() {
 
 func checkZC1806(node ast.Node) []Violation {
 	cmd, ok := node.(*ast.SimpleCommand)
-	if !ok {
-		return nil
-	}
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok || ident.Value != "zmv" {
-		return nil
-	}
-	if len(cmd.Arguments) < 2 {
+	if !ok || CommandIdentifier(cmd) != "zmv" || len(cmd.Arguments) < 2 {
 		return nil
 	}
 	for _, arg := range cmd.Arguments {
-		v := arg.String()
-		if v == "-n" || v == "--dry-run" || v == "-i" || v == "--interactive" {
+		if zc1806HasGuardFlag(arg.String()) {
 			return nil
-		}
-		// combined short flags like `-Mn` or `-wn`.
-		if len(v) > 1 && v[0] == '-' && v[1] != '-' {
-			for _, c := range v[1:] {
-				if c == 'n' || c == 'i' {
-					return nil
-				}
-			}
 		}
 	}
 	return []Violation{{
@@ -57,4 +41,20 @@ func checkZC1806(node ast.Node) []Violation {
 		Column: cmd.Token.Column,
 		Level:  SeverityWarning,
 	}}
+}
+
+func zc1806HasGuardFlag(v string) bool {
+	switch v {
+	case "-n", "--dry-run", "-i", "--interactive":
+		return true
+	}
+	if len(v) <= 1 || v[0] != '-' || v[1] == '-' {
+		return false
+	}
+	for _, c := range v[1:] {
+		if c == 'n' || c == 'i' {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/katas/zc1856.go
+++ b/pkg/katas/zc1856.go
@@ -73,15 +73,24 @@ func zc1856IsIdentifier(s string) bool {
 		return false
 	}
 	for i, r := range s {
-		if i == 0 {
-			if !(r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')) {
-				return false
-			}
-			continue
+		if i == 0 && !zc1856IsIdentStart(r) {
+			return false
 		}
-		if !(r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')) {
+		if i > 0 && !zc1856IsIdentTail(r) {
 			return false
 		}
 	}
 	return true
+}
+
+func zc1856IsIdentStart(r rune) bool {
+	return r == '_' || isAsciiLetter(r)
+}
+
+func zc1856IsIdentTail(r rune) bool {
+	return r == '_' || isAsciiLetter(r) || (r >= '0' && r <= '9')
+}
+
+func isAsciiLetter(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
 }

--- a/pkg/katas/zc1970.go
+++ b/pkg/katas/zc1970.go
@@ -24,30 +24,28 @@ func init() {
 	})
 }
 
+var (
+	zc1970LosetupFlags = map[string]struct{}{
+		"-P": {}, "--partscan": {}, "-Pf": {}, "-fP": {}, "-rP": {}, "-Pr": {},
+	}
+	zc1970KpartxFlags = map[string]struct{}{
+		"-a": {}, "-av": {}, "-va": {}, "-as": {}, "-sa": {},
+	}
+)
+
 func checkZC1970(node ast.Node) []Violation {
 	cmd, ok := node.(*ast.SimpleCommand)
 	if !ok {
 		return nil
 	}
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok {
-		return nil
-	}
-	switch ident.Value {
+	switch CommandIdentifier(cmd) {
 	case "losetup":
-		for _, arg := range cmd.Arguments {
-			v := arg.String()
-			if v == "-P" || v == "--partscan" ||
-				v == "-Pf" || v == "-fP" || v == "-rP" || v == "-Pr" {
-				return zc1970Hit(cmd, "losetup -P")
-			}
+		if HasArgFlag(cmd, zc1970LosetupFlags) {
+			return zc1970Hit(cmd, "losetup -P")
 		}
 	case "kpartx":
-		for _, arg := range cmd.Arguments {
-			v := arg.String()
-			if v == "-a" || v == "-av" || v == "-va" || v == "-as" || v == "-sa" {
-				return zc1970Hit(cmd, "kpartx -a")
-			}
+		if HasArgFlag(cmd, zc1970KpartxFlags) {
+			return zc1970Hit(cmd, "kpartx -a")
 		}
 	case "partprobe":
 		return zc1970Hit(cmd, "partprobe")

--- a/pkg/katas/zc1996.go
+++ b/pkg/katas/zc1996.go
@@ -28,34 +28,34 @@ func init() {
 	})
 }
 
+var zc1996ExactFlags = map[string]struct{}{
+	"-U": {}, "-r": {}, "-Ur": {}, "-rU": {},
+	"--user": {}, "--map-root-user": {},
+}
+
 func checkZC1996(node ast.Node) []Violation {
 	cmd, ok := node.(*ast.SimpleCommand)
-	if !ok {
-		return nil
-	}
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok {
-		return nil
-	}
-	if ident.Value != "unshare" {
+	if !ok || CommandIdentifier(cmd) != "unshare" {
 		return nil
 	}
 	for _, arg := range cmd.Arguments {
 		v := arg.String()
-		if v == "-U" || v == "-r" || v == "-Ur" || v == "-rU" ||
-			v == "--user" || v == "--map-root-user" {
+		if zc1996FlagHit(v) {
 			return zc1996Hit(cmd, "unshare "+v)
-		}
-		// Short-flag bundles like `-Urm`.
-		if strings.HasPrefix(v, "-") && !strings.HasPrefix(v, "--") &&
-			len(v) > 1 && !strings.Contains(v, "=") {
-			body := v[1:]
-			if strings.ContainsAny(body, "Ur") {
-				return zc1996Hit(cmd, "unshare "+v)
-			}
 		}
 	}
 	return nil
+}
+
+func zc1996FlagHit(v string) bool {
+	if _, hit := zc1996ExactFlags[v]; hit {
+		return true
+	}
+	// Short-flag bundles like `-Urm` carry user / root mapping via U or r.
+	if !strings.HasPrefix(v, "-") || strings.HasPrefix(v, "--") || len(v) <= 1 || strings.Contains(v, "=") {
+		return false
+	}
+	return strings.ContainsAny(v[1:], "Ur")
 }
 
 func zc1996Hit(cmd *ast.SimpleCommand, form string) []Violation {


### PR DESCRIPTION
## Summary
- First batch of refactors to push the project's Go Report Card gocyclo metric back to 100%.
- 12 kata Check / Fix functions trimmed below the > 15 threshold by extracting dispatch tables, predicate helpers, and offset accessors. No behaviour change.
- Adds shared helpers in \`pkg/katas/fixutil.go\` (\`HasArgFlag\`, \`ArgValueAfter\`, \`CommandIdentifier\`) that the remaining 75+ refactors will reuse.

## Touched katas
ZC1077, ZC1146, ZC1464, ZC1553, ZC1606, ZC1675, ZC1800, ZC1806, ZC1856, ZC1970, ZC1996.

## Test plan
- [x] \`go test ./...\` green
- [x] \`go vet ./...\` clean
- [x] \`gocyclo -over 15\` count drops from 97 → 86