### PR TITLE
test(katas): cover findSubscriptClose + isUnquotedGlob branches

### DIFF
--- a/pkg/katas/helper_coverage_test.go
+++ b/pkg/katas/helper_coverage_test.go
@@ -206,6 +206,56 @@ func TestZC1071SelfReferences(t *testing.T) {
 	}
 }
 
+// TestFindSubscriptClose exercises every quote-state and depth branch
+// of the subscript-end finder used by ZC1001 and friends.
+func TestFindSubscriptClose(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		open int
+		want int
+	}{
+		{"plain close", "[ab]", 0, 3},
+		{"nested", "[a[b]c]", 0, 6},
+		{"single-quoted body", "[a 'b]c' d]", 0, 10},
+		{"double-quoted body", "[a \"b]c\" d]", 0, 10},
+		{"escape inside double quote", "[a \"\\\"]\" b]", 0, 10},
+		{"newline aborts", "[abc\nx]", 0, -1},
+		{"no close at all", "[abc", 0, -1},
+	}
+	for _, tc := range cases {
+		if got := findSubscriptClose([]byte(tc.src), tc.open); got != tc.want {
+			t.Errorf("%s: got %d want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestIsUnquotedGlob exercises every node-type branch of the predicate
+// used by ZC1085 and friends.
+func TestIsUnquotedGlob(t *testing.T) {
+	if !isUnquotedGlob(&ast.SimpleCommand{Name: &ast.Identifier{Value: "["}}) {
+		t.Errorf("SimpleCommand[`[`]: expected true")
+	}
+	if isUnquotedGlob(&ast.SimpleCommand{Name: &ast.Identifier{Value: "echo"}}) {
+		t.Errorf("SimpleCommand[`echo`]: expected false")
+	}
+	if !isUnquotedGlob(&ast.IndexExpression{}) {
+		t.Errorf("IndexExpression: expected true")
+	}
+	if !isUnquotedGlob(&ast.PrefixExpression{Operator: "*"}) {
+		t.Errorf("PrefixExpression(*): expected true")
+	}
+	if !isUnquotedGlob(&ast.PrefixExpression{Operator: "?"}) {
+		t.Errorf("PrefixExpression(?): expected true")
+	}
+	if isUnquotedGlob(&ast.PrefixExpression{Operator: "$"}) {
+		t.Errorf("PrefixExpression($): expected false")
+	}
+	if isUnquotedGlob(&ast.IntegerLiteral{Value: 0}) {
+		t.Errorf("IntegerLiteral: expected false")
+	}
+}
+
 // TestCommandIdentifier covers the head-identifier helper used by
 // every Check entry point.
 func TestCommandIdentifier(t *testing.T) {


### PR DESCRIPTION
## What
Two predicate helpers each had their full branch coverage gap filled by direct unit tests.

- \`findSubscriptClose\`: 45.5% → 100%. Covers in-single-quote, in-double-quote, escape-inside-double, depth tracking, newline-abort, and no-close-found branches.
- \`isUnquotedGlob\`: 57.1% → 100%. Covers \`SimpleCommand\`-with-\`[\`-name, \`IndexExpression\`, \`PrefixExpression(*)\`, \`PrefixExpression(?)\`, the unrelated \`PrefixExpression($)\` negative, and \`IntegerLiteral\` fall-through.

## Numbers
Local Linux single-OS: 91.8% → 91.9%. Codecov 3-OS union should track upward from 95.0% to add margin above the floor.

## Verification
- \`go test ./...\` clean
- \`golangci-lint run ./...\` 0 issues