### PR TITLE
fix: brace-form for loop consumes its own terminator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.6] - 2026-06-15
+
+### Fixed
+- Parser: the Zsh short-form `for x ( list ) { body }` brace loop consumes its own closing `}`. Nested inside another brace block (`if (( c )) { for p ( … ) { … } } else { … }`), it no longer closes the enclosing block early and orphans the trailing `else`.
+
 ## [1.2.5] - 2026-06-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.2.5-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.2.6-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-137%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)

--- a/pkg/parser/parser_corpus_fixes_test.go
+++ b/pkg/parser/parser_corpus_fixes_test.go
@@ -380,3 +380,29 @@ func TestParseReturnValueSameLineOnly(t *testing.T) {
 	parseSourceClean(t, "f() {\n  if x; then return; fi\n}\n")
 	parseSourceClean(t, "f() {\n  return\n}\n")
 }
+
+// The Zsh short-form `for x ( list ) { body }` brace loop must consume
+// its own `}`. Previously it left curToken on the brace, so an enclosing
+// brace block (`if (( c )) { for p ( … ) { … } } else { … }`, the zinit
+// autoload path) mistook the loop's `}` for its own and closed early,
+// orphaning the trailing `else` and the rest of the block.
+func TestParseShortFormForBraceTerminator(t *testing.T) {
+	// A brace-group `{ … }` as the body of `&& { … }` inside the loop
+	// (`for p ( … ) { [[ … ]] && { … } }`) is a separate, still-open
+	// terminator leak in parseBraceGroupStatement and is not covered here.
+	cases := map[string]int{
+		"for p ( a b ) { echo $p }\nz\n":                   2,
+		"if (( c )) { for p ( x ) { a } } else { b }\nz\n": 2,
+		"if [[ c ]] { for p ( x ) { a } } else { b }\nz\n": 2,
+	}
+	for src, want := range cases {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if len(p.Errors()) != 0 {
+			t.Errorf("unexpected errors for %q: %v", src, p.Errors())
+		}
+		if len(prog.Statements) != want {
+			t.Errorf("want %d statements for %q, got %d (the brace-form for orphaned the enclosing close)", want, src, len(prog.Statements))
+		}
+	}
+}

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -1460,6 +1460,21 @@ func (p *Parser) parseShortFormForLoop(stmt *ast.ForLoopStatement) *ast.ForLoopS
 		stmt.Body = p.parseBlockStatement(token.DONE)
 		return stmt
 	}
+	if p.peekTokenIs(token.LBRACE) {
+		// Brace body `for x ( list ) { body }`. The brace group leaves
+		// curToken on its own `}`; consume it and signal a consumed
+		// terminator so an enclosing brace block (`if cond { for … { … } }`)
+		// does not mistake the loop's `}` for its own and close early,
+		// orphaning the trailing `else` / statement. Mirrors the `while`
+		// and `repeat` brace forms.
+		p.nextToken() // onto {
+		stmt.Body = wrapForLoopBody(stmt.Token, p.parseStatement())
+		if p.curTokenIs(token.RBRACE) {
+			p.nextToken()
+			p.consumedBraceTerminator = true
+		}
+		return stmt
+	}
 	p.nextToken()
 	stmt.Body = wrapForLoopBody(stmt.Token, p.parseStatement())
 	return stmt

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.2.5"
+const Version = "1.2.6"


### PR DESCRIPTION
## What

The Zsh short-form `for x ( list ) { body }` brace loop now consumes its own closing `}`.

## Why

The loop left `curToken` on its `}` for the caller to advance past. Nested inside another brace block (`if (( c )) { for p ( … ) { … } } else { … }`, the zinit autoload path), the enclosing block mistook the loop's `}` for its own terminator and closed early, orphaning the trailing `else` and building a wrong AST. The `while` and `repeat` brace forms already consume their `}`; this aligns `for`.

## Verification

- `go test ./...` green; new regression test `TestParseShortFormForBraceTerminator`.
- Parser-corpus sweep 402/0; violation-corpus sweep zero drift (7398).
- golangci-lint 0 issues; gocyclo clean; coverage 92.1% local.