### PR TITLE
fix(parser): array literal ) not subshell terminator (-3)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -4,6 +4,5 @@ fzf/shell/key-bindings.zsh	6
 fzf-tab/test/ztst.zsh	1
 zimfw/zimfw.zsh	15
 zinit/share/git-process-output.zsh	2
-zinit/zinit-autoload.zsh	3
 zinit/zinit-install.zsh	5
 zinit/zinit.zsh	3

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -83,6 +83,18 @@ func TestParseCaseClauseFallThroughExecuteNext(t *testing.T) {
 	parseSourceClean(t, "case x in a) echo a;& b) echo b;; esac\n")
 }
 
+// Two array assignments inside a subshell. The first `arr=( "x" )`
+// closes its array literal on `)`; without setting
+// consumedParenTerminator, parseBlockStatement misread that `)` as
+// the subshell's terminator and the second assignment never parsed.
+func TestParseArrayAssignmentsInsideSubshell(t *testing.T) {
+	parseSourceClean(t, "( arr=( \"x\" ); list=( \"y\" ) )\n")
+}
+
+func TestParseArrayAssignmentsInsideSubshellNewlineSeparated(t *testing.T) {
+	parseSourceClean(t, "(\narr=( \"x\" )\nlist=( \"y\" )\n)\n")
+}
+
 func TestParseProcessSubstitution(t *testing.T) {
 	parseSourceClean(t, "diff <(sort a) <(sort b)\n")
 }

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -463,6 +463,14 @@ func (p *Parser) parseGroupedExpression() ast.Expression {
 		p.nextToken()
 	}
 
+	// Advance past the array literal's `)` and signal the enclosing
+	// block to treat it as already-consumed. Without this, a `( arr=(
+	// "x" ); list=( "y" ) )` subshell broke at the array's `)` —
+	// parseBlockStatement saw curToken=RPAREN and ended the subshell
+	// body prematurely. Mirrors parseDollarParenExpression's flag.
+	if p.curTokenIs(token.RPAREN) {
+		p.consumedParenTerminator = true
+	}
 	return &ast.ArrayLiteral{Token: tok, Elements: elements}
 }
 


### PR DESCRIPTION
## Summary
- Inside a `( … )` subshell, two consecutive `arr=( … )` assignments broke parsing.
- parseGroupedExpression's array-literal branch left curToken on the array's closing `)` without signalling that the parenthesis was already consumed.
- parseBlockStatement matched that `)` against its RPAREN terminator and ended the subshell body prematurely; the next assignment's first token became orphaned.
- Mirror the consumedParenTerminator flag the parseDollarParenExpression path already sets so the enclosing block skips the false terminator and keeps walking statements.

## Test plan
- [x] go test ./... — two new positive tests for array assignments inside a subshell pass.
- [x] golangci-lint run ./... — 0 issues.
- [x] bash scripts/parser-corpus-sweep.sh — zinit/zinit-autoload.zsh drops 3 → 0; total 35 → 32; baseline updated.