### PR TITLE
docs: fix release badge rendering as literal text

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-<!-- release -->[![Release](https://img.shields.io/badge/release-v1.0.17-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)<!-- /release -->
+[![Release](https://img.shields.io/badge/release-v1.0.17-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-137%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)


### PR DESCRIPTION
The previous change wrapped the release badge in an inline `<!-- release -->` comment. In GitHub Markdown an inline HTML comment starts an HTML block that suppresses Markdown parsing for the line, so the badge rendered as raw link text instead of an image.

Drop the comment markers. The plain static shields `/badge/release-v1.0.17-blue` line now renders like every other badge in the row.