### PR TITLE
fix(parser): ? in arith / brace block in pipeline / glob group+bracket (-1)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,7 +1,6 @@
 # Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
 # Format: <relpath>\t<count>
 fzf/shell/key-bindings.zsh	6
-zimfw/zimfw.zsh	1
 zinit/share/git-process-output.zsh	2
 zinit/zinit-install.zsh	5
 zinit/zinit.zsh	1

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -161,6 +161,28 @@ func TestParseIfShortcutInsideStandardIfThenFi(t *testing.T) {
 	parseSourceClean(t, src)
 }
 
+// Inside `[[ … ]]`, a closing `)` of a glob-alternation group is
+// followed by `[…]` which is the next glob fragment — never an
+// array subscript on the parenthesised expression. The INDEX infix
+// used to walk past `]]`.
+func TestParseDoubleBracketGroupThenBracketClass(t *testing.T) {
+	parseSourceClean(t, "[[ x =~ (a)[:/] ]] && echo y\n")
+}
+
+// `?` is the last-exit-status special parameter `$?` when used as a
+// value inside `(( … ))`. parsePrefixExpression used to drag the
+// closing `))` into a bogus right-operand parse.
+func TestParseArithmeticQuestionAsExitStatus(t *testing.T) {
+	parseSourceClean(t, "(( X = ? ))\n")
+}
+
+// `$({ cmd } 2>&1)` — brace block as command-sub body with FD-prefix
+// redirection. parseCommandPipeline now routes LBRACE to
+// parseBraceGroupStatement and drains INT-prefixed redirections.
+func TestParseBraceBlockInsideCommandSub(t *testing.T) {
+	parseSourceClean(t, "ERR=$({ cmd ${A} ${B} } 2>&1)\n")
+}
+
 // Zsh shortcut: `if (( cond )) cmd` and `if [[ cond ]] cmd` omit the
 // `then`/`fi` pair. Inside `=( … )` proc-sub or `( … )` subshell,
 // parseBlockStatement(THEN, LBRACE) absorbed the trailing cmd into

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -28,28 +28,8 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 	if _, hit := expressionTerminators[p.curToken.Type]; hit {
 		return nil
 	}
-	// Inside `[[ … ]]` a `((` is glob alternation grouping (not
-	// arithmetic). Decompose the fused DoubleLparen into a LPAREN so
-	// parseGroupedExpression's glob-alt path handles it.
-	if p.inDoubleBracket && p.curTokenIs(token.DoubleLparen) {
-		p.curToken.Type = token.LPAREN
-		p.curToken.Literal = "("
-	}
-	// Inside `${…[KEY]}` subscripts and `[[ … ]]` tests, Zsh keywords
-	// are literal pattern words, not statement-block openers. Return
-	// an Identifier so the surrounding parse keeps moving.
-	if (p.inDoubleBracket || p.inArithmetic) && isDoubleBracketLiteralKeyword(p.curToken.Type) {
-		tok := p.curToken
-		return &ast.Identifier{Token: tok, Value: tok.Literal}
-	}
-	// Inside `[[ … ]]`, a leading `[` opens a glob bracket-class
-	// fragment (`[abc]`, `[[:alnum:]]`, `[^[:blank:]]`), not the `[`
-	// test-builtin or an array subscript. The default LBRACKET prefix
-	// (parseSingleCommand) gobbles every glued token until a command
-	// delimiter and walks past the closing `]]`. Consume the bracket
-	// body as a literal pattern fragment instead.
-	if p.inDoubleBracket && p.curTokenIs(token.LBRACKET) {
-		return p.parseDoubleBracketGlobBracket()
+	if early, ok := p.tryEarlyContextualReturn(); ok {
+		return early
 	}
 	prefix := p.prefixParseFns[p.curToken.Type]
 	if prefix == nil {
@@ -75,6 +55,30 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 	return leftExp
 }
 
+// tryEarlyContextualReturn handles the context-specific token
+// reinterpretations that fire before the regular prefix dispatch:
+// DoubleLparen→LPAREN inside `[[…]]`, keywords-as-literal-pattern,
+// `[…]` glob bracket-class walker, and `?` as `$?` in arithmetic.
+func (p *Parser) tryEarlyContextualReturn() (ast.Expression, bool) {
+	// Inside `[[ … ]]` a `((` is glob alternation grouping; rewrite
+	// to LPAREN so parseGroupedExpression's glob-alt path handles it.
+	if p.inDoubleBracket && p.curTokenIs(token.DoubleLparen) {
+		p.curToken.Type = token.LPAREN
+		p.curToken.Literal = "("
+	}
+	if (p.inDoubleBracket || p.inArithmetic) && isDoubleBracketLiteralKeyword(p.curToken.Type) {
+		tok := p.curToken
+		return &ast.Identifier{Token: tok, Value: tok.Literal}, true
+	}
+	if p.inDoubleBracket && p.curTokenIs(token.LBRACKET) {
+		return p.parseDoubleBracketGlobBracket(), true
+	}
+	if id, ok := p.tryArithSpecialParameter(); ok {
+		return id, true
+	}
+	return nil, false
+}
+
 // isDoubleBracketLiteralKeyword reports whether a Zsh keyword token
 // should be treated as a literal pattern word inside `[[ … ]]` or a
 // `${var[KEY]}` subscript. Most reserved words (FUNCTION, IF, FOR, …)
@@ -82,6 +86,22 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 // they are simply pattern strings.
 func isDoubleBracketLiteralKeyword(t token.Type) bool {
 	return t == token.FUNCTION
+}
+
+// tryArithSpecialParameter degrades a `?` token in arithmetic context
+// to the literal `$?` special parameter when peek is a closer
+// (`))`, `)`, `;`, `,`). Without this, parsePrefixExpression dragged
+// the closer into a bogus right-operand parse.
+func (p *Parser) tryArithSpecialParameter() (ast.Expression, bool) {
+	if !p.inArithmetic || !p.curTokenIs(token.QUESTION) {
+		return nil, false
+	}
+	switch p.peekToken.Type {
+	case token.DoubleRparen, token.RPAREN, token.SEMICOLON, token.COMMA:
+		tok := p.curToken
+		return &ast.Identifier{Token: tok, Value: tok.Literal}, true
+	}
+	return nil, false
 }
 
 // expressionInfixShouldBreak reports whether the infix chain in
@@ -110,6 +130,15 @@ func (p *Parser) expressionInfixShouldBreak() bool {
 // arms guard shell-control bytes that are only infix inside `((…))`.
 func (p *Parser) peekShouldBreakInfix() bool {
 	if p.peekTokenIs(token.LBRACKET) && p.peekToken.HasPrecedingSpace {
+		return true
+	}
+	// Inside `[[ … ]]`, a `[` after a closing `)` (glob-alt group)
+	// or `]` (prior bracket-class) is the next glob fragment, not
+	// an array subscript. Without this break the INDEX infix walks
+	// past the closing `]]` and the outer test fails to terminate.
+	if p.inDoubleBracket && p.peekTokenIs(token.LBRACKET) &&
+		(p.curTokenIs(token.RPAREN) || p.curTokenIs(token.RBRACKET) ||
+			p.curTokenIs(token.STRING)) {
 		return true
 	}
 	if p.peekTokenIs(token.SLASH) && !p.peekToken.HasPrecedingSpace {

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -94,6 +94,58 @@ func (p *Parser) parseStatementBranch() ast.Statement {
 	}
 }
 
+// parsePipelineHead dispatches the head expression of a pipeline.
+// Returns (expr, true) when the head is a keyword-compound command
+// whose parser already chained logical / redirection tails; in that
+// case parseCommandPipeline returns immediately. Otherwise returns
+// (expr, false) for the standard redirection / pipe-tail follow-up.
+func (p *Parser) parsePipelineHead() (ast.Expression, bool) {
+	switch p.curToken.Type {
+	case token.WHILE:
+		return p.parseWhileLoopStatement(), false
+	case token.LPAREN:
+		return p.parseGroupedExpression(), false
+	case token.LBRACE:
+		// Brace-group: `{ cmd1; cmd2 } 2>&1` appears inside `$(…)`
+		// and as a pipeline head. Parse as a brace block so the
+		// generic parseSingleCommand path doesn't read `{` as a
+		// command name and crash on the closing `}`.
+		left := keywordStmtToExpression(p.parseBraceGroupStatement())
+		p.drainFDPrefixedRedirections()
+		return left, false
+	case token.LDBRACKET:
+		return p.parseDoubleBracketExpression(), false
+	case token.DoubleLparen:
+		return p.parseArithmeticCommand(), false
+	case token.If, token.FOR, token.CASE, token.SELECT:
+		// Keyword-headed compound commands have their own parsers
+		// that already chain redirection / logical tails. Return
+		// (expr, true) so parseCommandPipeline exits early.
+		stmt := p.parseStatement()
+		return keywordStmtToExpression(stmt), true
+	}
+	return p.parseSingleCommand(), false
+}
+
+// drainFDPrefixedRedirections consumes trailing `N>...` / `N<...`
+// redirections after a brace-group / subshell body. The default
+// redirection loop in parseCommandPipeline only matches bare
+// GT/GTAMP openers so an explicit FD number prefix would orphan
+// without this drain.
+func (p *Parser) drainFDPrefixedRedirections() {
+	for p.peekTokenIs(token.INT) {
+		p.nextToken() // FD number
+		if !p.peekTokenIs(token.GT) && !p.peekTokenIs(token.GTGT) &&
+			!p.peekTokenIs(token.GTAMP) && !p.peekTokenIs(token.LT) &&
+			!p.peekTokenIs(token.LTAMP) {
+			return
+		}
+		p.nextToken() // operator
+		p.nextToken() // target
+		_ = p.parseCommandWord()
+	}
+}
+
 func (p *Parser) parseBraceGroupStatement() ast.Statement {
 	tok := p.curToken
 	p.nextToken()
@@ -368,34 +420,9 @@ func (p *Parser) parseCommandPipeline() ast.Expression {
 		return &ast.PrefixExpression{Token: tok, Operator: "!", Right: right}
 	}
 
-	var left ast.Expression
-	switch p.curToken.Type {
-	case token.WHILE:
-		left = p.parseWhileLoopStatement()
-	case token.LPAREN:
-		// Subshell group: `( cmd1; cmd2 )` appears as the RHS of
-		// logical chains like `[[ … ]] && ( … )`. Parse the group
-		// as a grouped expression so parseSingleCommand doesn't
-		// treat `(` as a command name.
-		left = p.parseGroupedExpression()
-	case token.LDBRACKET:
-		// `[[ … ]]` condition as a pipeline term (RHS of `&&`/`||`
-		// or head of a pipe). Call the prefix directly so the
-		// caller doesn't try to use it as a simple-command name.
-		left = p.parseDoubleBracketExpression()
-	case token.DoubleLparen:
-		left = p.parseArithmeticCommand()
-	case token.If, token.FOR, token.CASE, token.SELECT:
-		// Keyword-headed compound commands inside `$(…)` /
-		// pipelines need their dedicated parser. Without this the
-		// generic parseSingleCommand path treated the keyword as
-		// the command name and exploded on the body's structural
-		// tokens. Returns the statement-as-expression via
-		// keywordStatementAsExpression.
-		stmt := p.parseStatement()
-		return keywordStmtToExpression(stmt)
-	default:
-		left = p.parseSingleCommand()
+	left, returned := p.parsePipelineHead()
+	if returned {
+		return left
 	}
 
 	// Parse redirections


### PR DESCRIPTION
## Summary
Three small fixes that together drain zimfw's last error and make several common Zsh shapes parse cleanly.

1. Inside `(( … ))`, `?` is the last-exit-status special parameter `$?` when peek is a closer (`))`, `)`, `;`, `,`). parsePrefixExpression used to drag the closer into a bogus right-operand parse. `tryArithSpecialParameter` degrades the token to a literal Identifier.
2. Inside `[[ … ]]`, a `[` after a closing `)` (glob-alt group) or `]` (prior bracket-class) is the next glob fragment, not an array subscript on the parenthesised expression. Break the INDEX infix so the bracket body parses as its own pattern.
3. `{ cmd1; cmd2 } 2>&1` as a pipeline head — appears inside `$(…)` command-sub bodies and as a chain head. parseCommandPipeline routes LBRACE through parseBraceGroupStatement; `drainFDPrefixedRedirections` eats the FD-prefixed redirection tail.

Refactored parseCommandPipeline and parseExpression via extracted helpers (parsePipelineHead, tryEarlyContextualReturn, tryArithSpecialParameter) so gocyclo holds at 15.

## Test plan
- [x] go test ./... — three new positive tests (arith `?`, glob group+bracket, brace block in command-sub).
- [x] golangci-lint run ./... — 0 issues.
- [x] gocyclo -over 15 . — clean.
- [x] bash scripts/parser-corpus-sweep.sh — zimfw/zimfw.zsh drops 1 → 0 (cleared); total 15 → 14; baseline updated.