### PR TITLE
fix: ZC1075 assignment-RHS and ZC1285 sort false positives

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -36,7 +36,7 @@ antidote/antidote.zsh	ZC1059	1
 antidote/antidote.zsh	ZC1065	1
 antidote/antidote.zsh	ZC1071	1
 antidote/antidote.zsh	ZC1073	2
-antidote/antidote.zsh	ZC1075	46
+antidote/antidote.zsh	ZC1075	45
 antidote/antidote.zsh	ZC1091	14
 antidote/antidote.zsh	ZC1092	1
 antidote/antidote.zsh	ZC1097	1
@@ -1285,7 +1285,7 @@ zephyr/tests/__init__.zsh	ZC1031	1
 zephyr/tests/__init__.zsh	ZC1037	4
 zephyr/tests/__init__.zsh	ZC1051	1
 zephyr/tests/__init__.zsh	ZC1073	3
-zephyr/tests/__init__.zsh	ZC1075	12
+zephyr/tests/__init__.zsh	ZC1075	11
 zephyr/tests/__init__.zsh	ZC1086	8
 zephyr/tests/__init__.zsh	ZC1092	4
 zephyr/tests/__init__.zsh	ZC1136	1
@@ -1314,7 +1314,7 @@ zimfw/zimfw.zsh	ZC1043	23
 zimfw/zimfw.zsh	ZC1045	3
 zimfw/zimfw.zsh	ZC1046	1
 zimfw/zimfw.zsh	ZC1065	1
-zimfw/zimfw.zsh	ZC1075	120
+zimfw/zimfw.zsh	ZC1075	117
 zimfw/zimfw.zsh	ZC1080	1
 zimfw/zimfw.zsh	ZC1091	10
 zimfw/zimfw.zsh	ZC1637	19
@@ -1386,7 +1386,7 @@ zinit/zinit-install.zsh	ZC1053	1
 zinit/zinit-install.zsh	ZC1064	5
 zinit/zinit-install.zsh	ZC1071	2
 zinit/zinit-install.zsh	ZC1073	1
-zinit/zinit-install.zsh	ZC1075	82
+zinit/zinit-install.zsh	ZC1075	81
 zinit/zinit-install.zsh	ZC1083	2
 zinit/zinit-install.zsh	ZC1091	22
 zinit/zinit-install.zsh	ZC1092	3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-06-16
+
+### Fixed
+- ZC1075 no longer flags a concatenated path-style assignment right-hand side (`x=${a}/${b}`, `arr[k]=$H/$z`). The right-hand side split at the glued `/`, orphaning the tail into a bogus command that mis-flagged the trailing expansion.
+- ZC1285 no longer flags `sort <file>` with the `${(o)array}` suggestion. Sorting a file's lines cannot be replaced by the in-shell array flag; the idiom only applies to the pipe form.
+
 ## [1.3.0] - 2026-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.3.0-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.3.1-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-132%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)

--- a/pkg/katas/katatests/zc1200s_test.go
+++ b/pkg/katas/katatests/zc1200s_test.go
@@ -3092,16 +3092,17 @@ func TestZC1285(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
-			name:  "sort with single file argument",
-			input: `sort data.txt`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1285",
-					Message: "Use Zsh `${(o)array}` for sorting instead of piping to `sort`. The `(o)` flag sorts in-shell.",
-					Line:    1,
-					Column:  1,
-				},
-			},
+			// `sort <file>` sorts a file's lines; `${(o)array}` sorts an
+			// in-shell array, not a file, so it cannot replace this.
+			// Flagging the file form gave wrong advice — not flagged.
+			name:     "sort with single file argument is not flagged",
+			input:    `sort data.txt`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "sort of a quoted file path is not flagged",
+			input:    `sort "$logfile"`,
+			expected: []katas.Violation{},
 		},
 	}
 

--- a/pkg/katas/zc1200s.go
+++ b/pkg/katas/zc1200s.go
@@ -4969,13 +4969,14 @@ func checkZC1285(node ast.Node) []Violation {
 	if cmd.Arguments[0].String() == "" || cmd.Arguments[0].String()[0] == '-' {
 		return nil
 	}
-	return []Violation{{
-		KataID:  "ZC1285",
-		Message: "Use Zsh `${(o)array}` for sorting instead of piping to `sort`. The `(o)` flag sorts in-shell.",
-		Line:    cmd.Token.Line,
-		Column:  cmd.Token.Column,
-		Level:   SeverityStyle,
-	}}
+	// `sort <arg>` with a single non-flag argument sorts the lines of a
+	// FILE named by that argument (`sort log.txt`, `sort "$f"`). The
+	// `${(o)array}` flag sorts an in-shell array, not a file, so it cannot
+	// replace this — flagging it gives wrong advice on the most common,
+	// valid use of `sort`. The idiom only replaces the pipe form
+	// (`print -l -- $array | sort`), which this per-command check cannot
+	// see; detecting it needs pipeline context. Do not flag the file form.
+	return nil
 }
 
 func init() {

--- a/pkg/parser/parser_corpus_fixes_test.go
+++ b/pkg/parser/parser_corpus_fixes_test.go
@@ -406,3 +406,30 @@ func TestParseShortFormForBraceTerminator(t *testing.T) {
 		}
 	}
 }
+
+// A concatenated assignment right-hand side (`x=${a}/${b}`,
+// `arr[k]=$H/$z`) glues path segments with no separating space. The
+// expression parse stopped at the `/`, orphaning the tail into a bogus
+// `/${b}` command — which mis-flagged the trailing expansion (ZC1075).
+// The whole RHS now stays one statement.
+func TestParseConcatenatedAssignmentRHS(t *testing.T) {
+	cases := map[string]int{
+		"x=${a}/${b}\n":             1,
+		"_zpaths[${z}]=${H}/${z}\n": 1,
+		"t=${A}/${B}/${C}\n":        1,
+		"x=${a}/${b}\necho after\n": 2,
+		"x=$a\n":                    1,
+		"x=$(date)\n":               1,
+		"x=(a b c)\n":               1,
+	}
+	for src, want := range cases {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if len(p.Errors()) != 0 {
+			t.Errorf("unexpected errors for %q: %v", src, p.Errors())
+		}
+		if len(prog.Statements) != want {
+			t.Errorf("want %d statements for %q, got %d (the assignment RHS split at `/`)", want, src, len(prog.Statements))
+		}
+	}
+}

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -555,7 +555,40 @@ func (p *Parser) parseInfixExpression(left ast.Expression) ast.Expression {
 	}
 	p.nextToken()
 	expression.Right = p.parseExpression(precedence)
+	// A concatenated assignment RHS word (`x=${a}/${b}`, `x=$a-$b`,
+	// `x=$PATH:/usr/bin`) glues the first expansion to following segments
+	// with no separating space. parseExpression stops at the first glued
+	// operator (`/`, `-`, `:`), leaving the tail to be mis-parsed as a
+	// separate command (`/${b}`) — which then mis-flagged the trailing
+	// expansion. Absorb the rest of the glued word so it stays part of
+	// the assignment. Command context only; arithmetic has real operators.
+	if isAssign && !p.inArithmetic {
+		p.absorbGluedRhsTail()
+	}
 	return expression
+}
+
+// absorbGluedRhsTail consumes the path-style `/segment` continuations of
+// a concatenated assignment right-hand side that parseExpression stopped
+// short of (`x=${a}/${b}`, `arr[k]=$H/$z`, `t=${DIR}/init`). It is led by
+// a glued `/` only — never a bare identifier or array index — so it does
+// not disturb how other katas read array or arithmetic segments. After
+// each slash it consumes one glued segment (an identifier, integer, or
+// expansion, whose closer parseExpression resolves).
+func (p *Parser) absorbGluedRhsTail() {
+	for !p.peekToken.HasPrecedingSpace && p.peekTokenIs(token.SLASH) {
+		p.nextToken() // onto '/'
+		if p.peekToken.HasPrecedingSpace {
+			return
+		}
+		switch p.peekToken.Type {
+		case token.DollarLbrace, token.VARIABLE, token.DOLLAR_LPAREN, token.BACKTICK:
+			p.nextToken()
+			_ = p.parseExpression(LOWEST)
+		case token.IDENT, token.INT, token.MINUS, token.DOT:
+			p.nextToken()
+		}
+	}
 }
 
 func (p *Parser) parseGroupedExpression() ast.Expression {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.3.0"
+const Version = "1.3.1"


### PR DESCRIPTION
## v1.3.1 — false-positive fixes

### Fixed
- **ZC1075** no longer flags a concatenated path-style assignment RHS (`x=${a}/${b}`, `arr[k]=$H/$z`). The RHS split at the glued `/`, orphaning the tail into a bogus `/${b}` command that mis-flagged the trailing expansion.
- **ZC1285** no longer flags `sort <file>` with the `${(o)array}` suggestion. Sorting a file's lines cannot be replaced by the in-shell array flag; the idiom only applies to the pipe form.

### Verification
- `go test ./...` green; new regression test for the assignment RHS; ZC1285 test updated.
- Parser-corpus sweep 402/0; violation-corpus sweep no drift (baseline re-snapshotted for the assignment-RHS reductions).
- golangci-lint 0; gocyclo clean; coverage 92.1% local.