### PR TITLE
fix(parser): keywords as literal patterns (-2)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,7 +1,6 @@
 # Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
 # Format: <relpath>\t<count>
-fast-syntax-highlighting/test/to-parse.zsh	4
-fzf/shell/completion.zsh	1
+fast-syntax-highlighting/test/to-parse.zsh	3
 fzf/shell/key-bindings.zsh	6
 fzf-tab/test/ztst.zsh	1
 zimfw/zimfw.zsh	15

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -35,6 +35,13 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 		p.curToken.Type = token.LPAREN
 		p.curToken.Literal = "("
 	}
+	// Inside `${…[KEY]}` subscripts and `[[ … ]]` tests, Zsh keywords
+	// are literal pattern words, not statement-block openers. Return
+	// an Identifier so the surrounding parse keeps moving.
+	if (p.inDoubleBracket || p.inArithmetic) && isDoubleBracketLiteralKeyword(p.curToken.Type) {
+		tok := p.curToken
+		return &ast.Identifier{Token: tok, Value: tok.Literal}
+	}
 	prefix := p.prefixParseFns[p.curToken.Type]
 	if prefix == nil {
 		if p.inDoubleBracket {
@@ -57,6 +64,19 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 		leftExp = infix(leftExp)
 	}
 	return leftExp
+}
+
+// isDoubleBracketLiteralKeyword reports whether a Zsh keyword token
+// should be treated as a literal pattern word inside `[[ … ]]` or a
+// `${var[KEY]}` subscript. Most reserved words (FUNCTION, IF, FOR, …)
+// only mean "statement head" in command position; in pattern context
+// they are simply pattern strings.
+func isDoubleBracketLiteralKeyword(t token.Type) bool {
+	switch t {
+	case token.FUNCTION:
+		return true
+	}
+	return false
 }
 
 // expressionInfixShouldBreak reports whether the infix chain in


### PR DESCRIPTION
Drains 2 corpus parser errors (40 -> 38). fzf/completion clean.