### PR TITLE
fix(parser): guard typed-nil statement in pipeline head wrap

### DIFF
--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -328,7 +328,7 @@ func (p *Parser) parseExpressionOrFunctionDefinition() ast.Statement {
 // Detection katas that walk the statement type still see the original
 // node when traversing the wrapper.
 func keywordStmtToExpression(stmt ast.Statement) ast.Expression {
-	if stmt == nil {
+	if stmt == nil || isTypedNilStatement(stmt) {
 		return nil
 	}
 	if es, ok := stmt.(*ast.ExpressionStatement); ok {
@@ -338,6 +338,29 @@ func keywordStmtToExpression(stmt ast.Statement) ast.Expression {
 	// The Token preserves the head keyword for kata-side walks of
 	// containing CallExpression / DollarParenExpression bodies.
 	return &ast.Identifier{Token: stmt.TokenLiteralNode(), Value: stmt.TokenLiteral()}
+}
+
+// isTypedNilStatement reports whether stmt is an interface holding a
+// typed-nil concrete pointer. Recovery-path returns from sub-parsers
+// (`return (*ast.ForLoopStatement)(nil)` style) wrap a nil receiver in
+// a non-nil interface; calling a method on that receiver dereferences
+// nil. Catch the case here so pipeline-head wrapping degrades to nil.
+func isTypedNilStatement(stmt ast.Statement) bool {
+	switch s := stmt.(type) {
+	case *ast.ExpressionStatement:
+		return s == nil
+	case *ast.IfStatement:
+		return s == nil
+	case *ast.ForLoopStatement:
+		return s == nil
+	case *ast.CaseStatement:
+		return s == nil
+	case *ast.SelectStatement:
+		return s == nil
+	case *ast.BlockStatement:
+		return s == nil
+	}
+	return false
 }
 
 // consumePipelineTail drains trailing `| cmd` / `&& cmd` / `|| cmd`


### PR DESCRIPTION
## What
Detect typed-nil concrete pointers wrapped in an \`ast.Statement\` interface inside \`keywordStmtToExpression\`. Degrade to \`nil\` before invoking \`TokenLiteralNode\` on a nil receiver.

## Why
\`parsePipelineHead\` wraps the result of \`parseStatement\` for keyword-headed compounds (\`if\`, \`for\`, \`case\`, \`select\`). When a recovery path inside one of those parsers returns \`(*ast.ForLoopStatement)(nil)\`, the interface is non-nil but the data pointer is \`0x0\`. Calling \`TokenLiteralNode\` panics. Same pattern as the ZC1122 typed-nil guard.

## How
Add \`isTypedNilStatement\` covering every statement variant returned by sub-parsers. Mirrors the defensive nil check at the only known panic site.

## Verification
- \`go test ./...\` clean.
- \`go test -fuzz=FuzzParser -fuzztime=15s\` passes after the change; reproduces the panic before.
- Lint clean.

## Severity
Crash on minimised fuzz input; fuzz run on the parser-corpus drainage merge surfaced it.