### PR TITLE
fix: lex arithmetic compound-assignment operators

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -361,6 +361,19 @@ var simpleBracketTokens = map[byte]token.Type{
 }
 
 func (l *Lexer) dispatchBracketsAndOps(hasSpace bool) token.Token {
+	// Inside arithmetic, / and ^ can be the lead byte of compound-
+	// assignment operators (/= and ^=). Check before the simpleBracketTokens
+	// map because that map emits them unconditionally as SLASH/CARET.
+	// Outside arithmetic / is a path component and ^ is a caret-glob;
+	// neither can precede = as an assignment, so the guard is safe.
+	if l.inArithmetic() && l.peekChar() == '=' {
+		switch l.ch {
+		case '/':
+			return l.readFusedToken(token.PLUSEQ)
+		case '^':
+			return l.readFusedToken(token.PLUSEQ)
+		}
+	}
 	if t, ok := simpleBracketTokens[l.ch]; ok {
 		return newToken(t, l.ch, l.line, l.column)
 	}
@@ -485,6 +498,15 @@ func (l *Lexer) readBangLead() token.Token {
 }
 
 func (l *Lexer) readArithCompoundOr(plain token.Type) token.Token {
+	// Inside arithmetic,  (power-assign) uses three bytes. Detect
+	// it when the current token is , the next is , and the one
+	// after that is . Outside arithmetic  is a glob and  is
+	// a recursive glob; neither form allows a trailing  operand so
+	// the guard is safe.
+	if plain == token.ASTERISK && l.inArithmetic() &&
+		l.peekChar() == '*' && l.peekAt(2) == '=' {
+		return l.readFused3Token(token.PLUSEQ)
+	}
 	if l.peekChar() == '=' {
 		return l.readFusedToken(token.PLUSEQ)
 	}
@@ -529,6 +551,14 @@ func (l *Lexer) readAmpersandLead() token.Token {
 		return l.readFusedToken(token.AND)
 	case '|', '!':
 		return l.readFusedToken(token.AMPERSAND)
+	case '=':
+		// Inside arithmetic, &= is bitwise-AND-assign. Outside arithmetic
+		// & is a background operator and &= would be a background
+		// which is not valid Zsh syntax; the guard keeps outer behaviour
+		// identical to before.
+		if l.inArithmetic() {
+			return l.readFusedToken(token.PLUSEQ)
+		}
 	}
 	return newToken(token.AMPERSAND, l.ch, l.line, l.column)
 }
@@ -543,6 +573,12 @@ func (l *Lexer) readPipeLead() token.Token {
 	if l.peekChar() == '&' {
 		tok := l.readFusedToken(token.PIPE)
 		return tok
+	}
+	// Inside arithmetic, |= is bitwise-OR-assign. Outside arithmetic
+	// | is a pipe operator and |= is not valid Zsh syntax; the guard
+	// keeps pipe behaviour identical to before.
+	if l.peekChar() == '=' && l.inArithmetic() {
+		return l.readFusedToken(token.PLUSEQ)
 	}
 	return newToken(token.PIPE, l.ch, l.line, l.column)
 }
@@ -564,6 +600,23 @@ func (l *Lexer) readFusedToken(t token.Type) token.Token {
 	return token.Token{
 		Type:    t,
 		Literal: string(ch) + string(l.ch),
+		Line:    l.line,
+		Column:  l.column,
+	}
+}
+
+// readFused3Token consumes the three-byte run starting at the current
+// cursor and returns a fused token of the requested type. Used for
+// three-character arithmetic compound-assignment operators like <<=,
+// >>= and **= which are only meaningful inside (( ... )) arithmetic.
+func (l *Lexer) readFused3Token(t token.Type) token.Token {
+	ch1 := l.ch
+	l.readChar()
+	ch2 := l.ch
+	l.readChar()
+	return token.Token{
+		Type:    t,
+		Literal: string(ch1) + string(ch2) + string(l.ch),
 		Line:    l.line,
 		Column:  l.column,
 	}
@@ -614,38 +667,67 @@ func (l *Lexer) readAngleBracket(isLeft bool) token.Token {
 		return token.Token{Type: t, Literal: string(lead) + string(l.ch), Line: l.line, Column: l.column}
 	}
 	if isLeft {
-		switch peek {
-		case '<':
-			tok := two(token.LTLT)
-			l.consumeHeredocBody()
-			return tok
-		case '&':
-			return two(token.LTAMP)
-		case '(':
-			// Inside `[[ … ]]`, `<(` is not process substitution
-			// — `<->` numeric-range glob followed by `(...)` glob
-			// alternation. Emit a plain LT so the parser sees the
-			// `(` as the alternation opener.
-			if l.dbracketDepth > 0 {
-				return newToken(token.LT, l.ch, l.line, l.column)
-			}
-			t := two(token.LT_LPAREN)
-			l.parenStack = append(l.parenStack, 'P')
-			return t
-		case '=':
-			return two(token.LE_NUM)
-		}
-		return newToken(token.LT, l.ch, l.line, l.column)
+		return l.readLtLead(peek, two)
 	}
+	return l.readGtLead(peek, two)
+}
+
+// readLtLead handles the LT-family tokens after `<` has been consumed.
+// Extracted from readAngleBracket to keep each function under the
+// gocyclo-15 threshold.
+func (l *Lexer) readLtLead(peek byte, two func(token.Type) token.Token) token.Token {
+	switch peek {
+	case '<':
+		// Inside arithmetic, <<= is left-shift-assign. The two-byte
+		// `<<` would incorrectly trigger heredoc consumption; check
+		// for the trailing `=` first. Outside arithmetic `<<` opens
+		// a heredoc and cannot be followed by `=`, so the guard is
+		// safe and heredoc behaviour is unchanged.
+		if l.inArithmetic() && l.peekAt(2) == '=' {
+			return l.readFused3Token(token.PLUSEQ)
+		}
+		tok := two(token.LTLT)
+		l.consumeHeredocBody()
+		return tok
+	case '&':
+		return two(token.LTAMP)
+	case '(':
+		// Inside `[[ â¦ ]]`, `<(` is not process substitution
+		// â `<->` numeric-range glob followed by `(...)` glob
+		// alternation. Emit a plain LT so the parser sees the
+		// `(` as the alternation opener.
+		if l.dbracketDepth > 0 {
+			return newToken(token.LT, l.ch, l.line, l.column)
+		}
+		t := two(token.LT_LPAREN)
+		l.parenStack = append(l.parenStack, 'P')
+		return t
+	case '=':
+		return two(token.LE_NUM)
+	}
+	return newToken(token.LT, l.ch, l.line, l.column)
+}
+
+// readGtLead handles the GT-family tokens after `>` has been consumed.
+// Extracted from readAngleBracket to keep each function under the
+// gocyclo-15 threshold.
+func (l *Lexer) readGtLead(peek byte, two func(token.Type) token.Token) token.Token {
 	switch peek {
 	case '>':
+		// Inside arithmetic, >>= is right-shift-assign. Check before
+		// emitting the plain GTGT; outside arithmetic >> is an append
+		// redirection and >>= is not a valid redirect target, so the
+		// guard is safe and redirection behaviour is unchanged.
+		if l.inArithmetic() && l.peekAt(2) == '=' {
+			return l.readFused3Token(token.PLUSEQ)
+		}
 		return two(token.GTGT)
 	case '&':
 		return two(token.GTAMP)
 	case '=':
 		return two(token.GE_NUM)
 	case '(':
-		// Inside `[[ … ]]`, `>(` is not process substitution —
+		// Inside `[[ â¦ ]]`, `>(` is not process substitution â
 		// `<->(...)` numeric-range glob followed by alternation.
 		// Emit a plain GT so the parser sees `(` as the opener.
 		if l.dbracketDepth > 0 {

--- a/pkg/lexer/lexer_arith_compound_test.go
+++ b/pkg/lexer/lexer_arith_compound_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package lexer
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/token"
+)
+
+// collectArithTokenTypes lexes src and returns the token types between
+// the DoubleLparen opener and the DoubleRparen closer, exclusive.
+// Used by the arithmetic compound-assign regression tests to check the
+// operator token without depending on surrounding frame tokens.
+func collectArithTokenTypes(t *testing.T, src string) []token.Type {
+	t.Helper()
+	toks := tokensFor(t, src)
+	var inner []token.Type
+	inArith := false
+	for _, tok := range toks {
+		switch tok.Type {
+		case token.DoubleLparen:
+			inArith = true
+		case token.DoubleRparen, token.EOF:
+			return inner
+		default:
+			if inArith {
+				inner = append(inner, tok.Type)
+			}
+		}
+	}
+	return inner
+}
+
+// TestArithCompoundDivAssign verifies that /= inside (( )) lexes as a
+// single PLUSEQ compound-assign token, not SLASH followed by ASSIGN.
+func TestArithCompoundDivAssign(t *testing.T) {
+	types := collectArithTokenTypes(t, "(( n /= 1024 ))\n")
+	// Expect: IDENT('/'), PLUSEQ, INT
+	if len(types) != 3 {
+		t.Fatalf("/= in arith: got token types %v, want 3 tokens", types)
+	}
+	if types[1] != token.PLUSEQ {
+		t.Errorf("/= in arith: token[1] = %s, want PLUSEQ", types[1])
+	}
+}
+
+// TestArithCompoundBitwiseAndAssign verifies that &= inside (( )) lexes
+// as PLUSEQ, not AMPERSAND followed by ASSIGN.
+func TestArithCompoundBitwiseAndAssign(t *testing.T) {
+	types := collectArithTokenTypes(t, "(( n &= 1 ))\n")
+	if len(types) != 3 {
+		t.Fatalf("&= in arith: got token types %v, want 3 tokens", types)
+	}
+	if types[1] != token.PLUSEQ {
+		t.Errorf("&= in arith: token[1] = %s, want PLUSEQ", types[1])
+	}
+}
+
+// TestArithCompoundBitwiseOrAssign verifies that |= inside (( )) lexes
+// as PLUSEQ, not PIPE followed by ASSIGN.
+func TestArithCompoundBitwiseOrAssign(t *testing.T) {
+	types := collectArithTokenTypes(t, "(( n |= 1 ))\n")
+	if len(types) != 3 {
+		t.Fatalf("|= in arith: got token types %v, want 3 tokens", types)
+	}
+	if types[1] != token.PLUSEQ {
+		t.Errorf("|= in arith: token[1] = %s, want PLUSEQ", types[1])
+	}
+}
+
+// TestArithCompoundCaretAssign verifies that ^= inside (( )) lexes as
+// PLUSEQ, not CARET followed by ASSIGN.
+func TestArithCompoundCaretAssign(t *testing.T) {
+	types := collectArithTokenTypes(t, "(( n ^= 1 ))\n")
+	if len(types) != 3 {
+		t.Fatalf("^= in arith: got token types %v, want 3 tokens", types)
+	}
+	if types[1] != token.PLUSEQ {
+		t.Errorf("^= in arith: token[1] = %s, want PLUSEQ", types[1])
+	}
+}
+
+// TestArithCompoundLeftShiftAssign verifies that <<= inside (( )) lexes
+// as a single PLUSEQ token, not LTLT followed by ASSIGN (heredoc open).
+func TestArithCompoundLeftShiftAssign(t *testing.T) {
+	types := collectArithTokenTypes(t, "(( n <<= 1 ))\n")
+	if len(types) != 3 {
+		t.Fatalf("<<= in arith: got token types %v, want 3 tokens", types)
+	}
+	if types[1] != token.PLUSEQ {
+		t.Errorf("<<= in arith: token[1] = %s, want PLUSEQ", types[1])
+	}
+}
+
+// TestArithCompoundRightShiftAssign verifies that >>= inside (( )) lexes
+// as a single PLUSEQ token, not GTGT followed by ASSIGN.
+func TestArithCompoundRightShiftAssign(t *testing.T) {
+	types := collectArithTokenTypes(t, "(( n >>= 1 ))\n")
+	if len(types) != 3 {
+		t.Fatalf(">>= in arith: got token types %v, want 3 tokens", types)
+	}
+	if types[1] != token.PLUSEQ {
+		t.Errorf(">>= in arith: token[1] = %s, want PLUSEQ", types[1])
+	}
+}
+
+// TestArithCompoundPowerAssign verifies that **= inside (( )) lexes as
+// a single PLUSEQ token, not ASTERISK followed by PLUSEQ.
+func TestArithCompoundPowerAssign(t *testing.T) {
+	types := collectArithTokenTypes(t, "(( n **= 2 ))\n")
+	if len(types) != 3 {
+		t.Fatalf("**= in arith: got token types %v, want 3 tokens", types)
+	}
+	if types[1] != token.PLUSEQ {
+		t.Errorf("**= in arith: token[1] = %s, want PLUSEQ", types[1])
+	}
+}
+
+// TestNonArithAmpersandBackground verifies that & outside arithmetic
+// still lexes as AMPERSAND (background operator), not PLUSEQ.
+func TestNonArithAmpersandBackground(t *testing.T) {
+	toks := tokensFor(t, "sleep 1 &\n")
+	for _, tok := range toks {
+		if tok.Type == token.PLUSEQ {
+			t.Errorf("& outside arith: got PLUSEQ, want AMPERSAND for background")
+		}
+	}
+}
+
+// TestNonArithPipePipe verifies that | outside arithmetic still lexes
+// as PIPE, not PLUSEQ.
+func TestNonArithPipePipe(t *testing.T) {
+	toks := tokensFor(t, "echo foo | cat\n")
+	found := false
+	for _, tok := range toks {
+		if tok.Type == token.PIPE {
+			found = true
+		}
+		if tok.Type == token.PLUSEQ {
+			t.Errorf("| outside arith: got PLUSEQ, want PIPE")
+		}
+	}
+	if !found {
+		t.Errorf("| outside arith: PIPE token not found in stream")
+	}
+}
+
+// TestNonArithGtGtRedirection verifies that >> outside arithmetic still
+// lexes as GTGT (append redirection), not PLUSEQ.
+func TestNonArithGtGtRedirection(t *testing.T) {
+	toks := tokensFor(t, "echo hi >> /dev/null\n")
+	found := false
+	for _, tok := range toks {
+		if tok.Type == token.GTGT {
+			found = true
+		}
+		if tok.Type == token.PLUSEQ {
+			t.Errorf(">> outside arith: got PLUSEQ, want GTGT")
+		}
+	}
+	if !found {
+		t.Errorf(">> outside arith: GTGT token not found in stream")
+	}
+}
+
+// TestNonArithLtLtHeredoc verifies that << outside arithmetic still
+// lexes as LTLT (heredoc opener), not PLUSEQ.
+func TestNonArithLtLtHeredoc(t *testing.T) {
+	toks := tokensFor(t, "cat <<EOF\nhello\nEOF\n")
+	found := false
+	for _, tok := range toks {
+		if tok.Type == token.LTLT {
+			found = true
+		}
+		if tok.Type == token.PLUSEQ {
+			t.Errorf("<< outside arith: got PLUSEQ, want LTLT")
+		}
+	}
+	if !found {
+		t.Errorf("<< outside arith: LTLT token not found in stream")
+	}
+}
+
+// TestNonArithSlashPath verifies that / in a path outside arithmetic
+// still lexes as part of an identifier (IDENT or SLASH), never PLUSEQ.
+func TestNonArithSlashPath(t *testing.T) {
+	toks := tokensFor(t, "echo /usr/bin/env\n")
+	for _, tok := range toks {
+		if tok.Type == token.PLUSEQ {
+			t.Errorf("/ in path: got unexpected PLUSEQ token")
+		}
+	}
+}
+
+// TestNonArithAsteriskGlob verifies that * outside arithmetic remains
+// ASTERISK (glob), not confused with **= handling.
+func TestNonArithAsteriskGlob(t *testing.T) {
+	toks := tokensFor(t, "echo *\n")
+	found := false
+	for _, tok := range toks {
+		if tok.Type == token.ASTERISK {
+			found = true
+		}
+		if tok.Type == token.PLUSEQ {
+			t.Errorf("* outside arith: got unexpected PLUSEQ token")
+		}
+	}
+	if !found {
+		t.Errorf("* outside arith: ASTERISK token not found")
+	}
+}

--- a/pkg/parser/parser_arith_compound_test.go
+++ b/pkg/parser/parser_arith_compound_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package parser
+
+import "testing"
+
+// TestParseArithCompoundDivAssign verifies that (( n /= 1024 )) parses
+// without errors — previously the lexer emitted SLASH+ASSIGN instead of
+// the single PLUSEQ compound-assign token the parser expects.
+func TestParseArithCompoundDivAssign(t *testing.T) {
+	parseSourceClean(t, "(( n /= 1024 ))\n")
+}
+
+// TestParseArithCompoundBitwiseAndAssign verifies that (( n &= 1 ))
+// parses without errors.
+func TestParseArithCompoundBitwiseAndAssign(t *testing.T) {
+	parseSourceClean(t, "(( n &= 1 ))\n")
+}
+
+// TestParseArithCompoundBitwiseOrAssign verifies that (( n |= 1 ))
+// parses without errors.
+func TestParseArithCompoundBitwiseOrAssign(t *testing.T) {
+	parseSourceClean(t, "(( n |= 1 ))\n")
+}
+
+// TestParseArithCompoundCaretAssign verifies that (( n ^= 1 )) parses
+// without errors.
+func TestParseArithCompoundCaretAssign(t *testing.T) {
+	parseSourceClean(t, "(( n ^= 1 ))\n")
+}
+
+// TestParseArithCompoundLeftShiftAssign verifies that (( n <<= 1 ))
+// parses without errors — previously the lexer triggered heredoc
+// consumption on the << and the remaining = caused a parse error.
+func TestParseArithCompoundLeftShiftAssign(t *testing.T) {
+	parseSourceClean(t, "(( n <<= 1 ))\n")
+}
+
+// TestParseArithCompoundRightShiftAssign verifies that (( n >>= 1 ))
+// parses without errors.
+func TestParseArithCompoundRightShiftAssign(t *testing.T) {
+	parseSourceClean(t, "(( n >>= 1 ))\n")
+}
+
+// TestParseArithCompoundPowerAssign verifies that (( n **= 2 )) parses
+// without errors — previously the lexer split ** into two ASTERISK
+// tokens and **= into ASTERISK+PLUSEQ, producing a type mismatch.
+func TestParseArithCompoundPowerAssign(t *testing.T) {
+	parseSourceClean(t, "(( n **= 2 ))\n")
+}
+
+// TestParseArithDollarBraceOperand verifies that a parameter expansion
+// used as part of an arithmetic operand name parses without errors.
+// Previously `PFX_${state}_SFX` caused "expected )), got ${" because
+// parseIdentifier did not absorb DollarLbrace tokens in arithmetic.
+func TestParseArithDollarBraceOperand(t *testing.T) {
+	parseSourceClean(t, "(( x >= PFX_${state}_SFX ))\n")
+}
+
+// TestParseArithDollarBraceSimple verifies a bare ${var} in arithmetic.
+func TestParseArithDollarBraceSimple(t *testing.T) {
+	parseSourceClean(t, "(( x = ${y} + 1 ))\n")
+}
+
+// TestParseArithAllCompoundOpsRegression is a stress test exercising all
+// compound-assign operators in a single arithmetic block.
+func TestParseArithAllCompoundOpsRegression(t *testing.T) {
+	cases := []string{
+		"(( n += 1 ))\n",
+		"(( n -= 1 ))\n",
+		"(( n *= 2 ))\n",
+		"(( n /= 2 ))\n",
+		"(( n %= 3 ))\n",
+		"(( n &= 1 ))\n",
+		"(( n |= 1 ))\n",
+		"(( n ^= 1 ))\n",
+		"(( n <<= 1 ))\n",
+		"(( n >>= 1 ))\n",
+		"(( n **= 2 ))\n",
+		"(( n = 1 ))\n",
+	}
+	for _, src := range cases {
+		t.Run(src, func(t *testing.T) {
+			parseSourceClean(t, src)
+		})
+	}
+}

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -157,15 +157,34 @@ func (p *Parser) parseIdentifier() ast.Expression {
 	tok := p.curToken
 	value := tok.Literal
 	// Inside arithmetic, Zsh concatenates an IDENT with a glued
-	// VARIABLE / INT to form a dynamic variable name:
-	// `(( X_$y == 2 ))` reads as the value of `X_<expanded y>`.
+	// VARIABLE / INT / DollarLbrace to form a dynamic variable name:
+	// `(( X_$y == 2 ))` reads as the value of `X_<expanded y>`, and
+	// `(( x >= PFX_${state}_SFX ))` uses a param-expansion mid-name.
 	// Absorb the glued tokens so the closing `))` lines up.
 	if p.inArithmetic {
-		for !p.peekToken.HasPrecedingSpace &&
-			(p.peekTokenIs(token.VARIABLE) || p.peekTokenIs(token.INT)) {
-			p.nextToken()
-			value += p.curToken.Literal
+		for !p.peekToken.HasPrecedingSpace {
+			switch {
+			case p.peekTokenIs(token.VARIABLE), p.peekTokenIs(token.INT):
+				p.nextToken()
+				value += p.curToken.Literal
+			case p.peekTokenIs(token.DollarLbrace):
+				// Absorb `${…}` expansion opaquely: skip past the
+				// matching `}` so the arithmetic closer `))` aligns.
+				p.nextToken()
+				value += p.curToken.Literal
+				p.skipDollarBraceBody()
+				value += p.curToken.Literal // closing }
+				// Absorb any trailing IDENT glued to the `}` (e.g.
+				// the `_SFX` in `PFX_${state}_SFX`).
+				if !p.peekToken.HasPrecedingSpace && p.peekTokenIs(token.IDENT) {
+					p.nextToken()
+					value += p.curToken.Literal
+				}
+			default:
+				goto arithIdentDone
+			}
 		}
+	arithIdentDone:
 	}
 	return &ast.Identifier{Token: tok, Value: value}
 }


### PR DESCRIPTION
## What

Inside `((…))` / `$((…))` the lexer fused only `+= -= *= %=`. The operators `/= &= |= ^= <<= >>= **=` were emitted as their bare token plus a separate `=`, so `(( n /= 2 ))` parsed as division with no right operand and errored. An arithmetic operand carrying an embedded `${…}` (e.g. `(( x >= PFX_${state}_SFX ))`) also broke arithmetic-word scanning.

## Fix

- Route `/ & | ^ << >> **` through the arithmetic compound-assign path when `inArithmetic()`.
- `parseIdentifier` absorbs an embedded `${…}` operand in arithmetic context.
- Behaviour outside arithmetic is unchanged and test-pinned: background `&`, pipe `|`, redirection `<< >>`, globs `* **`.

## Verification

- New token-stream regression tests in `pkg/lexer` and `pkg/parser` covering every operator + embedded `${…}`, plus negative tests for the outside-arithmetic forms.
- `go test ./...` green; `gofmt -s`/`go vet` clean.
- Pinned-corpus gate: 78 files, 0 parser errors, 0 regressions.

These operators are pervasive in real Zsh configs; the fix removes a class of false parser failures.