### PR TITLE
fix(parser): typeset array literal flags consumedParenTerminator (-1)

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,3 +1,2 @@
 # Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
 # Format: <relpath>\t<count>
-zinit/zinit-install.zsh	1

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -278,6 +278,19 @@ func TestParsePipeAmpStderrPipe(t *testing.T) {
 	parseSourceClean(t, "cmd1 |& cmd2\n")
 }
 
+// `typeset -aU x=( … )` inside a `( … )` subshell. The declaration
+// value walker ends on the array's `)`; without flagging
+// consumedParenTerminator, parseBlockStatement misread that `)` as
+// the subshell's terminator and the next statement's first token
+// was advanced past.
+func TestParseDeclarationArrayInsideSubshell(t *testing.T) {
+	src := "(\n" +
+		"  typeset -aU x=(${(@s; ;)y})\n" +
+		"  x+=(\"--prefix=z\")\n" +
+		")\n"
+	parseSourceClean(t, src)
+}
+
 // Zsh shortcut: `if (( cond )) cmd` and `if [[ cond ]] cmd` omit the
 // `then`/`fi` pair. Inside `=( … )` proc-sub or `( … )` subshell,
 // parseBlockStatement(THEN, LBRACE) absorbed the trailing cmd into

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -1482,6 +1482,11 @@ func (p *Parser) parseDeclarationValue() ast.Expression {
 		}
 	arrDone:
 		val += " )"
+		// Signal the enclosing block that the `)` we ended on closed
+		// the declaration's own array literal, not the surrounding
+		// subshell — matches the consumedParenTerminator path used by
+		// parseGroupedExpression's array branch.
+		p.consumedParenTerminator = true
 		// Leave curToken on the closing `)` rather than advancing
 		// past it. The caller's declaration loop checks
 		// `curToken.Line == startLine`; if we step past `)` onto


### PR DESCRIPTION
## Summary
- `parseDeclarationValue` ends on the array literal's closing `)` when processing `typeset -aU x=( … )`.
- Inside a `( … )` subshell, the enclosing `parseBlockStatement(RPAREN)` saw cur=RPAREN and broke at that `)` — closing the subshell prematurely. The next statement's IDENT was then over-advanced and parser landed on `+=` mid-expression.
- Mirror the `consumedParenTerminator` path used by `parseGroupedExpression`'s array branch so the enclosing block honours the array's `)` as already-consumed.

Drains the last baseline error. **Baseline now at 0.**

## Test plan
- [x] go test ./... — new positive test for declaration array inside subshell.
- [x] golangci-lint run ./... — 0 issues.
- [x] gocyclo -over 15 . — clean.
- [x] bash scripts/parser-corpus-sweep.sh — zinit/zinit-install.zsh drops 1 → 0; total 1 → 0; baseline empty.