### PR TITLE
ci: lock parser-corpus baseline (170 errors, 13 files)

### DIFF
--- a/.github/parser-corpus-manifest.txt
+++ b/.github/parser-corpus-manifest.txt
@@ -1,0 +1,17 @@
+# Pinned upstream corpora for the parser-error gate.
+# Format: name<TAB>sha<TAB>url<TAB>globs(space-separated)
+# The sweep clones each at the pinned SHA, runs zshellcheck, and compares
+# per-file parser-error counts against .github/parser-error-baseline.txt.
+# Update SHAs deliberately — every bump rewrites the baseline.
+antidote	4913257e0ae3	https://github.com/mattmc3/antidote.git	*.zsh *.plugin.zsh
+fast-syntax-highlighting	3d574ccf4880	https://github.com/zdharma-continuum/fast-syntax-highlighting.git	*.zsh
+fzf	27dab2422e5f	https://github.com/junegunn/fzf.git	*.zsh
+fzf-tab	0983009f8666	https://github.com/Aloxaf/fzf-tab.git	*.zsh *.plugin.zsh
+starship	c97455d9debe	https://github.com/starship/starship.git	*.zsh
+zephyr	bdc1ad9cffad	https://github.com/mattmc3/zephyr.git	*.zsh *.plugin.zsh
+zimfw	472e884b9348	https://github.com/zimfw/zimfw.git	*.zsh
+zinit	6c9ac1c4bc9b	https://github.com/zdharma-continuum/zinit.git	*.zsh
+zsh-autocomplete	20f6c34f2027	https://github.com/marlonrichert/zsh-autocomplete.git	*.zsh *.plugin.zsh
+zsh-history-substring-search	14c8d2e0ffae	https://github.com/zsh-users/zsh-history-substring-search.git	*.zsh *.plugin.zsh
+zsh-utils	be71275c5050	https://github.com/belak/zsh-utils.git	*.zsh *.plugin.zsh
+zsh-vi-mode	08bd1c045204	https://github.com/jeffreytse/zsh-vi-mode.git	*.zsh *.plugin.zsh

--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,0 +1,15 @@
+# Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
+# Format: <relpath>\t<count>
+fast-syntax-highlighting/test/to-parse.zsh	5
+fzf/shell/completion.zsh	1
+fzf/shell/key-bindings.zsh	6
+fzf-tab/test/ztst.zsh	1
+zephyr/plugins/compstyle/compstyle.plugin.zsh	1
+zimfw/zimfw.zsh	21
+zinit/share/git-process-output.zsh	10
+zinit/zinit-autoload.zsh	20
+zinit/zinit-install.zsh	35
+zinit/zinit-side.zsh	2
+zinit/zinit.zsh	30
+zsh-utils/utility/utility.plugin.zsh	1
+zsh-vi-mode/zsh-vi-mode.zsh	37

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,26 @@ jobs:
             echo "$out"
           fi
 
+  parser-compat:
+    name: Parser corpus sweep
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.1.7
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 'stable'
+          cache: true
+      - name: Build zshellcheck
+        run: go build -o zshellcheck ./cmd/zshellcheck
+      - name: Sweep pinned corpora against baseline
+        env:
+          ZSHELLCHECK_BIN: ${{ github.workspace }}/zshellcheck
+        run: bash scripts/parser-corpus-sweep.sh
+
   lint-shell:
     name: Lint Shell Scripts
     runs-on: ubuntu-latest

--- a/scripts/parser-corpus-sweep.sh
+++ b/scripts/parser-corpus-sweep.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# parser-corpus-sweep.sh — Run zshellcheck against pinned upstream
+# corpora and compare per-file parser-error counts to a baseline.
+#
+# Manifest: .github/parser-corpus-manifest.txt
+# Baseline: .github/parser-error-baseline.txt
+#
+# Usage:
+#   scripts/parser-corpus-sweep.sh                   # gate (compare to baseline)
+#   scripts/parser-corpus-sweep.sh --update-baseline # rewrite baseline from current run
+#   ZSHELLCHECK_BIN=/path/to/binary scripts/parser-corpus-sweep.sh
+#
+# Exit status:
+#   0  every file matches its baseline (or improves below it)
+#   1  one or more files regressed
+#   2  manifest / clone / IO error
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="${REPO_ROOT}/.github/parser-corpus-manifest.txt"
+BASELINE="${REPO_ROOT}/.github/parser-error-baseline.txt"
+WORK_DIR="${PARSER_SWEEP_WORK:-${REPO_ROOT}/testdata/external-corpora}"
+BIN="${ZSHELLCHECK_BIN:-${REPO_ROOT}/zshellcheck}"
+
+UPDATE_BASELINE=0
+if [[ "${1:-}" == "--update-baseline" ]]; then
+    UPDATE_BASELINE=1
+fi
+
+if [[ ! -f "${MANIFEST}" ]]; then
+    echo "::error::manifest not found: ${MANIFEST}" >&2
+    exit 2
+fi
+
+if [[ ! -x "${BIN}" ]]; then
+    echo ">>> building zshellcheck into ${BIN}"
+    (cd "${REPO_ROOT}" && go build -o "${BIN}" ./cmd/zshellcheck)
+fi
+
+mkdir -p "${WORK_DIR}"
+
+# Fetch a corpus at a pinned SHA. Idempotent.
+fetch_corpus() {
+    local name="$1" sha="$2" url="$3"
+    local dir="${WORK_DIR}/${name}"
+    if [[ -d "${dir}/.git" ]]; then
+        local cur
+        cur=$(cd "${dir}" && git rev-parse HEAD 2>/dev/null || echo "")
+        if [[ "${cur}" == "${sha}"* ]]; then
+            return 0
+        fi
+        (cd "${dir}" && git fetch --quiet --depth=1 origin "${sha}" 2>/dev/null \
+            && git reset --quiet --hard "${sha}") || {
+            rm -rf "${dir}"
+        }
+    fi
+    if [[ ! -d "${dir}/.git" ]]; then
+        git clone --quiet "${url}" "${dir}"
+        (cd "${dir}" && git reset --quiet --hard "${sha}") || {
+            echo "::error::failed to checkout ${sha} in ${name}" >&2
+            return 2
+        }
+    fi
+}
+
+# Build the file list for one corpus given its glob list.
+list_files() {
+    local dir="$1"
+    shift
+    local globs=("$@")
+    local find_args=()
+    local first=1
+    for g in "${globs[@]}"; do
+        if (( first )); then
+            find_args+=(-name "${g}")
+            first=0
+        else
+            find_args+=(-o -name "${g}")
+        fi
+    done
+    find "${dir}" -type f \( "${find_args[@]}" \) -print 2>/dev/null | sort
+}
+
+# Run zshellcheck on one file, return parser-error count.
+parser_errors_for() {
+    local f="$1"
+    "${BIN}" "$f" 2>&1 | grep -c "^Parser Error" || true
+}
+
+declare -A CURRENT
+declare -A BASELINE_MAP
+
+if [[ -f "${BASELINE}" ]]; then
+    while IFS=$'\t' read -r path count; do
+        [[ -z "${path}" || "${path}" == \#* ]] && continue
+        BASELINE_MAP["${path}"]="${count}"
+    done < "${BASELINE}"
+fi
+
+total_files=0
+total_errors=0
+regressions=()
+improvements=()
+
+while IFS=$'\t' read -r name sha url glob_list; do
+    [[ -z "${name}" || "${name}" == \#* ]] && continue
+    fetch_corpus "${name}" "${sha}" "${url}" || exit 2
+
+    # shellcheck disable=SC2206
+    globs=( ${glob_list} )
+    while IFS= read -r f; do
+        [[ -z "${f}" ]] && continue
+        rel="${name}/${f#${WORK_DIR}/${name}/}"
+        n=$(parser_errors_for "${f}")
+        CURRENT["${rel}"]="${n}"
+        total_files=$((total_files+1))
+        total_errors=$((total_errors+n))
+        prior="${BASELINE_MAP[${rel}]:-0}"
+        if (( n > prior )); then
+            regressions+=("${rel}: ${prior} -> ${n}")
+        elif (( n < prior )); then
+            improvements+=("${rel}: ${prior} -> ${n}")
+        fi
+    done < <(list_files "${WORK_DIR}/${name}" "${globs[@]}")
+done < "${MANIFEST}"
+
+echo "parser-corpus sweep: files=${total_files} parser_errors=${total_errors}"
+
+if (( UPDATE_BASELINE )); then
+    {
+        echo "# Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline"
+        echo "# Format: <relpath>\t<count>"
+        for k in $(printf '%s\n' "${!CURRENT[@]}" | sort); do
+            v="${CURRENT[$k]}"
+            (( v == 0 )) && continue
+            printf '%s\t%s\n' "${k}" "${v}"
+        done
+    } > "${BASELINE}"
+    echo "wrote baseline: ${BASELINE}"
+    exit 0
+fi
+
+if (( ${#regressions[@]} > 0 )); then
+    echo "::error::parser-corpus gate: ${#regressions[@]} file(s) regressed"
+    for r in "${regressions[@]}"; do
+        echo "  + ${r}"
+    done
+    exit 1
+fi
+
+if (( ${#improvements[@]} > 0 )); then
+    echo "::warning::parser-corpus gate: ${#improvements[@]} file(s) improved below baseline. Run scripts/parser-corpus-sweep.sh --update-baseline to lock the gain in."
+    for i in "${improvements[@]}"; do
+        echo "  - ${i}"
+    done
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Add CI gate that sweeps 12 pinned upstream corpora and compares per-file parser-error counts to `.github/parser-error-baseline.txt`.
- Manifest at `.github/parser-corpus-manifest.txt` pins each corpus to a 12-char SHA.
- Sweep script: `scripts/parser-corpus-sweep.sh` (gate mode + `--update-baseline` mode).
- New `parser-compat` CI job runs in parallel with lint, fails on regression, warns on improvement.

## Why
Local manual run on 12 corpora surfaced 170 parser errors across 13 files. All corpora parse cleanly under `zsh -n` — these are zshellcheck parser gaps, not file errors. Without a gate, future parser changes can silently widen the gap. This locks the floor so each fix is a measurable drop in the baseline.

## Baseline (locked)
- fast-syntax-highlighting/test/to-parse.zsh: 5
- fzf/shell/completion.zsh: 1
- fzf/shell/key-bindings.zsh: 6
- fzf-tab/test/ztst.zsh: 1
- zephyr/plugins/compstyle/compstyle.plugin.zsh: 1
- zimfw/zimfw.zsh: 21
- zinit/share/git-process-output.zsh: 10
- zinit/zinit-autoload.zsh: 20
- zinit/zinit-install.zsh: 35
- zinit/zinit-side.zsh: 2
- zinit/zinit.zsh: 30
- zsh-utils/utility/utility.plugin.zsh: 1
- zsh-vi-mode/zsh-vi-mode.zsh: 37

## Test plan
- [ ] CI green on this PR (sweep matches baseline → exit 0)
- [ ] Local: `bash scripts/parser-corpus-sweep.sh --update-baseline` regenerates clean
- [ ] Local: artificially lowering a baseline entry triggers regression error
- [ ] Local: artificially raising a baseline entry triggers improvement warning