### PR TITLE
fix(lexer): division / + grouping ((( in arithmetic (-10)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -6,7 +6,6 @@ fzf/shell/key-bindings.zsh	6
 fzf-tab/test/ztst.zsh	1
 zephyr/plugins/compstyle/compstyle.plugin.zsh	1
 zimfw/zimfw.zsh	15
-zinit/share/git-process-output.zsh	10
 zinit/zinit-autoload.zsh	7
 zinit/zinit-install.zsh	21
 zinit/zinit-side.zsh	2

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -186,7 +186,7 @@ func (l *Lexer) dispatchEarlyReturn(hasSpace bool) (token.Token, bool) {
 			return tok, true
 		}
 		return token.Token{}, false
-	case isAsciiLetterOrUnderscore(l.ch):
+	case l.isIdentLeadByte(l.ch):
 		return l.readIdentifierToken(hasSpace), true
 	case isDigit(l.ch):
 		return l.readNumberToken(hasSpace), true
@@ -204,11 +204,17 @@ func (l *Lexer) dispatchEarlyReturn(hasSpace bool) (token.Token, bool) {
 // (`~`, `:`, `.`). It includes `/` and `@` because the original
 // switch had no explicit arm for them — they only ever entered the
 // identifier path via the wide isLetter check.
-func isAsciiLetterOrUnderscore(ch byte) bool {
+func (l *Lexer) isIdentLeadByte(ch byte) bool {
 	if ('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z') || ch == '_' {
 		return true
 	}
-	return ch == '/' || ch == '@'
+	if ch == '@' {
+		return true
+	}
+	// `/` triggers an identifier read only outside arithmetic. Inside
+	// `((…))` / `$((…))` `/` is the division operator and must lex as
+	// SLASH; the parenStack 'D' marker tracks the arithmetic frame.
+	return ch == '/' && !l.inArithmetic()
 }
 
 // dispatchSimpleByte handles the per-byte switch where the handler
@@ -269,6 +275,12 @@ func (l *Lexer) dispatchBracketsAndOps(hasSpace bool) token.Token {
 		return newToken(token.CARET, l.ch, l.line, l.column)
 	case '%':
 		return l.readArithCompoundOr(token.PERCENT)
+	case '/':
+		// Inside arithmetic `/` is the division operator. Outside,
+		// `/` is reached only via the identifier path; if it falls
+		// through here it lexes as SLASH so the parser's prefix
+		// registration (`echo /etc/hostname`) handles it.
+		return newToken(token.SLASH, l.ch, l.line, l.column)
 	case '.':
 		return newToken(token.DOT, l.ch, l.line, l.column)
 	case '"', '\'':
@@ -317,7 +329,7 @@ func (l *Lexer) readSemicolonLead() token.Token {
 
 func (l *Lexer) readOpenParen() token.Token {
 	defer func() { l.suppressLparenFusion = false }()
-	if l.peekChar() == '(' && !l.suppressLparenFusion {
+	if l.peekChar() == '(' && !l.suppressLparenFusion && !l.inArithmetic() {
 		tok := l.readFusedToken(token.DoubleLparen)
 		l.parenStack = append(l.parenStack, 'D')
 		return tok
@@ -818,7 +830,14 @@ func (l *Lexer) readDollarToken(hasSpace bool) (token.Token, bool) {
 
 func (l *Lexer) readIdentifier() string {
 	position := l.position
+	inArith := l.inArithmetic()
 	for isLetter(l.ch) || isDigit(l.ch) || l.ch == '-' {
+		// Inside arithmetic `/` is the division operator, never part
+		// of an identifier. Outside arithmetic `/` extends an
+		// identifier so `/usr/bin/foo` survives as a single word.
+		if inArith && l.ch == '/' {
+			break
+		}
 		l.readChar()
 	}
 	return l.input[position:l.position]

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -253,12 +253,20 @@ func (l *Lexer) dispatchSimpleByte(hasSpace bool) token.Token {
 	return l.dispatchBracketsAndOps(hasSpace)
 }
 
+// simpleBracketTokens maps single-byte tokens whose lex result has no
+// state side-effect — they just become the matching token type.
+var simpleBracketTokens = map[byte]token.Type{
+	'{': token.LBRACE, '}': token.RBRACE,
+	'`': token.BACKTICK, '~': token.TILDE,
+	'^': token.CARET, '/': token.SLASH,
+	'.': token.DOT, '$': token.DOLLAR,
+}
+
 func (l *Lexer) dispatchBracketsAndOps(hasSpace bool) token.Token {
+	if t, ok := simpleBracketTokens[l.ch]; ok {
+		return newToken(t, l.ch, l.line, l.column)
+	}
 	switch l.ch {
-	case '{':
-		return newToken(token.LBRACE, l.ch, l.line, l.column)
-	case '}':
-		return newToken(token.RBRACE, l.ch, l.line, l.column)
 	case '[':
 		return l.readOpenBracket()
 	case ']':
@@ -267,29 +275,10 @@ func (l *Lexer) dispatchBracketsAndOps(hasSpace bool) token.Token {
 		return l.readAmpersandLead()
 	case '|':
 		return l.readPipeLead()
-	case '`':
-		return newToken(token.BACKTICK, l.ch, l.line, l.column)
-	case '~':
-		return newToken(token.TILDE, l.ch, l.line, l.column)
-	case '^':
-		return newToken(token.CARET, l.ch, l.line, l.column)
 	case '%':
 		return l.readArithCompoundOr(token.PERCENT)
-	case '/':
-		// Inside arithmetic `/` is the division operator. Outside,
-		// `/` is reached only via the identifier path; if it falls
-		// through here it lexes as SLASH so the parser's prefix
-		// registration (`echo /etc/hostname`) handles it.
-		return newToken(token.SLASH, l.ch, l.line, l.column)
-	case '.':
-		return newToken(token.DOT, l.ch, l.line, l.column)
 	case '"', '\'':
 		return l.readQuotedString(l.ch)
-	case '$':
-		// readDollarToken claimed `$` early when it recognised one of
-		// the specialised forms; falling through here means the
-		// generic DOLLAR token is the right answer.
-		return newToken(token.DOLLAR, l.ch, l.line, l.column)
 	case 0:
 		return token.Token{Type: token.EOF, Line: l.line, Column: l.column}
 	}

--- a/pkg/lexer/lexer_coverage_test.go
+++ b/pkg/lexer/lexer_coverage_test.go
@@ -237,3 +237,10 @@ func TestLexerEscapedBacktickInBraceExpansion(t *testing.T) {
 func TestLexerEscapedBacktickAsArg(t *testing.T) {
 	drainTokens("echo \\`\n")
 }
+
+// `/` inside `((…))` lexes as the division operator. Outside it
+// extends an identifier so `/usr/bin/foo` survives as a single word.
+func TestLexerSlashInArithmetic(t *testing.T)      { drainTokens("(( 1/2 ))\n") }
+func TestLexerSlashInArithmeticIdent(t *testing.T) { drainTokens("(( a/b ))\n") }
+func TestLexerSlashOutsideArithmetic(t *testing.T) { drainTokens("echo /usr/bin/foo\n") }
+func TestLexerNestedParensInArith(t *testing.T)    { drainTokens("(( (((b - 1)/14) % 10) + 1 ))\n") }


### PR DESCRIPTION
## Summary
Drains 10 corpus parser errors (89 -> 79). zinit/share/git-process-output.zsh 10 -> 0 (file fully clean).

Two coupled lexer fixes for arithmetic context:
- `/` lexes as SLASH inside `((…))` / `$((…))`. Outside arith it still extends an identifier so path literals like `/usr/bin/foo` survive as one IDENT.
- `(` peek `(` no longer fuses into `DoubleLparen` when already inside an arithmetic frame. zinit's `(( (((b - 1)/14) % 10) + 1 ))` parses cleanly now.

The lexer's `inArithmetic()` predicate (parenStack `D` marker) is consulted in three places: comment dispatch, identifier-lead dispatch, paren fusion.

Refactor: `dispatchBracketsAndOps` extracted to a map for gocyclo ≤ 15.

## Test plan
- [ ] CI green
- [ ] New lexer tests: TestLexerSlashInArithmetic / Ident / OutsideArithmetic / NestedParensInArith