### PR TITLE
fix: release v1.2.1 parser and lexer corpus fixes

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -26,7 +26,7 @@ antidote/tests/bin/init_fixtures.zsh	ZC1004	1
 antidote/tests/bin/init_fixtures.zsh	ZC1016	1
 antidote/tests/bin/init_fixtures.zsh	ZC1043	3
 antidote/tests/bin/init_fixtures.zsh	ZC1097	3
-antidote/tests/bin/test_fzf_opts_manual.zsh	ZC1017	1
+antidote/tests/bin/test_fzf_opts_manual.zsh	ZC1017	2
 antidote/tests/bin/test_fzf_opts_manual.zsh	ZC1075	2
 antidote/tests/__init__.zsh	ZC1031	1
 antidote/tests/testdata/real/.zsh_plugins.zsh	ZC1001	2
@@ -914,7 +914,6 @@ zinit/zinit-additional.zsh	ZC1877	1
 zinit/zinit-additional.zsh	ZC1916	1
 zinit/zinit-autoload.zsh	ZC1001	16
 zinit/zinit-autoload.zsh	ZC1002	2
-zinit/zinit-autoload.zsh	ZC1010	1
 zinit/zinit-autoload.zsh	ZC1012	2
 zinit/zinit-autoload.zsh	ZC1015	2
 zinit/zinit-autoload.zsh	ZC1017	2
@@ -925,7 +924,6 @@ zinit/zinit-autoload.zsh	ZC1046	5
 zinit/zinit-autoload.zsh	ZC1049	7
 zinit/zinit-autoload.zsh	ZC1053	1
 zinit/zinit-autoload.zsh	ZC1064	1
-zinit/zinit-autoload.zsh	ZC1065	1
 zinit/zinit-autoload.zsh	ZC1071	1
 zinit/zinit-autoload.zsh	ZC1073	1
 zinit/zinit-autoload.zsh	ZC1075	40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-06-04
+
+### Fixed
+- Parser and lexer: four more real-world Zsh constructs that previously failed to parse, each confirmed valid by `zsh -n`, parsing with zero errors across the corpus sweep, and producing no false-positive drift.
+  - A command substitution whose body is a subshell with a leading space (`$( (cmd) )`) is no longer mistaken for arithmetic; the inner subshell's `)` is distinguished from the substitution's close.
+  - A `case … esac` or a `{ } always { }` try block inside a command substitution (`$( case … esac )`) now parses; the body drain follows the `case` past its own `esac` and honours the `always` continuation.
+  - Consecutive subshells separated only by a newline (`(a)⏎(b)`) no longer drop the second subshell; the linter had silently skipped scanning it.
+  - A double-quoted string whose `${…}` body contains an escaped `\${` no longer swallows its own closing quote. The lexer counted the lone `{` as opening a nested expansion; it now decrements on `}` only, matching Zsh, which closes the expansion at the next unescaped `}`. This unblocks Powerlevel10k's `p10k.zsh`.
+
 ## [1.2.0] - 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.2.0-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.2.1-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-137%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)

--- a/pkg/lexer/edge_test.go
+++ b/pkg/lexer/edge_test.go
@@ -70,6 +70,20 @@ func TestStringEscapedDollarBraceDoesNotSwallow(t *testing.T) {
 	}
 }
 
+// The nested-quote skip inside `${…}` covers a `'…'` span, a `"…"`
+// span with a `\"` escape, and an unterminated span that runs to EOF.
+// A brace hidden in any of these must not unbalance the expansion.
+func TestStringNestedQuoteSpansInsideDollarBrace(t *testing.T) {
+	for _, src := range []string{
+		"echo \"${x:-'a}b'}\"\nnext=1\n",       // single-quoted span hides `}`
+		"echo \"${x:-\"a\\\"}b\"}\"\nnext=2\n", // double-quoted span with \" and `}`
+		"echo \"${x:-\"unterminated}",          // nested span runs to EOF
+	} {
+		// Must not panic or loop; tokensFor caps runaway lexing.
+		tokensFor(t, src)
+	}
+}
+
 // A nested `${…${…}…}` must still balance: the inner `${` opener is
 // counted and its `}` decrements, so the outer expansion closes
 // correctly. Guards against over-correcting the #1377 fix.

--- a/pkg/lexer/edge_test.go
+++ b/pkg/lexer/edge_test.go
@@ -2,7 +2,11 @@
 // Copyright the ZShellCheck contributors.
 package lexer
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/token"
+)
 
 func TestBackslashEscapeIllegalChar(t *testing.T) {
 	tokensFor(t, "echo \\\x01\n")
@@ -30,6 +34,56 @@ func TestStringDoubleQuoteUnterminated(t *testing.T) {
 
 func TestStringSingleQuoteUnterminated(t *testing.T) {
 	tokensFor(t, "echo 'never ends\n")
+}
+
+// A double-quoted string whose `${…}` body contains an escaped `\${`
+// must not let the lexer count the following `{` as opening a nested
+// expansion. zsh closes the expansion at the next unescaped `}` and a
+// lone `{` is literal, so the closing `"` must terminate the string.
+// Before the fix the inflated brace depth swallowed the quote and the
+// rest of the file cascaded into one giant string (powerlevel10k
+// p10k.zsh line 6786). Issue #1377.
+func TestStringEscapedDollarBraceDoesNotSwallow(t *testing.T) {
+	for _, src := range []string{
+		"echo \"${(%):-a\\${b}\"\nnext=1\n",
+		"echo \"${x:-a{b}\"\nnext=2\n",
+		"echo \"${(%):-  %3F'(( ! \\${+functions[p10k]\\} )) || x'%f >>! $V}\"\nnext=3\n",
+	} {
+		toks := tokensFor(t, src)
+		var sawString, sawNext bool
+		for _, tk := range toks {
+			if tk.Type == token.STRING {
+				sawString = true
+			}
+			if tk.Type == token.IDENT && (tk.Literal == "next") {
+				sawNext = true
+			}
+		}
+		if !sawString {
+			t.Errorf("no STRING token for %q", src)
+		}
+		// The code after the string must survive — if the closing quote
+		// were swallowed, `next=N` would be lexed as string content.
+		if !sawNext {
+			t.Errorf("trailing assignment swallowed (quote not closed) for %q", src)
+		}
+	}
+}
+
+// A nested `${…${…}…}` must still balance: the inner `${` opener is
+// counted and its `}` decrements, so the outer expansion closes
+// correctly. Guards against over-correcting the #1377 fix.
+func TestStringNestedDollarBraceStillBalances(t *testing.T) {
+	toks := tokensFor(t, "echo \"${x:-${y:-z}}\"\nafter=1\n")
+	var sawAfter bool
+	for _, tk := range toks {
+		if tk.Type == token.IDENT && tk.Literal == "after" {
+			sawAfter = true
+		}
+	}
+	if !sawAfter {
+		t.Error("nested ${…${…}…} mis-closed: trailing code swallowed")
+	}
 }
 
 func TestPeekAtBeyondEnd(t *testing.T) {

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -1150,6 +1150,9 @@ func (l *Lexer) readStringFlavour(quote byte, honourEscapes bool) string {
 		if honourEscapes && l.absorbEmbeddedDollarParen() {
 			continue
 		}
+		if l.absorbNestedQuoteInBrace(braceDepth) {
+			continue
+		}
 		l.trackBraceDepth(&braceDepth)
 	}
 	return l.sliceClosedString(position)
@@ -1212,6 +1215,34 @@ func (l *Lexer) absorbStringEscape(honourEscapes bool) bool {
 	return true
 }
 
+// absorbNestedQuoteInBrace skips a quoted span nested inside a `${…}`
+// expansion (braceDepth > 0) so that braces inside it never reach the
+// depth tracker. zsh treats a `${…}` body's `"…"` / `'…'` as data; its
+// braces — including escaped `\${` / `\}` forms — must not open or
+// close the expansion. Without this, the unbalanced `'…\${+f[p10k]\}…'`
+// span in powerlevel10k's p10k.zsh inflated the depth and swallowed the
+// string's closing quote, cascading every later string. A double-quoted
+// span honours `\` escapes; a single-quoted span is literal. Issue #1377.
+func (l *Lexer) absorbNestedQuoteInBrace(braceDepth int) bool {
+	if braceDepth == 0 || (l.ch != '"' && l.ch != '\'') {
+		return false
+	}
+	q := l.ch
+	for {
+		l.readChar()
+		if l.ch == 0 {
+			return true
+		}
+		if q == '"' && l.ch == '\\' {
+			l.readChar()
+			continue
+		}
+		if l.ch == q {
+			return true
+		}
+	}
+}
+
 func (l *Lexer) absorbDollarBraceOpen(honourEscapes bool, braceDepth *int) bool {
 	if !honourEscapes || l.ch != '$' || l.peekChar() != '{' {
 		return false
@@ -1223,14 +1254,12 @@ func (l *Lexer) absorbDollarBraceOpen(honourEscapes bool, braceDepth *int) bool 
 
 func (l *Lexer) trackBraceDepth(braceDepth *int) {
 	// Inside a `${…}` only a nested `${` increases nesting, and that
-	// open is already counted by absorbDollarBraceOpen. A bare `{` is
-	// a literal: zsh closes the expansion at the next unescaped `}`
-	// (`"${x:-a{b}"` yields the value of `x`, the lone `{` is data).
-	// Counting a lone `{` here inflated the depth so the closing `}`
-	// never balanced — most visibly the `{` left behind after an
-	// escaped `\${` (`"${(%):-a\${b}"`) — and the string then swallowed
-	// its own closing quote, cascading every later string. Decrement
-	// on `}` only. Issue #1377.
+	// open is counted by absorbDollarBraceOpen. A bare `{` is literal
+	// data — zsh closes the expansion at the next unescaped `}`
+	// (`"${x:-a{b}"` is the value of `x`, the `{` is a literal byte) —
+	// so a lone `{` must not increment the depth. Braces hidden inside
+	// a nested quoted span are skipped earlier by absorbNestedQuoteInBrace.
+	// Decrement on `}` only.
 	if *braceDepth > 0 && l.ch == '}' {
 		*braceDepth--
 	}

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -849,7 +849,7 @@ func extractHeredocDelim(input string, pos int) (string, int) {
 		pos++
 	}
 	start := pos
-	for pos < len(input) && (isWordByte(input[pos])) {
+	for pos < len(input) && isWordByte(input[pos]) {
 		pos++
 	}
 	if pos == start {

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -1222,13 +1222,16 @@ func (l *Lexer) absorbDollarBraceOpen(honourEscapes bool, braceDepth *int) bool 
 }
 
 func (l *Lexer) trackBraceDepth(braceDepth *int) {
-	if *braceDepth == 0 {
-		return
-	}
-	switch l.ch {
-	case '{':
-		*braceDepth++
-	case '}':
+	// Inside a `${…}` only a nested `${` increases nesting, and that
+	// open is already counted by absorbDollarBraceOpen. A bare `{` is
+	// a literal: zsh closes the expansion at the next unescaped `}`
+	// (`"${x:-a{b}"` yields the value of `x`, the lone `{` is data).
+	// Counting a lone `{` here inflated the depth so the closing `}`
+	// never balanced — most visibly the `{` left behind after an
+	// escaped `\${` (`"${(%):-a\${b}"`) — and the string then swallowed
+	// its own closing quote, cascading every later string. Decrement
+	// on `}` only. Issue #1377.
+	if *braceDepth > 0 && l.ch == '}' {
 		*braceDepth--
 	}
 }

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -383,6 +383,18 @@ func TestParseCommandSubOfSubshell(t *testing.T) {
 	parseSourceClean(t, "y=$( ( echo x ) | cat )\n")
 }
 
+// A `case … esac` or a `{ } always { }` try block inside a command
+// substitution `$( … )` must parse. The body drain now honours
+// consumedBraceTerminator (a `case` advances past its own `esac`) and
+// the `always` continuation, with `;` and newline separators. Issue #1359.
+func TestParseCaseAndAlwaysInCommandSub(t *testing.T) {
+	parseSourceClean(t, "v=$( case x in a) : ;; esac )\n")
+	parseSourceClean(t, "echo $( case x in a) : ;; esac )\n")
+	parseSourceClean(t, "v=$( { : } always { : } )\n")
+	parseSourceClean(t, "n=$( case x in a) : ;; esac; echo two )\n")
+	parseSourceClean(t, "p=$( case x in a) : ;; esac\n  echo two )\n")
+}
+
 func TestParseSelectStatement(t *testing.T) {
 	parseSourceClean(t, "select opt in a b c; do echo $opt; break; done\n")
 }

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -127,6 +127,39 @@ func TestParseArrayAssignmentsInsideSubshellNewlineSeparated(t *testing.T) {
 	parseSourceClean(t, "(\narr=( \"x\" )\nlist=( \"y\" )\n)\n")
 }
 
+// Two top-level subshells separated only by a newline. The newline
+// emits no token, so parseSubshellStatement's trailing nextToken plus
+// the program loop's nextToken double-advanced and swallowed the
+// second `(`. A `;` between them masked the bug by supplying a
+// throwaway token. parseSubshellStatement now leaves curToken on its
+// `)` and signals consumedParenTerminator, mirroring `$(…)`. Issue
+// #1355.
+func TestParseConsecutiveSubshellsNewlineSeparated(t *testing.T) {
+	parseSourceClean(t, "(printf a)\n(printf b)\n")
+	parseSourceClean(t, "(printf a)\n(printf b)\n(printf c)\n")
+	parseSourceClean(t, "(cd /var && ls)\n(echo two)\n")
+}
+
+// A subshell may head a pipeline / logical chain. Leaving curToken on
+// the `)` must not regress the tail attach.
+func TestParseSubshellPipelineAndLogicalTail(t *testing.T) {
+	parseSourceClean(t, "(a) | cat\n")
+	parseSourceClean(t, "(a) && (b)\n")
+	parseSourceClean(t, "(a) > /dev/null\n")
+}
+
+// A final `case … esac` inside a subshell advances past `esac` onto
+// the subshell's `)` and sets consumedBraceTerminator. That signal
+// leaks through parseBlockStatement's terminator break;
+// parseSubshellStatement must clear it when claiming its `)`, or the
+// program loop skips the advance and the `)` parses as a bare
+// statement. Guards the #1355 fix against the case interaction.
+func TestParseCaseAsFinalSubshellStatement(t *testing.T) {
+	parseSourceClean(t, "( case $x in a) :;; esac )\n")
+	parseSourceClean(t, "( case $x { a) :;; } )\n")
+	parseSourceClean(t, "case $y in z) (a)\n(b);; esac\n")
+}
+
 // `${#}` is the special parameter "count of positional args", not a
 // length operator over a missing subject. Without RBRACE in the
 // subjectIsEmpty set, parseArrayAccess advanced past `#` looking for

--- a/pkg/parser/parser_case_test.go
+++ b/pkg/parser/parser_case_test.go
@@ -373,6 +373,16 @@ func TestParseProcessSubInSubshellBody(t *testing.T) {
 	parseSourceClean(t, "(\n  cmd 2> >(tee log)\n  echo done\n)\n")
 }
 
+// A command substitution whose body is a subshell — `$( (cmd) )` — must
+// parse: the inner subshell's `)` is consumed via consumedParenTerminator
+// and is not mistaken for the command-substitution's close. The space
+// after `$(` makes it a subshell, not arithmetic. Issue #1375.
+func TestParseCommandSubOfSubshell(t *testing.T) {
+	parseSourceClean(t, "s=$( (echo hi) )\n")
+	parseSourceClean(t, "x=$( (a; b) )\n")
+	parseSourceClean(t, "y=$( ( echo x ) | cat )\n")
+}
+
 func TestParseSelectStatement(t *testing.T) {
 	parseSourceClean(t, "select opt in a b c; do echo $opt; break; done\n")
 }

--- a/pkg/parser/parser_corpus_fixes_test.go
+++ b/pkg/parser/parser_corpus_fixes_test.go
@@ -47,6 +47,25 @@ func TestParseFunctionNameWithPositional(t *testing.T) {
 	parseSourceClean(t, "function _$0_fmt() {\n  echo hi\n}\n")
 }
 
+// `until` is a Zsh reserved word with the same grammar as `while`. It
+// previously lexed as a plain command, so its `(( … ))` condition was
+// parsed as an argument and a grouped sub-expression (`( a ) != b`)
+// errored. The zsh-z plugin uses this form; sharing the WHILE token
+// routes `until` through the loop parser. Each input is `zsh -n` clean.
+func TestParseUntilLoop(t *testing.T) {
+	cases := []string{
+		"until true; do break; done\n",
+		"until [[ -f x ]]; do sleep 1; done\n",
+		"until (( ( a ) != b )); do :; done\n",
+		"until (( ( ${#cd:h} - ${#${${cd:h}//${~q}/}} ) != q_chars )); do :; done\n",
+		"until (( ( ${#cd:h} - ${#${${${cd:h}:l}//${~${q:l}}/}} ) != q )); do :; done\n",
+		"until cmd; do echo loop; done\n",
+	}
+	for _, src := range cases {
+		parseSourceClean(t, src)
+	}
+}
+
 // Exercise every operand form the character-code prefix operator accepts,
 // plus the bare-`#` fallback when no operand is glued on.
 func TestParseArithmeticCharCodeOperandForms(t *testing.T) {

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -1178,35 +1178,67 @@ func (p *Parser) parseDollarParenExpression() ast.Expression {
 	// closing `)` cleanly. The AST keeps the first command; katas
 	// that care about the full body can walk source.
 	exp.Command = p.parseCommandList()
-	// Drain any further statements inside the `$( … )` body.
-	// Zsh separates statements with `;` or a newline, so advance
-	// past either and re-enter parseStatement. Stops at RPAREN or
-	// EOF; callers handle unexpected EOF as a parse error.
-	for !p.peekTokenIs(token.RPAREN) && !p.peekTokenIs(token.EOF) {
-		switch {
-		case p.peekTokenIs(token.SEMICOLON):
-			p.nextToken() // onto ;
-		case p.peekToken.Line > p.curToken.Line:
-			// implicit newline separator: fall through to nextToken
-		default:
-			// Unknown continuation — bail so the RPAREN expectPeek
-			// below reports a meaningful error.
-			goto drainDone
-		}
-		p.nextToken() // onto next stmt head
-		_ = p.parseStatement()
-	}
-drainDone:
-	if !p.expectPeek(token.RPAREN) {
+	if !p.drainDollarParenBody() {
 		return nil
 	}
 	// Signal that an inner expression consumed its own closing `)`.
 	// parseBlockStatement uses the flag to skip RPAREN as its own
-	// terminator and advance past it instead, so an enclosing
-	// `( … )` subshell body doesn't end at the inner `)` of
-	// `HOST=$(cmd)`.
+	// terminator and advance past it instead, so an enclosing `( … )`
+	// subshell body doesn't end at the inner `)` of `HOST=$(cmd)`.
 	p.consumedParenTerminator = true
 	return exp
+}
+
+// drainDollarParenBody consumes the statements of a `$( … )` body after
+// the first command and stops on the closing `)`, which it leaves on
+// curToken. Returns false when the close is missing (error recorded). A
+// `case … esac` / brace-form body advances past its own terminator and
+// sets consumedBraceTerminator, landing curToken on the next token; an
+// `always` block continues a preceding brace/try block. Issue #1359.
+func (p *Parser) drainDollarParenBody() bool {
+	for {
+		if p.consumedBraceTerminator {
+			p.consumedBraceTerminator = false
+			for p.curTokenIs(token.SEMICOLON) {
+				p.nextToken()
+			}
+			if p.curTokenIs(token.RPAREN) {
+				return true
+			}
+			if p.curTokenIs(token.EOF) {
+				break
+			}
+			_ = p.parseStatement()
+			continue
+		}
+		if p.peekTokenIs(token.RPAREN) || p.peekTokenIs(token.EOF) {
+			break
+		}
+		if !p.advanceDollarParenSeparator() {
+			break
+		}
+		p.nextToken() // onto next stmt head
+		_ = p.parseStatement()
+	}
+	return p.expectPeek(token.RPAREN)
+}
+
+// advanceDollarParenSeparator steps past a `;` or newline statement
+// separator inside a `$( … )` body, or an `always` keyword that continues
+// a preceding brace/try block. Returns false for an unknown continuation
+// so the caller reports the missing `)`.
+func (p *Parser) advanceDollarParenSeparator() bool {
+	switch {
+	case p.peekTokenIs(token.SEMICOLON):
+		p.nextToken() // onto ;
+		return true
+	case p.peekToken.Line > p.curToken.Line:
+		return true // implicit newline separator
+	case p.peekTokenIs(token.IDENT) && p.peekToken.Literal == "always":
+		p.nextToken() // onto always; caller advances onto the always-block
+		return true
+	}
+	return false
 }
 
 func (p *Parser) parseFunctionParameters() []*ast.Identifier {

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -1137,7 +1137,11 @@ func (p *Parser) parseCommandSubstitution() ast.Expression {
 func (p *Parser) parseDollarParenExpression() ast.Expression {
 	exp := &ast.DollarParenExpression{Token: p.curToken}
 
-	if p.peekTokenIs(token.LPAREN) {
+	// `$((…))` arithmetic: the inner `(` is glued to `$(` with no space.
+	// `$( (cmd) )` (a space before the `(`) is a command substitution
+	// whose body is a subshell, not arithmetic — fall through to the
+	// command-list path so the subshell parses.
+	if p.peekTokenIs(token.LPAREN) && !p.peekToken.HasPrecedingSpace {
 		p.nextToken()
 		p.nextToken() // consume `(`
 

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -38,7 +38,12 @@ func (p *Parser) parseSimpleStatement() (ast.Statement, bool) {
 	case token.TYPESET, token.DECLARE:
 		return p.parseDeclarationStatement(), true
 	case token.LPAREN:
-		return p.parseSubshellStatement(), true
+		stmt := p.parseSubshellStatement()
+		// A subshell may head a pipeline / logical chain
+		// (`(a) | cat`, `(a) && b`). The subshell now leaves curToken
+		// on its `)` so the tail's operator sits at peek.
+		p.consumePipelineTail()
+		return stmt, true
 	}
 	return nil, false
 }
@@ -1032,7 +1037,21 @@ func (p *Parser) parseSubshellStatement() ast.Statement {
 		p.peekError(token.RPAREN)
 		return nil
 	}
-	p.nextToken()
+	// Leave curToken on the closing `)` and signal that the subshell
+	// consumed its own terminator, mirroring the `$(…)` convention. A
+	// trailing `p.nextToken()` here double-advanced when no separator
+	// token followed: `(a); (b)` was saved by the throwaway `;`, but
+	// `(a)\n(b)` (newline emits no token) lost the second `(`. The
+	// caller's terminator handling now performs the single advance.
+	//
+	// A final inner statement that advanced past its own brace-style
+	// terminator onto this `)` (e.g. `( case x in a) :;; esac )`, where
+	// the case steps past `esac`) leaks consumedBraceTerminator through
+	// parseBlockStatement's curIsTerm break. The subshell owns its `)`
+	// terminator unconditionally, so clear that stale signal — otherwise
+	// the caller skips the advance the subshell now relies on.
+	p.consumedBraceTerminator = false
+	p.consumedParenTerminator = true
 	// Return a Subshell node instead of BlockStatement
 	return &ast.Subshell{Token: subshellToken, Command: block}
 }

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -152,23 +152,32 @@ var keywords = map[string]Type{
 	"fi":       Fi,
 	"for":      FOR,
 	"while":    WHILE,
-	"do":       DO,
-	"done":     DONE,
-	"in":       IN,
-	"case":     CASE,
-	"esac":     ESAC,
-	"elif":     ELIF,
-	"select":   SELECT,
-	"coproc":   COPROC,
-	"typeset":  TYPESET,
-	"declare":  DECLARE,
-	"-eq":      EQ_NUM,
-	"-ne":      NE_NUM,
-	"-lt":      LT_NUM,
-	"-le":      LE_NUM,
-	"-gt":      GT_NUM,
-	"-ge":      GE_NUM,
-	"/":        SLASH,
+	// `until` is a Zsh reserved word with the same grammar as `while`
+	// (condition + `do … done`), only the loop sense is inverted. It
+	// shares the WHILE token so the loop parser and katas treat it
+	// structurally as a while loop; the original `until` keyword is
+	// preserved in the token literal for any rule that distinguishes
+	// the two. Without this `until` lexed as a plain command and its
+	// `(( … ))` condition was misparsed as an argument, erroring on a
+	// grouped sub-expression (`until (( ( a ) != b )); do … done`).
+	"until":   WHILE,
+	"do":      DO,
+	"done":    DONE,
+	"in":      IN,
+	"case":    CASE,
+	"esac":    ESAC,
+	"elif":    ELIF,
+	"select":  SELECT,
+	"coproc":  COPROC,
+	"typeset": TYPESET,
+	"declare": DECLARE,
+	"-eq":     EQ_NUM,
+	"-ne":     NE_NUM,
+	"-lt":     LT_NUM,
+	"-le":     LE_NUM,
+	"-gt":     GT_NUM,
+	"-ge":     GE_NUM,
+	"/":       SLASH,
 }
 
 func LookupIdent(ident string) Type {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.2.0"
+const Version = "1.2.1"


### PR DESCRIPTION
Release v1.2.1. Four parser/lexer correctness fixes for real-world Zsh, each confirmed valid by `zsh -n`, parsing with zero errors across the corpus sweep, and producing no false-positive drift.

- `fix: parse command sub of subshell $( (cmd) )` — Closes #1375. A command substitution whose body is a space-led subshell is no longer mistaken for arithmetic.
- `fix: parse case and always inside command substitution` — Closes #1359. `$( case … esac )` and `$( { } always { } )` now parse; the body drain follows `case` past its `esac`.
- `fix: parse consecutive newline-separated subshells` — Closes #1355. `(a)⏎(b)` no longer drops the second subshell (which the linter had silently skipped scanning).
- `fix: stop lexer swallowing strings on escaped ${` — Closes #1377. A `${…}` body with an escaped `\${` no longer swallows its own closing quote; the lexer decrements on `}` only, matching Zsh. Unblocks Powerlevel10k's `p10k.zsh`.

Gates: `go test ./...` green, golangci-lint clean, gocyclo within threshold, parser-corpus sweep 402 files / 0 errors, violation-corpus sweep no drift.
