### PR TITLE
fix(parser): ${${INNER}MOD} modifier tail (-9)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -6,7 +6,6 @@ fzf/shell/key-bindings.zsh	6
 fzf-tab/test/ztst.zsh	1
 zephyr/plugins/compstyle/compstyle.plugin.zsh	1
 zimfw/zimfw.zsh	15
-zinit/zinit-autoload.zsh	7
-zinit/zinit-install.zsh	21
-zinit/zinit-side.zsh	2
+zinit/zinit-autoload.zsh	4
+zinit/zinit-install.zsh	17
 zinit/zinit.zsh	15

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -404,9 +404,14 @@ func (p *Parser) parseArrayAccess() ast.Expression {
 	hasLengthOp := p.consumeLengthOp()
 	p.consumePreflags()
 
+	subjectWasNested := false
 	if p.subjectIsEmpty() {
 		exp.Left = nil
 	} else {
+		// A nested `${INNER}` subject leaves curToken on the inner's
+		// RBRACE. Track that so the early-return below doesn't fire
+		// and skip the outer's modifier tail (`${${INNER}MOD}`).
+		subjectWasNested = p.peekTokenIs(token.DollarLbrace)
 		p.nextToken()
 		exp.Left, exp.Index = p.parseArrayAccessSubject()
 	}
@@ -436,7 +441,7 @@ func (p *Parser) parseArrayAccess() ast.Expression {
 	// inner ArrayAccess already left curToken on its close `}`
 	// while the outer's close is the next `}` (peek RBRACE), and
 	// we still need expectPeek(RBRACE) to advance.
-	if p.curTokenIs(token.RBRACE) && !p.peekTokenIs(token.RBRACE) {
+	if p.curTokenIs(token.RBRACE) && !p.peekTokenIs(token.RBRACE) && !subjectWasNested {
 		return exp
 	}
 	if !p.peekTokenIs(token.RBRACE) {
@@ -500,6 +505,12 @@ func (p *Parser) parseArrayAccessSubject() (ast.Expression, ast.Expression) {
 		return p.parseArrayAccessIdent()
 	case p.subjectIsSpecialName():
 		return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}, nil
+	case p.curTokenIs(token.DollarLbrace):
+		// Nested `${INNER}` subject. Call parseArrayAccess directly
+		// rather than going through parseExpression so the infix loop
+		// in parseExpression doesn't eat the outer's modifier tail
+		// (`%%pat`, `//pat/repl`) as misinterpreted operators.
+		return p.parseArrayAccess(), nil
 	}
 	expr := p.parseExpression(LOWEST)
 	if idx, ok := expr.(*ast.IndexExpression); ok {

--- a/pkg/parser/parser_function_extra_test.go
+++ b/pkg/parser/parser_function_extra_test.go
@@ -105,3 +105,19 @@ func TestParseNestedCase(t *testing.T) {
 func TestParseCasePipelineTail(t *testing.T) {
 	parseSourceClean(t, "case $x in a) echo a;; esac | tr a-z A-Z\n")
 }
+
+// `${${INNER}MOD}` — outer modifier after a nested subject. Previously
+// parseExpression's infix loop ate `MOD` tokens before parseArrayAccess
+// could route them through consumeArrayAccessModifierTail. zinit's
+// `${${key##(zinit|z-annex) hook:}%% <->}` (and friends) need this.
+func TestParseNestedExpansionWithOuterModifier(t *testing.T) {
+	parseSourceClean(t, "echo ${${X}%%pat}\n")
+}
+
+func TestParseNestedExpansionBracketClassPattern(t *testing.T) {
+	parseSourceClean(t, "echo ${${X}%%[abc]*}\n")
+}
+
+func TestParseNestedExpansionPatternSubst(t *testing.T) {
+	parseSourceClean(t, "echo ${${X}//pat/replacement}\n")
+}


### PR DESCRIPTION
## Summary
Drains 9 corpus parser errors (74 -> 65). zinit/zinit-side.zsh fully clean.

When a parameter expansion's subject is a nested expansion (`${${INNER}MOD}`), `parseArrayAccessSubject` called `parseExpression` which let its infix loop eat the outer modifier tokens (`%%`, `//`, `[…]`, `<->`, etc.) as misinterpreted operators. Result: outer `}` unmatched, "expected }, got EOF" / "no prefix parse function for >".

`parseArrayAccessSubject` now calls `parseArrayAccess` directly when the subject is `DollarLbrace`, plus a `subjectWasNested` flag that prevents the outer's early-return so `consumeArrayAccessModifierTail` runs.

## Drops
- zinit/zinit-side.zsh 2 -> 0
- zinit/zinit-autoload.zsh 7 -> 4
- zinit/zinit-install.zsh 21 -> 17

## Test plan
- [ ] CI green (parser-compat baseline 65)
- [ ] `TestParseNestedExpansionWithOuterModifier`
- [ ] `TestParseNestedExpansionBracketClassPattern`
- [ ] `TestParseNestedExpansionPatternSubst`