### PR TITLE
fix: parse zsh always-block as one statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.4] - 2026-06-16
+
+### Fixed
+- Zsh's `{ try-list } always { always-list }` construct parses as a single block. The `always` clause was treated as a separate `always { … }` command, which left a stray closing brace as its own statement.
+
 ## [1.3.3] - 2026-06-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.3.3-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.3.4-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-132%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -212,6 +212,7 @@ func (p *Parser) parseBraceGroupStatement() ast.Statement {
 	p.nextToken()
 	block := p.parseBlockStatement(token.RBRACE)
 	block.Token = tok
+	p.absorbAlwaysBlock(block)
 	for p.peekTokenIs(token.PIPE) || p.peekTokenIs(token.AND) || p.peekTokenIs(token.OR) {
 		p.nextToken()
 		p.nextToken()
@@ -221,6 +222,28 @@ func (p *Parser) parseBraceGroupStatement() ast.Statement {
 		p.nextToken()
 	}
 	return block
+}
+
+// absorbAlwaysBlock folds a Zsh `{ try } always { always-list }` tail into
+// the preceding block. The always-list runs regardless of how the
+// try-list exits; the linter treats both as ordinary command lists, so
+// its statements join the same block. Without this, `always { … }` parsed
+// as a bogus command statement and the inner commands escaped the block.
+// `always` is lexed as a plain identifier and is only valid here, so a
+// bare `always` immediately after a brace group is unambiguously the
+// keyword.
+func (p *Parser) absorbAlwaysBlock(block *ast.BlockStatement) {
+	if !p.peekTokenIs(token.IDENT) || p.peekToken.Literal != "always" {
+		return
+	}
+	p.nextToken() // consume `always`
+	if !p.peekTokenIs(token.LBRACE) {
+		return
+	}
+	p.nextToken() // move onto the always-list `{`
+	if always, ok := p.parseBraceGroupStatement().(*ast.BlockStatement); ok {
+		block.Statements = append(block.Statements, always.Statements...)
+	}
 }
 
 func (p *Parser) parseDoubleLparenStatement() ast.Statement {

--- a/pkg/parser/parser_stray_closer_test.go
+++ b/pkg/parser/parser_stray_closer_test.go
@@ -153,3 +153,18 @@ func TestParseAlwaysBlock(t *testing.T) {
 		}
 	}
 }
+
+// A bare `always` that is not followed by a brace block is consumed but
+// not folded; the parser must not panic or error on the degenerate form.
+func TestParseAlwaysWithoutBlock(t *testing.T) {
+	for _, src := range []string{
+		"{ echo a } always\n",
+		"{ echo a } always cmd\n",
+	} {
+		p := New(lexer.New(src))
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Fatalf("unexpected errors for %q: %v", src, errs)
+		}
+	}
+}

--- a/pkg/parser/parser_stray_closer_test.go
+++ b/pkg/parser/parser_stray_closer_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/afadesigns/zshellcheck/pkg/ast"
 	"github.com/afadesigns/zshellcheck/pkg/lexer"
 )
 
@@ -125,4 +126,30 @@ func TestParseBraceGroupCondition(t *testing.T) {
 	parseClean(t, "if { cmd }; then x; fi\n")
 	parseClean(t, "if { a || b }; then x; fi\n")
 	parseClean(t, "while { c }; do x; done\n")
+}
+
+// Zsh's `{ try } always { always-list }` parses as one block; the
+// always-list is not stranded as a bogus `always { … }` command.
+func TestParseAlwaysBlock(t *testing.T) {
+	for _, src := range []string{
+		"{ echo try } always { echo cleanup }\n",
+		"{ false && true } always { echo done }\n",
+		"{ a } always { b } always { c }\n",
+	} {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Fatalf("unexpected errors for %q: %v", src, errs)
+		}
+		if got := len(prog.Statements); got != 1 {
+			t.Fatalf("want 1 statement for %q, got %d", src, got)
+		}
+		block, ok := prog.Statements[0].(*ast.BlockStatement)
+		if !ok {
+			t.Fatalf("want *ast.BlockStatement for %q, got %T", src, prog.Statements[0])
+		}
+		if len(block.Statements) < 2 {
+			t.Fatalf("always-list not folded into block for %q: %d statements", src, len(block.Statements))
+		}
+	}
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.3.3"
+const Version = "1.3.4"


### PR DESCRIPTION
Zsh `{ try } always { always-list }` parsed the `always` clause as a separate `always { ... }` command and stranded its closing brace as its own statement.

What: fold the always-list into the preceding block so its commands are linted in place; no stray brace statement.
Why: `always` is a real Zsh construct used by integration corpora (zaw, zsh-defer). It is lexed as a plain identifier and is valid only after a brace group, so the keyword is unambiguous.

Severity: parser correctness.