### PR TITLE
fix(parser): bitwise & ^ in arithmetic + $+INT (-3 errors)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -7,7 +7,7 @@ fzf-tab/test/ztst.zsh	1
 zephyr/plugins/compstyle/compstyle.plugin.zsh	1
 zimfw/zimfw.zsh	15
 zinit/share/git-process-output.zsh	10
-zinit/zinit-autoload.zsh	20
+zinit/zinit-autoload.zsh	17
 zinit/zinit-install.zsh	23
 zinit/zinit-side.zsh	2
 zinit/zinit.zsh	29

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -53,6 +53,12 @@ var precedences = map[token.Type]int{
 	token.INC:           POSTFIX,
 	token.DEC:           POSTFIX,
 	token.PIPE:          LOWEST + 1,
+	// Bitwise operators inside `((…))`. Outside arithmetic these
+	// tokens carry shell-control meanings (`&` background, `^`
+	// caret-glob); expressionInfixShouldBreak keeps the infix loop
+	// from invoking them in non-arithmetic context.
+	token.AMPERSAND: LOGICAL,
+	token.CARET:     LOGICAL,
 	// Zsh arithmetic ternary `cond ? a : b`. QUESTION uses LOGICAL
 	// precedence; COLON is consumed inside parseInfixExpression's
 	// right-hand parse so it doesn't need its own infix entry (and
@@ -228,6 +234,8 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.LTLT, p.parseRedirection)
 	p.registerInfix(token.GTAMP, p.parseRedirection)
 	p.registerInfix(token.LTAMP, p.parseRedirection)
+	p.registerInfix(token.AMPERSAND, p.parseInfixExpression)
+	p.registerInfix(token.CARET, p.parseInfixExpression)
 
 	p.nextToken() // Initialize curToken
 	p.nextToken() // Initialize peekToken

--- a/pkg/parser/parser_dollar_test.go
+++ b/pkg/parser/parser_dollar_test.go
@@ -163,3 +163,24 @@ func TestParseArithBareHashCompare(t *testing.T) {
 func TestParseHashIsCommentOutsideArith(t *testing.T) {
 	parseSourceClean(t, "echo before # this is a comment\n")
 }
+
+// `$+3` — Zsh existence test for positional `$3` inside arithmetic.
+// fzf-tab's ls-colors.zsh uses `if (($+3)); then …`.
+func TestParseDollarPlusInt(t *testing.T) {
+	parseSourceClean(t, "(( $+3 ))\n")
+}
+
+// Bitwise `&` and `^` are infix operators inside `((…))`.
+// zinit-autoload's mode-flag tests use `(( unpacked[3] & 0x1 ))`.
+func TestParseArithBitwiseAnd(t *testing.T) {
+	parseSourceClean(t, "(( unpacked[3] & 0x1 ))\n")
+}
+
+func TestParseArithBitwiseXor(t *testing.T) {
+	parseSourceClean(t, "(( a ^ b ))\n")
+}
+
+// `&` outside arithmetic still backgrounds the command.
+func TestParseAmpersandStillBackgrounds(t *testing.T) {
+	parseSourceClean(t, "sleep 5 &\n")
+}

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -57,19 +57,33 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 // the various Zsh syntactic guards that prevent the infix loop from
 // crossing a statement / bracket / glob boundary.
 func (p *Parser) expressionInfixShouldBreak() bool {
-	if !p.inArithmetic && p.peekTokenIs(token.LBRACKET) && p.peekToken.HasPrecedingSpace {
-		return true
-	}
 	if p.peekTokenIs(token.RDBRACKET) || p.curTokenIs(token.RDBRACKET) {
-		return true
-	}
-	if !p.inArithmetic && p.peekTokenIs(token.SLASH) && !p.peekToken.HasPrecedingSpace {
 		return true
 	}
 	if p.inDoubleBracket && p.peekTokenIs(token.LPAREN) {
 		return true
 	}
 	if p.peekTokenIs(token.LPAREN) && p.peekToken.HasPrecedingSpace {
+		return true
+	}
+	if !p.inArithmetic && p.peekShouldBreakInfix() {
+		return true
+	}
+	return false
+}
+
+// peekShouldBreakInfix groups the not-in-arithmetic infix breaks so
+// expressionInfixShouldBreak stays under the gocyclo threshold. The
+// SLASH/LBRACKET arms guard glob-context shapes; AMPERSAND/CARET arms
+// guard shell-control bytes that are only infix inside `((…))`.
+func (p *Parser) peekShouldBreakInfix() bool {
+	if p.peekTokenIs(token.LBRACKET) && p.peekToken.HasPrecedingSpace {
+		return true
+	}
+	if p.peekTokenIs(token.SLASH) && !p.peekToken.HasPrecedingSpace {
+		return true
+	}
+	if p.peekTokenIs(token.AMPERSAND) || p.peekTokenIs(token.CARET) {
 		return true
 	}
 	return false
@@ -624,9 +638,14 @@ func (p *Parser) peekIsHashLengthOperand() bool {
 func (p *Parser) parseDollarPlusName(dollarToken token.Token) ast.Expression {
 	p.nextToken()
 	plusToken := p.curToken
-	if !p.expectPeek(token.IDENT) {
+	// Zsh accepts a name (`$+commands`), a positional digit
+	// (`$+3`), or `$+*` / `$+@` / `$+?` for the existence test of the
+	// special parameter. The lexer emits these as IDENT/INT plus a
+	// punctuation token; we accept either.
+	if !p.peekTokenIs(token.IDENT) && !p.peekTokenIs(token.INT) {
 		return nil
 	}
+	p.nextToken()
 	ident := &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
 	plus := &ast.PrefixExpression{Token: plusToken, Operator: "+", Right: ident}
 	if !p.peekTokenIs(token.LBRACKET) {


### PR DESCRIPTION
## Summary
- AMPERSAND + CARET now infix in arithmetic (`(( a & b ))`, `(( a ^ b ))`)
- `$+3` (existence of positional `$3`) now parses
- gocyclo of expressionInfixShouldBreak kept ≤ 15 via split helper

Baseline 119 -> 116. Cumulative 170 -> 116 (-54 across three PRs).

## Why
- zinit-autoload uses `(( unpacked[3] & 0x1 ))` heavily for mode-flag tests
- fzf-tab uses `(( \$+3 ))` to test positional-arg presence

## Test plan
- [ ] CI green (parser-compat baseline now 116)
- [ ] Bitwise-and / xor / dollar-plus-int unit tests added
- [ ] `&` outside arithmetic still backgrounds (`sleep 5 &` parses clean)