### PR TITLE
fix(parser): function keyword as assignment rhs (-1)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,6 +1,6 @@
 # Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
 # Format: <relpath>\t<count>
-fast-syntax-highlighting/test/to-parse.zsh	3
+fast-syntax-highlighting/test/to-parse.zsh	2
 fzf/shell/key-bindings.zsh	6
 fzf-tab/test/ztst.zsh	1
 zimfw/zimfw.zsh	15

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -769,7 +769,34 @@ func (p *Parser) finalizeInvalidArrayAccess(exp *ast.InvalidArrayAccess) ast.Exp
 	return exp
 }
 
+// peekIsFunctionDefinitionContinuation reports whether the token
+// after `function` shapes a Zsh function definition: a name token, a
+// `${…}`-spliced name, a leading `-` for dashed names, an opening
+// `(` for `function name()` form, or `{` for `function { body }`.
+// Used to guard parseFunctionLiteral so a stray `function` keyword
+// in expression position (assignment RHS, case label) degrades to a
+// literal identifier instead of erroring on the missing brace body.
+func (p *Parser) peekIsFunctionDefinitionContinuation() bool {
+	switch p.peekToken.Type {
+	case token.IDENT, token.STRING, token.VARIABLE,
+		token.DollarLbrace, token.MINUS, token.LPAREN, token.LBRACE:
+		return true
+	}
+	return false
+}
+
 func (p *Parser) parseFunctionLiteral() ast.Expression {
+	// `function` only opens a Zsh function definition when followed
+	// by a name token, a `${…}`-spliced name, a leading `-` (dashed
+	// name), or directly by `(` or `{`. Anywhere else — e.g. as the
+	// RHS of an assignment (`REPLY=function`) or as a case-label
+	// pattern — it is a literal identifier. Without this guard the
+	// expectPeek(LBRACE) below errored on the next statement's
+	// keyword (`expected next token to be {, got ELIF instead`).
+	if !p.peekIsFunctionDefinitionContinuation() {
+		tok := p.curToken
+		return &ast.Identifier{Token: tok, Value: tok.Literal}
+	}
 	lit := &ast.FunctionLiteral{Token: p.curToken}
 	if p.peekTokenIs(token.DollarLbrace) {
 		nameTok := p.peekToken

--- a/pkg/parser/parser_function_test.go
+++ b/pkg/parser/parser_function_test.go
@@ -19,3 +19,15 @@ func TestParseFunctionLiteralKeywordWithoutParens(t *testing.T) {
 func TestParseFunctionLiteralBody(t *testing.T) {
 	parseSourceClean(t, "f() { local x=1; echo $x; }\n")
 }
+
+// `function` as the right-hand side of an assignment is a literal
+// identifier, not a function-definition opener. Without the
+// peekIsFunctionDefinitionContinuation guard, parseFunctionLiteral
+// errored on the missing `{` body and broke the surrounding elif chain.
+func TestParseFunctionKeywordAsAssignmentRhs(t *testing.T) {
+	parseSourceClean(t, "REPLY=function\n")
+}
+
+func TestParseFunctionKeywordAsAssignmentRhsInElifChain(t *testing.T) {
+	parseSourceClean(t, "if (( a )); then REPLY=alias; elif (( b )); then REPLY=function; fi\n")
+}


### PR DESCRIPTION
## Summary
- Guard parseFunctionLiteral so a stray `function` keyword in expression position degrades to a literal Identifier instead of erroring on the missing `{` body.
- Triggers in real code where `function` is the right-hand side of an assignment (`REPLY=function`) inside an elif chain — prior behaviour cascaded the missing-brace error through the surrounding `if`/`elif`/`fi` block.

## Test plan
- [x] `go test ./...` — new TestParseFunctionKeywordAsAssignmentRhs / ...InElifChain pass; existing function-literal tests still pass.
- [x] `bash scripts/parser-corpus-sweep.sh` — fast-syntax-highlighting/test/to-parse.zsh drops 3 → 2 parser errors; no regressions; baseline updated.