### PR TITLE
fix(parser): ParseProgram ; consume without over-advance (-7)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -10,5 +10,5 @@ zinit/share/git-process-output.zsh	10
 zinit/zinit-autoload.zsh	7
 zinit/zinit-install.zsh	21
 zinit/zinit-side.zsh	2
-zinit/zinit.zsh	22
+zinit/zinit.zsh	15
 zsh-vi-mode/zsh-vi-mode.zsh	5

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -252,6 +252,14 @@ func (p *Parser) ParseProgram() *ast.Program {
 	program.Statements = []ast.Statement{}
 
 	for !p.curTokenIs(token.EOF) {
+		// `;` between statements: parseStatement consumes the
+		// terminator itself and returns nil. Continue without an extra
+		// nextToken — otherwise we'd skip the next statement's head
+		// (e.g. `((1)); (( y ))` would lose the second `((`).
+		if p.curTokenIs(token.SEMICOLON) {
+			p.nextToken()
+			continue
+		}
 		stmt := p.parseStatement()
 		if stmt != nil {
 			program.Statements = append(program.Statements, stmt)

--- a/pkg/parser/parser_function_extra_test.go
+++ b/pkg/parser/parser_function_extra_test.go
@@ -72,3 +72,14 @@ func TestParseBraceFormIfElifElse(t *testing.T) {
 func TestParseBraceFormIfFollowedByPlusEq(t *testing.T) {
 	parseSourceClean(t, "if [[ 1 ]] {\n  echo a\n}\nx+=1\n")
 }
+
+// `((1)); (( y ))` — semicolon between top-level statements must not
+// over-advance. Previously ParseProgram consumed the `;` via parseStatement,
+// then advanced again, swallowing the second `((`.
+func TestParseTopLevelSemicolonChain(t *testing.T) {
+	parseSourceClean(t, "((1)); (( y += 1 ))\n")
+}
+
+func TestParseTopLevelSemicolonAfterIf(t *testing.T) {
+	parseSourceClean(t, "if [[ 1 ]] { :; }; (( x = 1 ))\n")
+}


### PR DESCRIPTION
## Summary
Drains 7 corpus parser errors (96 -> 89). zinit/zinit.zsh 22 -> 15.

`parseStatement` on SEMICOLON internally calls `nextToken` before returning nil. `ParseProgram` then advanced again, skipping the following statement's head. Mirrors `parseBlockStatement`'s `continue` pattern.

Repro: `((1)); (( y += 1 ))` produced "no prefix parse function for ))" because the second `((` was lost.

## Test plan
- [ ] CI green
- [ ] `TestParseTopLevelSemicolonChain` / `TestParseTopLevelSemicolonAfterIf`