### PR TITLE
fix: guard typed-nil in ZC1069/ZC1053 walkers

### DIFF
--- a/.github/parser-corpus-manifest.txt
+++ b/.github/parser-corpus-manifest.txt
@@ -15,3 +15,10 @@ zsh-autocomplete	20f6c34f2027	https://github.com/marlonrichert/zsh-autocomplete.
 zsh-history-substring-search	14c8d2e0ffae	https://github.com/zsh-users/zsh-history-substring-search.git	*.zsh *.plugin.zsh
 zsh-utils	be71275c5050	https://github.com/belak/zsh-utils.git	*.zsh *.plugin.zsh
 zsh-vi-mode	08bd1c045204	https://github.com/jeffreytse/zsh-vi-mode.git	*.zsh *.plugin.zsh
+oh-my-zsh	c86ba78e1cba	https://github.com/ohmyzsh/ohmyzsh.git	*.zsh *.zsh-theme
+powerlevel10k	604f19a4426c	https://github.com/romkatv/powerlevel10k.git	*.zsh *.zsh-theme
+prezto	cff2d010f96f	https://github.com/sorin-ionescu/prezto.git	*.zsh
+spaceship-prompt	4ef1964fcebb	https://github.com/spaceship-prompt/spaceship-prompt.git	*.zsh *.zsh-theme
+zsh-autosuggestions	85919cd1ffa7	https://github.com/zsh-users/zsh-autosuggestions.git	*.zsh
+zsh-completions	6d21c2a70156	https://github.com/zsh-users/zsh-completions.git	*.zsh _*
+zsh-syntax-highlighting	1d85c69538dd	https://github.com/zsh-users/zsh-syntax-highlighting.git	*.zsh

--- a/.github/parser-corpus-manifest.txt
+++ b/.github/parser-corpus-manifest.txt
@@ -15,10 +15,10 @@ zsh-autocomplete	20f6c34f2027	https://github.com/marlonrichert/zsh-autocomplete.
 zsh-history-substring-search	14c8d2e0ffae	https://github.com/zsh-users/zsh-history-substring-search.git	*.zsh *.plugin.zsh
 zsh-utils	be71275c5050	https://github.com/belak/zsh-utils.git	*.zsh *.plugin.zsh
 zsh-vi-mode	08bd1c045204	https://github.com/jeffreytse/zsh-vi-mode.git	*.zsh *.plugin.zsh
-oh-my-zsh	c86ba78e1cba	https://github.com/ohmyzsh/ohmyzsh.git	*.zsh *.zsh-theme
-powerlevel10k	604f19a4426c	https://github.com/romkatv/powerlevel10k.git	*.zsh *.zsh-theme
-prezto	cff2d010f96f	https://github.com/sorin-ionescu/prezto.git	*.zsh
-spaceship-prompt	4ef1964fcebb	https://github.com/spaceship-prompt/spaceship-prompt.git	*.zsh *.zsh-theme
-zsh-autosuggestions	85919cd1ffa7	https://github.com/zsh-users/zsh-autosuggestions.git	*.zsh
-zsh-completions	6d21c2a70156	https://github.com/zsh-users/zsh-completions.git	*.zsh _*
-zsh-syntax-highlighting	1d85c69538dd	https://github.com/zsh-users/zsh-syntax-highlighting.git	*.zsh
+oh-my-zsh	c86ba78e2ff5c5a3e9282a84c0cc220dd3d5f253	https://github.com/ohmyzsh/ohmyzsh.git	*.zsh *.zsh-theme *.plugin.zsh
+powerlevel10k	604f19a9eaa18e76db2e60b8d446d5f879065f90	https://github.com/romkatv/powerlevel10k.git	*.zsh *.zsh-theme
+prezto	cff2d01871425b1b80710f8ec6a475c5a53145b4	https://github.com/sorin-ionescu/prezto.git	*.zsh *.zsh-theme
+spaceship-prompt	4ef1964a4e017c966e8b837d6ab47378403ecd02	https://github.com/spaceship-prompt/spaceship-prompt.git	*.zsh *.zsh-theme
+zsh-autosuggestions	85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5	https://github.com/zsh-users/zsh-autosuggestions.git	*.zsh
+zsh-completions	6d21c2a1de9cb88479a0e67df492da3f3bbdb054	https://github.com/zsh-users/zsh-completions.git	*.zsh
+zsh-syntax-highlighting	1d85c692615a25fe2293bdd44b34c217d5d2bf04	https://github.com/zsh-users/zsh-syntax-highlighting.git	*.zsh

--- a/.github/parser-corpus-manifest.txt
+++ b/.github/parser-corpus-manifest.txt
@@ -15,10 +15,3 @@ zsh-autocomplete	20f6c34f2027	https://github.com/marlonrichert/zsh-autocomplete.
 zsh-history-substring-search	14c8d2e0ffae	https://github.com/zsh-users/zsh-history-substring-search.git	*.zsh *.plugin.zsh
 zsh-utils	be71275c5050	https://github.com/belak/zsh-utils.git	*.zsh *.plugin.zsh
 zsh-vi-mode	08bd1c045204	https://github.com/jeffreytse/zsh-vi-mode.git	*.zsh *.plugin.zsh
-oh-my-zsh	c86ba78e2ff5c5a3e9282a84c0cc220dd3d5f253	https://github.com/ohmyzsh/ohmyzsh.git	*.zsh *.zsh-theme *.plugin.zsh
-powerlevel10k	604f19a9eaa18e76db2e60b8d446d5f879065f90	https://github.com/romkatv/powerlevel10k.git	*.zsh *.zsh-theme
-prezto	cff2d01871425b1b80710f8ec6a475c5a53145b4	https://github.com/sorin-ionescu/prezto.git	*.zsh *.zsh-theme
-spaceship-prompt	4ef1964a4e017c966e8b837d6ab47378403ecd02	https://github.com/spaceship-prompt/spaceship-prompt.git	*.zsh *.zsh-theme
-zsh-autosuggestions	85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5	https://github.com/zsh-users/zsh-autosuggestions.git	*.zsh
-zsh-completions	6d21c2a1de9cb88479a0e67df492da3f3bbdb054	https://github.com/zsh-users/zsh-completions.git	*.zsh
-zsh-syntax-highlighting	1d85c692615a25fe2293bdd44b34c217d5d2bf04	https://github.com/zsh-users/zsh-syntax-highlighting.git	*.zsh

--- a/pkg/katas/walker_typednil_regression_test.go
+++ b/pkg/katas/walker_typednil_regression_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+	"github.com/afadesigns/zshellcheck/pkg/lexer"
+	"github.com/afadesigns/zshellcheck/pkg/parser"
+)
+
+// TestWalkerTypedNilNoPanic guards against a regression where a kata's
+// hand-rolled AST walker descended into a typed-nil interface value (an
+// interface holding a nil concrete pointer, which is not == nil) and
+// dereferenced a field on the nil receiver, crashing the whole run.
+//
+// The ZC1069 and ZC1053 walkers both lacked the reflect-based typed-nil
+// guard that ast.Walk and the ZC1044 walker already carried. The inputs
+// below are reduced from real files in the integration corpora that
+// triggered SIGSEGV: prezto modules/terminal/init.zsh,
+// zsh-syntax-highlighting main-highlighter.zsh, and the canonical Zsh
+// Completion/Redhat/Command/_rpm. A panic here fails the test.
+func TestWalkerTypedNilNoPanic(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "if cond subshell-negation backslash-continued",
+			src:  "if [[ x == y ]] \\\n  && ( ! [[ -n \"$A\" ]] )\nthen\n  :\nfi\n",
+		},
+		{
+			name: "if cond subshell-negation single line",
+			src:  "if [[ $TERM == foo ]] && ( ! [[ -n \"$STY\" ]] ); then :; fi\n",
+		},
+		{
+			name: "nested subshell in if condition",
+			src:  "if ( ( ! [[ -n x ]] ) ); then local y=1; fi\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			l := lexer.New(tc.src)
+			p := parser.New(l)
+			program := p.ParseProgram()
+			// Drive the full registered-kata surface over every node,
+			// exactly as the CLI does. A typed-nil descent panics here.
+			ast.Walk(program, func(n ast.Node) bool {
+				_ = Registry.Check(n, nil)
+				return true
+			})
+		})
+	}
+}

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -3322,6 +3322,11 @@ func walkZC1053(node ast.Node, isSilenced bool, violations *[]Violation) {
 	if node == nil {
 		return
 	}
+	// Guard typed-nil interface values: a switch arm would otherwise
+	// receive a nil receiver and panic on the first field access.
+	if v := reflect.ValueOf(node); v.Kind() == reflect.Pointer && v.IsNil() {
+		return
+	}
 	switch n := node.(type) {
 	case *ast.BlockStatement:
 		for _, stmt := range n.Statements {
@@ -4632,6 +4637,12 @@ type zc1069Walker struct {
 
 func (w *zc1069Walker) walk(n ast.Node, inFunction bool) {
 	if n == nil {
+		return
+	}
+	// A Node interface can hold a concrete pointer type with a nil value
+	// underneath (typed nil); it does not compare equal to nil. Descending
+	// hands a switch arm a nil receiver and dereferencing a field panics.
+	if v := reflect.ValueOf(n); v.Kind() == reflect.Pointer && v.IsNil() {
 		return
 	}
 	w.recordIfBareLocal(n, inFunction)


### PR DESCRIPTION
## What

Two kata walkers crashed the whole linter with SIGSEGV on valid Zsh.

- `ZC1069` and `ZC1053` hand-rolled AST walkers (`pkg/katas/zc1000s.go`) guarded only against a plain `nil` node, not a **typed-nil** interface (an interface holding a nil concrete pointer, which is not `== nil`). A type-switch arm then received a nil receiver and the first field access panicked.
- Adds the same reflect-based typed-nil guard that `ast.Walk` (`pkg/ast/ast.go`) and the `ZC1044` walker already carry.
- New regression test drives the reduced crash inputs through the full registered-kata surface.

## Why

Found by sweeping the integration corpora with the freshly built binary. Three real files crashed:

- prezto `modules/terminal/init.zsh`
- zsh-syntax-highlighting `highlighters/main/main-highlighter.zsh`
- canonical Zsh `Completion/Redhat/Command/_rpm`

Minimal reproducer:

```zsh
if [[ x == y ]] && ( ! [[ -n "$A" ]] ); then : ; fi
```

A linter for a public ecosystem must never panic on input it lints. The root cause is fixed at the walker, not masked.

## Scope

This PR is the crash fix only. Expanding the parser-corpus manifest to the heavily-used integrations is deferred to a dedicated change: three of them (oh-my-zsh, powerlevel10k, zsh-syntax-highlighting) surface genuine parser gaps that must be fixed before they can be gated at zero errors.

## Verification

- `go test ./...` green; `gofmt`/`go vet` clean.
- Re-swept prezto / zsh-syntax-highlighting / canonical zsh post-fix: 0 crashes (were 1 each).
- Parser-corpus gate unchanged (12 pinned corpora, 0 errors).