### PR TITLE
fix(parser): process-sub body honours brace-terminator (-1)

### DIFF
--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -1072,9 +1072,20 @@ func (p *Parser) parseProcessSubstitution() ast.Expression {
 	// subsequent `;` separators were crashing as "expected ), got ;".
 	statements := []ast.Statement{}
 	for !p.curTokenIs(token.RPAREN) && !p.curTokenIs(token.EOF) {
+		if p.curTokenIs(token.SEMICOLON) {
+			p.nextToken()
+			continue
+		}
 		stmt := p.parseStatement()
 		if stmt != nil {
 			statements = append(statements, stmt)
+		}
+		// Brace-form / case statements advance past their own
+		// terminator and set consumedBraceTerminator. Skipping the
+		// trailing nextToken keeps the next statement's head live.
+		if p.consumedBraceTerminator {
+			p.consumedBraceTerminator = false
+			continue
 		}
 		p.nextToken()
 	}


### PR DESCRIPTION
Process substitution (`<(...)`, `>(...)`, `=(...)`) bodies now honour `consumedBraceTerminator` in their statement loop and consume `;` directly. zimfw's `_zimfw_mv =( … )` body has brace-form / case statements that were colliding with the unconditional advance.\n\nBaseline 65 -> 64.