### PR TITLE
fix(parser): zsh glob # / ## qualifier in command words (-1)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,7 +1,6 @@
 # Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
 # Format: <relpath>\t<count>
 fzf/shell/key-bindings.zsh	6
-fzf-tab/test/ztst.zsh	1
 zimfw/zimfw.zsh	2
 zinit/share/git-process-output.zsh	2
 zinit/zinit-install.zsh	5

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -123,6 +123,22 @@ func TestParseDollarBraceHashAfterSpaceNotComment(t *testing.T) {
 	parseSourceClean(t, "H=${${X## ##}%%y##}\n")
 }
 
+// Zsh glob qualifiers `#` / `##` attach to the preceding pattern
+// character without a space. Inside a case label, `[[:space:]]##`
+// and friends used to split at the HASH because parseCommandWord
+// treated it as a command delimiter.
+func TestParseCaseClauseGlobHashQualifier(t *testing.T) {
+	parseSourceClean(t, "case x in a##) echo y;; esac\n")
+}
+
+func TestParseCaseClauseGlobHashOnPosixClass(t *testing.T) {
+	parseSourceClean(t, "case x in [[:space:]]##[^[:space:]]*) echo y;; esac\n")
+}
+
+func TestParseCaseClauseGlobHashChainPosixClass(t *testing.T) {
+	parseSourceClean(t, "case x in a##[[:alpha:]]) echo y;; esac\n")
+}
+
 // Zsh shortcut: `if (( cond )) cmd` and `if [[ cond ]] cmd` omit the
 // `then`/`fi` pair. Inside `=( … )` proc-sub or `( … )` subshell,
 // parseBlockStatement(THEN, LBRACE) absorbed the trailing cmd into

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -500,7 +500,7 @@ var commandWordLiteralTokens = map[token.Type]struct{}{
 	token.ASTERISK: {}, token.QUESTION: {}, token.PLUS: {},
 	token.MINUS: {}, token.CARET: {}, token.TILDE: {}, token.DOT: {},
 	token.GT: {}, token.LT: {}, token.AMPERSAND: {},
-	token.LBRACKET: {}, token.RBRACKET: {},
+	token.LBRACKET: {}, token.RBRACKET: {}, token.HASH: {},
 	token.COMMA: {}, token.COLON: {}, token.GTGT: {}, token.LTLT: {},
 	token.GTAMP: {}, token.LTAMP: {},
 	token.DEC: {}, token.INC: {},
@@ -556,6 +556,14 @@ func (p *Parser) commandWordContinues(braceDepth int) bool {
 	if p.peekToken.HasPrecedingSpace || !p.peekOnSameLogicalLine() {
 		return false
 	}
+	// Zsh glob qualifiers `#` / `##` attach to the preceding pattern
+	// character (`]`, `*`, `?`, `+`, `)`, an IDENT) without a space,
+	// e.g. `[[:space:]]##` or `(a|b)#`. Without this exception
+	// isCommandDelimiter would split the word at the HASH because
+	// HASH starts a comment in command position.
+	if p.peekTokenIs(token.HASH) && p.curIsGlobQualifierLeft() {
+		return true
+	}
 	if braceDepth == 0 && p.isCommandDelimiter(p.peekToken) {
 		return false
 	}
@@ -563,6 +571,19 @@ func (p *Parser) commandWordContinues(braceDepth int) bool {
 		return false
 	}
 	return true
+}
+
+// curIsGlobQualifierLeft reports whether curToken is a token type that
+// can carry a trailing `#` / `##` glob-qualifier without a space.
+// HASH itself is included so the second `#` of a `##` doubled
+// qualifier glues onto the first.
+func (p *Parser) curIsGlobQualifierLeft() bool {
+	switch p.curToken.Type {
+	case token.RBRACKET, token.RPAREN, token.ASTERISK, token.QUESTION,
+		token.PLUS, token.IDENT, token.STRING, token.HASH:
+		return true
+	}
+	return false
 }
 
 func updateCommandWordBraceDepth(depth int, t token.Type) int {


### PR DESCRIPTION
## Summary
- Zsh glob-pattern qualifiers `#` (zero+) and `##` (one+) attach to the preceding pattern character without a space — `a##b`, `[[:space:]]##[^[:space:]]*`, `(a|b)#`.
- parseCommandWord treated the HASH token as a command delimiter (HASH starts a comment in command position) and split the word, so case labels like `[[:space:]]##[^[:space:]]*)` lost their tail past the qualifier and the closing `)` orphaned.
- Add HASH to `commandWordLiteralTokens` so it lexes as a literal pattern part inside a command word; teach `commandWordContinues` to glide past HASH when the preceding token can carry a qualifier (RBRACKET, RPAREN, ASTERISK, QUESTION, PLUS, IDENT, STRING, HASH itself).

## Test plan
- [x] go test ./... — three new positive tests pass.
- [x] golangci-lint run ./... — 0 issues.
- [x] gocyclo -over 15 . — clean.
- [x] bash scripts/parser-corpus-sweep.sh — fzf-tab/test/ztst.zsh drops 1 → 0; total 17 → 16; baseline updated.