### PR TITLE
feat: pin panic-free corpora and harden the sweep gate

### DIFF
--- a/.github/parser-corpus-manifest.txt
+++ b/.github/parser-corpus-manifest.txt
@@ -15,3 +15,10 @@ zsh-autocomplete	20f6c34f2027	https://github.com/marlonrichert/zsh-autocomplete.
 zsh-history-substring-search	14c8d2e0ffae	https://github.com/zsh-users/zsh-history-substring-search.git	*.zsh *.plugin.zsh
 zsh-utils	be71275c5050	https://github.com/belak/zsh-utils.git	*.zsh *.plugin.zsh
 zsh-vi-mode	08bd1c045204	https://github.com/jeffreytse/zsh-vi-mode.git	*.zsh *.plugin.zsh
+gitstatus	075baf6ecb19f58b09c9562f33c20b842e870961	https://github.com/romkatv/gitstatus.git	*.zsh *.plugin.zsh
+prezto-contrib	a05508a716cad6e45e90cb8b0f73c811cbd4438a	https://github.com/belak/prezto-contrib.git	*.zsh
+zsh-help	95cbc114078d8209730e38c72a6fa5859ca0773d	https://github.com/Freed-Wu/zsh-help.git	*.zsh *.plugin.zsh
+prezto	73ae7f11280adcc061c15ebb2f494954c2cc8a38	https://github.com/sorin-ionescu/prezto.git	*.zsh *.zsh-theme
+spaceship	19cf56d7bf8ca65b160c540dff35e8691da53ebf	https://github.com/spaceship-prompt/spaceship-prompt.git	*.zsh *.zsh-theme
+autosuggestions	85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5	https://github.com/zsh-users/zsh-autosuggestions.git	*.zsh
+completions	dbaeafd96c3fd9d84c8540f6d87c6b37c4c9173d	https://github.com/zsh-users/zsh-completions.git	*.zsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Seven upstream corpora pinned into the parser sweep matrix (12 → 19), each zero-parse-error and panic-free: gitstatus, prezto-contrib, prezto, spaceship-prompt, zsh-autosuggestions, zsh-completions, zsh-help.
+- Parser-corpus sweep now detects a linter crash per file (exit ≥ 2 or a Go stack trace) and fails the gate; a crash is never tolerated, even under `--update-baseline`.
+
+### Fixed
+- Parser: four Zsh word forms surfaced by the corpus sweep now parse cleanly — the arithmetic for-loop comma operator (`for ((i=0, j=1; i<j; i++, j--))`), concatenated `case` subjects (`case $a/$b in`, `case ${a}:${b} in`), the character-code prefix operator in arithmetic (`(( #name ))`, `(( ##c ))`), and function names that glue in a positional parameter (`function _$0_fmt()`).
+- Parser-corpus sweep: the glob list splits without pathname expansion, so a pattern such as `_*` reaches `find` literally instead of matching files in the repository root.
+
 ## [1.0.17] - 2026-04-30
 
 ### Added

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -23,6 +23,7 @@ The integrations the project tests most heavily and links from the docs.
 | :--- | ---: |
 | [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh) | 497 |
 | [prezto](https://github.com/sorin-ionescu/prezto) | 41 |
+| [prezto-contrib](https://github.com/belak/prezto-contrib) | 20 |
 | [zimfw](https://github.com/zimfw/zimfw) | 1 |
 | [zephyr](https://github.com/mattmc3/zephyr) | 21 |
 | [zsh-utils](https://github.com/belak/zsh-utils) | 5 |
@@ -52,6 +53,7 @@ The integrations the project tests most heavily and links from the docs.
 | [zsh-vi-mode](https://github.com/jeffreytse/zsh-vi-mode) | 2 |
 | [zsh-autocomplete](https://github.com/marlonrichert/zsh-autocomplete) | 3 |
 | [zsh-completions](https://github.com/zsh-users/zsh-completions) | 1 |
+| [zsh-help](https://github.com/Freed-Wu/zsh-help) | 1 |
 
 ## Prompts
 
@@ -60,15 +62,21 @@ The integrations the project tests most heavily and links from the docs.
 | [powerlevel10k](https://github.com/romkatv/powerlevel10k) | 16 |
 | [spaceship-prompt](https://github.com/spaceship-prompt/spaceship-prompt) | 119 |
 | [starship](https://github.com/starship/starship) | 1 |
+| [gitstatus](https://github.com/romkatv/gitstatus) | 2 |
 
 ## Roadmap — targeted next
 
-- [zsh-users/zsh](https://github.com/zsh-users/zsh) — `Functions/` and `Completion/` directories full of canonical Zsh.
-- [romkatv/zsh-bench](https://github.com/romkatv/zsh-bench)
-- [romkatv/gitstatus](https://github.com/romkatv/gitstatus)
-- [sorin-ionescu/prezto-contrib](https://github.com/sorin-ionescu/prezto-contrib)
-- [ohmyzsh-incubator](https://github.com/ohmyzsh-incubator)
-- [Freed-Wu/zsh-help](https://github.com/Freed-Wu/zsh-help)
+[gitstatus](https://github.com/romkatv/gitstatus),
+[prezto-contrib](https://github.com/belak/prezto-contrib), and
+[zsh-help](https://github.com/Freed-Wu/zsh-help) joined the pinned sweep matrix.
+
+Targeted next:
+
+- [zsh](https://github.com/zsh-users/zsh) — the reference shell. Its `Completion/`
+  tree leans on glob-pattern alternation (`(foo|bar)`), pending parser support.
+- [zsh-bench](https://github.com/romkatv/zsh-bench)
+
+To propose another corpus, follow [Adding an integration](#adding-an-integration).
 
 ## How the sweep runs
 

--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ The full catalog with file counts lives in [INTEGRATIONS.md](INTEGRATIONS.md).
 
 | Category | Examples |
 | :--- | :--- |
-| Frameworks | [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh), [prezto](https://github.com/sorin-ionescu/prezto), [zephyr](https://github.com/mattmc3/zephyr), [zimfw](https://github.com/zimfw/zimfw) |
+| Frameworks | [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh), [prezto](https://github.com/sorin-ionescu/prezto), [prezto-contrib](https://github.com/belak/prezto-contrib), [zephyr](https://github.com/mattmc3/zephyr), [zimfw](https://github.com/zimfw/zimfw) |
 | Plugin managers | [antidote](https://github.com/mattmc3/antidote), [zinit](https://github.com/zdharma-continuum/zinit) |
-| Plugins | [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting), [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions), [zsh-autocomplete](https://github.com/marlonrichert/zsh-autocomplete) |
-| Prompts | [powerlevel10k](https://github.com/romkatv/powerlevel10k), [spaceship-prompt](https://github.com/spaceship-prompt/spaceship-prompt), [starship](https://github.com/starship/starship) |
+| Plugins | [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting), [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions), [zsh-autocomplete](https://github.com/marlonrichert/zsh-autocomplete), [zsh-help](https://github.com/Freed-Wu/zsh-help) |
+| Prompts | [powerlevel10k](https://github.com/romkatv/powerlevel10k), [spaceship-prompt](https://github.com/spaceship-prompt/spaceship-prompt), [starship](https://github.com/starship/starship), [gitstatus](https://github.com/romkatv/gitstatus) |
 | Tooling | [fzf](https://github.com/junegunn/fzf), [fzf-tab](https://github.com/Aloxaf/fzf-tab), [fast-syntax-highlighting](https://github.com/zdharma-continuum/fast-syntax-highlighting) |
 
 ## Documentation

--- a/pkg/parser/parser_corpus_fixes_test.go
+++ b/pkg/parser/parser_corpus_fixes_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package parser
+
+import "testing"
+
+// Regression tests for parser gaps surfaced by the pinned integration
+// corpora. Each input is a minimal form of a construct that previously
+// produced a spurious parser error.
+
+func TestParseCaseSubjectConcatenation(t *testing.T) {
+	// A case subject is a shell word: it can concatenate expansions and
+	// literals with no separating space. Previously the parser stopped
+	// at the first `/` or `:` and reported the tail as unexpected.
+	cases := []string{
+		"case $state/$line[1] in\n  a) echo x ;;\nesac\n",
+		"case ${variant}:${${service#ping}:-4} in\n  4) echo v4 ;;\nesac\n",
+		"case $variant:$OSTYPE in\n  *) echo o ;;\nesac\n",
+		"case $x in\n  a) echo a ;;\nesac\n",
+	}
+	for _, src := range cases {
+		parseSourceClean(t, src)
+	}
+}
+
+func TestParseArithmeticCharCodeOperator(t *testing.T) {
+	// Inside `((…))`, `#name` / `##c` is the character-code prefix
+	// operator. A bare `#` keeps its positional-count meaning.
+	cases := []string{
+		"(( #disk_name ))\n",
+		"if (( #exts != 0 )); then echo y; fi\n",
+		"(( # > 0 ))\n",
+		"(( ! # ))\n",
+	}
+	for _, src := range cases {
+		parseSourceClean(t, src)
+	}
+}
+
+func TestParseFunctionNameWithPositional(t *testing.T) {
+	// A `function` name can glue in a positional parameter, e.g.
+	// `function _$0_fmt() { … }` (the lexer emits `$0` as DOLLAR + INT).
+	parseSourceClean(t, "function _$0_fmt() {\n  echo hi\n}\n")
+}

--- a/pkg/parser/parser_corpus_fixes_test.go
+++ b/pkg/parser/parser_corpus_fixes_test.go
@@ -2,7 +2,11 @@
 // Copyright the ZShellCheck contributors.
 package parser
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/lexer"
+)
 
 // Regression tests for parser gaps surfaced by the pinned integration
 // corpora. Each input is a minimal form of a construct that previously
@@ -41,4 +45,39 @@ func TestParseFunctionNameWithPositional(t *testing.T) {
 	// A `function` name can glue in a positional parameter, e.g.
 	// `function _$0_fmt() { … }` (the lexer emits `$0` as DOLLAR + INT).
 	parseSourceClean(t, "function _$0_fmt() {\n  echo hi\n}\n")
+}
+
+// Exercise every operand form the character-code prefix operator accepts,
+// plus the bare-`#` fallback when no operand is glued on.
+func TestParseArithmeticCharCodeOperandForms(t *testing.T) {
+	cases := []string{
+		"(( #name ))\n", // IDENT operand
+		"(( #$var ))\n", // VARIABLE operand
+		"(( ##c ))\n",   // nested HASH operand
+		"(( #${x} ))\n", // ${…} operand
+		"(( #0 ))\n",    // INT operand
+		"(( #>0 ))\n",   // no operand: bare `#` then `>` (fallback)
+		"(( # > 0 ))\n", // bare `#` with spacing
+	}
+	for _, src := range cases {
+		parseSourceClean(t, src)
+	}
+}
+
+// Malformed C-style for headers exercise the error-return paths of
+// parseArithForHeader (a missing `;` or closing `))`). The parser must
+// record an error and not panic; the program value is irrelevant here.
+func TestParseArithmeticForLoopMalformed(t *testing.T) {
+	cases := []string{
+		"for ((i=0 i<3; i++)); do :; done\n", // missing first `;`
+		"for ((i=0; i<3 i++)); do :; done\n", // missing second `;`
+		"for ((i=0; i<3; i++ do :; done\n",   // missing closing `))`
+	}
+	for _, src := range cases {
+		p := New(lexer.New(src))
+		p.ParseProgram()
+		if len(p.Errors()) == 0 {
+			t.Fatalf("expected a parser error for malformed for-header %q", src)
+		}
+	}
 }

--- a/pkg/parser/parser_corpus_fixes_test.go
+++ b/pkg/parser/parser_corpus_fixes_test.go
@@ -72,6 +72,9 @@ func TestParseArithmeticForLoopMalformed(t *testing.T) {
 		"for ((i=0 i<3; i++)); do :; done\n", // missing first `;`
 		"for ((i=0; i<3 i++)); do :; done\n", // missing second `;`
 		"for ((i=0; i<3; i++ do :; done\n",   // missing closing `))`
+		"for ((&&; i<3; i++)); do :; done\n", // init slot opens on a non-operand
+		"for ((i=0; &&; i++)); do :; done\n", // cond slot opens on a non-operand
+		"for ((i=0; i<3; &&)); do :; done\n", // post slot opens on a non-operand
 	}
 	for _, src := range cases {
 		p := New(lexer.New(src))

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -270,8 +270,34 @@ func (p *Parser) parseIntegerLiteral() ast.Expression {
 // for the count of positional arguments. Outside arithmetic HASH
 // opens a comment which the lexer skips before the parser sees it,
 // so this prefix only fires in arithmetic context.
+//
+// A `#` glued to an operand (`#name`, `##c`, `#$var`) is instead the
+// Zsh character-code prefix operator — the numeric code of the first
+// character of the operand. A bare `#` (space or operator follows, as
+// in `(( # > 0 ))` or `(( ! # ))`) keeps the positional-count meaning.
 func (p *Parser) parseHashSpecial() ast.Expression {
-	return &ast.Identifier{Token: p.curToken, Value: "#"}
+	hashTok := p.curToken
+	if p.inArithmetic && !p.peekToken.HasPrecedingSpace && p.hashOperandFollows() {
+		p.nextToken()
+		return &ast.PrefixExpression{
+			Token:    hashTok,
+			Operator: "#",
+			Right:    p.parseExpression(PREFIX),
+		}
+	}
+	return &ast.Identifier{Token: hashTok, Value: "#"}
+}
+
+// hashOperandFollows reports whether the token after a `#` can start an
+// arithmetic operand, marking `#` as the character-code prefix operator
+// rather than the bare positional-count parameter.
+func (p *Parser) hashOperandFollows() bool {
+	switch p.peekToken.Type {
+	case token.IDENT, token.VARIABLE, token.INT, token.HASH,
+		token.DollarLbrace, token.STRING:
+		return true
+	}
+	return false
 }
 
 // parseZshIntLiteral converts a Zsh integer literal to int64. Handles
@@ -986,6 +1012,14 @@ func (p *Parser) consumeCompositeFunctionName() {
 		case p.peekTokenIs(token.DollarLbrace):
 			p.nextToken()
 			p.skipDollarBraceBody()
+		case p.peekTokenIs(token.DOLLAR):
+			// Positional / special parameter glued into the name, e.g.
+			// `function _$0_fmt() { … }`. The lexer emits `$0` as DOLLAR
+			// + INT, so absorb the DOLLAR and its trailing digit operand.
+			p.nextToken()
+			if p.peekTokenIs(token.INT) && !p.peekToken.HasPrecedingSpace {
+				p.nextToken()
+			}
 		default:
 			return
 		}

--- a/pkg/parser/parser_for_extra_test.go
+++ b/pkg/parser/parser_for_extra_test.go
@@ -2,10 +2,41 @@
 // Copyright the ZShellCheck contributors.
 package parser
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+	"github.com/afadesigns/zshellcheck/pkg/lexer"
+)
 
 func TestParseForLoopArithmeticConditionOnly(t *testing.T) {
 	parseSourceClean(t, "for ((i=0; i<3; )) do echo $i; done\n")
+}
+
+func TestParseForLoopArithmeticCommaInit(t *testing.T) {
+	parseSourceClean(t, "for ((i=0, j=10; i<j; i++)) do echo $i; done\n")
+}
+
+func TestParseForLoopArithmeticCommaPost(t *testing.T) {
+	parseSourceClean(t, "for ((i=0; i<10; i++, j--)) do echo $i; done\n")
+}
+
+func TestParseForLoopArithmeticCommaBoth(t *testing.T) {
+	parseSourceClean(t, "for ((i=0, j=10; i<j; i++, j--)) do echo $i $j; done\n")
+}
+
+// The comma operator must chain into the slot expression, not be
+// dropped: stmt.Init has to carry both `i=0` and `j=10`.
+func TestParseForLoopArithmeticCommaChains(t *testing.T) {
+	prog := New(lexer.New("for ((i=0, j=10; i<j; )) do echo $i; done\n")).ParseProgram()
+	stmt, ok := prog.Statements[0].(*ast.ForLoopStatement)
+	if !ok {
+		t.Fatalf("Statements[0] is not *ast.ForLoopStatement; got %T", prog.Statements[0])
+	}
+	infix, ok := stmt.Init.(*ast.InfixExpression)
+	if !ok || infix.Operator != "," {
+		t.Fatalf("Init is not a comma-chained InfixExpression; got %T", stmt.Init)
+	}
 }
 
 func TestParseForLoopArithmeticInitOnly(t *testing.T) {

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -975,7 +975,13 @@ func (p *Parser) parseSubshellStatement() ast.Statement {
 func (p *Parser) parseCaseStatement() *ast.CaseStatement {
 	stmt := &ast.CaseStatement{Token: p.curToken}
 	p.nextToken()
-	stmt.Value = p.parseExpression(LOWEST)
+	// The case subject is a shell word, not a single expression: it can
+	// concatenate expansions and literals with no separating space
+	// (`case $state/$line[1] in`, `case ${a}:${b} in`). parseCommandWord
+	// glues those adjacent parts and stops at the space before `in`;
+	// parseExpression stopped at the first `/` or `:` and mis-reported
+	// the trailing parts as an unexpected token before `in`.
+	stmt.Value = p.parseCommandWord()
 	if !p.expectPeek(token.IN) {
 		return nil
 	}
@@ -1106,22 +1112,7 @@ func (p *Parser) parseForLoopStatement() *ast.ForLoopStatement {
 
 func (p *Parser) parseArithmeticForLoop(stmt *ast.ForLoopStatement) *ast.ForLoopStatement {
 	p.nextToken() // consume ((
-	if !p.parseArithSlot(&stmt.Init, token.SEMICOLON) {
-		return nil
-	}
-	if !p.expectPeek(token.SEMICOLON) {
-		return nil
-	}
-	if !p.parseArithSlot(&stmt.Condition, token.SEMICOLON) {
-		return nil
-	}
-	if !p.expectPeek(token.SEMICOLON) {
-		return nil
-	}
-	if !p.parseArithSlot(&stmt.Post, token.DoubleRparen) {
-		return nil
-	}
-	if !p.expectPeek(token.DoubleRparen) {
+	if !p.parseArithForHeader(stmt) {
 		return nil
 	}
 	if p.peekTokenIs(token.SEMICOLON) {
@@ -1145,6 +1136,33 @@ func (p *Parser) parseArithmeticForLoop(stmt *ast.ForLoopStatement) *ast.ForLoop
 	p.nextToken()
 	stmt.Body = p.parseBlockStatement(token.DONE)
 	return stmt
+}
+
+// parseArithForHeader parses the `init; cond; post ))` header of a
+// C-style arithmetic for loop. The slots run in arithmetic context so
+// the comma operator (`for ((i=0, j=1; i<j; i++, j--))`) chains as an
+// infix instead of breaking the expression loop. The flag is restored
+// on every exit path, including parse failures.
+func (p *Parser) parseArithForHeader(stmt *ast.ForLoopStatement) bool {
+	prevInArithmetic := p.inArithmetic
+	p.inArithmetic = true
+	defer func() { p.inArithmetic = prevInArithmetic }()
+	if !p.parseArithSlot(&stmt.Init, token.SEMICOLON) {
+		return false
+	}
+	if !p.expectPeek(token.SEMICOLON) {
+		return false
+	}
+	if !p.parseArithSlot(&stmt.Condition, token.SEMICOLON) {
+		return false
+	}
+	if !p.expectPeek(token.SEMICOLON) {
+		return false
+	}
+	if !p.parseArithSlot(&stmt.Post, token.DoubleRparen) {
+		return false
+	}
+	return p.expectPeek(token.DoubleRparen)
 }
 
 // parseArithSlot fills the optional init / cond / post slot of an

--- a/scripts/parser-corpus-sweep.sh
+++ b/scripts/parser-corpus-sweep.sh
@@ -82,12 +82,6 @@ list_files() {
     find "${dir}" -type f \( "${find_args[@]}" \) -print 2>/dev/null | sort
 }
 
-# Run zshellcheck on one file, return parser-error count.
-parser_errors_for() {
-    local f="$1"
-    "${BIN}" "$f" 2>&1 | grep -c "^Parser Error" || true
-}
-
 declare -A CURRENT
 declare -A BASELINE_MAP
 
@@ -102,17 +96,34 @@ total_files=0
 total_errors=0
 regressions=()
 improvements=()
+PANICS=()
 
 while IFS=$'\t' read -r name sha url glob_list; do
     [[ -z "${name}" || "${name}" == \#* ]] && continue
     fetch_corpus "${name}" "${sha}" "${url}" || exit 2
 
-    # shellcheck disable=SC2206
-    globs=( ${glob_list} )
+    # Split the glob list on spaces without pathname expansion. A
+    # bare `globs=( ${glob_list} )` would let a pattern such as `_*`
+    # match files in the repo root (e.g. `_typos.toml`) before it
+    # ever reaches find; read -a word-splits on IFS but never globs.
+    read -r -a globs <<< "${glob_list}"
     while IFS= read -r f; do
         [[ -z "${f}" ]] && continue
         rel="${name}/${f#${WORK_DIR}/${name}/}"
-        n=$(parser_errors_for "${f}")
+        # Run the binary once in the main shell (not a command-
+        # substitution subshell) so a detected panic can be recorded in
+        # the PANICS global. A panic exits >= 2 with a Go stack trace; it
+        # kills the whole run, so a corpus file that triggers one is a
+        # release-blocking regression. Parser errors are baselined and
+        # tolerated; panics never are.
+        set +e
+        out=$("${BIN}" "${f}" 2>&1)
+        rc=$?
+        set -e
+        if (( rc >= 2 )) || grep -qiE 'panic:|^goroutine [0-9]+ ' <<< "${out}"; then
+            PANICS+=("${rel} (exit ${rc})")
+        fi
+        n=$(grep -c "^Parser Error" <<< "${out}" || true)
         CURRENT["${rel}"]="${n}"
         total_files=$((total_files+1))
         total_errors=$((total_errors+n))
@@ -126,6 +137,16 @@ while IFS=$'\t' read -r name sha url glob_list; do
 done < "${MANIFEST}"
 
 echo "parser-corpus sweep: files=${total_files} parser_errors=${total_errors}"
+
+# A panic is always fatal — even in --update-baseline mode, so a crash
+# can never be silently baked into the baseline.
+if (( ${#PANICS[@]} > 0 )); then
+    echo "::error::parser-corpus gate: ${#PANICS[@]} file(s) panicked the linter — integrations must be panic-free"
+    for p in "${PANICS[@]}"; do
+        echo "  ! ${p}"
+    done
+    exit 2
+fi
 
 if (( UPDATE_BASELINE )); then
     {


### PR DESCRIPTION
## What

Grow the pinned parser-corpus sweep from 12 to 19 upstream corpora and harden the sweep gate so a linter crash can never slip through.

## Corpora added (each zero-parse-error and panic-free)

gitstatus, prezto-contrib, prezto, spaceship-prompt, zsh-autosuggestions, zsh-completions, zsh-help. The baseline stays empty.

## Gate hardening

- Detect a crash per file (exit >= 2 or a Go stack trace) and fail the gate. A crash is never tolerated, even under `--update-baseline`.
- Split the manifest glob list without pathname expansion so a pattern such as `_*` reaches `find` literally instead of matching repository-root files.

## Parser fixes (surfaced while vetting candidate corpora)

- arithmetic for-loop comma operator: `for ((i=0, j=1; i<j; i++, j--))`
- concatenated case subjects: `case $a/$b in`, `case ${a}:${b} in`
- character-code prefix operator in arithmetic: `(( #name ))`, `(( ##c ))`
- function names with a positional parameter: `function _$0_fmt()`

Regression tests cover every fix.

## Verification

- 19 corpora / 275 files: 0 parser errors, 0 panics (1100 invocations across lint, json, sarif, diff modes).
- `go test ./...` green; gate exit 0; baseline empty.

## Docs

README integration list, INTEGRATIONS.md, and CHANGELOG updated.