### PR TITLE
fix(parser): $(( … )) flags consumedParenTerminator

### DIFF
--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -183,6 +183,18 @@ func TestParseBraceBlockInsideCommandSub(t *testing.T) {
 	parseSourceClean(t, "ERR=$({ cmd ${A} ${B} } 2>&1)\n")
 }
 
+// `$(( … ))` arithmetic command-sub used to skip setting
+// consumedParenTerminator on the `))` close, so an enclosing
+// subshell body that followed `assign=$(( … ))` with a second
+// statement crashed on the next statement's first token.
+func TestParseDollarArithmeticInSubshellFollowedByStmt(t *testing.T) {
+	src := "(\n" +
+		"  X=$(( a > 1 ? (2 - x) : 3 ))\n" +
+		"  Y=1\n" +
+		")\n"
+	parseSourceClean(t, src)
+}
+
 // Zsh shortcut: `if (( cond )) cmd` and `if [[ cond ]] cmd` omit the
 // `then`/`fi` pair. Inside `=( … )` proc-sub or `( … )` subshell,
 // parseBlockStatement(THEN, LBRACE) absorbed the trailing cmd into

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -1013,6 +1013,7 @@ func (p *Parser) parseDollarParenExpression() ast.Expression {
 		if p.peekTokenIs(token.DoubleRparen) {
 			p.nextToken() // consume ))
 			exp.Command = cmd
+			p.consumedParenTerminator = true
 			return exp
 		}
 
@@ -1023,6 +1024,7 @@ func (p *Parser) parseDollarParenExpression() ast.Expression {
 			return nil
 		}
 		exp.Command = cmd
+		p.consumedParenTerminator = true
 		return exp
 	}
 


### PR DESCRIPTION
## Summary
- parseDollarParenExpression's arithmetic branch consumed the closing `))` (or its `)) `-as-`RPAREN+RPAREN` fallback) but never signalled consumedParenTerminator.
- An enclosing subshell body that followed `assign=$(( … ))` with a second statement crashed on the next statement's first token — parseBlockStatement fell through to the generic advance path on the trailing `))`.
- Set the flag on both arithmetic exit paths, mirroring what the regular `$(…)` cmd-sub path already does.

## Test plan
- [x] go test ./... — new positive test for arith cmd-sub inside subshell + follow-up statement.
- [x] golangci-lint run ./... — 0 issues.
- [x] gocyclo -over 15 . — clean.
- [x] bash scripts/parser-corpus-sweep.sh — total stays at 14 (no regression). Real corpus pattern parses cleanly in isolation; deeper cascades in zinit-install mask the per-file delta.