### PR TITLE
docs: static release badge avoids shields error

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/afadesigns/zshellcheck?color=blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+<!-- release -->[![Release](https://img.shields.io/badge/release-v1.0.17-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)<!-- /release -->
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-137%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)


### PR DESCRIPTION
## Problem

The README release badge used `img.shields.io/github/v/release/afadesigns/zshellcheck`, which intermittently renders **unable to select next github token from pool** when shields.io's GitHub API token pool is exhausted.

## Fix

Replace it with a static shields `/badge/` (`release-v1.0.17-blue`) wrapped in a `<!-- release -->…<!-- /release -->` marker, linking to the latest release. Static `/badge/` endpoints never call the GitHub API, so the error cannot recur. The marker is bumped to the new tag at release time alongside `version.go`.