### PR TITLE
feat: add fixable markers and -statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-16
+
+### Added
+- The text report tags every finding whose kata ships an auto-fix with a trailing `[*]`, and ends with a `[*] N fixable with the -fix option.` summary. You can now see how much `-fix` resolves before running it.
+- `-statistics` prints a per-kata count of findings, sorted by frequency and tagged with the `[*]` fixable marker, instead of individual reports. Use it to triage which checks dominate a large codebase.
+
 ## [1.3.7] - 2026-06-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.3.7-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.4.0-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-132%20katas-2ea44f)](KATAS.md)
 [![Dependencies](https://img.shields.io/badge/dependencies-0-2ea44f)](go.mod)

--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -39,6 +39,7 @@ type runFlags struct {
 	dryRun         *bool
 	listRules      *bool
 	explain        *string
+	statistics     *bool
 }
 
 func run() int {
@@ -81,9 +82,45 @@ func run() int {
 		return code
 	}
 	fixOpts := buildFixOpts(*flags.fixMode, *flags.diffMode, *flags.dryRun)
+	if *flags.statistics {
+		fixOpts.statistics = map[string]int{}
+	}
 	total := scanArgs(cfg, allowedSeverities, *flags.format, fixOpts)
 	emitFixSummary(fixOpts.stats)
-	return finalExitCode(total, *flags.format)
+	if fixOpts.statistics != nil {
+		emitStatistics(os.Stdout, katas.Registry, fixOpts.statistics)
+		if total == 0 {
+			return 0
+		}
+		return 1
+	}
+	return finalExitCode(total, *flags.format, fixOpts)
+}
+
+// emitStatistics prints a per-kata count table sorted by descending count
+// then kata ID, each row tagged `[*]` when the kata ships an auto-fix.
+func emitStatistics(out io.Writer, registry *katas.KatasRegistry, counts map[string]int) {
+	ids := make([]string, 0, len(counts))
+	for id := range counts {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		if counts[ids[i]] != counts[ids[j]] {
+			return counts[ids[i]] > counts[ids[j]]
+		}
+		return ids[i] < ids[j]
+	})
+	for _, id := range ids {
+		mark := "   "
+		if registry.IsFixable(id) {
+			mark = "[*]"
+		}
+		title := ""
+		if k, ok := registry.GetKata(id); ok {
+			title = k.Title
+		}
+		fmt.Fprintf(out, "%5d  %-8s  %s  %s\n", counts[id], id, mark, title)
+	}
 }
 
 func registerRunFlags() runFlags {
@@ -100,6 +137,7 @@ func registerRunFlags() runFlags {
 		dryRun:         flag.Bool("dry-run", false, "With -fix, report what would change without modifying files."),
 		listRules:      flag.Bool("list-rules", false, "Print every kata (ID, severity, title) and exit."),
 		explain:        flag.String("explain", "", "Print the full description of a kata by ID (e.g. ZC1001) and exit."),
+		statistics:     flag.Bool("statistics", false, "Print a per-kata count of findings instead of individual reports."),
 	}
 }
 
@@ -228,6 +266,7 @@ func buildFixOpts(fixMode, diffMode, dryRun bool) fixOptions {
 	if opts.enabled {
 		opts.stats = &fixStats{}
 	}
+	opts.fixable = new(int)
 	return opts
 }
 
@@ -274,12 +313,17 @@ func emitFixSummary(stats *fixStats) {
 		stats.totalEdits, stats.filesModified, stats.filesScanned)
 }
 
-func finalExitCode(total int, format string) int {
+func finalExitCode(total int, format string, fixOpts fixOptions) int {
 	if total == 0 {
 		return 0
 	}
 	if format == "text" {
 		fmt.Fprintf(os.Stderr, "\nFound %d violations.\n", total)
+		// Point at the auto-fixable subset, unless fixes are already
+		// being applied or previewed this run.
+		if !fixOpts.enabled && fixOpts.fixable != nil && *fixOpts.fixable > 0 {
+			fmt.Fprintf(os.Stderr, "[*] %d fixable with the `-fix` option.\n", *fixOpts.fixable)
+		}
 	}
 	return 1
 }
@@ -324,6 +368,12 @@ type fixOptions struct {
 	// formats so they are emitted once as a single JSON / SARIF document.
 	// nil for the text format, which streams per file.
 	collector *[]reporter.FileViolations
+	// fixable counts findings across the run whose kata ships an auto-fix,
+	// for the `[*] N fixable` hint shown after a text report.
+	fixable *int
+	// statistics, when non-nil, switches output to a per-kata count table:
+	// individual findings are suppressed and tallied here instead.
+	statistics map[string]int
 }
 
 // fixStats accumulates fix activity across all files visited in one
@@ -539,7 +589,7 @@ func processFile(filename string, out, errOut io.Writer, cfg config.Config, regi
 	violations, edits = applySeverityFilter(violations, edits, allowedSeverities)
 
 	applyFixIfEnabled(filename, data, registry, disabled, cfg, allowedSeverities, edits, violations, fixOpts, out, errOut)
-	emitReport(filename, out, errOut, format, cfg, violations, data, fixOpts.collector)
+	emitReport(filename, out, errOut, format, cfg, violations, data, registry, fixOpts)
 	return len(violations)
 }
 
@@ -652,17 +702,33 @@ func applyFixInPlace(filename string, data []byte, registry *katas.KatasRegistry
 	}
 }
 
-func emitReport(filename string, out, errOut io.Writer, format string, cfg config.Config, violations []katas.Violation, data []byte, collector *[]reporter.FileViolations) {
+func emitReport(filename string, out, errOut io.Writer, format string, cfg config.Config, violations []katas.Violation, data []byte, registry *katas.KatasRegistry, fixOpts fixOptions) {
 	if len(violations) == 0 {
+		return
+	}
+	// Statistics mode tallies findings per kata and suppresses the
+	// individual reports.
+	if fixOpts.statistics != nil {
+		for _, v := range violations {
+			fixOpts.statistics[v.KataID]++
+		}
 		return
 	}
 	// The machine-readable formats are aggregated and emitted once by the
 	// caller; collect this file's findings and return. Text reports inline.
-	if collector != nil {
-		*collector = append(*collector, reporter.FileViolations{Filename: filename, Violations: violations})
+	if fixOpts.collector != nil {
+		*fixOpts.collector = append(*fixOpts.collector, reporter.FileViolations{Filename: filename, Violations: violations})
 		return
 	}
+	if fixOpts.fixable != nil {
+		for _, v := range violations {
+			if registry.IsFixable(v.KataID) {
+				*fixOpts.fixable++
+			}
+		}
+	}
 	r := reporter.NewTextReporter(out, filename, string(data), cfg)
+	r.MarkFixable(registry.IsFixable)
 	if err := r.Report(violations); err != nil {
 		fmt.Fprintf(errOut, "Error reporting violations: %s\n", err)
 	}

--- a/cmd/zshellcheck/main_test.go
+++ b/cmd/zshellcheck/main_test.go
@@ -661,11 +661,11 @@ func TestRun_Statistics(t *testing.T) {
 
 func TestFinalExitCode_FixableFooter(t *testing.T) {
 	n := 3
-	fo := fixOptions{fixable: &n}
-	if code := finalExitCode(5, "text", fo); code != 1 {
+	opts := fixOptions{fixable: &n}
+	if code := finalExitCode(5, "text", opts); code != 1 {
 		t.Errorf("want exit 1 with violations, got %d", code)
 	}
-	if code := finalExitCode(0, "text", fo); code != 0 {
+	if code := finalExitCode(0, "text", opts); code != 0 {
 		t.Errorf("want exit 0 with no violations, got %d", code)
 	}
 }

--- a/cmd/zshellcheck/main_test.go
+++ b/cmd/zshellcheck/main_test.go
@@ -627,6 +627,49 @@ func TestHomeDir(t *testing.T) {
 	_ = homeDir()
 }
 
+func TestEmitStatistics(t *testing.T) {
+	counts := map[string]int{"ZC1037": 3, "ZC1075": 10}
+	var buf bytes.Buffer
+	emitStatistics(&buf, katas.Registry, counts)
+	out := buf.String()
+	// Sorted by descending count: ZC1075 (10) precedes ZC1037 (3).
+	i1075 := strings.Index(out, "ZC1075")
+	i1037 := strings.Index(out, "ZC1037")
+	if i1075 < 0 || i1037 < 0 || i1075 > i1037 {
+		t.Errorf("statistics not sorted by count desc:\n%s", out)
+	}
+	// ZC1037 ships an auto-fix and must carry the marker.
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "ZC1037") && !strings.Contains(line, "[*]") {
+			t.Errorf("ZC1037 line missing fixable marker: %q", line)
+		}
+	}
+}
+
+func TestRun_Statistics(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.zsh")
+	if err := os.WriteFile(path, []byte("#!/bin/zsh\nfor i in $(ls); do echo $i; done\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resetFlags()
+	old := os.Args
+	defer func() { os.Args = old }()
+	os.Args = []string{"zshellcheck", "-statistics", "-no-banner", path}
+	_ = run()
+}
+
+func TestFinalExitCode_FixableFooter(t *testing.T) {
+	n := 3
+	fo := fixOptions{fixable: &n}
+	if code := finalExitCode(5, "text", fo); code != 1 {
+		t.Errorf("want exit 1 with violations, got %d", code)
+	}
+	if code := finalExitCode(0, "text", fo); code != 0 {
+		t.Errorf("want exit 0 with no violations, got %d", code)
+	}
+}
+
 func TestProcessFile_NonexistentFile(t *testing.T) {
 	var out, errOut bytes.Buffer
 	cfg := config.DefaultConfig()

--- a/cmd/zshellcheck/usage.go
+++ b/cmd/zshellcheck/usage.go
@@ -37,7 +37,7 @@ func printUsage(out io.Writer, fset *flag.FlagSet, showBanner bool) {
 	groups := []flagGroup{
 		{
 			title: "OUTPUT",
-			names: []string{"format", "no-color", "no-banner", "verbose"},
+			names: []string{"format", "statistics", "no-color", "no-banner", "verbose"},
 			blurb: "Shape what lands on stdout / stderr.",
 		},
 		{
@@ -77,6 +77,7 @@ func printUsage(out io.Writer, fset *flag.FlagSet, showBanner bool) {
 		{"Lint a single script", "zshellcheck path/to/script.zsh"},
 		{"List every kata, or explain one", "zshellcheck -list-rules; zshellcheck -explain ZC1001"},
 		{"Lint a tree, suppress style-level findings", "zshellcheck -severity warning ./scripts"},
+		{"Triage by frequency: per-kata counts", "zshellcheck -statistics ./scripts"},
 		{"Emit SARIF for GitHub Code Scanning", "zshellcheck -format sarif ./scripts > zshellcheck.sarif"},
 		{"Preview every available auto-fix as a diff", "zshellcheck -diff path/to/script.zsh"},
 		{"Apply auto-fixes in place", "zshellcheck -fix path/to/script.zsh"},

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -31,6 +31,7 @@ Files with `.go`, `.md`, `.json`, `.yml`, `.yaml`, or `.txt` extensions are skip
 | Flag | Default | Purpose |
 | --- | --- | --- |
 | `-format <text\|json\|sarif>` | `text` | Output format. `sarif` is for GitHub Code Scanning ingestion. |
+| `-statistics` | off | Print a per-kata count of findings, sorted by frequency, instead of individual reports. |
 | `-severity <level[,level...]>` | (all) | Comma-separated filter. Accepts `error`, `warning`, `info`, `style`. |
 | `-verbose` | off | Emit full kata descriptions in text output. |
 | `-no-color` | off | Disable ANSI colours. Implied when stdout is not a TTY. |
@@ -76,6 +77,7 @@ zshellcheck -explain ZC1001
 ### Auto-fixes
 
 Katas with a deterministic, reversible rewrite ship a `Fix` implementation.
+A finding from such a kata is tagged with a trailing `[*]` in the text report, and the run ends with a `[*] N fixable with the -fix option.` summary, so you can see at a glance how much the fixer resolves before touching anything.
 Run `zshellcheck -fix <path>` to apply rewrites in place, or `zshellcheck -diff <path>` to preview the unified diff.
 The fixer rewrites only the exact span the kata points at — arguments, quoting, and surrounding whitespace are preserved byte-for-byte.
 

--- a/pkg/katas/fixes_for_test.go
+++ b/pkg/katas/fixes_for_test.go
@@ -51,3 +51,25 @@ func TestFixesForKataWithFix(t *testing.T) {
 		t.Errorf("unexpected fix output: %v", got)
 	}
 }
+
+func TestIsFixable(t *testing.T) {
+	kr := NewKatasRegistry()
+	kr.RegisterKata(ast.IdentifierNode, Kata{
+		ID:    "ZC_FIXABLE",
+		Check: func(ast.Node) []Violation { return nil },
+		Fix:   func(ast.Node, Violation, []byte) []FixEdit { return nil },
+	})
+	kr.RegisterKata(ast.IdentifierNode, Kata{
+		ID:    "ZC_PLAIN",
+		Check: func(ast.Node) []Violation { return nil },
+	})
+	if !kr.IsFixable("ZC_FIXABLE") {
+		t.Error("ZC_FIXABLE should be fixable")
+	}
+	if kr.IsFixable("ZC_PLAIN") {
+		t.Error("ZC_PLAIN should not be fixable")
+	}
+	if kr.IsFixable("ZC_UNKNOWN") {
+		t.Error("unknown kata should not be fixable")
+	}
+}

--- a/pkg/katas/katas.go
+++ b/pkg/katas/katas.go
@@ -83,6 +83,13 @@ func (kr *KatasRegistry) GetKata(id string) (Kata, bool) {
 	return kata, ok
 }
 
+// IsFixable reports whether the kata with the given ID ships a
+// deterministic auto-fix.
+func (kr *KatasRegistry) IsFixable(id string) bool {
+	kata, ok := kr.KatasByID[id]
+	return ok && kata.Fix != nil
+}
+
 // KatasByNodeType returns all registered Katas grouped by node type.
 func (kr *KatasRegistry) KatasByNodeType() map[string][]Kata {
 	return kr.KatasByType

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -22,6 +22,15 @@ type TextReporter struct {
 	filename string
 	lines    []string
 	config   config.Config
+	// fixable, when set, reports whether a kata ID ships an auto-fix; a
+	// fixable finding is tagged with a trailing ` [*]` marker.
+	fixable func(string) bool
+}
+
+// MarkFixable sets the predicate used to tag findings whose kata ships an
+// auto-fix with a ` [*]` marker. Passing nil disables the marker.
+func (r *TextReporter) MarkFixable(fn func(string) bool) {
+	r.fixable = fn
 }
 
 // NewTextReporter creates a new TextReporter.
@@ -42,20 +51,24 @@ func (r *TextReporter) getColor(code string) string {
 }
 
 // Report prints the violations to the writer.
+// levelColor returns the ANSI colour for a severity, honouring NoColor.
+func (r *TextReporter) levelColor(level katas.Severity) string {
+	switch level {
+	case katas.SeverityError:
+		return r.getColor("\033[31m") // Red
+	case katas.SeverityWarning:
+		return r.getColor("\033[33m") // Yellow
+	case katas.SeverityInfo:
+		return r.getColor("\033[34m") // Blue
+	case katas.SeverityStyle:
+		return r.getColor("\033[36m") // Cyan
+	}
+	return ""
+}
+
 func (r *TextReporter) Report(violations []katas.Violation) error {
 	for _, v := range violations {
-		// Severity Color
-		color := ""
-		switch v.Level {
-		case katas.SeverityError:
-			color = r.getColor("\033[31m") // Red
-		case katas.SeverityWarning:
-			color = r.getColor("\033[33m") // Yellow
-		case katas.SeverityInfo:
-			color = r.getColor("\033[34m") // Blue
-		case katas.SeverityStyle:
-			color = r.getColor("\033[36m") // Cyan
-		}
+		color := r.levelColor(v.Level)
 		reset := r.getColor("\033[0m")
 		bold := r.getColor("\033[1m")
 
@@ -64,9 +77,13 @@ func (r *TextReporter) Report(violations []katas.Violation) error {
 			return err
 		}
 
-		// Severity, ID, Message
-		// Example: Error: [ZC1001] Some message
-		if _, err := fmt.Fprintf(r.writer, "%s%s%s: [%s] %s\n", color, v.Level, reset, v.KataID, v.Message); err != nil {
+		// Severity, ID, Message, and a ` [*]` marker when the kata is
+		// auto-fixable. Example: warning: [ZC1001] Some message [*]
+		mark := ""
+		if r.fixable != nil && r.fixable(v.KataID) {
+			mark = " [*]"
+		}
+		if _, err := fmt.Fprintf(r.writer, "%s%s%s: [%s] %s%s\n", color, v.Level, reset, v.KataID, v.Message, mark); err != nil {
 			return err
 		}
 

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -200,6 +200,28 @@ func TestTextReporter_MultiLineSource(t *testing.T) {
 	}
 }
 
+func TestTextReporter_FixableMark(t *testing.T) {
+	violations := []katas.Violation{
+		{KataID: "ZC0001", Message: "fixable one", Level: katas.SeverityWarning, Line: 1, Column: 1},
+		{KataID: "ZC0002", Message: "not fixable", Level: katas.SeverityWarning, Line: 1, Column: 1},
+	}
+	var buf bytes.Buffer
+	cfg := config.DefaultConfig()
+	cfg.NoColor = true
+	r := NewTextReporter(&buf, "test.zsh", "echo hello", cfg)
+	r.MarkFixable(func(id string) bool { return id == "ZC0001" })
+	if err := r.Report(violations); err != nil {
+		t.Fatalf("Report() error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[ZC0001] fixable one [*]") {
+		t.Errorf("fixable finding not marked:\n%s", out)
+	}
+	if strings.Contains(out, "[ZC0002] not fixable [*]") {
+		t.Errorf("non-fixable finding wrongly marked:\n%s", out)
+	}
+}
+
 type failWriter struct{}
 
 func (w *failWriter) Write(p []byte) (n int, err error) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.3.7"
+const Version = "1.4.0"


### PR DESCRIPTION
Two of Ruff's volume-management UX wins, the answer to "thousands of findings is overwhelming".

What:
- Findings from auto-fixable katas are tagged `[*]` in the text report; the run ends with `[*] N fixable with the -fix option.` So you see how much `-fix` resolves before running it.
- `-statistics` prints a per-kata count sorted by frequency (with the `[*]` marker) instead of individual reports — triage which checks dominate.

Backed by `KatasRegistry.IsFixable` and `TextReporter.MarkFixable`. New code covered; docs + help + CHANGELOG updated.

Severity: feature (UX).