### PR TITLE
ci: bump codecov-action to v7.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
         # those runs; the gate still fires on every human-authored PR
         # because secrets are available there.
         if: github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.txt


### PR DESCRIPTION
## Why

The `test` check failed on every run at the "Upload coverage to Codecov" step. The v6.0.1 uploader verified the downloaded Codecov CLI against a PGP key from the `codecovsecurity` keybase account, which Codecov deleted during a keybase migration. The key import returned no data, so the signature check failed with `Can't check signature: No public key` and the step exited non-zero.

## Fix

Bump `codecov/codecov-action` to v7.0.0, which fetches the key from the live `codecovsecops` account (per the upstream v7.0.0 release notes).

The integrity verification stays enabled and `fail_ci_if_error: true` is unchanged. The gate is fixed at the root, not relaxed.

Pinned to the 40-char commit SHA `fb8b3582c8e4def4969c97caa2f19720cb33a72f`.