### PR TITLE
fix(parser): brace-form for/while loops (-1)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -6,6 +6,6 @@ fzf/shell/key-bindings.zsh	6
 fzf-tab/test/ztst.zsh	1
 zephyr/plugins/compstyle/compstyle.plugin.zsh	1
 zimfw/zimfw.zsh	15
-zinit/zinit-autoload.zsh	4
+zinit/zinit-autoload.zsh	3
 zinit/zinit-install.zsh	17
 zinit/zinit.zsh	15

--- a/pkg/parser/parser_function_extra_test.go
+++ b/pkg/parser/parser_function_extra_test.go
@@ -121,3 +121,14 @@ func TestParseNestedExpansionBracketClassPattern(t *testing.T) {
 func TestParseNestedExpansionPatternSubst(t *testing.T) {
 	parseSourceClean(t, "echo ${${X}//pat/replacement}\n")
 }
+
+// Brace-form arithmetic for: `for ((..)) { body }`. zinit uses this
+// in load-counting helpers.
+func TestParseArithForBraceForm(t *testing.T) {
+	parseSourceClean(t, "for (( i = 1; i <= 5; ++i )) { echo $i }\n")
+}
+
+// Brace-form while: `while cond { body }`.
+func TestParseWhileBraceForm(t *testing.T) {
+	parseSourceClean(t, "while [[ -n $x ]] { echo $x; x= }\n")
+}

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -985,6 +985,18 @@ func (p *Parser) parseArithmeticForLoop(stmt *ast.ForLoopStatement) *ast.ForLoop
 	if p.peekTokenIs(token.SEMICOLON) {
 		p.nextToken()
 	}
+	// Zsh short-form arithmetic for: `for ((..)) { body }`. Detect a
+	// LBRACE peek and treat it as the body opener instead of `do`.
+	if p.peekTokenIs(token.LBRACE) {
+		p.nextToken() // onto {
+		p.nextToken() // into body
+		stmt.Body = p.parseBlockStatement(token.RBRACE)
+		if p.curTokenIs(token.RBRACE) {
+			p.nextToken()
+			p.consumedBraceTerminator = true
+		}
+		return stmt
+	}
 	if !p.expectPeek(token.DO) {
 		return nil
 	}
@@ -1093,7 +1105,17 @@ func wrapForLoopBody(tok token.Token, body ast.Statement) *ast.BlockStatement {
 func (p *Parser) parseWhileLoopStatement() *ast.WhileLoopStatement {
 	stmt := &ast.WhileLoopStatement{Token: p.curToken}
 	p.nextToken()
-	stmt.Condition = p.parseBlockStatement(token.DO)
+	stmt.Condition = p.parseBlockStatement(token.DO, token.LBRACE)
+	// Zsh short-form `while cond { body }`.
+	if p.curTokenIs(token.LBRACE) {
+		p.nextToken()
+		stmt.Body = p.parseBlockStatement(token.RBRACE)
+		if p.curTokenIs(token.RBRACE) {
+			p.nextToken()
+			p.consumedBraceTerminator = true
+		}
+		return stmt
+	}
 	if !p.curTokenIs(token.DO) {
 		return nil
 	}


### PR DESCRIPTION
Zsh shorthand `for ((..)) { body }` and `while cond { body }` now parse alongside `do … done`. zinit uses the brace shape for load-counting helpers.

Baseline 65 -> 64.