### PR TITLE
fix(lexer): <( / >( not process sub inside [[ ]] (-1)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,4 +1,3 @@
 # Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
 # Format: <relpath>\t<count>
 zinit/zinit-install.zsh	5
-zinit/zinit.zsh	1

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -595,6 +595,13 @@ func (l *Lexer) readAngleBracket(isLeft bool) token.Token {
 		case '&':
 			return two(token.LTAMP)
 		case '(':
+			// Inside `[[ … ]]`, `<(` is not process substitution
+			// — `<->` numeric-range glob followed by `(...)` glob
+			// alternation. Emit a plain LT so the parser sees the
+			// `(` as the alternation opener.
+			if l.dbracketDepth > 0 {
+				return newToken(token.LT, l.ch, l.line, l.column)
+			}
 			t := two(token.LT_LPAREN)
 			l.parenStack = append(l.parenStack, 'P')
 			return t
@@ -611,6 +618,12 @@ func (l *Lexer) readAngleBracket(isLeft bool) token.Token {
 	case '=':
 		return two(token.GE_NUM)
 	case '(':
+		// Inside `[[ … ]]`, `>(` is not process substitution —
+		// `<->(...)` numeric-range glob followed by alternation.
+		// Emit a plain GT so the parser sees `(` as the opener.
+		if l.dbracketDepth > 0 {
+			return newToken(token.GT, l.ch, l.line, l.column)
+		}
 		t := two(token.GT_LPAREN)
 		l.parenStack = append(l.parenStack, 'P')
 		return t

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -225,6 +225,23 @@ func TestParseTripleParenArithGrouping(t *testing.T) {
 	parseSourceClean(t, "(((x * 1000 + y) * 1000 + z >= 1003004)) && echo y\n")
 }
 
+// Inside `[[ … ]]`, `<(` and `>(` are NOT process substitution —
+// they are the glob `<->` numeric range followed by `(…)` alternation
+// (`<->(a|)` etc.). The lexer fused `>(` into GT_LPAREN and the
+// trailing alternation tokens orphaned the closing `]]`.
+func TestParseDoubleBracketGlobNumericRangeWithAlternation(t *testing.T) {
+	parseSourceClean(t, "[[ x = <->(a|) ]] && echo y\n")
+}
+
+func TestParseDoubleBracketGlobNumericRangeNested(t *testing.T) {
+	parseSourceClean(t, "[[ x = (\\!|)(<->(a|b|c|)|) ]] && echo y\n")
+}
+
+// Process substitution outside `[[ ]]` still parses.
+func TestParseProcessSubstitutionOutsideDoubleBracket(t *testing.T) {
+	parseSourceClean(t, "diff <(echo a) <(echo b)\n")
+}
+
 // Zsh shortcut: `if (( cond )) cmd` and `if [[ cond ]] cmd` omit the
 // `then`/`fi` pair. Inside `=( … )` proc-sub or `( … )` subshell,
 // parseBlockStatement(THEN, LBRACE) absorbed the trailing cmd into


### PR DESCRIPTION
## Summary
- Inside a `[[ … ]]` test, `<(` and `>(` are not process substitution. They are the glob numeric-range `<->` followed by `(...)` glob alternation.
- Examples: `[[ x = <->(a|) ]]`, `[[ x = (\!|)(<->(a|b|c|)|) ]]`.
- The lexer's unconditional `>(` / `<(` fusion pulled the trailing alternation into a process-substitution body and orphaned the closing `]]`.
- Gate the fusion on `dbracketDepth == 0` so process substitution still lexes outside `[[ ]]`.

## Test plan
- [x] go test ./... — three new positive tests (numeric range + alt, nested glob, proc-sub outside dbracket).
- [x] golangci-lint run ./... — 0 issues.
- [x] gocyclo -over 15 . — clean.
- [x] bash scripts/parser-corpus-sweep.sh — zinit/zinit.zsh drops 1 → 0 (cleared); total 6 → 5; baseline updated.