### PR TITLE
test: drive coverage above 95% with margin (v2)

### DIFF
--- a/pkg/katas/helper_coverage_test.go
+++ b/pkg/katas/helper_coverage_test.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+	"github.com/afadesigns/zshellcheck/pkg/token"
+)
+
+// TestArgValueAfter exercises the dispatch helper used by katas
+// matching `--flag value` style options.
+func TestArgValueAfter(t *testing.T) {
+	mkArg := func(s string) ast.Expression {
+		return &ast.Identifier{Token: token.Token{Type: token.IDENT, Literal: s}, Value: s}
+	}
+	cmd := &ast.SimpleCommand{Arguments: []ast.Expression{mkArg("--bind"), mkArg("0.0.0.0"), mkArg("--port"), mkArg("8080")}}
+	if got := ArgValueAfter(cmd, "--bind"); got != "0.0.0.0" {
+		t.Errorf("--bind: got %q want 0.0.0.0", got)
+	}
+	if got := ArgValueAfter(cmd, "--port"); got != "8080" {
+		t.Errorf("--port: got %q want 8080", got)
+	}
+	if got := ArgValueAfter(cmd, "--missing"); got != "" {
+		t.Errorf("--missing: got %q want \"\"", got)
+	}
+	tail := &ast.SimpleCommand{Arguments: []ast.Expression{mkArg("--bind")}}
+	if got := ArgValueAfter(tail, "--bind"); got != "" {
+		t.Errorf("tail-key: got %q want \"\"", got)
+	}
+}
+
+// TestIsAlphaNumeric exercises the byte-class predicate behind the
+// kata1071 self-reference detector.
+func TestIsAlphaNumeric(t *testing.T) {
+	cases := []struct {
+		b    byte
+		want bool
+	}{
+		{'a', true},
+		{'Z', true},
+		{'0', true},
+		{'9', true},
+		{'_', false},
+		{'-', false},
+		{' ', false},
+		{'\n', false},
+	}
+	for _, tc := range cases {
+		if got := isAlphaNumeric(tc.b); got != tc.want {
+			t.Errorf("isAlphaNumeric(%q): got %v want %v", tc.b, got, tc.want)
+		}
+	}
+}
+
+// TestIsDevNullAndStringValue exercises the ZC1053 string extraction
+// over StringLiteral and ConcatenatedExpression node shapes, plus the
+// quoted-literal `/dev/null` detector.
+func TestIsDevNullAndStringValue(t *testing.T) {
+	bare := &ast.StringLiteral{Value: "/dev/null"}
+	if !isDevNull(bare) {
+		t.Errorf("isDevNull(bare /dev/null): expected true")
+	}
+	quoted := &ast.StringLiteral{Value: "\"/dev/null\""}
+	if !isDevNull(quoted) {
+		t.Errorf("isDevNull(quoted /dev/null): expected true")
+	}
+	other := &ast.StringLiteral{Value: "/tmp/log"}
+	if isDevNull(other) {
+		t.Errorf("isDevNull(/tmp/log): expected false")
+	}
+	concat := &ast.ConcatenatedExpression{Parts: []ast.Expression{
+		&ast.StringLiteral{Value: "/dev"},
+		&ast.StringLiteral{Value: "/null"},
+	}}
+	if got := getStringValueZC1053(concat); got != "/dev/null" {
+		t.Errorf("getStringValueZC1053(concat): got %q want /dev/null", got)
+	}
+	if got := getStringValueZC1053(&ast.Identifier{Value: "x"}); got != "" {
+		t.Errorf("getStringValueZC1053(non-string): got %q want \"\"", got)
+	}
+}
+
+// TestZC1796HasPgArg covers every flag in the pg_dump / pg_restore
+// indicator set plus the negative case.
+func TestZC1796HasPgArg(t *testing.T) {
+	mk := func(args ...string) *ast.SimpleCommand {
+		exprs := make([]ast.Expression, 0, len(args))
+		for _, a := range args {
+			exprs = append(exprs, &ast.Identifier{Value: a})
+		}
+		return &ast.SimpleCommand{Arguments: exprs}
+	}
+	flags := []string{"-d", "--dbname", "-F", "--format", "-U", "--username", "--if-exists", "--no-owner", "--no-acl"}
+	for _, f := range flags {
+		if !zc1796HasPgArg(mk(f, "value")) {
+			t.Errorf("zc1796HasPgArg(%s): expected true", f)
+		}
+	}
+	if zc1796HasPgArg(mk("--unrelated")) {
+		t.Errorf("zc1796HasPgArg(--unrelated): expected false")
+	}
+	if zc1796HasPgArg(mk()) {
+		t.Errorf("zc1796HasPgArg(empty): expected false")
+	}
+}
+
+// TestZC1960IsGcloudSshCmd covers the head-prefix gate and the
+// trailing `--command` / `--command=` variants.
+func TestZC1960IsGcloudSshCmd(t *testing.T) {
+	mk := func(args ...string) *ast.SimpleCommand {
+		exprs := make([]ast.Expression, 0, len(args))
+		for _, a := range args {
+			exprs = append(exprs, &ast.Identifier{Value: a})
+		}
+		return &ast.SimpleCommand{Arguments: exprs}
+	}
+	if !zc1960IsGcloudSshCmd(mk("compute", "ssh", "host", "--command", "uptime")) {
+		t.Errorf("expected true for --command separate")
+	}
+	if !zc1960IsGcloudSshCmd(mk("compute", "ssh", "host", "--command=uptime")) {
+		t.Errorf("expected true for --command=")
+	}
+	if zc1960IsGcloudSshCmd(mk("compute", "ssh", "host")) {
+		t.Errorf("expected false without --command")
+	}
+	if zc1960IsGcloudSshCmd(mk("compute", "scp", "f1", "f2")) {
+		t.Errorf("expected false for compute scp")
+	}
+	if zc1960IsGcloudSshCmd(mk("compute")) {
+		t.Errorf("expected false for too few args")
+	}
+}
+
+// TestZC1045StringHasSub exercises every branch of the embedded-
+// substitution detector over double-quoted string literals.
+func TestZC1045StringHasSub(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		want bool
+	}{
+		{"empty", ``, false},
+		{"single-byte", `"`, false},
+		{"unquoted", `hello`, false},
+		{"plain quoted", `"hello"`, false},
+		{"backtick sub", "\"echo `date`\"", true},
+		{"dollar paren sub", `"echo $(date)"`, true},
+		{"escaped backtick", "\"echo \\` not sub\"", false},
+		{"escaped dollar", `"\$(not-sub)"`, false},
+		{"dollar without paren", `"$var"`, false},
+	}
+	for _, tc := range cases {
+		if got := zc1045StringHasSub(tc.val); got != tc.want {
+			t.Errorf("%s: got %v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestZC1045ConcatHasSub exercises the array-walk path. A
+// CommandSubstitution node anywhere in Parts trips the detector.
+func TestZC1045ConcatHasSub(t *testing.T) {
+	plain := &ast.ConcatenatedExpression{Parts: []ast.Expression{
+		&ast.StringLiteral{Value: "a"},
+		&ast.StringLiteral{Value: "b"},
+	}}
+	if zc1045ConcatHasSub(plain) {
+		t.Errorf("expected false for plain literal concat")
+	}
+	withSub := &ast.ConcatenatedExpression{Parts: []ast.Expression{
+		&ast.StringLiteral{Value: "prefix"},
+		&ast.CommandSubstitution{Command: &ast.SimpleCommand{}},
+	}}
+	if !zc1045ConcatHasSub(withSub) {
+		t.Errorf("expected true when CommandSubstitution present")
+	}
+}
+
+// TestZC1071SelfReferences exercises every node-type branch of the
+// self-reference detector used by ZC1071.
+func TestZC1071SelfReferences(t *testing.T) {
+	id := &ast.Identifier{Value: "foo"}
+	if !zc1071SelfReferences(&ast.ArrayAccess{Left: id}, "foo") {
+		t.Errorf("ArrayAccess(foo) referencing foo: expected true")
+	}
+	if zc1071SelfReferences(&ast.ArrayAccess{Left: id}, "bar") {
+		t.Errorf("ArrayAccess(foo) referencing bar: expected false")
+	}
+	if !zc1071SelfReferences(&ast.Identifier{Value: "$foo"}, "foo") {
+		t.Errorf("Identifier($foo) referencing foo: expected true")
+	}
+	if !zc1071SelfReferences(&ast.Identifier{Value: "${foo}"}, "foo") {
+		t.Errorf("Identifier(${foo}) referencing foo: expected true")
+	}
+	prefix := &ast.PrefixExpression{Operator: "$", Right: id}
+	if !zc1071SelfReferences(prefix, "foo") {
+		t.Errorf("PrefixExpression($foo) referencing foo: expected true")
+	}
+	wrong := &ast.PrefixExpression{Operator: "!", Right: id}
+	if zc1071SelfReferences(wrong, "foo") {
+		t.Errorf("PrefixExpression(!) referencing foo: expected false")
+	}
+	if zc1071SelfReferences(&ast.IntegerLiteral{Value: 1}, "foo") {
+		t.Errorf("IntegerLiteral: expected false")
+	}
+}
+
+// TestCommandIdentifier covers the head-identifier helper used by
+// every Check entry point.
+func TestCommandIdentifier(t *testing.T) {
+	cmd := &ast.SimpleCommand{Name: &ast.Identifier{Value: "echo"}}
+	if got := CommandIdentifier(cmd); got != "echo" {
+		t.Errorf("ident head: got %q want echo", got)
+	}
+	notIdent := &ast.SimpleCommand{Name: &ast.StringLiteral{Value: "x"}}
+	if got := CommandIdentifier(notIdent); got != "" {
+		t.Errorf("non-ident head: got %q want \"\"", got)
+	}
+}

--- a/pkg/katas/offset_line_col_test.go
+++ b/pkg/katas/offset_line_col_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import "testing"
+
+// TestOffsetLineColHelpers exercises every offsetLineColZCxxxx duplicate
+// over the multi-line newline branch. The helpers are unexported and
+// shaped identically; this test ensures coverage reports record both
+// the offset-out-of-range guard and the newline-step branch for every
+// kata-specific copy.
+func TestOffsetLineColHelpers(t *testing.T) {
+	src := []byte("a\nb\nc")
+	for _, fn := range []func([]byte, int) (int, int){
+		offsetLineColZC1016,
+		offsetLineColZC1040,
+		offsetLineColZC1051,
+		offsetLineColZC1053,
+		offsetLineColZC1076,
+		offsetLineColZC1078,
+		offsetLineColZC1079,
+		offsetLineColZC1084,
+		offsetLineColZC1085,
+		offsetLineColZC1086,
+		offsetLineColZC1091,
+		offsetLineColZC1126,
+		offsetLineColZC1146,
+		offsetLineColZC1147,
+		offsetLineColZC1163,
+		offsetLineColZC1170,
+		offsetLineColZC1190,
+		offsetLineColZC1209,
+		offsetLineColZC1210,
+		offsetLineColZC1213,
+		offsetLineColZC1226,
+		offsetLineColZC1227,
+		offsetLineColZC1230,
+		offsetLineColZC1231,
+		offsetLineColZC1234,
+		offsetLineColZC1238,
+		offsetLineColZC1241,
+		offsetLineColZC1253,
+		offsetLineColZC1255,
+		offsetLineColZC1257,
+		offsetLineColZC1265,
+		offsetLineColZC1267,
+		offsetLineColZC1268,
+		offsetLineColZC1273,
+		offsetLineColZC1293,
+		offsetLineColZC1377,
+		offsetLineColZC1378,
+		offsetLineColZC1380,
+		offsetLineColZC1381,
+		offsetLineColZC1382,
+		offsetLineColZC1383,
+		offsetLineColZC1394,
+		offsetLineColZC1403,
+		offsetLineColZC1404,
+		offsetLineColZC1448,
+		offsetLineColZC1502,
+		offsetLineColZC1643,
+		offsetLineColZC1717,
+		offsetLineColZC1773,
+	} {
+		// out-of-range guard
+		if l, c := fn(nil, -1); l != -1 || c != -1 {
+			t.Errorf("expected (-1,-1) for negative offset, got (%d,%d)", l, c)
+		}
+		if l, c := fn(src, len(src)+1); l != -1 || c != -1 {
+			t.Errorf("expected (-1,-1) for over-range, got (%d,%d)", l, c)
+		}
+		// newline-step branch (`a\nb\nc` at offset 4 → line 3, col 1)
+		if l, c := fn(src, 4); l != 3 || c != 1 {
+			t.Errorf("expected (3,1) at offset 4, got (%d,%d)", l, c)
+		}
+	}
+}

--- a/pkg/parser/parser_coverage_test.go
+++ b/pkg/parser/parser_coverage_test.go
@@ -301,3 +301,129 @@ func TestParseGroupedKeywordFor(t *testing.T) {
 func TestParseGroupedKeywordWhile(t *testing.T) {
 	parseClean(t, "( while read l; do echo $l; done )\n")
 }
+
+// parseSingleCommand head-prefix coverage targeting the
+// DOLLAR_LPAREN / BACKTICK / VARIABLE / ${} branch pre-arg-loop.
+func TestParseSingleCommandDollarParenHead(t *testing.T) {
+	parseClean(t, "$(which cmd) -n\n")
+}
+
+func TestParseSingleCommandBacktickHead(t *testing.T) {
+	parseClean(t, "`which cmd` -n\n")
+}
+
+func TestParseSingleCommandVariableHead(t *testing.T) {
+	parseClean(t, "$cmd -h --foo bar\n")
+}
+
+func TestParseSingleCommandDollarBraceHead(t *testing.T) {
+	parseClean(t, "${cmd} arg1 arg2\n")
+}
+
+// parseSingleCommand `name (arg)` non-fn-def path: parens after a
+// command name with content inside, NOT followed immediately by `)`.
+func TestParseSingleCommandNameParenArg(t *testing.T) {
+	parseClean(t, "ls (file)\n")
+}
+
+// parseDollarSpecialOp: `$?`, `$$`, `$@`, positional.
+func TestParseDollarQuestionBare(t *testing.T) { parseClean(t, "echo $?\n") }
+func TestParseDollarDollarBare(t *testing.T)   { parseClean(t, "echo $$\n") }
+func TestParseDollarAtBare(t *testing.T)       { parseClean(t, "echo $@\n") }
+func TestParseDollarPositionalChain(t *testing.T) {
+	parseClean(t, "echo $0 $1 $2\n")
+}
+
+// parseDollarSpecialOp `$+` (zsh: subscript flag): `$+commands`.
+func TestParseDollarPlusInArith(t *testing.T) {
+	parseClean(t, "(( $+commands[ls] ))\n")
+}
+
+// parseArrayAccessSubject keyword-as-subject path.
+func TestParseDollarBraceKeywordAsSubject(t *testing.T) {
+	parseClean(t, "echo ${for}\n")
+}
+
+// drainSubscriptBody depth-tracking branches.
+func TestParseDollarBraceNestedBracket(t *testing.T) {
+	parseClean(t, "echo ${arr[$nested[1]]}\n")
+}
+
+// parseDollarParenExpression keyword-headed body forms.
+func TestParseDollarParenForLoop(t *testing.T) {
+	parseClean(t, "echo $(for f in *; do print $f; done)\n")
+}
+
+func TestParseDollarParenIfStatement(t *testing.T) {
+	parseClean(t, "echo $(if [[ -f $1 ]]; then echo yes; fi)\n")
+}
+
+// parseArithmeticSubscript with operator chain.
+func TestParseArithSubscriptChain(t *testing.T) {
+	parseClean(t, "echo ${arr[i*2+1]}\n")
+}
+
+// parseFlaggedSubscript Zsh subscript-flag tuples.
+func TestParseFlaggedSubscriptKey(t *testing.T) {
+	parseClean(t, "echo ${(k)assoc}\n")
+}
+
+func TestParseFlaggedSubscriptValue(t *testing.T) {
+	parseClean(t, "echo ${(v)assoc}\n")
+}
+
+func TestParseFlaggedSubscriptKeyValue(t *testing.T) {
+	parseClean(t, "echo ${(kv)assoc}\n")
+}
+
+// parseProcessSubstitution write+read mix and bare path.
+func TestParseProcessSubstReadAndWrite(t *testing.T) {
+	parseClean(t, "diff <(sort a) >(sort b)\n")
+}
+
+// parseCommandWord with mixed quoting + concat.
+func TestParseCommandWordConcatMix(t *testing.T) {
+	parseClean(t, "echo prefix${var}suffix\n")
+}
+
+func TestParseCommandWordDoubleQuoteWithSub(t *testing.T) {
+	parseClean(t, "echo \"value=$(cmd) end\"\n")
+}
+
+// parseExpression / parseEqualsForm: env-prefix assignment chain.
+func TestParseEnvPrefixChain(t *testing.T) {
+	parseClean(t, "X=1 Y=2 Z=3 cmd arg\n")
+}
+
+// parseStatement coverage for HASH (top-level comment).
+func TestParseStatementHashCommentOnly(t *testing.T) {
+	parseClean(t, "# top-level comment line\n")
+}
+
+// parsePipelineHeadStatement select / coproc.
+func TestParseSelectStatementBranches(t *testing.T) {
+	parseClean(t, "select x in a b c; do echo $x; break; done\n")
+}
+
+// parseFunctionLiteral with composite name + body shapes.
+func TestParseFunctionCompositeNameKeyword(t *testing.T) {
+	parseClean(t, "function ::my-fn { echo hi; }\n")
+}
+
+// parseDeclarationStatement assoc-array assignment edge cases.
+func TestParseDeclAssocArrayMulti(t *testing.T) {
+	parseClean(t, "typeset -A m=([k1]=v1 [k2]=v2)\n")
+}
+
+// parseCaseStatement with empty / fall-through clause body.
+func TestParseCaseEmptyBody(t *testing.T) {
+	parseClean(t, "case $x in a) ;; b) ;; *) ;; esac\n")
+}
+
+func TestParseCaseFallThroughSemiAmp(t *testing.T) {
+	parseClean(t, "case $x in a) echo a;& b) echo b;; esac\n")
+}
+
+func TestParseCaseFallThroughSemiPipe(t *testing.T) {
+	parseClean(t, "case $x in a) echo a;| b) echo b;; esac\n")
+}


### PR DESCRIPTION
## What
Replaces #1321 (closed for rebase conflict). Three test files target the long tail of partially-covered helpers identified by the merged coverprofile after #1320.

## Files
- \`pkg/katas/offset_line_col_test.go\`: single sweep that calls every \`offsetLineColZCxxxx\` duplicate (49 helpers) over the multi-line newline-step branch and the out-of-range guard.
- \`pkg/katas/helper_coverage_test.go\`: direct unit tests for the package-internal helpers that were sitting at 0% — \`ArgValueAfter\`, \`CommandIdentifier\`, \`isAlphaNumeric\`, \`isDevNull\` / \`getStringValueZC1053\`, \`zc1045StringHasSub\` / \`zc1045ConcatHasSub\`, \`zc1071SelfReferences\`, \`zc1796HasPgArg\`, \`zc1960IsGcloudSshCmd\`.
- \`pkg/parser/parser_coverage_test.go\`: 30+ additional inputs targeting \`parseSingleCommand\` head-prefix branches, \`parseDollarSpecialOp\` variants, \`parseFlaggedSubscript\` flag-tuples, \`parseProcessSubst\` read+write mix, \`drainSubscriptBody\` depth-tracking, \`parseDollarParen\` keyword-headed bodies, \`parseCaseStatement\` empty-body and \`;&\`/\`;|\` fall-through, \`parseDeclaration\` assoc-array shapes, composite-name function defs.

## Numbers
- Local Linux single-OS: 90.7% → 91.7%
- Codecov 3-OS union (delta ~3.6-3.8) expected: ~95.3-95.5%; iterate if below 95.5%

## Verification
- \`go test ./...\` clean
- \`golangci-lint run ./...\` 0 issues