### PR TITLE
fix: release v1.2.2 p10k glob and $=name parsing

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -947,7 +947,7 @@ zinit/zinit-autoload.zsh	ZC1856	3
 zinit/zinit-autoload.zsh	ZC1875	3
 zinit/zinit-autoload.zsh	ZC1877	10
 zinit/zinit-autoload.zsh	ZC1916	3
-zinit/zinit-install.zsh	ZC1001	25
+zinit/zinit-install.zsh	ZC1001	24
 zinit/zinit-install.zsh	ZC1030	3
 zinit/zinit-install.zsh	ZC1037	2
 zinit/zinit-install.zsh	ZC1043	1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2] - 2026-06-04
+
+### Fixed
+- Parser: two command-word gaps that left Powerlevel10k's `p10k.zsh` unparseable, each confirmed valid by `zsh -n`, parsing with zero errors across the corpus sweep, and producing no false-positive drift.
+  - A glob bracket class glued to a path word in a `for … in` list (`for plugin in $dir/[^[:space:]]##(/N)`) was mistaken for an array subscript; the subscript parser then swallowed the loop's `do … done`. A `[` after a word that carries a `/` now opens a glob, not a subscript; `$var[1]` still indexes.
+  - The `$=name` forced-word-split expansion (the bare-`$` form of `${=name}`) failed to parse. The split flag is a single `=`; the expansion-flag dispatch matched `==` instead. The sibling `$^name` and `$~name` forms were unaffected.
+
 ## [1.2.1] - 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.2.1-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.2.2-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-137%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)

--- a/pkg/parser/parser_corpus_fixes_test.go
+++ b/pkg/parser/parser_corpus_fixes_test.go
@@ -66,6 +66,44 @@ func TestParseUntilLoop(t *testing.T) {
 	}
 }
 
+// A `[` glued to a path-glob word (a `/` before it) is a glob bracket
+// class, not an array subscript. Inside a `for … in` list the INDEX
+// infix used to treat the path as the array name and swallow the rest
+// of the loop, leaving its `do`/`done` orphaned. The zsh-z and
+// powerlevel10k plugins use `$dir/[^[:space:]]##(/N)`. A `$var[idx]`
+// with no `/` stays a real subscript.
+func TestParseGlobBracketAfterPath(t *testing.T) {
+	clean := []string{
+		"for x in a/[[:space:]]##; do :; done\n",
+		"for x in /[^[:space:]]##; do :; done\n",
+		"for plugin in $root/plugins/[^[:space:]]##(/N); do :; done\n",
+		"echo $path[1]\n",
+		"echo ${arr[1]}\n",
+		"echo $arr[$i/2]\n",
+	}
+	for _, src := range clean {
+		parseSourceClean(t, src)
+	}
+}
+
+// Zsh's `$=name` forces word-splitting on the expansion (the bare-`$`
+// counterpart of `${=name}`). The split flag is a single `=`
+// (token.ASSIGN), not `==`; the dollar-flag dispatch checked the wrong
+// token, so `$=line` errored with "expected IDENT". Sibling forms
+// `$^name` and `$~name` already worked. p10k uses `local w=($=line)`.
+func TestParseDollarForcedSplitFlag(t *testing.T) {
+	clean := []string{
+		"echo $=var\n",
+		"local words=($=line)\n",
+		"local header=($=lines[1])\n",
+		"for a b in $=x[1]; do :; done\n",
+		"x=( $=foo )\n",
+	}
+	for _, src := range clean {
+		parseSourceClean(t, src)
+	}
+}
+
 // Exercise every operand form the character-code prefix operator accepts,
 // plus the bare-`#` fallback when no operand is glued on.
 func TestParseArithmeticCharCodeOperandForms(t *testing.T) {

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -171,17 +171,8 @@ func (p *Parser) expressionInfixShouldBreak() bool {
 // SLASH/LBRACKET arms guard glob-context shapes; AMPERSAND/CARET/COMMA
 // arms guard shell-control bytes that are only infix inside `((…))`.
 func (p *Parser) peekShouldBreakInfix() bool {
-	if p.peekTokenIs(token.LBRACKET) && p.peekToken.HasPrecedingSpace {
-		return true
-	}
-	// Inside `[[ … ]]`, a `[` after a closing `)` (glob-alt group)
-	// or `]` (prior bracket-class) is the next glob fragment, not
-	// an array subscript. Without this break the INDEX infix walks
-	// past the closing `]]` and the outer test fails to terminate.
-	if p.inDoubleBracket && p.peekTokenIs(token.LBRACKET) &&
-		(p.curTokenIs(token.RPAREN) || p.curTokenIs(token.RBRACKET) ||
-			p.curTokenIs(token.STRING)) {
-		return true
+	if p.peekTokenIs(token.LBRACKET) {
+		return p.peekLBracketBreaksInfix()
 	}
 	if p.peekTokenIs(token.SLASH) && !p.peekToken.HasPrecedingSpace {
 		return true
@@ -193,6 +184,32 @@ func (p *Parser) peekShouldBreakInfix() bool {
 		return true
 	}
 	return false
+}
+
+// peekLBracketBreaksInfix reports whether a peeked `[` opens a glob
+// bracket class rather than an array-subscript infix. The caller has
+// confirmed peek == LBRACKET.
+func (p *Parser) peekLBracketBreaksInfix() bool {
+	// A spaced `[` is a separate word, not a subscript.
+	if p.peekToken.HasPrecedingSpace {
+		return true
+	}
+	// A `[` glued to a path-glob word — a `/` already in curToken's
+	// literal (a SLASH token, or an IDENT/VARIABLE like `$root/plugins/`)
+	// — opens a glob bracket class: `/` can never appear in an array
+	// name. Without this the INDEX infix treats the path as the array
+	// name and the subscript parser swallows the rest of the input
+	// (p10k `for plugin in $root/plugins/[^[:space:]]##(/N)` ate the
+	// loop's `; do … done`). `$path[1]` (no `/`) stays a real subscript.
+	if strings.Contains(p.curToken.Literal, "/") {
+		return true
+	}
+	// Inside `[[ … ]]`, a `[` after a closing `)` (glob-alt group), `]`
+	// (prior bracket-class), or a STRING is the next glob fragment, not
+	// a subscript. Without this the INDEX infix walks past `]]`.
+	return p.inDoubleBracket &&
+		(p.curTokenIs(token.RPAREN) || p.curTokenIs(token.RBRACKET) ||
+			p.curTokenIs(token.STRING))
 }
 
 func (p *Parser) parseIdentifier() ast.Expression {
@@ -832,7 +849,7 @@ func (p *Parser) peekIsDollarSpecialOp() bool {
 	return p.peekTokenIs(token.HASH) || p.peekTokenIs(token.INT) ||
 		p.peekTokenIs(token.ASTERISK) || p.peekTokenIs(token.BANG) ||
 		p.peekTokenIs(token.MINUS) || p.peekTokenIs(token.CARET) ||
-		p.peekTokenIs(token.EQ) || p.peekTokenIs(token.TILDE)
+		p.peekTokenIs(token.ASSIGN) || p.peekTokenIs(token.TILDE)
 }
 
 func (p *Parser) parseDollarArithExpansion(dollarToken token.Token) ast.Expression {
@@ -887,9 +904,13 @@ func (p *Parser) parseDollarSpecialOp(dollarToken token.Token) ast.Expression {
 	return &ast.PrefixExpression{Token: dollarToken, Operator: "$", Right: ident}
 }
 
+// isDollarFlagOp reports whether a token following a bare `$` is one of
+// Zsh's expansion-flag operators: `$^name` (RC_EXPAND_PARAM broadcast),
+// `$=name` (forced word-split — a single `=`, token.ASSIGN), `$~name`
+// (forced glob). The split flag is one `=`, not `==`.
 func isDollarFlagOp(t token.Type) bool {
 	switch t {
-	case token.CARET, token.EQ, token.TILDE:
+	case token.CARET, token.ASSIGN, token.TILDE:
 		return true
 	}
 	return false

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.2.1"
+const Version = "1.2.2"


### PR DESCRIPTION
Release v1.2.2. Two parser command-word fixes that make Powerlevel10k's `p10k.zsh` parse with zero errors.

- `fix: parse glob brackets after path and $=name`
  - A `[` glued to a path word in a `for … in` list (`$dir/[^[:space:]]##(/N)`) was parsed as an array subscript and swallowed the loop's `do … done`. It now opens a glob bracket class when the subject carries a `/`; `$var[1]` still indexes.
  - `$=name` (forced word-split) failed to parse — the flag is a single `=` but the dispatch matched `==`. `$^name`/`$~name` were unaffected.

Gates: `go test ./...` green, golangci-lint clean, gocyclo within threshold, parser-corpus sweep 402/0, violation-corpus sweep no drift (one legitimate false-positive removed: a path-glob `dir/[...]` is no longer mis-flagged as array access).
