### PR TITLE
fix(lexer): `#` is not a comment inside ${...}

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -60,6 +60,11 @@ type Lexer struct {
 	// (e.g. `_os=$_sys*~*((alt|alt))` is a glob, not arith).
 	lastEmittedType     token.Type
 	lastEmittedHadSpace bool
+
+	// dollarBraceDepth tracks how many `${` openers are still awaiting
+	// their `}`. Inside a `${ … }` expansion `#` is the length /
+	// pattern operator, never a comment opener.
+	dollarBraceDepth int
 }
 
 func New(input string) *Lexer {
@@ -118,6 +123,14 @@ func (l *Lexer) NextToken() (tok token.Token) {
 		if prevSuppress && tok.Type != token.DOLLAR_LPAREN {
 			l.suppressLparenFusion = false
 		}
+		switch tok.Type {
+		case token.DollarLbrace:
+			l.dollarBraceDepth++
+		case token.RBRACE:
+			if l.dollarBraceDepth > 0 {
+				l.dollarBraceDepth--
+			}
+		}
 		l.lastEmittedType = tok.Type
 		l.lastEmittedHadSpace = tok.HasPrecedingSpace
 	}()
@@ -154,6 +167,12 @@ func (l *Lexer) tryShebangOrComment(hasSpace bool) (token.Token, bool) {
 	// open `D` ('((') marker on the paren stack. zimfw uses
 	// `(( ! # ))` and `(( # > 0 ))` heavily.
 	if l.inArithmetic() {
+		return token.Token{}, false
+	}
+	// Inside `${…}` parameter expansion, `#` is the length / pattern
+	// operator, never a comment opener. Without this guard
+	// `${${X## ##}%%y##}` lost its trailing `##}` to skipComment.
+	if l.dollarBraceDepth > 0 {
 		return token.Token{}, false
 	}
 	if hasSpace || l.column == 1 {

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -115,6 +115,14 @@ func TestParseDollarBraceFlagsKeywordSubject(t *testing.T) {
 	parseSourceClean(t, "echo ${(j: :)in}\n")
 }
 
+// `#` inside a `${…}` expansion is the length / pattern operator,
+// never a comment opener. The lexer's hasSpace heuristic for
+// comment-skip used to gobble the trailing `##}` of patterns like
+// `${${X## ##}%%y##}` once a space appeared inside the modifier.
+func TestParseDollarBraceHashAfterSpaceNotComment(t *testing.T) {
+	parseSourceClean(t, "H=${${X## ##}%%y##}\n")
+}
+
 // Zsh shortcut: `if (( cond )) cmd` and `if [[ cond ]] cmd` omit the
 // `then`/`fi` pair. Inside `=( … )` proc-sub or `( … )` subshell,
 // parseBlockStatement(THEN, LBRACE) absorbed the trailing cmd into


### PR DESCRIPTION
## Summary
- Inside a `${…}` parameter expansion, `#` is the length / pattern operator, never a comment opener.
- Lexer's hasSpace heuristic in tryShebangOrComment treated a `#` after whitespace as comment-start and swallowed the rest of the line — broke patterns like `${${X## ##}%%y##}` where `##` appears after a literal space inside the modifier.
- Track `${` openers via `dollarBraceDepth` and short-circuit the comment path when depth > 0. Mirrors the existing `inArithmetic` guard for `((…))`.

## Test plan
- [x] go test ./... — new positive test `TestParseDollarBraceHashAfterSpaceNotComment` passes.
- [x] golangci-lint run ./... — 0 issues.
- [x] bash scripts/parser-corpus-sweep.sh — total stays at 17 (no regression). Real corpus pattern parses cleanly in isolation; cascade in zimfw masks the per-file delta.