### PR TITLE
ci: bump setup-qemu v4.1.0 and typos v1.47.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           cosign-release: 'v2.4.3'
       - name: Set up QEMU (for cross-arch Docker builds)
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -24,4 +24,4 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.1.7
       - name: Check spelling
-        uses: crate-ci/typos@7b04f660f4ee4f048d18fd341887cf28dfbedfe2 # v1
+        uses: crate-ci/typos@f8a58b6b53f2279f71eb605f03a4ae4d10608f45 # v1


### PR DESCRIPTION
What: bump two GitHub Actions to the versions that the github-actions Dependabot group offered but that did not land on main.

- `docker/setup-qemu-action`: v4.0.0 to v4.1.0 (`release.yml`)
- `crate-ci/typos`: v1.46.1 to v1.47.0 (`typos.yml`)

Why: the grouped bump PR #1335 merged 12 of the 13 updates in the group. PR #1337 carried the full set of 13 but conflicted irrecoverably with main after #1335 and #1336 reflowed the same workflow lines, so it was closed. These two actions were the remainder. Both pins are 40-char commit SHAs with the human-readable version in a trailing comment, per the supply-chain policy.

Verification: each target SHA resolves to the stated tag and is strictly ahead of the SHA on main (setup-qemu ahead by 20 commits, typos ahead by 15).
Severity: n/a (CI dependency hygiene).