### PR TITLE
fix(parser): distinguish ${...} close from brace-block close (-1)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,7 +1,7 @@
 # Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
 # Format: <relpath>\t<count>
 fzf/shell/key-bindings.zsh	6
-zimfw/zimfw.zsh	2
+zimfw/zimfw.zsh	1
 zinit/share/git-process-output.zsh	2
 zinit/zinit-install.zsh	5
 zinit/zinit.zsh	1

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -129,6 +129,7 @@ func (l *Lexer) NextToken() (tok token.Token) {
 		case token.RBRACE:
 			if l.dollarBraceDepth > 0 {
 				l.dollarBraceDepth--
+				tok.ClosesDollarBrace = true
 			}
 		}
 		l.lastEmittedType = tok.Type

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -139,6 +139,28 @@ func TestParseCaseClauseGlobHashChainPosixClass(t *testing.T) {
 	parseSourceClean(t, "case x in a##[[:alpha:]]) echo y;; esac\n")
 }
 
+// `${X}`'s closing `}` is a parameter-expansion close, not a brace
+// block terminator. parseBlockStatement now distinguishes the two
+// via the lexer's ClosesDollarBrace flag, so a `cmd ${X}` arg
+// followed by the function body's `}` parses cleanly.
+func TestParseCommandArgEndingInDollarBraceInsideFunction(t *testing.T) {
+	parseSourceClean(t, "foo() {\n  cmd ${X}\n}\n")
+}
+
+// `if cond cmd` shortcut nested inside a regular `if … then … fi`
+// block. parseBlockStatement(cond) used to absorb the outer `fi`
+// into the inner cond; outer keywords (Fi/DONE/ESAC/ELSE/ELIF) now
+// terminate the cond so the shortcut yields control back.
+func TestParseIfShortcutInsideStandardIfThenFi(t *testing.T) {
+	src := "foo() {\n" +
+		"  if (( a )); then\n" +
+		"    if (( d )) print -R '${e}'\n" +
+		"    print fi\n" +
+		"  fi\n" +
+		"}\n"
+	parseSourceClean(t, src)
+}
+
 // Zsh shortcut: `if (( cond )) cmd` and `if [[ cond ]] cmd` omit the
 // `then`/`fi` pair. Inside `=( … )` proc-sub or `( … )` subshell,
 // parseBlockStatement(THEN, LBRACE) absorbed the trailing cmd into

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -660,9 +660,13 @@ func (p *Parser) parseIfStatement() *ast.IfStatement {
 	// RPAREN / RBRACE join the cond terminator set so the Zsh
 	// shortcut `if (( cond )) cmd` inside `=( … )` / `( … )` /
 	// function bodies hands control back to the enclosing
-	// construct once the `then`-less form ends.
+	// construct once the `then`-less form ends. Fi / DONE / ESAC /
+	// ELSE / ELIF cover the case where the shortcut sits inside an
+	// outer if/loop/case body — without them parseBlockStatement
+	// would absorb the outer construct's terminator into the cond.
 	stmt.Condition = p.parseBlockStatement(token.THEN, token.LBRACE,
-		token.RPAREN, token.RBRACE)
+		token.RPAREN, token.RBRACE,
+		token.Fi, token.DONE, token.ESAC, token.ELSE, token.ELIF)
 
 	// Zsh short form `if cond { body } [elif cond { body }]…
 	// [else { body }]` uses brace blocks instead of `then … fi`.
@@ -736,15 +740,18 @@ func (p *Parser) parseIfStatement() *ast.IfStatement {
 }
 
 // tryDegradeNoThenShortcut handles the Zsh `if (( cond )) cmd` /
-// `if [[ cond ]] cmd` shortcut. parseBlockStatement(THEN, LBRACE,
-// RPAREN, RBRACE) absorbs the trailing cmd into the cond block;
-// once cur lands on the enclosing `)` / `}` / EOF terminator we
-// hand control back so the surrounding construct closes cleanly.
-// Promotes the absorbed last cond statement to Consequence so the
-// AST still records the body. Returns true when the shortcut shape
-// applies.
+// `if [[ cond ]] cmd` shortcut. parseBlockStatement absorbs the
+// trailing cmd into the cond block; once cur lands on the enclosing
+// terminator (`)`, `}`, EOF, or an outer keyword like `fi`/`done`/
+// `esac`/`else`/`elif`) we hand control back so the surrounding
+// construct closes cleanly. Promotes the absorbed last cond statement
+// to Consequence so the AST still records the body. Returns true
+// when the shortcut shape applies.
 func (p *Parser) tryDegradeNoThenShortcut(stmt *ast.IfStatement) bool {
-	if !p.curTokenIs(token.RPAREN) && !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) {
+	switch p.curToken.Type {
+	case token.RPAREN, token.RBRACE, token.EOF,
+		token.Fi, token.DONE, token.ESAC, token.ELSE, token.ELIF:
+	default:
 		return false
 	}
 	if cond, ok := stmt.Condition.(*ast.BlockStatement); ok && len(cond.Statements) >= 2 {
@@ -857,6 +864,13 @@ func (p *Parser) parseBlockStatement(terminators ...token.Type) *ast.BlockStatem
 		curIsTerm := false
 		for _, t := range terminators {
 			if p.curTokenIs(t) {
+				// An RBRACE that closed a `${…}` is not the block's
+				// terminator — `cmd ${X} }` leaves curToken on the
+				// `${X}`'s `}` while the brace-block close is the
+				// next RBRACE. The lexer flags the inner one.
+				if t == token.RBRACE && p.curToken.ClosesDollarBrace {
+					break
+				}
 				curIsTerm = true
 				break
 			}

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -24,6 +24,12 @@ type Token struct {
 	// it were on the previous line — matching how Zsh collapses
 	// line-continuations into one logical command.
 	HasPrecedingContinuation bool
+	// ClosesDollarBrace is set on an RBRACE token that closes a
+	// `${ … }` parameter expansion (rather than a regular brace
+	// block). The parser uses it to distinguish `${X} }` — two
+	// RBRACE tokens whose semantics differ — when deciding whether
+	// a `}` is a block terminator.
+	ClosesDollarBrace bool
 }
 
 const (


### PR DESCRIPTION
## Summary
- A `}` closing a `${ … }` parameter expansion is lexically identical to the `}` closing a brace block.
- parseBlockStatement(RBRACE) used to break on the first `}` it saw — so `cmd \${X}` inside a function body ended the function's block at the expansion's `}`, and a Zsh `if (( cond )) cmd \${X}` shortcut nested inside an outer `if … fi` absorbed the outer `fi` into the inner cond.
- Tag the RBRACE token with `ClosesDollarBrace` when the lexer's `dollarBraceDepth` was positive at emit time. parseBlockStatement honours the flag.
- Outer keywords (`fi`/`done`/`esac`/`else`/`elif`) join the cond terminator set so a shortcut form yields control back. `tryDegradeNoThenShortcut` accepts the new terminators.

## Test plan
- [x] go test ./... — two new positive tests pass.
- [x] golangci-lint run ./... — 0 issues.
- [x] gocyclo -over 15 . — clean.
- [x] bash scripts/parser-corpus-sweep.sh — zimfw/zimfw.zsh drops 2 → 1; total 16 → 15; baseline updated.