### PR TITLE
fix: stop auto-fix from corrupting source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.5] - 2026-06-16
+
+### Fixed
+- Auto-fix never writes source that fails to parse. When a pass would introduce a parser error — for example two fixes colliding on the same token — only the individually safe edits are kept, and a still-conflicting set is skipped entirely.
+- The ZC1001 `${...}` rewrite emits a single replacement spanning `$name[subscript]`. The previous pair of `{` / `}` insertions straddled ZC1073's `$` deletion inside `(( … ))` and produced the broken `{name[subscript]}`.
+- The ZC1040 `(N)` nullglob fix no longer stacks qualifiers (`pattern(N)(N)(N)…`) when run more than once.
+
 ## [1.3.4] - 2026-06-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.3.4-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.3.5-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-132%20katas-2ea44f)](KATAS.md)
 [![Go Report](https://goreportcard.com/badge/github.com/afadesigns/zshellcheck)](https://goreportcard.com/report/github.com/afadesigns/zshellcheck)

--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -294,12 +294,57 @@ func applyFixesUntilStable(src string, initialEdits []katas.FixEdit, registry *k
 		if next == current {
 			break
 		}
-		totalEdits += len(edits)
+		applied := len(edits)
+		// Safety net: never accept a pass that introduces parse errors.
+		// Two fixes can collide on adjacent spans (for example ZC1073
+		// deleting the `$` while another rewrites the same token) and
+		// produce broken source. Rather than write it, keep only the
+		// edits that are individually safe.
+		if parseErrorCount(next) > parseErrorCount(current) {
+			next, applied = applySafeEdits(current, edits)
+			if next == current {
+				break
+			}
+		}
+		totalEdits += applied
 		current = next
 		// Re-collect edits from the new source.
 		edits = collectEdits(current, registry, disabled, cfg, allowedSeverities)
 	}
 	return current, totalEdits, nil
+}
+
+// parseErrorCount reports how many parser errors src produces. Used by
+// the auto-fix safety net to reject any rewrite that breaks the parse.
+func parseErrorCount(src string) int {
+	p := parser.New(lexer.New(src))
+	p.ParseProgram()
+	return len(p.Errors())
+}
+
+// applySafeEdits is the fallback when the full edit batch breaks the
+// parse. It keeps only the edits that, applied alone to base, do not
+// raise the parser-error count, then verifies the combined result still
+// parses cleanly. If the surviving set still collides, it returns base
+// unchanged so a broken file is never written.
+func applySafeEdits(base string, edits []katas.FixEdit) (string, int) {
+	baseErrs := parseErrorCount(base)
+	safe := make([]katas.FixEdit, 0, len(edits))
+	for _, e := range edits {
+		one, err := fix.Apply(base, []katas.FixEdit{e})
+		if err != nil || parseErrorCount(one) > baseErrs {
+			continue
+		}
+		safe = append(safe, e)
+	}
+	if len(safe) == 0 {
+		return base, 0
+	}
+	combined, err := fix.Apply(base, safe)
+	if err != nil || parseErrorCount(combined) > baseErrs {
+		return base, 0
+	}
+	return combined, len(safe)
 }
 
 // collectEdits parses src and returns the auto-fix edits the registry

--- a/cmd/zshellcheck/main_test.go
+++ b/cmd/zshellcheck/main_test.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/afadesigns/zshellcheck/pkg/config"
@@ -463,6 +464,75 @@ func TestApplyFixesUntilStable_RewritesBackticks(t *testing.T) {
 	}
 	if out == src {
 		t.Errorf("expected source rewrite, got identity")
+	}
+}
+
+// Auto-fix must never write source that parses worse than the input.
+// These inputs trigger colliding fixes (ZC1073 deleting `$` while ZC1001
+// rewrites the same subscript; the `[ ]`->`[[ ]]` rewrite over an array
+// subscript) that used to corrupt the source.
+func TestApplyFixesUntilStable_NeverBreaksParse(t *testing.T) {
+	cfg := config.DefaultConfig()
+	registry := katas.Registry
+	for _, src := range []string{
+		"(( $reply[x] )) && return\n",
+		"if [ $commands[oc] ]; then :; fi\n",
+	} {
+		initial := collectEdits(src, registry, nil, cfg, nil)
+		out, _, err := applyFixesUntilStable(src, initial, registry, nil, cfg, nil, 5)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", src, err)
+		}
+		if got := parseErrorCount(out); got != 0 {
+			t.Errorf("auto-fix introduced %d parse error(s) for %q:\n%s", got, src, out)
+		}
+	}
+}
+
+// The ZC1001 subscript fix produces `${arr[x]}`, never the brace-stripped
+// `{arr[x]}` that resulted when its `{`/`}` inserts straddled ZC1073's
+// `$` deletion inside `(( … ))`.
+func TestApplyFixesUntilStable_ArithSubscript(t *testing.T) {
+	cfg := config.DefaultConfig()
+	registry := katas.Registry
+	src := "(( $reply[x] )) && return\n"
+	out, _, err := applyFixesUntilStable(src, collectEdits(src, registry, nil, cfg, nil), registry, nil, cfg, nil, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out, "{reply[x]}") && !strings.Contains(out, "${reply[x]}") {
+		t.Errorf("ZC1001 dropped the `$`: %q", out)
+	}
+}
+
+// The ZC1040 nullglob fix must not stack qualifiers on repeated runs.
+func TestApplyFixesUntilStable_NullglobIdempotent(t *testing.T) {
+	cfg := config.DefaultConfig()
+	registry := katas.Registry
+	src := "for f in *.txt; do print -r -- $f; done\n"
+	once, _, _ := applyFixesUntilStable(src, collectEdits(src, registry, nil, cfg, nil), registry, nil, cfg, nil, 5)
+	twice, _, _ := applyFixesUntilStable(once, collectEdits(once, registry, nil, cfg, nil), registry, nil, cfg, nil, 5)
+	if once != twice {
+		t.Errorf("ZC1040 fix not idempotent:\n once:  %q\n twice: %q", once, twice)
+	}
+	if !strings.Contains(once, "*.txt(N)") {
+		t.Errorf("ZC1040 fix did not apply: %q", once)
+	}
+}
+
+func TestApplySafeEdits_Bailouts(t *testing.T) {
+	base := "echo hi\n"
+	// Every candidate edit breaks the parse alone -> nothing is kept and
+	// base is returned unchanged.
+	stray := katas.FixEdit{Line: 1, Column: 1, Length: 0, Replace: "fi\n"}
+	if out, n := applySafeEdits(base, []katas.FixEdit{stray}); out != base || n != 0 {
+		t.Errorf("all-break: want base/0, got %q/%d", out, n)
+	}
+	// A safe edit is kept while the breaking one is dropped.
+	safe := katas.FixEdit{Line: 1, Column: 1, Length: 4, Replace: "print -r --"}
+	out, n := applySafeEdits(base, []katas.FixEdit{stray, safe})
+	if n != 1 || !strings.Contains(out, "print -r --") {
+		t.Errorf("mixed: want 1 kept with rewrite, got %q/%d", out, n)
 	}
 }
 

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -57,12 +57,18 @@ func fixZC1001(node ast.Node, v Violation, source []byte) []FixEdit {
 	if closeOff < 0 {
 		return nil
 	}
-	return []FixEdit{
-		// Insert `{` immediately after the `$`.
-		{Line: v.Line, Column: v.Column + 1, Length: 0, Replace: "{"},
-		// Insert `}` immediately after the closing `]`.
-		offsetToEdit(source, closeOff+1, 0, "}"),
-	}
+	// Emit one replacement spanning `$name[subscript]` rather than two
+	// separate `{` / `}` insertions. A single span lets the fix engine's
+	// overlap check see a conflict with an adjacent edit on the same
+	// token — notably ZC1073, which deletes the `$` inside `(( … ))`.
+	// Two zero-width inserts straddle that delete without overlapping it,
+	// so both used to apply and produced the broken `{name[subscript]}`.
+	return []FixEdit{{
+		Line:    v.Line,
+		Column:  v.Column,
+		Length:  closeOff + 1 - dollarOff,
+		Replace: "${" + string(source[dollarOff+1:closeOff+1]) + "}",
+	}}
 }
 
 // findSubscriptClose returns the byte offset of the `]` that closes
@@ -2200,6 +2206,14 @@ func fixZC1040(_ ast.Node, v Violation, source []byte) []FixEdit {
 		return nil
 	}
 	end := start + argLen
+	// Double-qualify guard: if the pattern's source span already carries a
+	// null-glob qualifier, do not append another `(N)`. unquotedArgLen
+	// absorbs a trailing `(…)` group, but the parser does not fold it back
+	// into the loop item's value, so checkZC1040's own hasNullGlobQualifier
+	// stays false and every fix pass would stack another: `pat(N)(N)(N)…`.
+	if hasNullGlobQualifier(string(source[start:end])) {
+		return nil
+	}
 	endLine, endCol := offsetLineColZC1040(source, end)
 	if endLine < 0 {
 		return nil

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.3.4"
+const Version = "1.3.5"


### PR DESCRIPTION
A full-corpus auto-fix round-trip (apply `-fix`, re-parse) found 14 files the fixer corrupted into unparseable source and one it rewrote without converging.

What:
- Safety net in the fix loop: a pass that raises the parser-error count falls back to applying only individually safe edits, and skips a still-conflicting set rather than writing broken source. Auto-fix can no longer increase parse errors.
- ZC1001 emits one replacement spanning `$name[subscript]` instead of separate `{` / `}` insertions, so it overlaps (and the engine resolves) a competing edit on the same token. Fixes the broken `{name[subscript]}` produced when ZC1073 deleted the `$` inside `(( … ))`.
- ZC1040 `(N)` nullglob fix no longer stacks qualifiers on repeated runs.

Why: a linter that rewrites code must never corrupt it. Verified: 1095-corpus round-trip now reports broke=0 unstable=0 (was 14 + 1).

Severity: auto-fix correctness.