### PR TITLE
fix(parser): arithmetic radix + number bases (-28 errors)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -12,4 +12,4 @@ zinit/zinit-install.zsh	35
 zinit/zinit-side.zsh	2
 zinit/zinit.zsh	30
 zsh-utils/utility/utility.plugin.zsh	1
-zsh-vi-mode/zsh-vi-mode.zsh	37
+zsh-vi-mode/zsh-vi-mode.zsh	7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,8 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          go test -coverpkg=./... -coverprofile=cov-total.out ./... > /dev/null 2>&1
+          go clean -testcache
+          go test -count=1 -coverpkg=./... -coverprofile=cov-total.out ./... > /dev/null 2>&1
           total=$(go tool cover -func=cov-total.out | tail -1 | awk '{print $NF}' | tr -d '%')
           echo "project-wide statement coverage: ${total}%"
           awk -v t="$total" 'BEGIN { exit (t >= 90.0) ? 0 : 1 }' || {

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -807,32 +807,8 @@ func (l *Lexer) readIdentifier() string {
 
 func (l *Lexer) readNumber() string {
 	position := l.position
-	// Zsh accepts `0x…` (hex), `0b…` (binary), `0o…` (octal), and
-	// `BASE#…` (custom-base) integer literals inside arithmetic. Read
-	// the leading prefix, then drain digits + base alphas. The parser
-	// uses strconv.ParseInt with base 0 which only recognises 0x/0b/0o,
-	// so the BASE# form rounds back to a string in the AST — but
-	// keeping the bytes as a single INT token is what the arithmetic
-	// expression layer needs to avoid mis-parsing `0x${var}` as
-	// `INT 0` + `IDENT x` + `${…}`.
-	if l.ch == '0' {
-		peek := l.peekChar()
-		if peek == 'x' || peek == 'X' || peek == 'b' || peek == 'B' || peek == 'o' || peek == 'O' {
-			// Only consume the base prefix when at least one digit
-			// follows. `0x${var}` (Zsh string concat with parameter
-			// expansion) must lex as INT(0) + IDENT(x) + DollarLbrace
-			// for the parser to recover; eating `0x` alone produced
-			// "could not parse \"0x\" as integer" downstream.
-			third := l.peekAt(2)
-			if isDigit(third) || isHexDigit(third) {
-				l.readChar() // 0
-				l.readChar() // base prefix letter
-				for isDigit(l.ch) || isHexDigit(l.ch) {
-					l.readChar()
-				}
-				return l.input[position:l.position]
-			}
-		}
+	if l.tryReadBaseLiteral() {
+		return l.input[position:l.position]
 	}
 	for isDigit(l.ch) {
 		l.readChar()
@@ -845,6 +821,38 @@ func (l *Lexer) readNumber() string {
 		}
 	}
 	return l.input[position:l.position]
+}
+
+// tryReadBaseLiteral consumes a Zsh `0x…` / `0b…` / `0o…` integer
+// literal when the prefix is followed by at least one digit. Returns
+// true iff bytes were consumed. `0x${var}` (Zsh string concat with a
+// parameter expansion) must NOT consume the prefix — the parser
+// recovers via INT(0) + IDENT(x) + DollarLbrace concatenation.
+func (l *Lexer) tryReadBaseLiteral() bool {
+	if l.ch != '0' {
+		return false
+	}
+	if !isBasePrefix(l.peekChar()) {
+		return false
+	}
+	third := l.peekAt(2)
+	if !isDigit(third) && !isHexDigit(third) {
+		return false
+	}
+	l.readChar() // 0
+	l.readChar() // base prefix letter
+	for isDigit(l.ch) || isHexDigit(l.ch) {
+		l.readChar()
+	}
+	return true
+}
+
+func isBasePrefix(ch byte) bool {
+	switch ch {
+	case 'x', 'X', 'b', 'B', 'o', 'O':
+		return true
+	}
+	return false
 }
 
 func isHexDigit(ch byte) bool {

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -807,10 +807,48 @@ func (l *Lexer) readIdentifier() string {
 
 func (l *Lexer) readNumber() string {
 	position := l.position
+	// Zsh accepts `0x…` (hex), `0b…` (binary), `0o…` (octal), and
+	// `BASE#…` (custom-base) integer literals inside arithmetic. Read
+	// the leading prefix, then drain digits + base alphas. The parser
+	// uses strconv.ParseInt with base 0 which only recognises 0x/0b/0o,
+	// so the BASE# form rounds back to a string in the AST — but
+	// keeping the bytes as a single INT token is what the arithmetic
+	// expression layer needs to avoid mis-parsing `0x${var}` as
+	// `INT 0` + `IDENT x` + `${…}`.
+	if l.ch == '0' {
+		peek := l.peekChar()
+		if peek == 'x' || peek == 'X' || peek == 'b' || peek == 'B' || peek == 'o' || peek == 'O' {
+			// Only consume the base prefix when at least one digit
+			// follows. `0x${var}` (Zsh string concat with parameter
+			// expansion) must lex as INT(0) + IDENT(x) + DollarLbrace
+			// for the parser to recover; eating `0x` alone produced
+			// "could not parse \"0x\" as integer" downstream.
+			third := l.peekAt(2)
+			if isDigit(third) || isHexDigit(third) {
+				l.readChar() // 0
+				l.readChar() // base prefix letter
+				for isDigit(l.ch) || isHexDigit(l.ch) {
+					l.readChar()
+				}
+				return l.input[position:l.position]
+			}
+		}
+	}
 	for isDigit(l.ch) {
 		l.readChar()
 	}
+	if l.ch == '#' && isDigit(l.peekChar()) {
+		// `BASE#NUM` — Zsh custom-base literal, e.g. `16#ff`.
+		l.readChar() // #
+		for isDigit(l.ch) || isHexDigit(l.ch) {
+			l.readChar()
+		}
+	}
 	return l.input[position:l.position]
+}
+
+func isHexDigit(ch byte) bool {
+	return (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
 }
 
 func (l *Lexer) readString(quote byte) string {

--- a/pkg/lexer/lexer_coverage_test.go
+++ b/pkg/lexer/lexer_coverage_test.go
@@ -216,3 +216,12 @@ func TestLexerPosixCharClassAvoidsLDBracket(t *testing.T) {
 func TestLexerLineContinuation(t *testing.T) {
 	drainTokens("echo hi \\\nworld\n")
 }
+
+// Zsh number bases: `0x…` hex, `0b…` binary, `0o…` octal, `BASE#…`.
+// Used inside `((…))` arithmetic.
+func TestLexerHexLiteral(t *testing.T)            { drainTokens("(( x = 0xff ))\n") }
+func TestLexerBinaryLiteral(t *testing.T)         { drainTokens("(( x = 0b101 ))\n") }
+func TestLexerOctalLiteral(t *testing.T)          { drainTokens("(( x = 0o755 ))\n") }
+func TestLexerCustomBaseLiteral(t *testing.T)     { drainTokens("(( x = 16#ff ))\n") }
+func TestLexerHexBareNoDigits(t *testing.T)       { drainTokens("(( x == 0x${var} ))\n") }
+func TestLexerBinaryBareNoDigits(t *testing.T)    { drainTokens("(( x == 0b${var} ))\n") }

--- a/pkg/lexer/lexer_coverage_test.go
+++ b/pkg/lexer/lexer_coverage_test.go
@@ -219,9 +219,9 @@ func TestLexerLineContinuation(t *testing.T) {
 
 // Zsh number bases: `0x…` hex, `0b…` binary, `0o…` octal, `BASE#…`.
 // Used inside `((…))` arithmetic.
-func TestLexerHexLiteral(t *testing.T)            { drainTokens("(( x = 0xff ))\n") }
-func TestLexerBinaryLiteral(t *testing.T)         { drainTokens("(( x = 0b101 ))\n") }
-func TestLexerOctalLiteral(t *testing.T)          { drainTokens("(( x = 0o755 ))\n") }
-func TestLexerCustomBaseLiteral(t *testing.T)     { drainTokens("(( x = 16#ff ))\n") }
-func TestLexerHexBareNoDigits(t *testing.T)       { drainTokens("(( x == 0x${var} ))\n") }
-func TestLexerBinaryBareNoDigits(t *testing.T)    { drainTokens("(( x == 0b${var} ))\n") }
+func TestLexerHexLiteral(t *testing.T)         { drainTokens("(( x = 0xff ))\n") }
+func TestLexerBinaryLiteral(t *testing.T)      { drainTokens("(( x = 0b101 ))\n") }
+func TestLexerOctalLiteral(t *testing.T)       { drainTokens("(( x = 0o755 ))\n") }
+func TestLexerCustomBaseLiteral(t *testing.T)  { drainTokens("(( x = 16#ff ))\n") }
+func TestLexerHexBareNoDigits(t *testing.T)    { drainTokens("(( x == 0x${var} ))\n") }
+func TestLexerBinaryBareNoDigits(t *testing.T) { drainTokens("(( x == 0b${var} ))\n") }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -290,12 +290,14 @@ func (p *Parser) expectPeek(t token.Type) bool {
 }
 
 func (p *Parser) peekError(t token.Type) {
-	msg := fmt.Sprintf("expected next token to be %s, got %s instead", t, p.peekToken.Type)
+	msg := fmt.Sprintf("line %d:%d: expected next token to be %s, got %s instead",
+		p.peekToken.Line, p.peekToken.Column, t, p.peekToken.Type)
 	p.errors = append(p.errors, msg)
 }
 
 func (p *Parser) noPrefixParseFnError(t token.Type) {
-	msg := fmt.Sprintf("no prefix parse function for %s found", t)
+	msg := fmt.Sprintf("line %d:%d: no prefix parse function for %s found",
+		p.curToken.Line, p.curToken.Column, t)
 	p.errors = append(p.errors, msg)
 }
 

--- a/pkg/parser/parser_dollar_test.go
+++ b/pkg/parser/parser_dollar_test.go
@@ -2,7 +2,11 @@
 // Copyright the ZShellCheck contributors.
 package parser
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/lexer"
+)
 
 func TestParseBareDollarBeforeSemicolon(t *testing.T) {
 	parseSourceClean(t, "echo $;\n")
@@ -103,4 +107,42 @@ func TestParseArithBinaryLiteral(t *testing.T) {
 
 func TestParseArithCustomBaseLiteral(t *testing.T) {
 	parseSourceClean(t, "(( x = 16#ff ))\n")
+}
+
+// Drive every absorbArithmeticNumberTail branch.
+func TestParseArithNumTailVariableConcat(t *testing.T) {
+	parseSourceClean(t, "(( a == 0x$h ))\n")
+}
+
+func TestParseArithNumTailIntConcat(t *testing.T) {
+	parseSourceClean(t, "(( a == 16#1234 ))\n")
+}
+
+func TestParseArithNumTailBraceVar(t *testing.T) {
+	parseSourceClean(t, "(( a == 0b${(l:8::0:)bits} ))\n")
+}
+
+// Drive every consumeArithmeticRadixPrefix branch.
+func TestParseArithNoRadixIdentStart(t *testing.T) {
+	parseSourceClean(t, "(( x + 1 ))\n")
+}
+
+func TestParseArithRadixUnclosed(t *testing.T) {
+	// Recovery path: malformed radix prefix without `]` exits at EOF.
+	src := "(( [#16\n"
+	p := New(lexer.New(src))
+	_ = p.ParseProgram()
+	if len(p.Errors()) == 0 {
+		t.Errorf("expected parser errors for unclosed radix; got none")
+	}
+}
+
+// Drive every peekIsHashLengthOperand branch.
+func TestParseDollarHashHash(t *testing.T) {
+	parseSourceClean(t, "echo $##\n")
+}
+
+func TestParseDollarHashWithSpace(t *testing.T) {
+	// Space after $# means it's not a length op — falls through.
+	parseSourceClean(t, "echo $# arg\n")
 }

--- a/pkg/parser/parser_dollar_test.go
+++ b/pkg/parser/parser_dollar_test.go
@@ -24,6 +24,21 @@ func TestParseDollarHashLength(t *testing.T) {
 	parseSourceClean(t, "echo $#name\n")
 }
 
+// $#1 — length of positional $1. Used inside `for ((i=1;i<=$#1;i++))`
+// loops in zsh-vi-mode. Previously the parser rejected the trailing
+// digit because parseDollarSpecialOp only accepted IDENT after `#`.
+func TestParseDollarHashPositional(t *testing.T) {
+	parseSourceClean(t, "for ((i=1;i<=$#1;i++)); do :; done\n")
+}
+
+func TestParseDollarHashStar(t *testing.T) {
+	parseSourceClean(t, "echo $#*\n")
+}
+
+func TestParseDollarHashQuestion(t *testing.T) {
+	parseSourceClean(t, "echo $#?\n")
+}
+
 func TestParseDollarInteger(t *testing.T) {
 	parseSourceClean(t, "echo $1\n")
 }
@@ -46,4 +61,46 @@ func TestParseDollarPlusName(t *testing.T) {
 
 func TestParseDollarPlusNameSubscript(t *testing.T) {
 	parseSourceClean(t, "(( $+name[key] ))\n")
+}
+
+// $((`[##N]` …)) — Zsh arithmetic radix prefix that prints the result
+// in a non-decimal base. zsh-vi-mode uses `h=$(([##16]$h+1))` to
+// generate hex-encoded keymap names. The parser previously failed
+// because LBRACKET inside `((` is registered as parseSingleCommand
+// (command-position `[ ... ]`), not as a radix opener.
+func TestParseArithRadixHashHash(t *testing.T) {
+	parseSourceClean(t, "h=$(([##16]$h+1))\n")
+}
+
+func TestParseArithRadixHashOne(t *testing.T) {
+	parseSourceClean(t, "echo $(([#8]7))\n")
+}
+
+func TestParseArithRadixHashOnly(t *testing.T) {
+	parseSourceClean(t, "echo $(([#]42))\n")
+}
+
+func TestParseDoubleParenRadix(t *testing.T) {
+	parseSourceClean(t, "(([##16]$x+1))\n")
+}
+
+// Arithmetic comparison with hex/binary literal prefix and parameter
+// expansion. zsh-vi-mode line 2734: `(( $number == 0x${(l:15::f:)} ))`.
+// The lexer extension keeps `0x…` digits as one INT token; the parser
+// then treats `0x` followed by `${…}` as INT(0) + IDENT(x) + DollarLbrace
+// (degenerate Zsh string concat) and recovers cleanly.
+func TestParseArithHexWithExpansion(t *testing.T) {
+	parseSourceClean(t, "(( $number == 0x${var} ))\n")
+}
+
+func TestParseArithBinaryWithExpansion(t *testing.T) {
+	parseSourceClean(t, "(( $number == 0b${var} ))\n")
+}
+
+func TestParseArithBinaryLiteral(t *testing.T) {
+	parseSourceClean(t, "(( $number == 0b101 ))\n")
+}
+
+func TestParseArithCustomBaseLiteral(t *testing.T) {
+	parseSourceClean(t, "(( x = 16#ff ))\n")
 }

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -138,7 +138,7 @@ func (p *Parser) parseKeywordAsCommand() ast.Expression {
 
 func (p *Parser) parseIntegerLiteral() ast.Expression {
 	lit := &ast.IntegerLiteral{Token: p.curToken}
-	value, err := strconv.ParseInt(p.curToken.Literal, 0, 64)
+	value, err := parseZshIntLiteral(p.curToken.Literal)
 	if err != nil {
 		msg := fmt.Sprintf("could not parse %q as integer", p.curToken.Literal)
 		p.errors = append(p.errors, msg)
@@ -166,6 +166,20 @@ func (p *Parser) parseIntegerLiteral() ast.Expression {
 		p.absorbArithmeticNumberTail()
 	}
 	return lit
+}
+
+// parseZshIntLiteral converts a Zsh integer literal to int64. Handles
+// the standard 0x / 0b / 0o / decimal forms via strconv plus the
+// custom-base `BASE#NUM` form (e.g. `16#ff`).
+func parseZshIntLiteral(s string) (int64, error) {
+	if hash := strings.IndexByte(s, '#'); hash > 0 {
+		base, err := strconv.Atoi(s[:hash])
+		if err != nil {
+			return 0, err
+		}
+		return strconv.ParseInt(s[hash+1:], base, 64)
+	}
+	return strconv.ParseInt(s, 0, 64)
 }
 
 // absorbArithmeticNumberTail walks the no-preceding-space tail after

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -158,7 +158,34 @@ func (p *Parser) parseIntegerLiteral() ast.Expression {
 			p.nextToken() // consume fractional INT
 		}
 	}
+	// Zsh number-base concat: `0x${var}`, `16#$base`, `0b${b}` —
+	// arithmetic treats these as a single literal whose value comes
+	// from the surrounding string concat. Absorb glued IDENT / `${…}`
+	// / VARIABLE / HASH+INT tail tokens so the closing `))` lines up.
+	if p.inArithmetic {
+		p.absorbArithmeticNumberTail()
+	}
 	return lit
+}
+
+// absorbArithmeticNumberTail walks the no-preceding-space tail after
+// an INT, swallowing the tokens that complete a Zsh numeric literal
+// with concat or custom-base form. Stops at the first whitespace gap
+// or non-eligible token.
+func (p *Parser) absorbArithmeticNumberTail() {
+	for !p.peekToken.HasPrecedingSpace {
+		switch p.peekToken.Type {
+		case token.IDENT, token.VARIABLE, token.INT:
+			p.nextToken()
+		case token.DollarLbrace:
+			p.nextToken()
+			p.skipDollarBraceBody()
+		case token.HASH:
+			p.nextToken()
+		default:
+			return
+		}
+	}
 }
 
 func (p *Parser) parseStringLiteral() ast.Expression {
@@ -539,7 +566,7 @@ func (p *Parser) parseDollarArithExpansion(dollarToken token.Token) ast.Expressi
 func (p *Parser) parseDollarSpecialOp(dollarToken token.Token) ast.Expression {
 	p.nextToken()
 	opToken := p.curToken
-	if opToken.Type == token.HASH && p.peekTokenIs(token.IDENT) {
+	if opToken.Type == token.HASH && p.peekIsHashLengthOperand() {
 		p.nextToken()
 		name := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 		return &ast.PrefixExpression{
@@ -554,6 +581,21 @@ func (p *Parser) parseDollarSpecialOp(dollarToken token.Token) ast.Expression {
 	}
 	ident := &ast.Identifier{Token: opToken, Value: opToken.Literal}
 	return &ast.PrefixExpression{Token: dollarToken, Operator: "$", Right: ident}
+}
+
+// peekIsHashLengthOperand reports whether the upcoming token is a valid
+// operand for `$#` (length of). Zsh accepts a name (`$#name`), a
+// positional digit (`$#1`), or `$#*` / `$#?` / `$##` for the count of
+// the special parameter.
+func (p *Parser) peekIsHashLengthOperand() bool {
+	if p.peekToken.HasPrecedingSpace {
+		return false
+	}
+	switch p.peekToken.Type {
+	case token.IDENT, token.INT, token.ASTERISK, token.QUESTION, token.HASH:
+		return true
+	}
+	return false
 }
 
 func (p *Parser) parseDollarPlusName(dollarToken token.Token) ast.Expression {
@@ -715,6 +757,7 @@ func (p *Parser) parseDollarParenExpression() ast.Expression {
 
 		prevInArithmetic := p.inArithmetic
 		p.inArithmetic = true
+		p.consumeArithmeticRadixPrefix()
 		cmd := p.parseExpression(LOWEST)
 		p.inArithmetic = prevInArithmetic
 
@@ -828,11 +871,29 @@ func (p *Parser) parseCallArguments() []ast.Expression {
 
 func (p *Parser) parseDoubleParenExpression() ast.Expression {
 	p.nextToken()
+	p.consumeArithmeticRadixPrefix()
 	exp := p.parseExpression(LOWEST)
 	if !p.expectPeek(token.DoubleRparen) {
 		return nil
 	}
 	return exp
+}
+
+// consumeArithmeticRadixPrefix drains an optional Zsh arithmetic radix
+// prefix `[#]`, `[#N]`, or `[##N]` that prints the result in a non-
+// decimal base (`(([#16] 0xff))`). Only valid at the start of an
+// arithmetic expression. Caller must have already advanced curToken
+// onto the first body token.
+func (p *Parser) consumeArithmeticRadixPrefix() {
+	if !p.curTokenIs(token.LBRACKET) || !p.peekTokenIs(token.HASH) {
+		return
+	}
+	for !p.curTokenIs(token.RBRACKET) && !p.curTokenIs(token.EOF) {
+		p.nextToken()
+	}
+	if p.curTokenIs(token.RBRACKET) {
+		p.nextToken()
+	}
 }
 
 func (p *Parser) parseRedirection(left ast.Expression) ast.Expression {

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -1131,6 +1131,7 @@ func (p *Parser) parseArithmeticCommand() *ast.ArithmeticCommand {
 
 	prevInArithmetic := p.inArithmetic
 	p.inArithmetic = true
+	p.consumeArithmeticRadixPrefix()
 	cmd.Expression = p.parseExpression(LOWEST)
 	p.inArithmetic = prevInArithmetic
 


### PR DESCRIPTION
## Summary
Drains 28 corpus parser errors; baseline 170 -> 140. zsh-vi-mode 37 -> 7.

## Five fixes
- Parser errors now carry `line:col` (debug aid).
- \`\$#1\`, \`\$#*\`, \`\$#?\`, \`\$##\` length-of-special parameter (was only \`\$#name\`).
- Arithmetic radix prefix \`[##N]\`, \`[#N]\`, \`[#]\` (e.g. \`((\$((`[##16]\$h+1\`)))\` for hex output).
- Hex / binary / octal / custom-base integer lex: \`0xff\`, \`0b101\`, \`0o755\`, \`16#ff\`.
- Arithmetic INT-tail absorption so \`0x\${var}\` concat lexes-then-parses cleanly.

## Why
zsh-vi-mode and zinit both rely on these constructs in arithmetic expressions; the parser used to bail with `no prefix parse function for ))` or `expected )), got IDENT instead`. The `parser-compat` gate would have caught this if it existed before.

## Test plan
- [ ] CI green (parser-compat gate passes against new baseline 140)
- [ ] New unit tests in `pkg/parser/parser_dollar_test.go` (Hash positional, radix, hex/bin concat, custom base)
- [ ] New lexer tests in `pkg/lexer/lexer_coverage_test.go` (Hex, Binary, Octal, CustomBase, BareNoDigits)
- [ ] `bash scripts/parser-corpus-sweep.sh` reports `parser_errors=140` matching baseline