### PR TITLE
fix(lexer): comment-skip ran NextToken defer twice

### DIFF
--- a/.github/parser-error-baseline.txt
+++ b/.github/parser-error-baseline.txt
@@ -1,3 +1,2 @@
 # Parser-error baseline. Regenerate with scripts/parser-corpus-sweep.sh --update-baseline
 # Format: <relpath>\t<count>
-fzf-tab/lib/zsh-ls-colors/ls-colors.zsh	12

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -120,6 +120,11 @@ func (l *Lexer) NextToken() (tok token.Token) {
 	// skipWhitespace sets pendingContinuation when a `\<NL>` pair
 	// was absorbed; stamp the flag onto the returned token via this
 	// named-return defer so every early return path inherits it.
+	// The defer also tracks dollarBraceDepth — increment on `${`,
+	// decrement on `}`. The defer must run exactly once per emitted
+	// token, so the comment-skip path uses a loop rather than a
+	// recursive NextToken call (recursion would run the inner and
+	// outer defers on the same token, double-counting depth).
 	prevSuppress := l.suppressLparenFusion
 	defer func() {
 		if l.pendingContinuation {
@@ -142,8 +147,18 @@ func (l *Lexer) NextToken() (tok token.Token) {
 		l.lastEmittedHadSpace = tok.HasPrecedingSpace
 	}()
 	hasSpace := l.skipWhitespace()
-	if shebang, ok := l.tryShebangOrComment(hasSpace); ok {
-		return shebang
+	for {
+		shebang, sb := l.tryShebangOrComment(hasSpace)
+		if !sb {
+			break
+		}
+		if shebang.Type == token.SHEBANG {
+			return shebang
+		}
+		// tryShebangOrComment returned (zero, true) to signal the
+		// comment was skipped; loop to absorb the next token, refreshing
+		// hasSpace from the post-comment whitespace state.
+		hasSpace = l.skipWhitespace() || hasSpace
 	}
 	if early, ok := l.dispatchEarlyReturn(hasSpace); ok {
 		return early
@@ -158,6 +173,11 @@ func (l *Lexer) NextToken() (tok token.Token) {
 // on `#!` and reports the result; for a regular comment it consumes
 // the comment and recurses into NextToken. ok=false leaves state
 // unchanged for callers to continue the dispatch.
+// tryShebangOrComment classifies the current `#` byte. Returns
+// (SHEBANG-token, true) when the cursor sits on `#!` at top of file,
+// (zero token, true) when a `#`-introduced comment was skipped (the
+// caller loops to fetch the next non-comment token), and
+// (zero token, false) when `#` should be emitted as a token.
 func (l *Lexer) tryShebangOrComment(hasSpace bool) (token.Token, bool) {
 	if l.ch != '#' {
 		return token.Token{}, false
@@ -184,7 +204,7 @@ func (l *Lexer) tryShebangOrComment(hasSpace bool) (token.Token, bool) {
 	}
 	if hasSpace || l.column == 1 {
 		l.skipComment()
-		return l.NextToken(), true
+		return token.Token{}, true
 	}
 	return token.Token{}, false
 }


### PR DESCRIPTION
## What
Replace the recursive \`return l.NextToken()\` inside \`tryShebangOrComment\` with a loop in \`NextToken\` so the named-return defer runs exactly once per emitted token.

## Why
The defer tracks \`dollarBraceDepth\`: increment on \`\${\`, decrement on \`}\`. When a comment-skip recursed into \`NextToken\`, the inner defer ran first and updated state for the token; then the outer defer ran on the same token (Go named-return propagates through \`return l.NextToken()\`) and updated state a second time. \`\${\` after a skipped comment double-incremented depth, leaving it stuck > 0; subsequent \`#\` bytes were classified as \`\${…}\` length operators rather than comment openers, so inline comments after \`;;\` leaked into the parser as \`# IDENT\` tokens.

## Reproduces
\`\`\`zsh
# c
\${pfx}::f () {
    case \$x in
        a ) c=( ); r=1 ;; # comment
    esac
}
\`\`\`
Pre-fix: \`expected next token to be ), got IDENT instead\` at the inline comment. Post-fix: parses clean.

## Impact
Drains the 12-error baseline entry on \`fzf-tab/lib/zsh-ls-colors/ls-colors.zsh\` back to 0. The baseline is now empty: every pinned corpus file parses without error.

## Verification
- \`go test ./...\` clean.
- \`go test -fuzz=FuzzLexer -fuzztime=10s\` and \`-fuzz=FuzzParser -fuzztime=15s\` pass.
- \`bash scripts/parser-corpus-sweep.sh\` reports 0 errors across 78 files.
- Lint clean.