### PR TITLE
fix(lexer): zsh case fall-through ;| and ;& (-1)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,6 +1,5 @@
 # Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
 # Format: <relpath>\t<count>
-fast-syntax-highlighting/test/to-parse.zsh	1
 fzf/shell/key-bindings.zsh	6
 fzf-tab/test/ztst.zsh	1
 zimfw/zimfw.zsh	15

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -358,6 +358,13 @@ func (l *Lexer) readSemicolonLead() token.Token {
 	if l.peekChar() == ';' {
 		return l.readFusedToken(token.DSEMI)
 	}
+	// Zsh case-clause fall-through markers `;|` and `;&` terminate
+	// the clause body just like `;;`. Fuse them into DSEMI so the
+	// parser's case loop honours the boundary; the literal preserves
+	// the source spelling for katas that walk it.
+	if l.peekChar() == '|' || l.peekChar() == '&' {
+		return l.readFusedToken(token.DSEMI)
+	}
 	return newToken(token.SEMICOLON, l.ch, l.line, l.column)
 }
 

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -71,6 +71,18 @@ func TestParseCaseClauseGlobBracketPattern(t *testing.T) {
 	parseSourceClean(t, "case x in [*?]*|*[^\\\\][*?]*) echo y;; esac\n")
 }
 
+// Zsh case-clause fall-through markers `;|` (test next) and `;&`
+// (execute next) terminate a clause body the same way `;;` does. The
+// lexer fuses them into DSEMI so the parser's case loop honours the
+// boundary.
+func TestParseCaseClauseFallThroughTestNext(t *testing.T) {
+	parseSourceClean(t, "case x in a) echo a;| b) echo b;; esac\n")
+}
+
+func TestParseCaseClauseFallThroughExecuteNext(t *testing.T) {
+	parseSourceClean(t, "case x in a) echo a;& b) echo b;; esac\n")
+}
+
 func TestParseProcessSubstitution(t *testing.T) {
 	parseSourceClean(t, "diff <(sort a) <(sort b)\n")
 }


### PR DESCRIPTION
## Summary
- Zsh case-clause fall-through markers `;|` (test next pattern) and `;&` (execute next clause) terminate a clause body the same way `;;` does.
- The lexer split them into SEMICOLON + PIPE / AMPERSAND, the parser's case loop never saw a clause terminator, and the next pattern's `)` orphaned.
- Fuse both markers into DSEMI alongside the existing `;;` path. The literal preserves the source spelling for katas that walk it.

## Test plan
- [x] go test ./... — two new tests for `;|` and `;&` pass.
- [x] golangci-lint run ./... — 0 issues.
- [x] bash scripts/parser-corpus-sweep.sh — fast-syntax-highlighting/test/to-parse.zsh drops 1 → 0; total 36 → 35; baseline updated.