### PR TITLE
fix(parser): glob bracket-class in [[..]] and case labels (-1)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,6 +1,6 @@
 # Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
 # Format: <relpath>\t<count>
-fast-syntax-highlighting/test/to-parse.zsh	2
+fast-syntax-highlighting/test/to-parse.zsh	1
 fzf/shell/key-bindings.zsh	6
 fzf-tab/test/ztst.zsh	1
 zimfw/zimfw.zsh	15

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -44,6 +44,33 @@ func TestParseDoubleBracketRegex(t *testing.T) {
 	parseSourceClean(t, "[[ $x =~ ^[a-z]+$ ]]\n")
 }
 
+// Inside `[[ … ]]`, a leading `[` opens a glob bracket-class
+// fragment, not the `[` test-builtin or an array subscript. The
+// default LBRACKET prefix used to gobble through the closing `]]`.
+func TestParseDoubleBracketGlobBracketClass(t *testing.T) {
+	parseSourceClean(t, "[[ $x = [abc]* ]]\n")
+}
+
+func TestParseDoubleBracketPosixClass(t *testing.T) {
+	parseSourceClean(t, "[[ $x = [[:alnum:]]## ]]\n")
+}
+
+func TestParseDoubleBracketNegatedPosixClass(t *testing.T) {
+	parseSourceClean(t, "[[ $x = [[:blank:]]##[^[:blank:]]* ]]\n")
+}
+
+func TestParseDoubleBracketPosixClassWithCharLiteral(t *testing.T) {
+	parseSourceClean(t, "[[ $x = ([[:alpha:]_][[:alnum:]_]#) ]]\n")
+}
+
+// Case-clause patterns can carry `[…]` glob bracket-class fragments.
+// The default RBRACKET prefix used to invite an INDEX infix, so the
+// inner `]` of `[*?]` recursed into a phantom array subscript and
+// the outer `)` of the case label became orphaned.
+func TestParseCaseClauseGlobBracketPattern(t *testing.T) {
+	parseSourceClean(t, "case x in [*?]*|*[^\\\\][*?]*) echo y;; esac\n")
+}
+
 func TestParseProcessSubstitution(t *testing.T) {
 	parseSourceClean(t, "diff <(sort a) <(sort b)\n")
 }

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -42,6 +42,15 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 		tok := p.curToken
 		return &ast.Identifier{Token: tok, Value: tok.Literal}
 	}
+	// Inside `[[ … ]]`, a leading `[` opens a glob bracket-class
+	// fragment (`[abc]`, `[[:alnum:]]`, `[^[:blank:]]`), not the `[`
+	// test-builtin or an array subscript. The default LBRACKET prefix
+	// (parseSingleCommand) gobbles every glued token until a command
+	// delimiter and walks past the closing `]]`. Consume the bracket
+	// body as a literal pattern fragment instead.
+	if p.inDoubleBracket && p.curTokenIs(token.LBRACKET) {
+		return p.parseDoubleBracketGlobBracket()
+	}
 	prefix := p.prefixParseFns[p.curToken.Type]
 	if prefix == nil {
 		if p.inDoubleBracket {
@@ -271,6 +280,39 @@ func (p *Parser) parsePrefixExpression() ast.Expression {
 
 func (p *Parser) parsePostfixExpression(left ast.Expression) ast.Expression {
 	return &ast.PostfixExpression{Token: p.curToken, Left: left, Operator: p.curToken.Literal}
+}
+
+// parseDoubleBracketGlobBracket consumes a balanced `[ … ]` glob
+// bracket-class while inside `[[ … ]]`. POSIX classes (`[:alnum:]`)
+// nest a leading `[` that does NOT increment depth; their closing
+// `]` does NOT decrement the outer depth. Returns an Identifier
+// carrying the literal text and leaves curToken on the matching
+// outer `]`.
+func (p *Parser) parseDoubleBracketGlobBracket() ast.Expression {
+	startTok := p.curToken
+	literal := p.curToken.Literal
+	depth := 1
+	for depth > 0 && !p.peekTokenIs(token.EOF) && !p.peekTokenIs(token.RDBRACKET) {
+		p.nextToken()
+		literal += p.curToken.Literal
+		switch {
+		case p.curTokenIs(token.LBRACKET) && p.peekTokenIs(token.COLON):
+			// POSIX class `[:name:]`: drain `:`, IDENT, `]` without
+			// touching outer depth.
+			for !p.peekTokenIs(token.EOF) && !p.peekTokenIs(token.RDBRACKET) {
+				p.nextToken()
+				literal += p.curToken.Literal
+				if p.curTokenIs(token.RBRACKET) {
+					break
+				}
+			}
+		case p.curTokenIs(token.LBRACKET):
+			depth++
+		case p.curTokenIs(token.RBRACKET):
+			depth--
+		}
+	}
+	return &ast.Identifier{Token: startTok, Value: literal}
 }
 
 func (p *Parser) parseDoubleBracketExpression() ast.Expression {

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -499,7 +499,8 @@ func (p *Parser) parseSingleCommand() ast.Expression {
 var commandWordLiteralTokens = map[token.Type]struct{}{
 	token.ASTERISK: {}, token.QUESTION: {}, token.PLUS: {},
 	token.MINUS: {}, token.CARET: {}, token.TILDE: {}, token.DOT: {},
-	token.GT: {}, token.LT: {}, token.AMPERSAND: {}, token.LBRACKET: {},
+	token.GT: {}, token.LT: {}, token.AMPERSAND: {},
+	token.LBRACKET: {}, token.RBRACKET: {},
 	token.COMMA: {}, token.COLON: {}, token.GTGT: {}, token.LTLT: {},
 	token.GTAMP: {}, token.LTAMP: {},
 	token.DEC: {}, token.INC: {},


### PR DESCRIPTION
## Summary
- Two paired parser fixes that were blocking each other.
- Inside `[[ … ]]`, a leading `[` opens a glob bracket-class fragment, not the `[` test-builtin or an array subscript. The default LBRACKET prefix gobbled past the closing `]]`. `parseDoubleBracketGlobBracket` consumes the bracket body as a literal pattern, depth-tracking nested brackets while leaving POSIX classes (`[:name:]`) outside the depth count.
- Case-clause patterns carry the same `[…]` shape (`[*?]*|*[^\\][*?]*)`). The default RBRACKET prefix invited an INDEX infix on the inner `]`, recursing into a phantom subscript and orphaning the case label's `)`. RBRACKET joins the command-word literal token set.

## Test plan
- [x] go test ./... — six new positive tests pass; existing parser tests still pass.
- [x] golangci-lint run ./... — 0 issues.
- [x] bash scripts/parser-corpus-sweep.sh — fast-syntax-highlighting/test/to-parse.zsh drops 2 → 1; total 37 → 36; baseline updated.