### PR TITLE
fix: parse reserved words as command arguments

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -305,9 +305,7 @@ var commandDelimiterTokens = map[token.Type]struct{}{
 	token.EOF: {}, token.SEMICOLON: {}, token.PIPE: {},
 	token.AND: {}, token.OR: {},
 	token.RPAREN: {}, token.RBRACE: {}, token.HASH: {},
-	token.THEN: {}, token.ELSE: {}, token.ELIF: {}, token.Fi: {},
-	token.DO: {}, token.DONE: {},
-	token.ESAC: {}, token.DSEMI: {},
+	token.DSEMI: {},
 }
 
 func (p *Parser) isCommandDelimiter(t token.Token) bool {

--- a/pkg/parser/parser_corpus_fixes_test.go
+++ b/pkg/parser/parser_corpus_fixes_test.go
@@ -194,6 +194,31 @@ func TestParseBraceGroupTrailingRedirection(t *testing.T) {
 	}
 }
 
+// A reserved closer word (`done`, `fi`, `esac`, `then`, `do`, `else`,
+// `elif`) is a literal argument in Zsh when it is not in command
+// position. `echo done` used to stop argument gathering at `done` and
+// orphan it into a second bogus statement; it now parses as one command
+// with the closer captured as an argument.
+func TestParseReservedWordAsArgument(t *testing.T) {
+	cases := []string{
+		"echo done\n",
+		"echo fi esac then\n",
+		"print -l function do done\n",
+		"local x=done\n",
+		"args=(do done fi)\n",
+	}
+	for _, src := range cases {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if len(p.Errors()) != 0 {
+			t.Errorf("unexpected errors for %q: %v", src, p.Errors())
+		}
+		if len(prog.Statements) != 1 {
+			t.Errorf("want 1 statement for %q, got %d (the reserved word orphaned)", src, len(prog.Statements))
+		}
+	}
+}
+
 // A process substitution as the first argument (`diff <(a) <(b)`) fell
 // to the expression path, which parsed only the bare command name and
 // orphaned each `<(…)` into its own bogus top-level statement. Every

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -309,6 +309,15 @@ func (p *Parser) peekStartsArgPrefix() bool {
 		// the expression path, parsing only the bare name and orphaning
 		// each substitution into its own bogus top-level statement.
 		return true
+	case p.peekTokenIs(token.DONE), p.peekTokenIs(token.Fi), p.peekTokenIs(token.ESAC),
+		p.peekTokenIs(token.THEN), p.peekTokenIs(token.DO),
+		p.peekTokenIs(token.ELSE), p.peekTokenIs(token.ELIF):
+		// A reserved closer word is a literal command argument in Zsh
+		// when it is not in command position (`echo done`, `print fi`).
+		// Route to the command path so the argument loop captures it;
+		// otherwise the command falls to the expression path and the
+		// closer orphans into its own statement.
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
## What

In Zsh a reserved closer word (`done`, `fi`, `esac`, `then`, `do`, `else`, `elif`) is a literal word outside command position — `echo done` prints `done`. The parser treated these as command-word delimiters and non-argument peeks, so `echo done` stopped argument gathering at `done` and orphaned it into a second bogus top-level statement.

## Fix

Drop the closer words from the command-delimiter set and accept them as argument-prefix peeks. `echo done` now parses as one command with `done` as its argument. Compound terminators are still recognised through the block-terminator sets, so `if`/loop/`case` bodies are unaffected.

## Validation

- `go test ./...` passes; `golangci-lint` 0 issues; `gocyclo -over 15` clean.
- Parser corpus sweep: 402 files, zero parse errors.
- Violation corpus sweep: baseline unchanged (zero drift).

Groundwork for #1362. The stray-closer detection itself needs the separate compound-terminator-consumption change and is not in this PR.