### PR TITLE
fix(lexer): ((( subshell+arith vs arith+group disambiguation (-6)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,5 +1,4 @@
 # Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
 # Format: <relpath>\t<count>
-fzf/shell/key-bindings.zsh	6
 zinit/zinit-install.zsh	5
 zinit/zinit.zsh	1

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -404,6 +404,16 @@ func (l *Lexer) readSemicolonLead() token.Token {
 func (l *Lexer) readOpenParen() token.Token {
 	defer func() { l.suppressLparenFusion = false }()
 	if l.peekChar() == '(' && !l.suppressLparenFusion && !l.inArithmetic() && l.atArithCommandPos() {
+		// `(((` at command position is ambiguous: `( ((` (subshell
+		// open + arith) when a space separates the inner `((` from
+		// the operand (`if ((( cond ))`), or `(( (` (arith with
+		// grouping) when no space appears (`(((x * y) + z))`).
+		// Disambiguate by peeking past the third `(`.
+		if l.peekAt(2) == '(' && l.peekAt(3) == ' ' {
+			tok := newToken(token.LPAREN, l.ch, l.line, l.column)
+			l.parenStack = append(l.parenStack, 'P')
+			return tok
+		}
 		tok := l.readFusedToken(token.DoubleLparen)
 		l.parenStack = append(l.parenStack, 'D')
 		return tok

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -212,6 +212,19 @@ func TestParseArithmeticCommandWithTripleParenAfterNewline(t *testing.T) {
 	parseSourceClean(t, src)
 }
 
+// `(((` at command position is ambiguous. Subshell+arith form has a
+// space after the third `(`: `if ((( cond ))` = `( ((`. Arith+group
+// form glues the operand directly: `(((x + y) * z))` = `(( (`.
+// readOpenParen disambiguates by peeking past the third `(` for a
+// space.
+func TestParseTripleParenSubshellArithIfHead(t *testing.T) {
+	parseSourceClean(t, "if ((( a )) && [[ x ]]); then echo y; fi\n")
+}
+
+func TestParseTripleParenArithGrouping(t *testing.T) {
+	parseSourceClean(t, "(((x * 1000 + y) * 1000 + z >= 1003004)) && echo y\n")
+}
+
 // Zsh shortcut: `if (( cond )) cmd` and `if [[ cond ]] cmd` omit the
 // `then`/`fi` pair. Inside `=( … )` proc-sub or `( … )` subshell,
 // parseBlockStatement(THEN, LBRACE) absorbed the trailing cmd into


### PR DESCRIPTION
## Summary
- `(((` at command position is ambiguous between two Zsh shapes:
  - Subshell + arith: `if ((( cond )) && …` lexes as `(` (subshell) + `((` (arith). The third `(` is the inner arith opener.
  - Arith + group: `(((x + y) * z))` lexes as `((` (arith) + `(` (grouped expression). The third `(` opens a grouping inside arith.
- Distinguishing signal: subshell+arith has a space after the third `(` (`((( cond ` — Zsh requires whitespace inside `(( … ))`), while arith+group glues the operand directly (`(((x`).
- readOpenParen peeks past the third `(` and emits a single LPAREN (subshell open) when followed by a space, otherwise falls through to the existing DoubleLparen fusion.

Drains the entire `(((` ambiguity bucket — the hardest remaining one in the baseline.

## Test plan
- [x] go test ./... — two new positive tests pass (subshell+arith if-head; arith+group `(((`).
- [x] golangci-lint run ./... — 0 issues.
- [x] gocyclo -over 15 . — clean.
- [x] bash scripts/parser-corpus-sweep.sh — fzf/shell/key-bindings.zsh drops 6 → 0 (cleared); total 12 → 6; baseline updated.