### PR TITLE
fix(parser): zsh `if cond cmd` shortcut without then/fi (-13)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -2,7 +2,7 @@
 # Format: <relpath>\t<count>
 fzf/shell/key-bindings.zsh	6
 fzf-tab/test/ztst.zsh	1
-zimfw/zimfw.zsh	15
+zimfw/zimfw.zsh	2
 zinit/share/git-process-output.zsh	2
 zinit/zinit-install.zsh	5
 zinit/zinit.zsh	1

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -115,6 +115,22 @@ func TestParseDollarBraceFlagsKeywordSubject(t *testing.T) {
 	parseSourceClean(t, "echo ${(j: :)in}\n")
 }
 
+// Zsh shortcut: `if (( cond )) cmd` and `if [[ cond ]] cmd` omit the
+// `then`/`fi` pair. Inside `=( … )` proc-sub or `( … )` subshell,
+// parseBlockStatement(THEN, LBRACE) absorbed the trailing cmd into
+// the cond block and walked past the enclosing terminator.
+func TestParseIfShortcutInProcSub(t *testing.T) {
+	parseSourceClean(t, "foo =(\n  if (( x )) print y\n)\n")
+}
+
+func TestParseIfShortcutDoubleBracketInProcSub(t *testing.T) {
+	parseSourceClean(t, "foo =(\n  if [[ z == w ]] echo hi\n)\n")
+}
+
+func TestParseIfShortcutInsideFunctionBody(t *testing.T) {
+	parseSourceClean(t, "foo() {\n  if (( x )) print y\n}\n")
+}
+
 func TestParseProcessSubstitution(t *testing.T) {
 	parseSourceClean(t, "diff <(sort a) <(sort b)\n")
 }

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -1233,6 +1233,7 @@ func (p *Parser) parseProcessSubstitution() ast.Expression {
 			p.nextToken()
 			continue
 		}
+		p.consumedParenTerminator = false
 		stmt := p.parseStatement()
 		if stmt != nil {
 			statements = append(statements, stmt)
@@ -1243,6 +1244,22 @@ func (p *Parser) parseProcessSubstitution() ast.Expression {
 		if p.consumedBraceTerminator {
 			p.consumedBraceTerminator = false
 			continue
+		}
+		// An inner array literal / `$(…)` consumed its own RPAREN —
+		// honour the flag so the proc-sub body keeps walking past
+		// the false terminator instead of ending early.
+		if p.consumedParenTerminator {
+			p.consumedParenTerminator = false
+			if p.curTokenIs(token.RPAREN) {
+				p.nextToken()
+				continue
+			}
+		}
+		// `if (( cond )) cmd` Zsh shortcut hands control back with
+		// curToken on the proc-sub's `)`. Don't advance past it —
+		// the loop guard will see RPAREN and exit cleanly.
+		if p.curTokenIs(token.RPAREN) {
+			break
 		}
 		p.nextToken()
 	}

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -636,7 +636,12 @@ func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 func (p *Parser) parseIfStatement() *ast.IfStatement {
 	stmt := &ast.IfStatement{Token: p.curToken}
 	p.nextToken()
-	stmt.Condition = p.parseBlockStatement(token.THEN, token.LBRACE)
+	// RPAREN / RBRACE join the cond terminator set so the Zsh
+	// shortcut `if (( cond )) cmd` inside `=( … )` / `( … )` /
+	// function bodies hands control back to the enclosing
+	// construct once the `then`-less form ends.
+	stmt.Condition = p.parseBlockStatement(token.THEN, token.LBRACE,
+		token.RPAREN, token.RBRACE)
 
 	// Zsh short form `if cond { body } [elif cond { body }]…
 	// [else { body }]` uses brace blocks instead of `then … fi`.
@@ -661,6 +666,9 @@ func (p *Parser) parseIfStatement() *ast.IfStatement {
 	}
 
 	if !p.curTokenIs(token.THEN) {
+		if p.tryDegradeNoThenShortcut(stmt) {
+			return stmt
+		}
 		return nil
 	}
 
@@ -704,6 +712,26 @@ func (p *Parser) parseIfStatement() *ast.IfStatement {
 		return nil
 	}
 	return stmt
+}
+
+// tryDegradeNoThenShortcut handles the Zsh `if (( cond )) cmd` /
+// `if [[ cond ]] cmd` shortcut. parseBlockStatement(THEN, LBRACE,
+// RPAREN, RBRACE) absorbs the trailing cmd into the cond block;
+// once cur lands on the enclosing `)` / `}` / EOF terminator we
+// hand control back so the surrounding construct closes cleanly.
+// Promotes the absorbed last cond statement to Consequence so the
+// AST still records the body. Returns true when the shortcut shape
+// applies.
+func (p *Parser) tryDegradeNoThenShortcut(stmt *ast.IfStatement) bool {
+	if !p.curTokenIs(token.RPAREN) && !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+		return false
+	}
+	if cond, ok := stmt.Condition.(*ast.BlockStatement); ok && len(cond.Statements) >= 2 {
+		last := cond.Statements[len(cond.Statements)-1]
+		cond.Statements = cond.Statements[:len(cond.Statements)-1]
+		stmt.Consequence = &ast.BlockStatement{Statements: []ast.Statement{last}}
+	}
+	return true
 }
 
 // parseBraceFormElifChain walks any `} elif COND { BODY }` chain plus


### PR DESCRIPTION
## Summary
- Zsh accepts the shorthand `if (( cond )) cmd` and `if [[ cond ]] cmd` — the trailing command is the consequence, no `then`/`fi` pair.
- parseBlockStatement(THEN, LBRACE) walked past the cmd into the enclosing terminator, then crashed on the `)` of a `=( … )` proc-sub or the `}` of a function body. zimfw's init-builder relied on this shape pervasively (15 cascading errors from one site).
- Pass RPAREN / RBRACE as additional cond-block terminators so the cmd gets absorbed into the cond block but parsing yields control as soon as the surrounding terminator is reached. `tryDegradeNoThenShortcut` promotes the last absorbed statement to Consequence so the AST still records the body. parseProcessSubstitution honours the same break without advancing past its closing `)`.

## Test plan
- [x] go test ./... — three new positive tests for the shortcut form pass.
- [x] golangci-lint run ./... — 0 issues.
- [x] gocyclo -over 15 . — clean (parseIfStatement holds at 15 via the extracted helper).
- [x] bash scripts/parser-corpus-sweep.sh — zimfw/zimfw.zsh drops 15 → 2; total 30 → 17; baseline updated.