### PR TITLE
fix(parser/lexer): zinit-install drainage cluster (-4)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,3 +1,3 @@
 # Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
 # Format: <relpath>\t<count>
-zinit/zinit-install.zsh	5
+zinit/zinit-install.zsh	1

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -517,6 +517,13 @@ func (l *Lexer) readPipeLead() token.Token {
 	if l.peekChar() == '|' {
 		return l.readFusedToken(token.OR)
 	}
+	// Zsh `|&` is the stderr-pipe shorthand (`2>&1 |`). Fuse to a
+	// PIPE token so the parser routes through the pipeline path; the
+	// literal preserves the source spelling for katas that need it.
+	if l.peekChar() == '&' {
+		tok := l.readFusedToken(token.PIPE)
+		return tok
+	}
 	return newToken(token.PIPE, l.ch, l.line, l.column)
 }
 
@@ -1025,9 +1032,46 @@ func (l *Lexer) readStringFlavour(quote byte, honourEscapes bool) string {
 		if l.absorbDollarBraceOpen(honourEscapes, &braceDepth) {
 			continue
 		}
+		if honourEscapes && l.absorbEmbeddedDollarParen() {
+			continue
+		}
 		l.trackBraceDepth(&braceDepth)
 	}
 	return l.sliceClosedString(position)
+}
+
+// absorbEmbeddedDollarParen handles `$(…)` command substitution
+// inside a double-quoted string body. Walks past the matching `)`
+// while honouring nested `'…'` single-quoted runs so a `"` inside a
+// single-quoted regex (`'[^"]+' `) doesn't close the outer
+// double-quoted string.
+func (l *Lexer) absorbEmbeddedDollarParen() bool {
+	if l.ch != '$' || l.peekChar() != '(' {
+		return false
+	}
+	l.readChar() // onto `(`
+	depth := 1
+	for depth > 0 {
+		l.readChar()
+		switch l.ch {
+		case 0:
+			return true
+		case '\\':
+			l.readChar()
+		case '\'':
+			for l.ch != 0 {
+				l.readChar()
+				if l.ch == '\'' {
+					break
+				}
+			}
+		case '(':
+			depth++
+		case ')':
+			depth--
+		}
+	}
+	return true
 }
 
 func (l *Lexer) absorbStringEscape(honourEscapes bool) bool {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -242,6 +242,11 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.AMPERSAND, p.parseInfixExpression)
 	p.registerInfix(token.CARET, p.parseInfixExpression)
 	p.registerInfix(token.COMMA, p.parseInfixExpression)
+	// PIPE is bitwise-OR inside `(( … ))`. The dynamic precedence
+	// override in peekPrecedence/curPrecedence promotes it to LOGICAL
+	// only when inArithmetic; the global precedences map keeps it at
+	// LOWEST+1 so non-arith pipelines still chain correctly.
+	p.registerInfix(token.PIPE, p.parseInfixExpression)
 
 	p.nextToken() // Initialize curToken
 	p.nextToken() // Initialize peekToken
@@ -375,15 +380,21 @@ func (p *Parser) peekOnSameLogicalLine() bool {
 }
 
 func (p *Parser) peekPrecedence() int {
-	if p, ok := precedences[p.peekToken.Type]; ok {
-		return p
+	if p.inArithmetic && p.peekToken.Type == token.PIPE {
+		return LOGICAL
+	}
+	if pr, ok := precedences[p.peekToken.Type]; ok {
+		return pr
 	}
 	return LOWEST
 }
 
 func (p *Parser) curPrecedence() int {
-	if p, ok := precedences[p.curToken.Type]; ok {
-		return p
+	if p.inArithmetic && p.curToken.Type == token.PIPE {
+		return LOGICAL
+	}
+	if pr, ok := precedences[p.curToken.Type]; ok {
+		return pr
 	}
 	return LOWEST
 }

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -242,6 +242,42 @@ func TestParseProcessSubstitutionOutsideDoubleBracket(t *testing.T) {
 	parseSourceClean(t, "diff <(echo a) <(echo b)\n")
 }
 
+// `"$(... '...[^"]+...')"` — single-quoted regex containing `"`
+// inside `$(…)` inside `"…"`. Lexer's string scanner used to stop
+// at the inner `"` and orphan the trailing tokens. The embedded
+// `$(…)` walker honours nested `'…'` runs.
+func TestParseEmbeddedDollarParenWithQuotedRegex(t *testing.T) {
+	parseSourceClean(t, "X=\"$(grep 'a'$U'b/c[^\"]\\+')\"\n")
+}
+
+// Brace-form `if (( a )) { if (( b )) { … } } elif (( c )) { … }`.
+// The inner brace-form `if`'s consumedBraceTerminator flag used to
+// leak into parseBraceFormElifChain's cond-block parse and dropped
+// the elif's `(( cond ))` close into expression position.
+func TestParseBraceFormIfElifWithNestedBraceFormIf(t *testing.T) {
+	src := "if (( a )) {\n" +
+		"  if (( b )) {\n" +
+		"    cmd\n" +
+		"  }\n" +
+		"} elif (( c )) {\n" +
+		"  cmd2\n" +
+		"}\n"
+	parseSourceClean(t, src)
+}
+
+// `(( move | move2 ))` — `|` is bitwise OR inside arithmetic, not a
+// pipeline. peekPrecedence/curPrecedence promote PIPE to LOGICAL
+// when inArithmetic; PIPE infix routes through parseInfixExpression.
+func TestParseArithmeticBitwiseOr(t *testing.T) {
+	parseSourceClean(t, "(( move | move2 ))\n")
+}
+
+// Zsh `|&` is the stderr-pipe shorthand. Lexer fuses `|&` into a
+// single PIPE token so the parser routes through pipeline parsing.
+func TestParsePipeAmpStderrPipe(t *testing.T) {
+	parseSourceClean(t, "cmd1 |& cmd2\n")
+}
+
 // Zsh shortcut: `if (( cond )) cmd` and `if [[ cond ]] cmd` omit the
 // `then`/`fi` pair. Inside `=( … )` proc-sub or `( … )` subshell,
 // parseBlockStatement(THEN, LBRACE) absorbed the trailing cmd into

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -701,6 +701,13 @@ func (p *Parser) parseIfStatement() *ast.IfStatement {
 	if p.curTokenIs(token.LBRACE) {
 		p.nextToken() // into body
 		stmt.Consequence = p.parseBlockStatement(token.RBRACE)
+		// Clear the consumedBraceTerminator flag potentially left set
+		// by an inner brace-form `if`/`for`/`while` that closed its
+		// own `}`. Without this, parseBraceFormElifChain's inner
+		// parseBlockStatement(LBRACE) inherits the flag and skips
+		// nextToken on the elif's `(( cond ))` close, dropping into
+		// an expression-position parse on `))`.
+		p.consumedBraceTerminator = false
 		if alt := p.parseBraceFormElifChain(); alt != nil {
 			stmt.Alternative = alt
 		}


### PR DESCRIPTION
## Summary
Four paired fixes that drain zinit-install.zsh from 5 → 1 errors.

1. **lexer `absorbEmbeddedDollarParen`** — `"$(... '...' ...)"` with single-quoted regex containing `"` inside `$(…)` inside `"…"`. String scanner stopped at the inner `"`. Walker skips `$(…)` body honouring nested `'…'` runs.
2. **parseIfStatement clears `consumedBraceTerminator`** after the brace-form body. The flag leaked into parseBraceFormElifChain's inner parseBlockStatement(LBRACE) and dropped the elif cond's `((…))` close into expression position.
3. **PIPE as bitwise-OR in arithmetic**: `(( move | move2 ))`. Register PIPE as infix; peekPrecedence/curPrecedence promote PIPE to LOGICAL when inArithmetic so the global LOWEST+1 pipeline precedence still chains pipelines outside arith.
4. **lexer `|&` stderr-pipe fusion**: `cmd1 |& cmd2`. Fuse into a single PIPE token.

## Test plan
- [x] go test ./... — five new positive tests pass.
- [x] golangci-lint run ./... — 0 issues.
- [x] gocyclo -over 15 . — clean.
- [x] bash scripts/parser-corpus-sweep.sh — zinit/zinit-install.zsh drops 5 → 1; total 5 → 1; baseline updated.