### PR TITLE
chore(lint): clear singleCaseSwitch + dead helper

### DIFF
--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -5925,15 +5925,6 @@ func zc1083ScanString(scan *zc1083Scan, lastPartWasDot *bool, val string, i int)
 	}
 }
 
-func zc1083HasIndexAfter(indices []int, after int) bool {
-	for _, idx := range indices {
-		if idx > after {
-			return true
-		}
-	}
-	return false
-}
-
 // zc1083HasIndexBetween reports whether any index sits strictly between
 // the brace-open and brace-close. A closeIdx of -1 means the brace
 // never closed in the parts run, so any index past startIdx counts.

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -72,11 +72,7 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 // only mean "statement head" in command position; in pattern context
 // they are simply pattern strings.
 func isDoubleBracketLiteralKeyword(t token.Type) bool {
-	switch t {
-	case token.FUNCTION:
-		return true
-	}
-	return false
+	return t == token.FUNCTION
 }
 
 // expressionInfixShouldBreak reports whether the infix chain in


### PR DESCRIPTION
## Summary
- Two carry-over lint failures that have been blocking the CI lint job on every recent merge.
- isDoubleBracketLiteralKeyword had a single-case switch — gocritic singleCaseSwitch. Collapsed to a one-line type comparison.
- zc1083HasIndexAfter was dead code left over from a refactor. The active path uses zc1083HasIndexBetween instead.

## Test plan
- [x] go test ./... clean
- [x] golangci-lint run ./... reports 0 issues