### PR TITLE
fix(lexer): `((` after newline fuses to DoubleLparen (-2)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,6 +1,5 @@
 # Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
 # Format: <relpath>\t<count>
 fzf/shell/key-bindings.zsh	6
-zinit/share/git-process-output.zsh	2
 zinit/zinit-install.zsh	5
 zinit/zinit.zsh	1

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -65,6 +65,12 @@ type Lexer struct {
 	// their `}`. Inside a `${ … }` expansion `#` is the length /
 	// pattern operator, never a comment opener.
 	dollarBraceDepth int
+
+	// precedingNewline is set by skipWhitespace when at least one
+	// physical newline was consumed before the current token. Used
+	// by atArithCommandPos so `((` after `cmd<NL>` fuses into
+	// DoubleLparen as a fresh statement head.
+	precedingNewline bool
 }
 
 func New(input string) *Lexer {
@@ -200,6 +206,13 @@ func (l *Lexer) atArithCommandPos() bool {
 		token.LDBRACKET, token.If, token.THEN, token.ELSE, token.ELIF,
 		token.DO, token.WHILE, token.FOR, token.CASE,
 		token.LET, token.RETURN:
+		return true
+	}
+	// A newline-separated `((` always opens a fresh statement, even
+	// after an IDENT / value token (e.g. `cmd<NL>(( expr ))`). The
+	// physical newline is the statement separator that the case list
+	// above covers for `;` / `&&` / `||`.
+	if l.precedingNewline {
 		return true
 	}
 	// A space-separated `((` after a value-like token is also a
@@ -1040,10 +1053,16 @@ func (l *Lexer) sliceClosedString(position int) string {
 
 func (l *Lexer) skipWhitespace() bool {
 	skipped := false
+	l.precedingNewline = false
 	for {
 		switch l.ch {
-		case ' ', '\t', '\n', '\r':
+		case ' ', '\t', '\r':
 			skipped = true
+			l.readChar()
+			continue
+		case '\n':
+			skipped = true
+			l.precedingNewline = true
 			l.readChar()
 			continue
 		case '\\':

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -195,6 +195,23 @@ func TestParseDollarArithmeticInSubshellFollowedByStmt(t *testing.T) {
 	parseSourceClean(t, src)
 }
 
+// `((` after a newline-separated previous statement must fuse into
+// DoubleLparen as a fresh arithmetic command head, even when the
+// last emitted token was an IDENT (or other non-separator). Without
+// the precedingNewline check, `cmd<NL>(( … ))` lexed as
+// `cmd<NL>( ( … ) )` and the `(((` chain inside lost a `))` pairing.
+func TestParseArithmeticCommandAfterNewline(t *testing.T) {
+	parseSourceClean(t, "echo a\n(( x = 1 ))\n")
+}
+
+func TestParseArithmeticCommandWithTripleParenAfterNewline(t *testing.T) {
+	src := "foo() {\n" +
+		"  integer pr\n" +
+		"  (( pr = a ? b : ((( g - 1 )/14 ) % 10) + 1 ))\n" +
+		"}\n"
+	parseSourceClean(t, src)
+}
+
 // Zsh shortcut: `if (( cond )) cmd` and `if [[ cond ]] cmd` omit the
 // `then`/`fi` pair. Inside `=( … )` proc-sub or `( … )` subshell,
 // parseBlockStatement(THEN, LBRACE) absorbed the trailing cmd into


### PR DESCRIPTION
## Summary
- A newline separates statements just like `;` / `&&` / `||`.
- atArithCommandPos missed this case — after `cmd<NL>`, the last emitted token was IDENT (the cmd's last word) and the case list of head-position tokens didn't cover IDENT.
- The next `((` lexed as two separate `(` LPAREN tokens, so `(( expr ))` became `( ( expr ) )` and any `(((` chain inside lost a `))` pairing.
- Track `precedingNewline` in skipWhitespace; atArithCommandPos returns true whenever a newline was consumed before the current token.

## Test plan
- [x] go test ./... — two new positive tests pass.
- [x] golangci-lint run ./... — 0 issues.
- [x] gocyclo -over 15 . — clean.
- [x] bash scripts/parser-corpus-sweep.sh — zinit/share/git-process-output.zsh drops 2 → 0 (cleared); total 14 → 12; baseline updated.