### PR TITLE
fix: ZC1043 false positive on env-var prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Parser: four Zsh word forms surfaced by the corpus sweep now parse cleanly — the arithmetic for-loop comma operator (`for ((i=0, j=1; i<j; i++, j--))`), concatenated `case` subjects (`case $a/$b in`, `case ${a}:${b} in`), the character-code prefix operator in arithmetic (`(( #name ))`, `(( ##c ))`), and function names that glue in a positional parameter (`function _$0_fmt()`).
 - Parser-corpus sweep: the glob list splits without pathname expansion, so a pattern such as `_*` reaches `find` literally instead of matching files in the repository root.
+- ZC1043 no longer flags an inline env-var prefix (`DEBUG=true echo foo`) as a missing-`local` global — the assignment is scoped to the following command, not a persistent global. A standalone `DEBUG=true` (or one ended by `;`) is still flagged. Reported by @eeweegh. (#1332)
 
 ## [1.0.17] - 2026-04-30
 

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -98,6 +98,11 @@ func (rs *ReturnStatement) String() string {
 type ExpressionStatement struct {
 	Token      token.Token // the first token of the expression
 	Expression Expression  // expression node
+	// EnvPrefix marks an assignment that prefixes a command on the same
+	// line (Zsh inline env-var prefix, e.g. `DEBUG=true echo foo`). Such
+	// an assignment is scoped to the following command, not a persistent
+	// global, so scope-oriented katas (ZC1043) skip it.
+	EnvPrefix bool
 }
 
 func (es *ExpressionStatement) statementNode()                {}

--- a/pkg/katas/katatests/zc1000s_test.go
+++ b/pkg/katas/katatests/zc1000s_test.go
@@ -1444,6 +1444,27 @@ func TestZC1043(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Regression for #1332 — an inline env-var prefix scopes the
+			// assignment to the following command; it is not a global.
+			name:     "env-prefix on a command is not flagged",
+			input:    "myfunc() { DEBUG=true echo \"foo\"; }",
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "multiple env-prefix assignments are not flagged",
+			input:    "myfunc() { A=1 B=2 mycmd; }",
+			expected: []katas.Violation{},
+		},
+		{
+			// A `;` ends the assignment, so it is a standalone global
+			// and must still be flagged.
+			name:  "semicolon-separated assignment is still flagged",
+			input: "myfunc() { DEBUG=true; echo foo; }",
+			expected: []katas.Violation{
+				{KataID: "ZC1043", Message: "Variable 'DEBUG' is assigned without 'local'. It will be global. Use `local DEBUG=true`.", Line: 1, Column: 12},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -2486,6 +2486,12 @@ func zc1043UnscopedAssign(n ast.Node, locals map[string]bool) (Violation, bool) 
 	if !ok {
 		return Violation{}, false
 	}
+	// A Zsh inline env-var prefix (`DEBUG=true echo foo`) scopes the
+	// assignment to the following command — it is not a persistent
+	// global, so it must not be flagged.
+	if exprStmt.EnvPrefix {
+		return Violation{}, false
+	}
 	assign, ok := exprStmt.Expression.(*ast.InfixExpression)
 	if !ok || assign.Operator != "=" {
 		return Violation{}, false

--- a/pkg/parser/parser_for_extra_test.go
+++ b/pkg/parser/parser_for_extra_test.go
@@ -9,6 +9,33 @@ import (
 	"github.com/afadesigns/zshellcheck/pkg/lexer"
 )
 
+// TestParseEnvPrefixAssignmentFlag locks the #1332 fix: an assignment
+// that prefixes a command on the same line is marked EnvPrefix, while a
+// standalone assignment (or one ended by `;`) is not.
+func TestParseEnvPrefixAssignmentFlag(t *testing.T) {
+	cases := []struct {
+		src  string
+		want bool
+	}{
+		{"DEBUG=true echo foo\n", true},   // inline env-var prefix
+		{"x+=1 mycmd\n", true},            // `+=` prefix form
+		{"DEBUG=true\n", false},           // standalone assignment
+		{"DEBUG=true; echo foo\n", false}, // `;` ends the assignment
+		{"echo foo\n", false},             // not an assignment at all
+		{"a[0]=1 echo foo\n", false},      // indexed LHS is not a plain name
+	}
+	for _, tc := range cases {
+		prog := New(lexer.New(tc.src)).ParseProgram()
+		es, ok := prog.Statements[0].(*ast.ExpressionStatement)
+		if !ok {
+			t.Fatalf("%q: statement 0 is %T, want *ast.ExpressionStatement", tc.src, prog.Statements[0])
+		}
+		if es.EnvPrefix != tc.want {
+			t.Errorf("%q: EnvPrefix = %v, want %v", tc.src, es.EnvPrefix, tc.want)
+		}
+	}
+}
+
 func TestParseForLoopArithmeticConditionOnly(t *testing.T) {
 	parseSourceClean(t, "for ((i=0; i<3; )) do echo $i; done\n")
 }

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -697,11 +697,30 @@ func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
 func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 	stmt := &ast.ExpressionStatement{Token: p.curToken}
 	stmt.Expression = p.parseExpression(LOWEST)
+	stmt.EnvPrefix = p.isEnvPrefixAssignment(stmt.Expression)
 
 	if p.peekTokenIs(token.SEMICOLON) {
 		p.nextToken()
 	}
 	return stmt
+}
+
+// isEnvPrefixAssignment reports whether the just-parsed expression is a
+// bare `NAME=value` assignment that prefixes a command on the same line
+// — the Zsh inline env-var prefix `NAME=value cmd …`. The parser does
+// not fuse the prefix into the command (the command parses as the next
+// statement); this flag lets scope-oriented katas tell a command-scoped
+// prefix from a persistent global assignment. A trailing `;`, newline,
+// or block close means it is a standalone assignment, not a prefix.
+func (p *Parser) isEnvPrefixAssignment(expr ast.Expression) bool {
+	inf, ok := expr.(*ast.InfixExpression)
+	if !ok || (inf.Operator != "=" && inf.Operator != "+=") {
+		return false
+	}
+	if _, ok := inf.Left.(*ast.Identifier); !ok {
+		return false
+	}
+	return p.peekToken.Line == p.curToken.Line && p.peekStartsArgPrefix()
 }
 
 func (p *Parser) parseIfStatement() *ast.IfStatement {


### PR DESCRIPTION
## What

`DEBUG=true echo "foo"` is a Zsh inline environment-variable prefix — the assignment is scoped to that single command, not a persistent global — but ZC1043 flagged it as a missing-`local` global.

## Fix

The parser marks an assignment that prefixes a command on the same line (`ExpressionStatement.EnvPrefix`), and ZC1043 skips those. A standalone `DEBUG=true`, or one ended by `;`, is still flagged. The trailing command still parses and lints as usual.

## Tests

- ZC1043: env-prefix (single + multiple) not flagged; standalone and `;`-separated still flagged.
- Parser: `EnvPrefix` set/unset across prefix, `+=`, standalone, `;`, non-assignment, and indexed-LHS forms.

Reported by @eeweegh.

Closes #1332.