### PR TITLE
fix(parser): nested case inside case clause body (-5)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -10,4 +10,3 @@ zinit/zinit-autoload.zsh	7
 zinit/zinit-install.zsh	21
 zinit/zinit-side.zsh	2
 zinit/zinit.zsh	15
-zsh-vi-mode/zsh-vi-mode.zsh	5

--- a/pkg/parser/parser_function_extra_test.go
+++ b/pkg/parser/parser_function_extra_test.go
@@ -83,3 +83,25 @@ func TestParseTopLevelSemicolonChain(t *testing.T) {
 func TestParseTopLevelSemicolonAfterIf(t *testing.T) {
 	parseSourceClean(t, "if [[ 1 ]] { :; }; (( x = 1 ))\n")
 }
+
+// Nested case inside a case clause body. Previously the inner `esac`
+// was treated as the outer body's terminator, collapsing the outer
+// case prematurely. zsh-vi-mode uses this pattern in its
+// range-handler dispatch.
+func TestParseNestedCase(t *testing.T) {
+	src := "case $x in\n" +
+		"  a)\n" +
+		"    case $y in\n" +
+		"      b) :;;\n" +
+		"    esac\n" +
+		"    :\n" +
+		"    ;;\n" +
+		"  c) :;;\n" +
+		"esac\n"
+	parseSourceClean(t, src)
+}
+
+// Pipeline tail after case must still work after the nested-case fix.
+func TestParseCasePipelineTail(t *testing.T) {
+	parseSourceClean(t, "case $x in a) echo a;; esac | tr a-z A-Z\n")
+}

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -872,21 +872,30 @@ func (p *Parser) parseCaseStatement() *ast.CaseStatement {
 	}
 	// Consume the closing ESAC so a caller parsing a nested case
 	// (`case x in a) case y in …;; esac ;; esac`) doesn't see the
-	// inner `esac` as the outer's terminator. Without this advance
-	// parseBlockStatement's terminator check would fire on the
-	// inner ESAC and collapse the outer case body.
-	if p.curTokenIs(token.ESAC) {
-		// Leave at-ESAC if we're the outermost call (no advance
-		// necessary — parseBlockStatement will re-check peek);
-		// but always leave curToken pointing at ESAC's successor
-		// when there is one so the outer DSEMI check works.
-		// Peek past ESAC only if there's a trailing `;;` pattern
-		// terminator or ;/newline.
-		if p.peekTokenIs(token.DSEMI) || p.peekTokenIs(token.SEMICOLON) {
-			p.nextToken()
-		}
+	// inner `esac` as the outer's terminator. parseBlockStatement
+	// includes ESAC in its terminator set so a clause body whose
+	// final `;;` is replaced by `esac` stops cleanly; without the
+	// advance below, an inner `esac` would close the outer body too.
+	// Skip the advance when the successor is a pipeline / logical
+	// continuation — consumePipelineTail expects peek=PIPE/AND/OR
+	// — or EOF, where there is nothing to advance onto.
+	if p.curTokenIs(token.ESAC) && p.shouldAdvancePastEsac() {
+		p.nextToken()
+		p.consumedBraceTerminator = true
 	}
 	return stmt
+}
+
+// shouldAdvancePastEsac reports whether parseCaseStatement should step
+// past ESAC. It must NOT advance when peek is a pipeline / logical
+// continuation (those need peek=PIPE/AND/OR for consumePipelineTail)
+// or EOF (nothing to advance onto).
+func (p *Parser) shouldAdvancePastEsac() bool {
+	switch p.peekToken.Type {
+	case token.EOF, token.PIPE, token.AND, token.OR:
+		return false
+	}
+	return true
 }
 
 func (p *Parser) parseShebangStatement() *ast.Shebang {


### PR DESCRIPTION
## Summary
Drains 5 corpus parser errors (79 -> 74).
zsh-vi-mode/zsh-vi-mode.zsh 5 -> 0 (file fully clean).

When a case clause body contained an inner case, the inner `esac` satisfied parseBlockStatement's terminator check and collapsed the outer body. Symptom: outer clauses after the nested case fired "no prefix parse function for )" on their pattern `)`.

parseCaseStatement now advances past its own ESAC and sets `consumedBraceTerminator` so the outer dispatch sees the successor token. `shouldAdvancePastEsac` preserves the pipeline-tail path by leaving curToken=ESAC when next token is PIPE/AND/OR/EOF.

## Test plan
- [ ] CI green (parser-compat baseline 74)
- [ ] TestParseNestedCase / TestParseCasePipelineTail