### PR TITLE
fix: use reflect.Pointer over deprecated Ptr

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -658,7 +658,7 @@ func Walk(node Node, f WalkFn) {
 	// value hands every kata switch arm a nil receiver, so fields
 	// like Identifier.Value or SimpleCommand.Name panic immediately.
 	// Reflect is the cheapest reliable check for this case.
-	if v := reflect.ValueOf(node); v.Kind() == reflect.Ptr && v.IsNil() {
+	if v := reflect.ValueOf(node); v.Kind() == reflect.Pointer && v.IsNil() {
 		return
 	}
 	if !f(node) {

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -2539,7 +2539,7 @@ func walkZC1044(node ast.Node, isChecked bool, violations *[]Violation) {
 	if node == nil {
 		return
 	}
-	if v := reflect.ValueOf(node); v.Kind() == reflect.Ptr && v.IsNil() {
+	if v := reflect.ValueOf(node); v.Kind() == reflect.Pointer && v.IsNil() {
 		return
 	}
 	if walkZC1044Compound(node, isChecked, violations) {


### PR DESCRIPTION
What: replace the deprecated `reflect.Ptr` alias with `reflect.Pointer` in `pkg/ast/ast.go` and `pkg/katas/zc1000s.go`.

Why: the lint action pins golangci-lint to `latest`, which now resolves to v2.12.2. Its govet `inline` check flags `reflect.Ptr` as a constant that should be inlined to its canonical name `reflect.Pointer`. Same underlying value; the newer linter enforces the canonical spelling. This breaks the Lint gate on main and on every open PR, including the Dependabot action-bump PR #1335.

Fix: mechanical rename. Build, vet, and tests pass.
Severity: n/a (internal lint fix).