### PR TITLE
fix(parser): escaped backtick + bare # in arithmetic (-21 errors)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -5,11 +5,11 @@ fzf/shell/completion.zsh	1
 fzf/shell/key-bindings.zsh	6
 fzf-tab/test/ztst.zsh	1
 zephyr/plugins/compstyle/compstyle.plugin.zsh	1
-zimfw/zimfw.zsh	21
+zimfw/zimfw.zsh	15
 zinit/share/git-process-output.zsh	10
 zinit/zinit-autoload.zsh	20
-zinit/zinit-install.zsh	35
+zinit/zinit-install.zsh	23
 zinit/zinit-side.zsh	2
-zinit/zinit.zsh	30
+zinit/zinit.zsh	29
 zsh-utils/utility/utility.plugin.zsh	1
-zsh-vi-mode/zsh-vi-mode.zsh	7
+zsh-vi-mode/zsh-vi-mode.zsh	5

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -140,11 +140,29 @@ func (l *Lexer) tryShebangOrComment(hasSpace bool) (token.Token, bool) {
 		}
 		return token.Token{Type: token.SHEBANG, Literal: l.input[start:l.position], Line: l.line, Column: l.column}, true
 	}
+	// Inside `((…))` / `$((…))` arithmetic, `#` is a special parameter
+	// (count of positional args), not a comment opener. Detect by an
+	// open `D` ('((') marker on the paren stack. zimfw uses
+	// `(( ! # ))` and `(( # > 0 ))` heavily.
+	if l.inArithmetic() {
+		return token.Token{}, false
+	}
 	if hasSpace || l.column == 1 {
 		l.skipComment()
 		return l.NextToken(), true
 	}
 	return token.Token{}, false
+}
+
+// inArithmetic reports whether the lexer is currently inside a `((`
+// arithmetic group. The parser's `((`-marker is 'D' on parenStack.
+func (l *Lexer) inArithmetic() bool {
+	for i := len(l.parenStack) - 1; i >= 0; i-- {
+		if l.parenStack[i] == 'D' {
+			return true
+		}
+	}
+	return false
 }
 
 // dispatchEarlyReturn covers the byte categories whose handler fully
@@ -637,6 +655,7 @@ var backslashEscapable = map[byte]struct{}{
 	'$': {}, '\\': {}, '/': {}, '.': {}, '!': {}, '~': {},
 	'^': {}, ' ': {}, '\t': {}, '#': {}, '"': {}, '\'': {},
 	'=': {}, '%': {}, ',': {}, ':': {}, '@': {}, '+': {}, '-': {},
+	'`': {},
 }
 
 func (l *Lexer) readBackslashEscape() token.Token {

--- a/pkg/lexer/lexer_coverage_test.go
+++ b/pkg/lexer/lexer_coverage_test.go
@@ -225,3 +225,15 @@ func TestLexerOctalLiteral(t *testing.T)       { drainTokens("(( x = 0o755 ))\n"
 func TestLexerCustomBaseLiteral(t *testing.T)  { drainTokens("(( x = 16#ff ))\n") }
 func TestLexerHexBareNoDigits(t *testing.T)    { drainTokens("(( x == 0x${var} ))\n") }
 func TestLexerBinaryBareNoDigits(t *testing.T) { drainTokens("(( x == 0b${var} ))\n") }
+
+// Escaped backtick appears in brace-expansion lists and pattern
+// strings. The lexer treats it as an IDENT word so the surrounding
+// command-word fold keeps working. Used heavily by zinit and
+// zsh-vi-mode.
+func TestLexerEscapedBacktickInBraceExpansion(t *testing.T) {
+	drainTokens("for s in {\\',\\\",\\`}; do echo $s; done\n")
+}
+
+func TestLexerEscapedBacktickAsArg(t *testing.T) {
+	drainTokens("echo \\`\n")
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -192,6 +192,11 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.LT_LPAREN, p.parseProcessSubstitution)
 	p.registerPrefix(token.GT_LPAREN, p.parseProcessSubstitution)
 	p.registerPrefix(token.EQ_LPAREN, p.parseProcessSubstitution)
+	// `#` standalone inside `((…))` is the special parameter holding
+	// the count of positional arguments (Zsh / POSIX `$#`). zimfw
+	// uses `(( ! # ))` and `(( # > 0 ))` heavily. Outside arithmetic
+	// HASH is a comment opener, handled separately.
+	p.registerPrefix(token.HASH, p.parseHashSpecial)
 
 	p.infixParseFns = make(map[token.Type]infixParseFn)
 	p.registerInfix(token.PLUS, p.parseInfixExpression)

--- a/pkg/parser/parser_dollar_test.go
+++ b/pkg/parser/parser_dollar_test.go
@@ -146,3 +146,20 @@ func TestParseDollarHashWithSpace(t *testing.T) {
 	// Space after $# means it's not a length op — falls through.
 	parseSourceClean(t, "echo $# arg\n")
 }
+
+// `(( # ))` — `#` standalone is the count of positional args inside
+// arithmetic. zimfw uses `(( ! # ))` for "no args" and
+// `(( # > 0 ))` for "have args".
+func TestParseArithBareHashCount(t *testing.T) {
+	parseSourceClean(t, "(( ! # ))\n")
+}
+
+func TestParseArithBareHashCompare(t *testing.T) {
+	parseSourceClean(t, "(( # > 0 ))\n")
+}
+
+// Backtick comment-suppression inside arithmetic must not eat the
+// closing `))`. `#` outside arithmetic is still a comment opener.
+func TestParseHashIsCommentOutsideArith(t *testing.T) {
+	parseSourceClean(t, "echo before # this is a comment\n")
+}

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -168,6 +168,15 @@ func (p *Parser) parseIntegerLiteral() ast.Expression {
 	return lit
 }
 
+// parseHashSpecial returns `#` as a special-parameter identifier when
+// curToken is HASH. Used inside `((…))` arithmetic where HASH stands
+// for the count of positional arguments. Outside arithmetic HASH
+// opens a comment which the lexer skips before the parser sees it,
+// so this prefix only fires in arithmetic context.
+func (p *Parser) parseHashSpecial() ast.Expression {
+	return &ast.Identifier{Token: p.curToken, Value: "#"}
+}
+
 // parseZshIntLiteral converts a Zsh integer literal to int64. Handles
 // the standard 0x / 0b / 0o / decimal forms via strconv plus the
 // custom-base `BASE#NUM` form (e.g. `16#ff`).


### PR DESCRIPTION
## Summary
Drains 21 corpus parser errors. Baseline 140 -> 119.

## Three fixes
- `\\\`` (escaped backtick) added to lexer's backslashEscapable set. Used by zinit/zsh-vi-mode in brace-expansion lists like `{\\',\\\",\\\`,\\(}`.
- `HASH` prefix returns Identifier when curToken is `#` inside arithmetic. zimfw uses `(( ! # ))` and `(( # > 0 ))` to test positional-arg count.
- Lexer no longer treats `#` as a comment opener inside `((…))` / `$((…))`. Gated via the parenStack `D` marker so plain `#` outside arithmetic still opens comments.

## Drops
- zinit/zinit-install.zsh 35 -> 23
- zimfw/zimfw.zsh 21 -> 15
- zsh-vi-mode/zsh-vi-mode.zsh 7 -> 5
- zinit/zinit.zsh 30 -> 29

## Test plan
- [ ] CI green (parser-compat baseline now 119)
- [ ] New tests in `pkg/parser/parser_dollar_test.go` (`(( ! # ))`, `(( # > 0 ))`)
- [ ] New tests in `pkg/lexer/lexer_coverage_test.go` (escaped backtick in brace expansion)
- [ ] Comment-outside-arith test still passes