### PR TITLE
fix(parser): function names starting with - (-1 error, file clean)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -11,5 +11,4 @@ zinit/zinit-autoload.zsh	17
 zinit/zinit-install.zsh	23
 zinit/zinit-side.zsh	2
 zinit/zinit.zsh	29
-zsh-utils/utility/utility.plugin.zsh	1
 zsh-vi-mode/zsh-vi-mode.zsh	5

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -710,6 +710,19 @@ func (p *Parser) parseFunctionLiteral() ast.Expression {
 		p.skipDollarBraceBody()
 		lit.Name = &ast.Identifier{Token: nameTok, Value: nameTok.Literal}
 	}
+	// Zsh allows function names that start with `-` (e.g.
+	// `function -coreutils-alias-setup { … }`). The lexer emits the
+	// leading `-` as a MINUS token followed by an IDENT (with no
+	// space between them), so glue the pair into the name.
+	if p.peekTokenIs(token.MINUS) {
+		dashTok := p.peekToken
+		p.nextToken()
+		if p.peekTokenIs(token.IDENT) && !p.peekToken.HasPrecedingSpace {
+			p.nextToken()
+			lit.Name = &ast.Identifier{Token: dashTok, Value: "-" + p.curToken.Literal}
+			p.consumeCompositeFunctionName()
+		}
+	}
 	if p.peekTokenIs(token.IDENT) {
 		p.nextToken()
 		lit.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}

--- a/pkg/parser/parser_function_extra_test.go
+++ b/pkg/parser/parser_function_extra_test.go
@@ -47,3 +47,10 @@ func TestParseForLoopBraceStyle(t *testing.T) {
 func TestParseForLoopArithmeticHeader(t *testing.T) {
 	parseSourceClean(t, "for ((i=0; i<3; i++)); do echo $i; done\n")
 }
+
+// Zsh function names can start with `-` (e.g.
+// `function -coreutils-alias-setup { … }`). zsh-utils uses this
+// pattern for internal-only helpers.
+func TestParseFunctionDashPrefixedName(t *testing.T) {
+	parseSourceClean(t, "function -coreutils-alias-setup { :; }\n")
+}


### PR DESCRIPTION
## Summary
Zsh accepts function names that start with `-`. zsh-utils uses
`function -coreutils-alias-setup { ... }` for internal helpers.

`zsh-utils/utility/utility.plugin.zsh` now parses cleanly.
Baseline 116 -> 115.

## Test plan
- [ ] CI green (parser-compat baseline 115)
- [ ] New test: TestParseFunctionDashPrefixedName