### PR TITLE
fix(parser): ${#} special parameter (-1)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -5,4 +5,4 @@ fzf-tab/test/ztst.zsh	1
 zimfw/zimfw.zsh	15
 zinit/share/git-process-output.zsh	2
 zinit/zinit-install.zsh	5
-zinit/zinit.zsh	3
+zinit/zinit.zsh	2

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -95,6 +95,14 @@ func TestParseArrayAssignmentsInsideSubshellNewlineSeparated(t *testing.T) {
 	parseSourceClean(t, "(\narr=( \"x\" )\nlist=( \"y\" )\n)\n")
 }
 
+// `${#}` is the special parameter "count of positional args", not a
+// length operator over a missing subject. Without RBRACE in the
+// subjectIsEmpty set, parseArrayAccess advanced past `#` looking for
+// a subject and erroring on the closing `}`.
+func TestParseDollarBraceHashSpecialParameter(t *testing.T) {
+	parseSourceClean(t, "[[ ${#} = 1 ]]\n")
+}
+
 func TestParseProcessSubstitution(t *testing.T) {
 	parseSourceClean(t, "diff <(sort a) <(sort b)\n")
 }

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -564,10 +564,13 @@ func (p *Parser) consumePreflags() {
 }
 
 // subjectIsEmpty reports whether the upcoming token starts a modifier
-// tail directly (no parameter name).
+// tail directly (no parameter name) or closes the `${ … }` immediately.
+// RBRACE covers `${#}` — the `#` is the special parameter (count of
+// positional args), not a length operator over a missing subject.
 func (p *Parser) subjectIsEmpty() bool {
 	return p.peekTokenIs(token.COLON) || p.peekTokenIs(token.HASH) ||
-		p.peekTokenIs(token.PERCENT) || p.peekTokenIs(token.SLASH)
+		p.peekTokenIs(token.PERCENT) || p.peekTokenIs(token.SLASH) ||
+		p.peekTokenIs(token.RBRACE)
 }
 
 // parseArrayAccessSubject parses the parameter-name subject and


### PR DESCRIPTION
## Summary
- `${#}` is the Zsh special parameter "count of positional arguments", not a length operator over a missing subject.
- parseArrayAccess saw the `#`, marked it as the length op, then advanced expecting a subject and erroring on the closing `}`.
- Add RBRACE to subjectIsEmpty so the expansion closes cleanly with Left=nil. `${@}`, `${*}`, `${?}` already worked through the special-name path; `${#}` was the gap.

## Test plan
- [x] go test ./... — new positive test passes; existing parameter-expansion tests still pass.
- [x] golangci-lint run ./... — 0 issues.
- [x] bash scripts/parser-corpus-sweep.sh — zinit/zinit.zsh drops 3 → 2; total 32 → 31; baseline updated.