### PR TITLE
fix(parser-corpus): record true ls-colors error count

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,2 +1,3 @@
 # Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
 # Format: <relpath>\t<count>
+fzf-tab/lib/zsh-ls-colors/ls-colors.zsh	12


### PR DESCRIPTION
## What
Bake the 12 real parser errors in \`fzf-tab/lib/zsh-ls-colors/ls-colors.zsh\` into the baseline. The previous \`0\` was masked by a parser panic that grep counted as zero.

## Why
PR #1314 swapped the typed-nil dereference inside \`keywordStmtToExpression\` for a graceful nil return. The panic was hiding 12 errors in this file behind a \`grep -c \"^Parser Error\"\` that returned 0 when the binary died before printing anything.

## Underlying issue
\`true && case \$(( arith )) in ... esac\` makes \`parseCaseStatement\` return nil because the \`expectPeek(IN)\` after the arithmetic subject fails when \`case\` heads a pipeline. Tracked separately; draining it will pull the count back to 0.

## Verification
- \`bash scripts/parser-corpus-sweep.sh\` exits 0 with the new baseline.
- 77 of 78 corpus files remain at 0 errors.