### PR TITLE
fix(parser): zsh keyword as ${...} subject (-1)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -5,4 +5,4 @@ fzf-tab/test/ztst.zsh	1
 zimfw/zimfw.zsh	15
 zinit/share/git-process-output.zsh	2
 zinit/zinit-install.zsh	5
-zinit/zinit.zsh	2
+zinit/zinit.zsh	1

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -103,6 +103,18 @@ func TestParseDollarBraceHashSpecialParameter(t *testing.T) {
 	parseSourceClean(t, "[[ ${#} = 1 ]]\n")
 }
 
+// Zsh keywords double as variable names in `${…}` subject position.
+// `${(flags)in}` and `${for}` previously errored on the keyword token
+// because parseArrayAccessSubject's fallthrough hit
+// noPrefixParseFnError on IN / FOR.
+func TestParseDollarBraceKeywordSubject(t *testing.T) {
+	parseSourceClean(t, "echo ${in} ${for} ${while}\n")
+}
+
+func TestParseDollarBraceFlagsKeywordSubject(t *testing.T) {
+	parseSourceClean(t, "echo ${(j: :)in}\n")
+}
+
 func TestParseProcessSubstitution(t *testing.T) {
 	parseSourceClean(t, "diff <(sort a) <(sort b)\n")
 }

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -584,6 +584,13 @@ func (p *Parser) parseArrayAccessSubject() (ast.Expression, ast.Expression) {
 		return p.parseArrayAccessIdent()
 	case p.subjectIsSpecialName():
 		return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}, nil
+	case isSubjectKeyword(p.curToken.Type):
+		// Zsh keywords (`in`, `for`, `while`, …) double as ordinary
+		// variable names when they appear as the subject of a `${…}`
+		// expansion. The lexer always emits them as keyword tokens;
+		// degrade to a literal identifier here so `${(flags)in}` and
+		// kin parse as a parameter name.
+		return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}, nil
 	case p.curTokenIs(token.DollarLbrace):
 		// Nested `${INNER}` subject. Call parseArrayAccess directly
 		// rather than going through parseExpression so the infix loop
@@ -609,6 +616,21 @@ func (p *Parser) parseArrayAccessIdent() (ast.Expression, ast.Expression) {
 		return id, nil
 	}
 	return idx.Left, idx.Index
+}
+
+// isSubjectKeyword reports whether a Zsh keyword token is being used
+// as a parameter name in a `${…}` subject slot. Reserved words live
+// in the same namespace as ordinary variables when they appear in
+// expansion subjects (`${(flags)in}`, `${for}`, `${while}`).
+func isSubjectKeyword(t token.Type) bool {
+	switch t {
+	case token.IN, token.FOR, token.WHILE, token.If, token.CASE,
+		token.SELECT, token.COPROC, token.FUNCTION, token.LET, token.RETURN,
+		token.DO, token.DONE, token.ESAC, token.THEN, token.ELSE,
+		token.ELIF, token.Fi, token.TYPESET, token.DECLARE:
+		return true
+	}
+	return false
 }
 
 func (p *Parser) subjectIsSpecialName() bool {


### PR DESCRIPTION
## Summary
- Zsh keywords (`in`, `for`, `while`, `case`, `function`, …) double as ordinary variable names when they appear as the subject of a `${…}` expansion.
- Lexer always emits them as keyword tokens, so parseArrayAccessSubject's fallthrough hit noPrefixParseFnError on `IN` / `FOR` / etc. and the surrounding expansion failed to close.
- Add an `isSubjectKeyword` guard to degrade those tokens to a literal identifier in subject position. Covers `${in}`, `${(flags)in}` (zinit's `${(Z+Cn+)in}`), and the modifier tail.

## Test plan
- [x] go test ./... — two new positive tests pass.
- [x] golangci-lint run ./... — 0 issues.
- [x] bash scripts/parser-corpus-sweep.sh — zinit/zinit.zsh drops 2 → 1; total 31 → 30; baseline updated.