### PR TITLE
ci: skip Codecov upload on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,11 @@ jobs:
           chmod +x tests/integration_test.zsh
           ./tests/integration_test.zsh
       - name: Upload coverage to Codecov
+        # Dependabot PRs run with restricted secrets, so CODECOV_TOKEN is
+        # not exposed and the upload fails the build. Skip the upload for
+        # those runs; the gate still fires on every human-authored PR
+        # because secrets are available there.
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## What
Gate the Codecov upload step in \`ci.yml\` on \`github.actor != 'dependabot[bot]'\`.

## Why
Dependabot PRs run with restricted secrets, so \`CODECOV_TOKEN\` is unavailable. The Codecov v6 action's \`fail_ci_if_error: true\` then breaks every \`Build & Test\` job on a bump, blocking merge with \`Token required because branch is protected\`. Skipping the upload on dependabot runs unblocks dep bumps; human-authored PRs still upload and enforce the coverage gate.

## Verification
Manual: re-run \`#1318\` after merge of this PR; coverage upload step is skipped, build green.