### PR TITLE
fix: parser consumes nested compound terminators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.5] - 2026-06-15
+
+### Fixed
+- Parser: nested compound commands now consume their own terminator, so an inner `fi`, `done`, or `esac` is never mistaken for the enclosing compound's closer. Affects `if`, `for`, `while`, `until`, `repeat`, and `select` when nested inside another loop or conditional.
+- Parser: a `( … )` subshell on the right of a pipeline (`cmd | ( … )`) no longer swallows the following statement when its body ends in a compound command.
+- Parser: `return` takes its optional value only on the same logical line, so a bare `return` no longer absorbs the next statement as its value.
+
 ## [1.2.4] - 2026-06-14
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.2.4-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.2.5-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-137%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)

--- a/pkg/parser/parser_corpus_fixes_test.go
+++ b/pkg/parser/parser_corpus_fixes_test.go
@@ -301,3 +301,82 @@ func TestParseRepeatAndForeachLoops(t *testing.T) {
 		}
 	}
 }
+
+// Nested compound commands each consume their own closing keyword
+// (`fi`, `done`, `esac`), so an inner closer is never mistaken for the
+// outer compound's terminator. Without finishCompound / finishLoopTail
+// an inner `done` was taken as the outer loop's `done`, orphaning the
+// real outer `done` to statement-head as a second bogus statement.
+func TestParseNestedCompoundClosers(t *testing.T) {
+	cases := []string{
+		"while x; do for i in a; do echo; done; done\n",
+		"for i in a; do while x; do echo; done; done\n",
+		"while a; do for i in x; do while b; do echo; done; done; done\n",
+		"select o in a b; do for i in x; do echo; done; done\n",
+		"repeat 3; do for i in a; do echo; done; done\n",
+		"if x; then for i in a; do echo; done; fi\n",
+		"while x; do if a; then b; fi; done\n",
+		"for i in a; do case $i in x) :;; esac; done\n",
+	}
+	for _, src := range cases {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if len(p.Errors()) != 0 {
+			t.Errorf("unexpected errors for %q: %v", src, p.Errors())
+		}
+		if len(prog.Statements) != 1 {
+			t.Errorf("want 1 compound statement for %q, got %d (an inner closer leaked)", src, len(prog.Statements))
+		}
+	}
+}
+
+// A pipeline whose right side is a `( … )` subshell containing a
+// compound is parsed through parseGroupedExpression's hand-rolled loop.
+// A finishCompound'd inner `if` advances curToken onto the subshell's
+// `)`; the loop's unconditional advance then stepped PAST `)` and kept
+// swallowing the enclosing block, dropping the following statement. zaw's
+// bookmark sources hit this via `: >>| file` (the stray `|` forms a
+// pipeline) feeding a subshell whose body ends in `if … fi`.
+func TestParsePipeIntoSubshellWithCompound(t *testing.T) {
+	cases := map[string]int{
+		"echo x | (\n  if a; then b; fi\n)\nf() { y }\n":             2,
+		"echo x | (\n  for i in a; do echo $i; done\n)\nf() { y }\n": 2,
+		"echo x | (\n  case $v in a) :;; esac\n)\nf() { y }\n":       2,
+		"echo x | (\n  if a; then b; else c; fi\n)\necho after\n":    2,
+	}
+	for src, want := range cases {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if len(p.Errors()) != 0 {
+			t.Errorf("unexpected errors for %q: %v", src, p.Errors())
+		}
+		if len(prog.Statements) != want {
+			t.Errorf("want %d statements for %q, got %d (the subshell swallowed the following statement)", want, src, len(prog.Statements))
+		}
+	}
+}
+
+// `return` takes its optional value only on the same logical line. A
+// newline ends the statement, so the next line is a separate statement —
+// the enclosing block's `fi` / `}` or the following command. Without the
+// same-line guard, bare `return` swallowed the next line as its value
+// (`return⏎echo x` captured `echo`, `return⏎}` captured `}`).
+func TestParseReturnValueSameLineOnly(t *testing.T) {
+	twoStmt := []string{
+		"return\necho x\n",
+		"return 1\necho x\n",
+	}
+	for _, src := range twoStmt {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if len(p.Errors()) != 0 {
+			t.Errorf("unexpected errors for %q: %v", src, p.Errors())
+		}
+		if len(prog.Statements) != 2 {
+			t.Errorf("want 2 statements for %q, got %d (return swallowed the next line)", src, len(prog.Statements))
+		}
+	}
+	// `return` immediately before a closer must not absorb it.
+	parseSourceClean(t, "f() {\n  if x; then return; fi\n}\n")
+	parseSourceClean(t, "f() {\n  return\n}\n")
+}

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -591,8 +591,21 @@ func (p *Parser) parseGroupedExpression() ast.Expression {
 				if stmt != nil {
 					statements = append(statements, stmt)
 				}
+				// A finishCompound'd inner statement (`if … fi`, a loop,
+				// a case) already advanced curToken onto its own
+				// terminator — here the subshell's `)`. The unconditional
+				// nextToken below would then step PAST `)` and the loop
+				// would keep swallowing the enclosing block. Honor the
+				// signal: clear it and let the loop re-test for `)`.
+				if p.consumedBraceTerminator {
+					p.consumedBraceTerminator = false
+					continue
+				}
 				p.nextToken()
 			}
+			// This group owns its `)`; drop any stale terminator signal so
+			// it does not leak to the enclosing parser.
+			p.consumedBraceTerminator = false
 			return &ast.GroupedExpression{Token: tok, Expression: &ast.BlockStatement{Statements: statements}}
 		}
 	}

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -53,20 +53,25 @@ func (p *Parser) parseSimpleStatement() (ast.Statement, bool) {
 func (p *Parser) parsePipelineHeadStatement() (ast.Statement, bool) {
 	switch p.curToken.Type {
 	case token.If:
+		// parseIfStatement's then…fi form consumes its own `fi` and any
+		// trailing pipeline tail via finishCompound; the brace-form and
+		// no-then shortcut still need the external tail drain.
 		stmt := p.parseIfStatement()
-		p.consumePipelineTail()
+		if !p.consumedBraceTerminator {
+			p.consumePipelineTail()
+		}
 		return stmt, true
 	case token.FOR:
 		stmt := p.parseForLoopStatement()
-		p.consumePipelineTail()
+		p.finishLoopTail()
 		return stmt, true
 	case token.WHILE:
 		stmt := p.parseWhileLoopStatement()
-		p.consumePipelineTail()
+		p.finishLoopTail()
 		return stmt, true
 	case token.REPEAT:
 		stmt := p.parseRepeatLoopStatement()
-		p.consumePipelineTail()
+		p.finishLoopTail()
 		return stmt, true
 	case token.FOREACH:
 		stmt := p.parseForeachLoopStatement()
@@ -74,7 +79,7 @@ func (p *Parser) parsePipelineHeadStatement() (ast.Statement, bool) {
 		return stmt, true
 	case token.SELECT:
 		stmt := p.parseSelectStatement()
-		p.consumePipelineTail()
+		p.finishLoopTail()
 		return stmt, true
 	case token.CASE:
 		stmt := p.parseCaseStatement()
@@ -461,6 +466,43 @@ func (p *Parser) consumePipelineTail() {
 	}
 }
 
+// finishCompound is called with curToken ON a compound command's closing
+// keyword (`fi` / `done` / `esac`). It consumes that closer and any
+// trailing pipeline or logical tail (`fi | cat`, `done && x`), then sets
+// consumedBraceTerminator so the enclosing parseBlockStatement skips its
+// own post-statement advance. Without this the parser left curToken on
+// the closer and relied on the caller to advance — but in a nested
+// compound the inner closer was mistaken for the outer compound's
+// terminator, orphaning the outer closer to statement-head (issue #1362).
+func (p *Parser) finishCompound() {
+	if p.peekTokenIs(token.PIPE) || p.peekTokenIs(token.AND) || p.peekTokenIs(token.OR) {
+		// A tail leaves curToken on the LAST token of the tail
+		// (`fi | cat` → on `cat`); the caller advances past it normally,
+		// so the consumed-terminator signal must NOT be set.
+		p.consumePipelineTail()
+		return
+	}
+	// Consume just the closer: curToken now sits on the following
+	// statement head / separator, which the caller must not skip.
+	p.nextToken()
+	p.consumedBraceTerminator = true
+}
+
+// finishLoopTail completes a `do … done` loop after its body parse.
+// When curToken rests on the loop's own `done`, consume it (and any
+// trailing pipeline tail) via finishCompound so a nested inner `done`
+// is not mistaken for an outer loop's terminator, which would orphan
+// the outer `done` to statement-head (issue #1362). The brace-form and
+// short-form bodies leave curToken elsewhere and already advanced, so
+// they only need the ordinary trailing-pipeline drain.
+func (p *Parser) finishLoopTail() {
+	if p.curTokenIs(token.DONE) {
+		p.finishCompound()
+		return
+	}
+	p.consumePipelineTail()
+}
+
 // parsePipelineStartingWithExpression parses a statement whose head
 // is a command-producing expression (backtick or `$(…)`) and then
 // folds any trailing pipeline / logical chain onto it. The generic
@@ -807,9 +849,16 @@ func (p *Parser) parseLetStatement() *ast.LetStatement {
 
 func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
 	stmt := &ast.ReturnStatement{Token: p.curToken}
-	p.nextToken()
-	stmt.ReturnValue = p.parseExpression(LOWEST)
-
+	// `return` takes its optional value only on the same logical line.
+	// A newline or a delimiter (`;`, `}`, a closer keyword) ends the
+	// statement, so the next line is a separate statement — the
+	// enclosing block's `fi` / `}` or the following command. Without
+	// this guard `return` swallowed the next statement as its value
+	// (`return⏎echo x` captured `echo`, `return⏎}` captured `}`).
+	if p.peekOnSameLogicalLine() && !p.isCommandDelimiter(p.peekToken) {
+		p.nextToken()
+		stmt.ReturnValue = p.parseExpression(LOWEST)
+	}
 	if p.peekTokenIs(token.SEMICOLON) {
 		p.nextToken()
 	}
@@ -941,6 +990,7 @@ func (p *Parser) parseIfStatement() *ast.IfStatement {
 		p.peekError(token.Fi)
 		return nil
 	}
+	p.finishCompound()
 	return stmt
 }
 
@@ -1081,6 +1131,12 @@ func (p *Parser) parseBlockStatement(terminators ...token.Type) *ast.BlockStatem
 			}
 		}
 		if curIsTerm {
+			// A consumed-terminator signal from the last body statement
+			// (a finishCompound'd `if`, a brace-form close) applied only
+			// to that statement's own terminator. Clear it before
+			// leaving so it does not leak to the enclosing parser, which
+			// handles this block's terminator itself.
+			p.consumedBraceTerminator = false
 			break
 		}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.2.4"
+const Version = "1.2.5"


### PR DESCRIPTION
## What

Each compound command now consumes its own closing keyword, so an inner `fi`, `done`, or `esac` is never mistaken for the enclosing compound's terminator.

## Why

The previous parser left the closer as `curToken` for the caller to advance past. When two compounds nested and shared a closer keyword (`while …; do for …; do …; done; done`), the inner closer was taken as the outer loop's terminator and the real outer closer orphaned to statement-head, building a wrong AST that left the trailing statement unlinted.

## Scope

- `if`, `for`, `while`, `until`, `repeat`, `select` nested inside another loop or conditional.
- A `( … )` subshell on a pipeline right-hand side (`cmd | ( … )`) whose body ends in a compound command no longer swallows the following statement.
- `return` takes its optional value only on the same logical line.

## Verification

- `go test ./...` green; three new regression tests in `parser_corpus_fixes_test.go`.
- Parser-corpus sweep: 402 files, 0 parse errors.
- Violation-corpus sweep: zero drift (7398 findings, unchanged).
- golangci-lint 0 issues; gocyclo clean; coverage 92.1% local (new functions 100%).