### PR TITLE
fix(parser): if-elif brace form + ParseProgram brace-terminator (-19)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -7,8 +7,8 @@ fzf-tab/test/ztst.zsh	1
 zephyr/plugins/compstyle/compstyle.plugin.zsh	1
 zimfw/zimfw.zsh	15
 zinit/share/git-process-output.zsh	10
-zinit/zinit-autoload.zsh	17
-zinit/zinit-install.zsh	23
+zinit/zinit-autoload.zsh	7
+zinit/zinit-install.zsh	21
 zinit/zinit-side.zsh	2
-zinit/zinit.zsh	29
+zinit/zinit.zsh	22
 zsh-vi-mode/zsh-vi-mode.zsh	5

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -256,6 +256,15 @@ func (p *Parser) ParseProgram() *ast.Program {
 		if stmt != nil {
 			program.Statements = append(program.Statements, stmt)
 		}
+		// Brace-form statements advance past their own closing `}` and
+		// set consumedBraceTerminator. Skipping the trailing nextToken
+		// keeps the next statement's head on curToken; otherwise we
+		// over-advance and parseStatement starts on the second token
+		// (e.g. `+=` in `if {} ; x+=1`).
+		if p.consumedBraceTerminator {
+			p.consumedBraceTerminator = false
+			continue
+		}
 		p.nextToken()
 	}
 	return program

--- a/pkg/parser/parser_function_extra_test.go
+++ b/pkg/parser/parser_function_extra_test.go
@@ -54,3 +54,21 @@ func TestParseForLoopArithmeticHeader(t *testing.T) {
 func TestParseFunctionDashPrefixedName(t *testing.T) {
 	parseSourceClean(t, "function -coreutils-alias-setup { :; }\n")
 }
+
+// Brace-form `if X { } elif Y { }` chain. zinit relies on this Zsh
+// shorthand. Previously the parser handled `if X { } else { }` only.
+func TestParseBraceFormIfElif(t *testing.T) {
+	parseSourceClean(t, "if [[ 1 ]] {\n  echo a\n} elif [[ 2 ]] {\n  echo b\n}\n")
+}
+
+func TestParseBraceFormIfElifElse(t *testing.T) {
+	parseSourceClean(t, "if [[ 1 ]] {\n  echo a\n} elif [[ 2 ]] {\n  echo b\n} else {\n  echo c\n}\n")
+}
+
+// `IDENT+=value` immediately after a brace-form if. Previously failed
+// because ParseProgram unconditionally advanced past the head token
+// after parseStatement returned, despite the consumedBraceTerminator
+// flag indicating the brace-form had already advanced.
+func TestParseBraceFormIfFollowedByPlusEq(t *testing.T) {
+	parseSourceClean(t, "if [[ 1 ]] {\n  echo a\n}\nx+=1\n")
+}

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -632,19 +632,14 @@ func (p *Parser) parseIfStatement() *ast.IfStatement {
 	p.nextToken()
 	stmt.Condition = p.parseBlockStatement(token.THEN, token.LBRACE)
 
-	// Zsh short form `if cond { body } [else { body }]` uses brace
-	// blocks instead of `then … fi`. Detect by curToken being
-	// LBRACE after the condition.
+	// Zsh short form `if cond { body } [elif cond { body }]…
+	// [else { body }]` uses brace blocks instead of `then … fi`.
+	// Detect by curToken being LBRACE after the condition.
 	if p.curTokenIs(token.LBRACE) {
 		p.nextToken() // into body
 		stmt.Consequence = p.parseBlockStatement(token.RBRACE)
-		if p.peekTokenIs(token.ELSE) {
-			p.nextToken() // onto else
-			p.nextToken() // expect {
-			if p.curTokenIs(token.LBRACE) {
-				p.nextToken() // into else body
-				stmt.Alternative = p.parseBlockStatement(token.RBRACE)
-			}
+		if alt := p.parseBraceFormElifChain(); alt != nil {
+			stmt.Alternative = alt
 		}
 		// Step past the closing RBRACE so an enclosing brace-scoped
 		// body (for/while/subshell brace body) does not mistake the
@@ -703,6 +698,47 @@ func (p *Parser) parseIfStatement() *ast.IfStatement {
 		return nil
 	}
 	return stmt
+}
+
+// parseBraceFormElifChain walks any `} elif COND { BODY }` chain plus
+// an optional trailing `} else { BODY }` for the Zsh brace-form `if`.
+// Caller has just parsed the consequence body and curToken is RBRACE.
+// Returns the head Alternative (right-nested IfStatement chain), or
+// nil when no chain is present.
+func (p *Parser) parseBraceFormElifChain() ast.Statement {
+	var head ast.Statement
+	var tail *ast.IfStatement
+	for p.peekTokenIs(token.ELIF) {
+		p.nextToken() // onto elif
+		elifTok := p.curToken
+		p.nextToken() // into condition
+		elif := &ast.IfStatement{Token: elifTok}
+		elif.Condition = p.parseBlockStatement(token.LBRACE)
+		if !p.curTokenIs(token.LBRACE) {
+			return head
+		}
+		p.nextToken() // into body
+		elif.Consequence = p.parseBlockStatement(token.RBRACE)
+		if head == nil {
+			head = elif
+		} else {
+			tail.Alternative = elif
+		}
+		tail = elif
+	}
+	if p.peekTokenIs(token.ELSE) {
+		p.nextToken() // onto else
+		p.nextToken() // expect {
+		if p.curTokenIs(token.LBRACE) {
+			p.nextToken() // into else body
+			elseBody := p.parseBlockStatement(token.RBRACE)
+			if head == nil {
+				return elseBody
+			}
+			tail.Alternative = elseBody
+		}
+	}
+	return head
 }
 
 func (p *Parser) parseBlockStatement(terminators ...token.Type) *ast.BlockStatement {


### PR DESCRIPTION
## Summary
Drains 19 corpus parser errors (115 -> 96).

Two coupled fixes:
- **ParseProgram now honours `consumedBraceTerminator`**. The flag is set by brace-form statements after they advance past their own `}`. Previously ParseProgram unconditionally advanced, so a statement immediately after `if [[..]] { ... }` had its head token swallowed (e.g. `x+=1` errored as "no prefix parse function for +=").
- **parseIfStatement walks `} elif COND { BODY }` chains** plus optional trailing `} else { BODY }`. Previously only `if {} else {}` was recognised, so elif chains parsed as orphan statements and cascaded errors downstream.

## Drops
- zinit/zinit-autoload.zsh 17 -> 7
- zinit/zinit.zsh 29 -> 22
- zinit/zinit-install.zsh 23 -> 21

## Test plan
- [ ] CI green (parser-compat baseline 96)
- [ ] `TestParseBraceFormIfElif` / `TestParseBraceFormIfElifElse` / `TestParseBraceFormIfFollowedByPlusEq`