### PR TITLE
fix: repair redirect chains and stray closers

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -9,10 +9,8 @@ agkozak-prompt/agkozak-zsh-prompt.plugin.zsh	ZC1091	1
 agkozak-prompt/agkozak-zsh-prompt.plugin.zsh	ZC1337	1
 agkozak-prompt/agkozak-zsh-prompt.plugin.zsh	ZC1604	2
 agkozak-prompt/lib/async.zsh	ZC1001	5
-agkozak-prompt/lib/async.zsh	ZC1010	1
 agkozak-prompt/lib/async.zsh	ZC1043	2
 agkozak-prompt/lib/async.zsh	ZC1046	1
-agkozak-prompt/lib/async.zsh	ZC1065	1
 agkozak-prompt/lib/async.zsh	ZC1075	30
 agkozak-prompt/lib/async.zsh	ZC1098	1
 agkozak-prompt/lib/async.zsh	ZC1134	1
@@ -26,7 +24,7 @@ antidote/antidote.zsh	ZC1001	11
 antidote/antidote.zsh	ZC1004	1
 antidote/antidote.zsh	ZC1010	2
 antidote/antidote.zsh	ZC1011	3
-antidote/antidote.zsh	ZC1037	1
+antidote/antidote.zsh	ZC1037	3
 antidote/antidote.zsh	ZC1043	12
 antidote/antidote.zsh	ZC1046	3
 antidote/antidote.zsh	ZC1059	1
@@ -178,7 +176,9 @@ bullet-train/bullet-train.zsh-theme	ZC1339	1
 bullet-train/bullet-train.zsh-theme	ZC1643	1
 emoji-cli/emoji-cli.zsh	ZC1010	4
 emoji-cli/emoji-cli.zsh	ZC1037	6
+emoji-cli/emoji-cli.zsh	ZC1038	2
 emoji-cli/emoji-cli.zsh	ZC1043	2
+emoji-cli/emoji-cli.zsh	ZC1046	1
 fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh	ZC1043	1
 fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh	ZC1046	3
 fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh	ZC1049	1
@@ -315,7 +315,7 @@ fzf-zsh-plugin/fzf-zsh-plugin.plugin.zsh	ZC1591	1
 geometry/geometry.zsh	ZC1001	1
 geometry/geometry.zsh	ZC1043	1
 geometry/geometry.zsh	ZC1045	5
-geometry/geometry.zsh	ZC1075	8
+geometry/geometry.zsh	ZC1075	11
 geometry/geometry.zsh	ZC1091	1
 geometry/geometry.zsh	ZC1097	1
 geometry/geometry.zsh	ZC1517	1
@@ -334,7 +334,7 @@ git-open/git-open.plugin.zsh	ZC1275	1
 gitstatus/gitstatus.plugin.zsh	ZC1001	7
 gitstatus/gitstatus.plugin.zsh	ZC1043	3
 gitstatus/gitstatus.plugin.zsh	ZC1046	1
-gitstatus/gitstatus.plugin.zsh	ZC1075	63
+gitstatus/gitstatus.plugin.zsh	ZC1075	61
 gitstatus/gitstatus.plugin.zsh	ZC1086	11
 gitstatus/gitstatus.plugin.zsh	ZC1167	1
 gitstatus/gitstatus.plugin.zsh	ZC1176	3
@@ -524,10 +524,8 @@ purer/pure.zsh	ZC1075	4
 purer/pure.zsh	ZC1091	2
 purer/pure.zsh	ZC1293	1
 spaceship/async.zsh	ZC1001	5
-spaceship/async.zsh	ZC1010	1
 spaceship/async.zsh	ZC1043	2
 spaceship/async.zsh	ZC1046	1
-spaceship/async.zsh	ZC1065	1
 spaceship/async.zsh	ZC1075	30
 spaceship/async.zsh	ZC1098	1
 spaceship/async.zsh	ZC1134	1
@@ -978,10 +976,8 @@ spaceship/tests/zig.test.zsh	ZC1602	1
 starship/src/init/starship.zsh	ZC1043	3
 starship/src/init/starship.zsh	ZC1967	1
 typewritten/async.zsh	ZC1001	5
-typewritten/async.zsh	ZC1010	1
 typewritten/async.zsh	ZC1043	2
 typewritten/async.zsh	ZC1046	1
-typewritten/async.zsh	ZC1065	1
 typewritten/async.zsh	ZC1075	30
 typewritten/async.zsh	ZC1098	1
 typewritten/async.zsh	ZC1134	1
@@ -1007,7 +1003,7 @@ typewritten/lib/git.zsh	ZC1339	1
 typewritten/tests/smoke.zsh	ZC1004	1
 typewritten/tests/smoke.zsh	ZC1043	3
 typewritten/tests/smoke.zsh	ZC1059	1
-typewritten/tests/smoke.zsh	ZC1170	1
+typewritten/tests/smoke.zsh	ZC1170	2
 typewritten/tests/smoke.zsh	ZC1415	1
 typewritten/tests/smoke.zsh	ZC1873	1
 typewritten/typewritten.zsh	ZC1001	5
@@ -1117,6 +1113,7 @@ zaw/zaw.zsh	ZC1091	2
 zaw/zaw.zsh	ZC1098	2
 zaw/zaw.zsh	ZC1176	1
 zcolors/zcolors.plugin.zsh	ZC1031	1
+zcomet/zcomet.zsh	ZC1017	1
 zcomet/zcomet.zsh	ZC1043	18
 zcomet/zcomet.zsh	ZC1065	2
 zcomet/zcomet.zsh	ZC1068	1
@@ -1150,7 +1147,9 @@ zephyr/plugins/compstyle/compstyle.plugin.zsh	ZC1591	1
 zephyr/plugins/compstyle/compstyle.plugin.zsh	ZC1643	1
 zephyr/plugins/compstyle/compstyle.plugin.zsh	ZC1863	1
 zephyr/plugins/confd/confd.plugin.zsh	ZC1001	1
+zephyr/plugins/confd/confd.plugin.zsh	ZC1037	1
 zephyr/plugins/confd/confd.plugin.zsh	ZC1086	1
+zephyr/plugins/directory/directory.plugin.zsh	ZC1037	1
 zephyr/plugins/directory/directory.plugin.zsh	ZC1049	3
 zephyr/plugins/directory/directory.plugin.zsh	ZC1086	1
 zephyr/plugins/directory/directory.plugin.zsh	ZC1091	1
@@ -1180,6 +1179,7 @@ zephyr/plugins/prompt/prompt.plugin.zsh	ZC1967	1
 zephyr/plugins/utility/utility.plugin.zsh	ZC1049	20
 zephyr/plugins/utility/utility.plugin.zsh	ZC1052	2
 zephyr/plugins/utility/utility.plugin.zsh	ZC1086	1
+zephyr/plugins/zfunctions/zfunctions.plugin.zsh	ZC1037	7
 zephyr/plugins/zfunctions/zfunctions.plugin.zsh	ZC1064	1
 zephyr/plugins/zfunctions/zfunctions.plugin.zsh	ZC1075	2
 zephyr/plugins/zfunctions/zfunctions.plugin.zsh	ZC1086	4
@@ -1190,7 +1190,7 @@ zephyr/runcoms/zshrc.zsh	ZC1231	1
 zephyr/runcoms/zstyles.zsh	ZC1031	1
 zephyr/tests/__init__.zsh	ZC1001	4
 zephyr/tests/__init__.zsh	ZC1031	1
-zephyr/tests/__init__.zsh	ZC1037	4
+zephyr/tests/__init__.zsh	ZC1037	6
 zephyr/tests/__init__.zsh	ZC1051	1
 zephyr/tests/__init__.zsh	ZC1073	3
 zephyr/tests/__init__.zsh	ZC1075	11
@@ -1200,6 +1200,7 @@ zephyr/tests/__init__.zsh	ZC1165	1
 zephyr/tests/__init__.zsh	ZC1194	1
 zephyr/tests/__init__.zsh	ZC1283	1
 zephyr/tests/__init__.zsh	ZC1591	1
+zephyr/zephyr.zsh	ZC1037	1
 zephyr/zephyr.zsh	ZC1091	1
 zephyr/zephyr.zsh	ZC1604	1
 zgen/zgen.zsh	ZC1010	1
@@ -1266,8 +1267,9 @@ zinit/zinit-autoload.zsh	ZC1083	2
 zinit/zinit-autoload.zsh	ZC1091	32
 zinit/zinit-autoload.zsh	ZC1098	3
 zinit/zinit-autoload.zsh	ZC1111	1
+zinit/zinit-autoload.zsh	ZC1124	1
 zinit/zinit-autoload.zsh	ZC1133	1
-zinit/zinit-autoload.zsh	ZC1170	1
+zinit/zinit-autoload.zsh	ZC1170	2
 zinit/zinit-autoload.zsh	ZC1197	1
 zinit/zinit-autoload.zsh	ZC1227	2
 zinit/zinit-autoload.zsh	ZC1241	1
@@ -1375,7 +1377,7 @@ zsh-abbr/zsh-abbr.zsh	ZC1001	25
 zsh-abbr/zsh-abbr.zsh	ZC1043	45
 zsh-abbr/zsh-abbr.zsh	ZC1046	2
 zsh-abbr/zsh-abbr.zsh	ZC1073	1
-zsh-abbr/zsh-abbr.zsh	ZC1075	65
+zsh-abbr/zsh-abbr.zsh	ZC1075	64
 zsh-abbr/zsh-abbr.zsh	ZC1078	1
 zsh-abbr/zsh-abbr.zsh	ZC1086	3
 zsh-abbr/zsh-abbr.zsh	ZC1098	1
@@ -1392,10 +1394,8 @@ zsh-async/async_test.zsh	ZC1134	7
 zsh-async/async_test.zsh	ZC1149	1
 zsh-async/async_test.zsh	ZC1869	1
 zsh-async/async.zsh	ZC1001	5
-zsh-async/async.zsh	ZC1010	1
 zsh-async/async.zsh	ZC1043	2
 zsh-async/async.zsh	ZC1046	1
-zsh-async/async.zsh	ZC1065	1
 zsh-async/async.zsh	ZC1075	30
 zsh-async/async.zsh	ZC1098	1
 zsh-async/async.zsh	ZC1134	1
@@ -1421,7 +1421,7 @@ zsh-autocomplete/zsh-autocomplete.plugin.zsh	ZC1031	1
 zsh-autocomplete/zsh-autocomplete.plugin.zsh	ZC1414	1
 zsh-autoenv/autoenv.zsh	ZC1001	2
 zsh-autoenv/autoenv.zsh	ZC1012	1
-zsh-autoenv/autoenv.zsh	ZC1037	22
+zsh-autoenv/autoenv.zsh	ZC1037	26
 zsh-autoenv/autoenv.zsh	ZC1043	6
 zsh-autoenv/autoenv.zsh	ZC1045	1
 zsh-autoenv/autoenv.zsh	ZC1046	1
@@ -1513,7 +1513,7 @@ zsh-histdb/sqlite-history.zsh	ZC1037	10
 zsh-histdb/sqlite-history.zsh	ZC1043	4
 zsh-histdb/sqlite-history.zsh	ZC1045	5
 zsh-histdb/sqlite-history.zsh	ZC1059	1
-zsh-histdb/sqlite-history.zsh	ZC1075	11
+zsh-histdb/sqlite-history.zsh	ZC1075	10
 zsh-histdb/sqlite-history.zsh	ZC1076	1
 zsh-histdb/sqlite-history.zsh	ZC1091	6
 zsh-histdb/sqlite-history.zsh	ZC1114	1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.3] - 2026-06-16
+
+### Fixed
+- An orphan compound closer (`fi`, `done`, `esac`) at the top level of a script is now reported as a parse error instead of being silently accepted.
+- `&>file` is lexed as the combined stdout-and-stderr redirect. It was split into a background `&` and an orphaned `>`, which desynced the surrounding parse (for example a leading `if { … } &>/dev/null; then`).
+- A command followed only by redirects parses as one statement. A redirect chain such as `cmd >/dev/null 2>&1`, `cmd >> log`, `cmd >& fd`, or `cmd <& 3` no longer orphans its target word into a bogus second statement.
+- An expression-led pipeline (`$cmd && echo hello`) gathers the right-hand command's arguments instead of stranding them as a separate statement.
+- A leading brace-group condition (`if { cmd }; then …; fi`) is no longer mistaken for the brace-form body opener.
+
 ## [1.3.2] - 2026-06-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.3.2-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.3.3-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-132%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -562,6 +562,12 @@ func (l *Lexer) readAmpersandLead() token.Token {
 	switch l.peekChar() {
 	case '&':
 		return l.readFusedToken(token.AND)
+	case '>':
+		// `&>file` redirects both stdout and stderr — the same operator as
+		// `>&` (GTAMP). Emit GTAMP so the existing redirection handling
+		// applies; otherwise `&` lexed as a background operator and the
+		// `>` orphaned (`if { … } &>/dev/null; then …` then desynced).
+		return l.readFusedToken(token.GTAMP)
 	case '|', '!':
 		return l.readFusedToken(token.AMPERSAND)
 	case '=':

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -25,12 +25,23 @@ const (
 )
 
 var precedences = map[token.Type]int{
-	token.AND:           LOGICAL,
-	token.OR:            LOGICAL,
-	token.EQ:            EQUALS,
-	token.NotEq:         EQUALS,
-	token.LT:            LESSGREATER,
-	token.GT:            LESSGREATER,
+	token.AND:   LOGICAL,
+	token.OR:    LOGICAL,
+	token.EQ:    EQUALS,
+	token.NotEq: EQUALS,
+	token.LT:    LESSGREATER,
+	token.GT:    LESSGREATER,
+	// The compound redirections share GT/LT's parseRedirection infix
+	// handler but were missing a precedence entry, so a trailing
+	// redirect reached through the expression path (`cmd >> out`,
+	// `cmd >& out`, `cmd <& 3`) was left unconsumed and its target
+	// orphaned into a bogus second statement. LTLT (`<<`) is excluded:
+	// it opens a heredoc whose body the lexer handles separately, and
+	// giving it infix precedence routes it through parseRedirection,
+	// which mis-reads the delimiter word as a redirect target.
+	token.GTGT:          LESSGREATER,
+	token.GTAMP:         LESSGREATER,
+	token.LTAMP:         LESSGREATER,
 	token.PLUS:          SUM,
 	token.MINUS:         SUM,
 	token.SLASH:         PRODUCT,
@@ -276,6 +287,16 @@ func (p *Parser) ParseProgram() *ast.Program {
 			p.nextToken()
 			continue
 		}
+		// An orphan compound closer (`fi`, `done`, `esac`) at the top
+		// level of the program is unmatched — Zsh rejects it. This is the
+		// only place the check runs: a closer nested inside a body can be
+		// a parse-desync artefact, so flagging it there would risk a
+		// false positive (issue #1362).
+		if p.curTokenIs(token.Fi) || p.curTokenIs(token.DONE) || p.curTokenIs(token.ESAC) {
+			p.parseStrayCloser()
+			p.nextToken()
+			continue
+		}
 		stmt := p.parseStatement()
 		if stmt != nil {
 			program.Statements = append(program.Statements, stmt)
@@ -342,6 +363,20 @@ func (p *Parser) peekError(t token.Type) {
 func (p *Parser) noPrefixParseFnError(t token.Type) {
 	msg := fmt.Sprintf("line %d:%d: no prefix parse function for %s found",
 		p.curToken.Line, p.curToken.Column, t)
+	p.errors = append(p.errors, msg)
+}
+
+// parseStrayCloser records an unmatched compound-closer keyword (`fi`,
+// `done`, `esac`) that reached the top level of the program with no open
+// compound — Zsh itself rejects this ("parse error near `<kw>'"). The
+// caller (ParseProgram) invokes it only at program top level: a closer
+// nested inside a body can be the artefact of an upstream parse desync,
+// so flagging it there would risk a false positive (issue #1362).
+// curToken is left on the closer; the caller advances past it so
+// recovery continues.
+func (p *Parser) parseStrayCloser() {
+	msg := fmt.Sprintf("line %d:%d: unexpected `%s` without a matching compound command",
+		p.curToken.Line, p.curToken.Column, p.curToken.Literal)
 	p.errors = append(p.errors, msg)
 }
 

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -290,7 +290,22 @@ func (p *Parser) peekStartsSimpleCommand() bool {
 	if p.peekTokenIs(token.DEC) || p.peekTokenIs(token.INC) {
 		return true
 	}
+	if p.peekStartsRedirection() {
+		return true
+	}
 	return p.peekTokenIs(token.PIPE) || p.peekTokenIs(token.AND) || p.peekTokenIs(token.OR)
+}
+
+// peekStartsRedirection reports whether the peek token opens a
+// redirection that immediately follows the command name (`cmd >out`,
+// `cmd >& fd`). Routing these through the simple-command path lets its
+// redirection loop gather the whole chain — including a trailing
+// FD-prefixed redirect (`cmd >/dev/null 2>&1`) — instead of the
+// expression path consuming one redirect and orphaning the rest.
+func (p *Parser) peekStartsRedirection() bool {
+	return p.peekTokenIs(token.GT) || p.peekTokenIs(token.GTGT) ||
+		p.peekTokenIs(token.LT) || p.peekTokenIs(token.LTLT) ||
+		p.peekTokenIs(token.GTAMP) || p.peekTokenIs(token.LTAMP)
 }
 
 func (p *Parser) peekStartsArgPrefix() bool {
@@ -512,7 +527,14 @@ func (p *Parser) finishLoopTail() {
 // IDENT path would produce for `cmd | other`.
 func (p *Parser) parsePipelineStartingWithExpression() ast.Statement {
 	tok := p.curToken
-	expr := p.parseExpression(LOWEST)
+	// Parse the head at LOGICAL, not LOWEST: a LOWEST parse swallows a
+	// trailing `&&`/`||` as an infix whose right operand is a single
+	// primary (`$cmd && echo`), stranding the rest of that command's
+	// words (`hello` in `$cmd && echo hello`) as a separate statement.
+	// Stopping at LOGICAL leaves the connector for the loop below, which
+	// parses each right-hand side through parseCommandPipeline so its
+	// arguments are gathered.
+	expr := p.parseExpression(LOGICAL)
 	if expr == nil {
 		return nil
 	}
@@ -1058,19 +1080,35 @@ func (p *Parser) parseBraceFormElifChain() ast.Statement {
 	return head
 }
 
+// blockTerminatorMatch reports whether curToken closes a block whose
+// terminator set is terminators. Two position-specific exceptions apply:
+// a leading `{` in an empty block is a brace-group condition
+// (`if { cmd }; then …`), not the brace-form body opener; and a `}` that
+// closed a `${…}` expansion is the lexer-flagged inner brace, not the
+// block's own close (`cmd ${X} }`).
+func (p *Parser) blockTerminatorMatch(terminators []token.Type, empty bool) bool {
+	for _, t := range terminators {
+		if !p.curTokenIs(t) {
+			continue
+		}
+		if t == token.LBRACE && empty {
+			return false
+		}
+		if t == token.RBRACE && p.curToken.ClosesDollarBrace {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
 func (p *Parser) parseBlockStatement(terminators ...token.Type) *ast.BlockStatement {
 	block := &ast.BlockStatement{Token: p.curToken}
 	block.Statements = []ast.Statement{}
 
 	for !p.curTokenIs(token.EOF) {
-		isTerm := p.curIsForeachEnd()
-		for _, t := range terminators {
-			if p.curTokenIs(t) {
-				isTerm = true
-				break
-			}
-		}
-		if isTerm {
+		if p.curIsForeachEnd() ||
+			p.blockTerminatorMatch(terminators, len(block.Statements) == 0) {
 			break
 		}
 
@@ -1116,21 +1154,7 @@ func (p *Parser) parseBlockStatement(terminators ...token.Type) *ast.BlockStatem
 		// on block keywords. Advancing unconditionally here would
 		// step past it and the outer if/loop/case would then see
 		// EOF and report "expected FI got EOF".
-		curIsTerm := p.curIsForeachEnd()
-		for _, t := range terminators {
-			if p.curTokenIs(t) {
-				// An RBRACE that closed a `${…}` is not the block's
-				// terminator — `cmd ${X} }` leaves curToken on the
-				// `${X}`'s `}` while the brace-block close is the
-				// next RBRACE. The lexer flags the inner one.
-				if t == token.RBRACE && p.curToken.ClosesDollarBrace {
-					break
-				}
-				curIsTerm = true
-				break
-			}
-		}
-		if curIsTerm {
+		if p.curIsForeachEnd() || p.blockTerminatorMatch(terminators, false) {
 			// A consumed-terminator signal from the last body statement
 			// (a finishCompound'd `if`, a brace-form close) applied only
 			// to that statement's own terminator. Clear it before

--- a/pkg/parser/parser_stray_closer_test.go
+++ b/pkg/parser/parser_stray_closer_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/lexer"
+)
+
+// parseStrayExpectErr parses src and fails unless exactly one error is
+// reported and it names the unmatched closer.
+func parseStrayExpectErr(t *testing.T, src, closer string) {
+	t.Helper()
+	p := New(lexer.New(src))
+	_ = p.ParseProgram()
+	errs := p.Errors()
+	if len(errs) != 1 {
+		t.Fatalf("want 1 error for %q, got %d: %v", src, len(errs), errs)
+	}
+	if !strings.Contains(errs[0], "unexpected `"+closer+"`") {
+		t.Fatalf("error for %q does not name closer %q: %s", src, closer, errs[0])
+	}
+}
+
+// An orphan compound closer at the top level is unmatched — Zsh rejects
+// it. The parser records one error and recovers (issue #1362).
+func TestParseStrayCloserTopLevel(t *testing.T) {
+	parseStrayExpectErr(t, "done\n", "done")
+	parseStrayExpectErr(t, "fi\n", "fi")
+	parseStrayExpectErr(t, "esac\n", "esac")
+	parseStrayExpectErr(t, "for i in a; do echo; done\ndone\n", "done")
+	parseStrayExpectErr(t, "if x; then y; fi\nfi\n", "fi")
+	parseStrayExpectErr(t, "echo ok\nesac\n", "esac")
+}
+
+// A closer that legitimately closes its own compound, however nested,
+// must not be flagged.
+func TestParseNestedClosersClean(t *testing.T) {
+	parseClean(t, "while x; do for i in a; do echo; done; done\n")
+	parseClean(t, "if x; then for i in a; do echo; done; fi\n")
+	parseClean(t, "case $x in a) echo a ;; esac\n")
+}
+
+// A closer keyword used as a plain command word is not a stray closer.
+func TestParseCloserAsWordClean(t *testing.T) {
+	parseClean(t, "echo done\n")
+	parseClean(t, "a && echo done\n")
+	parseClean(t, "echo done\necho fi\n")
+}
+
+// A command followed only by redirects parses as one statement: the
+// redirect chain must not orphan a target word into a bogus second
+// statement. Covers bare (`>>`, `>&`, `<&`), the combined `&>`, and the
+// `>/dev/null 2>&1` FD-prefixed tail.
+func TestParseRedirectChains(t *testing.T) {
+	for _, src := range []string{
+		"cmd >out\n",
+		"cmd >> log\n",
+		"cmd >& out\n",
+		"cmd <& 3\n",
+		"cmd <in\n",
+		"cmd >/dev/null 2>&1\n",
+		"cmd >out 2>&1\n",
+		"cmd >out >>log\n",
+		"cmd 2>&1 >out\n",
+		"cmd arg >out 2>&1\n",
+	} {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Fatalf("unexpected errors for %q: %v", src, errs)
+		}
+		if got := len(prog.Statements); got != 1 {
+			t.Fatalf("want 1 statement for %q, got %d", src, got)
+		}
+	}
+}
+
+// `&>file` is the combined stdout+stderr redirect, lexed as GTAMP. It
+// must not background the command (`&`) and orphan the `>`.
+func TestParseAmpGtRedirect(t *testing.T) {
+	for _, src := range []string{
+		"cmd &>/dev/null\n",
+		"cmd &> out\n",
+		"zpty -t $worker &>/dev/null || return 1\n",
+		"if { cmd } &>/dev/null; then x; fi\n",
+	} {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Fatalf("unexpected errors for %q: %v", src, errs)
+		}
+		if got := len(prog.Statements); got != 1 {
+			t.Fatalf("want 1 statement for %q, got %d", src, got)
+		}
+	}
+}
+
+// An expression-led pipeline (`$cmd && echo arg`) gathers the right-hand
+// command's arguments instead of stranding them as a separate statement.
+func TestParseExpressionLedPipelineArgs(t *testing.T) {
+	for _, src := range []string{
+		"$cmd && echo hello\n",
+		"$cmd && echo done\n",
+		"${x} && echo hi there\n",
+		"`foo` && bar baz qux\n",
+		"$cmd && echo a || echo b\n",
+	} {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Fatalf("unexpected errors for %q: %v", src, errs)
+		}
+		if got := len(prog.Statements); got != 1 {
+			t.Fatalf("want 1 statement for %q, got %d", src, got)
+		}
+	}
+}
+
+// A leading `{` in an if/while condition is a brace-group condition, not
+// the brace-form body opener (`if { cmd }; then …; fi`).
+func TestParseBraceGroupCondition(t *testing.T) {
+	parseClean(t, "if { cmd }; then x; fi\n")
+	parseClean(t, "if { a || b }; then x; fi\n")
+	parseClean(t, "while { c }; do x; done\n")
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.3.2"
+const Version = "1.3.3"


### PR DESCRIPTION
Parser correctness fixes for redirections, orphan closers, and expression-led pipelines.

What:
- A command followed only by redirects parses as one statement; a chain like `cmd >/dev/null 2>&1`, `cmd >> log`, `cmd >& fd`, or `cmd <& 3` no longer orphans its target word into a bogus second statement.
- `&>file` lexes as the combined stdout+stderr redirect instead of a background `&` plus an orphaned `>`.
- An expression-led pipeline (`$cmd && echo hello`) gathers the right-hand command arguments.
- A leading brace-group condition (`if { cmd }; then ...; fi`) is no longer mistaken for the brace-form body opener.
- An orphan `fi`/`done`/`esac` at the top level is reported as a parse error instead of being silently accepted.

Why: the expression path consumed only one redirect via the infix table and `&>` was mis-lexed, desyncing real scripts. Recovered findings on commands that carry a redirect; removed false positives on redirect targets (Zsh does not word-split them).

Severity: parser correctness.