### PR TITLE
fix(codecov): badge gradient should peak at floor, not bottom

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,7 +19,13 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: 95..100                 # gold-tier label-green floor — anything below renders yellow/red
+  # range = badge-colour gradient. RED at the bottom, GREEN at the top.
+  # 80 = below the project-wide floor by a wide margin (red).
+  # 95 = at the floor, badge renders solid GREEN.
+  # The floor itself is enforced by `status.project.target` below; the
+  # range value is purely cosmetic but MUST keep the floor at the GREEN
+  # end so the badge does not render red while the status check passes.
+  range: 80..95
 
   status:
     project:


### PR DESCRIPTION
## Symptom
Badge renders **red** despite Codecov reporting **95.05%** project-wide and the status check passing.

## Root cause
\`codecov.yml\` had \`range: 95..100\`. Codecov interprets this as:
- bottom of range (95%) = RED
- top of range (100%) = GREEN

At the floor, coverage sits at the **bottom** of the gradient → red.

The status gate (\`status.project.target: 95%\`) is separate from the badge gradient. They disagreed: status said pass, badge said fail.

## Fix
Flip the gradient so 95% = GREEN end:
\`\`\`yaml
range: 80..95
\`\`\`
Below 80% renders bright red; above 95% caps at green. Floor itself unchanged (\`target: 95%\`).