### PR TITLE
fix(parser): comma operator in arithmetic (-1)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -8,4 +8,4 @@ zephyr/plugins/compstyle/compstyle.plugin.zsh	1
 zimfw/zimfw.zsh	15
 zinit/zinit-autoload.zsh	3
 zinit/zinit-install.zsh	17
-zinit/zinit.zsh	15
+zinit/zinit.zsh	14

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -59,6 +59,11 @@ var precedences = map[token.Type]int{
 	// from invoking them in non-arithmetic context.
 	token.AMPERSAND: LOGICAL,
 	token.CARET:     LOGICAL,
+	// Comma operator inside arithmetic (`(( a, b, c ))`). Precedence
+	// just above LOWEST so a parseExpression(LOWEST) call still
+	// consumes commas, but nested parseExpression(LOGICAL) (e.g.
+	// inside ternary) doesn't accidentally absorb them.
+	token.COMMA: LOWEST + 1,
 	// Zsh arithmetic ternary `cond ? a : b`. QUESTION uses LOGICAL
 	// precedence; COLON is consumed inside parseInfixExpression's
 	// right-hand parse so it doesn't need its own infix entry (and
@@ -236,6 +241,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.LTAMP, p.parseRedirection)
 	p.registerInfix(token.AMPERSAND, p.parseInfixExpression)
 	p.registerInfix(token.CARET, p.parseInfixExpression)
+	p.registerInfix(token.COMMA, p.parseInfixExpression)
 
 	p.nextToken() // Initialize curToken
 	p.nextToken() // Initialize peekToken

--- a/pkg/parser/parser_dollar_test.go
+++ b/pkg/parser/parser_dollar_test.go
@@ -184,3 +184,17 @@ func TestParseArithBitwiseXor(t *testing.T) {
 func TestParseAmpersandStillBackgrounds(t *testing.T) {
 	parseSourceClean(t, "sleep 5 &\n")
 }
+
+// Comma operator inside arithmetic. zinit chains side effects via
+// `(( ++idx, count += val ))`.
+func TestParseArithCommaOperator(t *testing.T) {
+	parseSourceClean(t, "(( ++a, b += 1 ))\n")
+}
+
+func TestParseArithCommaInDollarParen(t *testing.T) {
+	parseSourceClean(t, "echo $(( ++a, b += 1 ))\n")
+}
+
+func TestParseFuncCallCommasUnaffected(t *testing.T) {
+	parseSourceClean(t, "let x = add(a, b, 1)\n")
+}

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -74,8 +74,8 @@ func (p *Parser) expressionInfixShouldBreak() bool {
 
 // peekShouldBreakInfix groups the not-in-arithmetic infix breaks so
 // expressionInfixShouldBreak stays under the gocyclo threshold. The
-// SLASH/LBRACKET arms guard glob-context shapes; AMPERSAND/CARET arms
-// guard shell-control bytes that are only infix inside `((…))`.
+// SLASH/LBRACKET arms guard glob-context shapes; AMPERSAND/CARET/COMMA
+// arms guard shell-control bytes that are only infix inside `((…))`.
 func (p *Parser) peekShouldBreakInfix() bool {
 	if p.peekTokenIs(token.LBRACKET) && p.peekToken.HasPrecedingSpace {
 		return true
@@ -84,6 +84,9 @@ func (p *Parser) peekShouldBreakInfix() bool {
 		return true
 	}
 	if p.peekTokenIs(token.AMPERSAND) || p.peekTokenIs(token.CARET) {
+		return true
+	}
+	if p.peekTokenIs(token.COMMA) {
 		return true
 	}
 	return false
@@ -923,11 +926,14 @@ func (p *Parser) parseCallArguments() []ast.Expression {
 		return args
 	}
 	p.nextToken()
-	args = append(args, p.parseExpression(LOWEST))
+	// Parse each argument at LOGICAL so the comma-separator (precedence
+	// LOWEST+1) does not get absorbed as a binary operator inside the
+	// argument expression itself.
+	args = append(args, p.parseExpression(LOGICAL))
 	for p.peekTokenIs(token.COMMA) {
 		p.nextToken()
 		p.nextToken()
-		args = append(args, p.parseExpression(LOWEST))
+		args = append(args, p.parseExpression(LOGICAL))
 	}
 	if !p.expectPeek(token.RPAREN) {
 		return nil


### PR DESCRIPTION
Comma operator inside ((..)) registered as infix at LOWEST+1. parseCallArguments uses LOGICAL precedence to keep commas as arg separators.\n\nBaseline 64 -> 63.