### PR TITLE
feat: split auto-fixes into safe and unsafe tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-06-16
+
+### Added
+- `-unsafe-fixes` applies fixes that may change runtime behavior. Without it, `-fix` now applies only safe (value-preserving) fixes.
+- The text report counts the two fix tiers separately: `[*] N fixable with the -fix option.` followed by `M more fixable with -fix -unsafe-fixes.`
+
+### Changed
+- `-fix` is safe-by-default. Each auto-fix is classified safe or unsafe: a safe fix cannot change runtime behavior or drop a comment (for example `` `cmd` `` to `$(cmd)`, `$arr[i]` to `${arr[i]}`); an unsafe fix may (a command or flag swap such as `which` to `whence` or `netstat` to `ss`, a scope change, a glob qualifier). `-fix` previously applied every fix, including behavior-changing ones; it now withholds those unless `-unsafe-fixes` is passed.
+
 ## [1.4.0] - 2026-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.4.0-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.5.0-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-132%20katas-2ea44f)](KATAS.md)
 [![Dependencies](https://img.shields.io/badge/dependencies-0-2ea44f)](go.mod)

--- a/cmd/zshellcheck/collect_edits_test.go
+++ b/cmd/zshellcheck/collect_edits_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestCollectEdits_FileWideDisableDirective(t *testing.T) {
 	src := "result=`which git`\n# noka: ZC1002\n"
-	edits := collectEdits(src, katas.Registry, nil, config.DefaultConfig(), nil)
+	edits := collectEdits(src, katas.Registry, nil, config.DefaultConfig(), nil, true)
 	for _, e := range edits {
 		_ = e
 	}
@@ -19,7 +19,7 @@ func TestCollectEdits_FileWideDisableDirective(t *testing.T) {
 
 func TestCollectEdits_PerLineDisable(t *testing.T) {
 	src := "result=`which git` # noka: ZC1002\n"
-	edits := collectEdits(src, katas.Registry, nil, config.DefaultConfig(), nil)
+	edits := collectEdits(src, katas.Registry, nil, config.DefaultConfig(), nil, true)
 	for _, e := range edits {
 		_ = e
 	}
@@ -27,7 +27,7 @@ func TestCollectEdits_PerLineDisable(t *testing.T) {
 
 func TestCollectEdits_ExternalDisable(t *testing.T) {
 	src := "result=`which git`\n"
-	edits := collectEdits(src, katas.Registry, []string{"ZC1002"}, config.DefaultConfig(), nil)
+	edits := collectEdits(src, katas.Registry, []string{"ZC1002"}, config.DefaultConfig(), nil, true)
 	for _, e := range edits {
 		_ = e
 	}
@@ -35,7 +35,7 @@ func TestCollectEdits_ExternalDisable(t *testing.T) {
 
 func TestCollectEdits_SeverityFilterError(t *testing.T) {
 	src := "result=`which git`\n"
-	edits := collectEdits(src, katas.Registry, nil, config.DefaultConfig(), []katas.Severity{katas.SeverityError})
+	edits := collectEdits(src, katas.Registry, nil, config.DefaultConfig(), []katas.Severity{katas.SeverityError}, true)
 	for _, e := range edits {
 		_ = e
 	}
@@ -43,7 +43,7 @@ func TestCollectEdits_SeverityFilterError(t *testing.T) {
 
 func TestCollectEdits_SeverityFilterStyle(t *testing.T) {
 	src := "result=`which git`\n"
-	edits := collectEdits(src, katas.Registry, nil, config.DefaultConfig(), []katas.Severity{katas.SeverityStyle})
+	edits := collectEdits(src, katas.Registry, nil, config.DefaultConfig(), []katas.Severity{katas.SeverityStyle}, true)
 	for _, e := range edits {
 		_ = e
 	}
@@ -51,7 +51,7 @@ func TestCollectEdits_SeverityFilterStyle(t *testing.T) {
 
 func TestCollectEdits_NestedFix(t *testing.T) {
 	src := "result=`which git`\necho $arr[1]\n"
-	edits := collectEdits(src, katas.Registry, nil, config.DefaultConfig(), nil)
+	edits := collectEdits(src, katas.Registry, nil, config.DefaultConfig(), nil, true)
 	for _, e := range edits {
 		_ = e
 	}
@@ -59,7 +59,7 @@ func TestCollectEdits_NestedFix(t *testing.T) {
 
 func TestCollectEdits_CleanSource(t *testing.T) {
 	src := "echo hello\n"
-	edits := collectEdits(src, katas.Registry, nil, config.DefaultConfig(), nil)
+	edits := collectEdits(src, katas.Registry, nil, config.DefaultConfig(), nil, true)
 	for _, e := range edits {
 		_ = e
 	}

--- a/cmd/zshellcheck/helper_test.go
+++ b/cmd/zshellcheck/helper_test.go
@@ -114,14 +114,14 @@ func TestParseSeverityFilterEmpty(t *testing.T) {
 }
 
 func TestBuildFixOptsAllOff(t *testing.T) {
-	got := buildFixOpts(false, false, false)
-	if got.enabled || got.diff || got.dryRun {
+	got := buildFixOpts(false, false, false, false)
+	if got.enabled || got.diff || got.dryRun || got.unsafe {
 		t.Errorf("expected all-off, got %+v", got)
 	}
 }
 
 func TestBuildFixOptsFix(t *testing.T) {
-	got := buildFixOpts(true, false, false)
+	got := buildFixOpts(true, false, false, false)
 	if !got.enabled || got.diff || got.dryRun {
 		t.Errorf("expected enabled-only, got %+v", got)
 	}
@@ -131,16 +131,23 @@ func TestBuildFixOptsFix(t *testing.T) {
 }
 
 func TestBuildFixOptsDiff(t *testing.T) {
-	got := buildFixOpts(false, true, false)
+	got := buildFixOpts(false, true, false, false)
 	if !got.enabled || !got.diff || !got.dryRun {
 		t.Errorf("expected diff implies dry-run + enabled, got %+v", got)
 	}
 }
 
 func TestBuildFixOptsDryRun(t *testing.T) {
-	got := buildFixOpts(true, false, true)
+	got := buildFixOpts(true, false, true, false)
 	if !got.enabled || got.diff || !got.dryRun {
 		t.Errorf("expected fix+dry-run, got %+v", got)
+	}
+}
+
+func TestBuildFixOptsUnsafe(t *testing.T) {
+	got := buildFixOpts(true, false, false, true)
+	if !got.unsafe {
+		t.Errorf("expected unsafe set, got %+v", got)
 	}
 }
 

--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -37,6 +37,7 @@ type runFlags struct {
 	fixMode        *bool
 	diffMode       *bool
 	dryRun         *bool
+	unsafeFixes    *bool
 	listRules      *bool
 	explain        *string
 	statistics     *bool
@@ -81,7 +82,7 @@ func run() int {
 	if code != 0 {
 		return code
 	}
-	fixOpts := buildFixOpts(*flags.fixMode, *flags.diffMode, *flags.dryRun)
+	fixOpts := buildFixOpts(*flags.fixMode, *flags.diffMode, *flags.dryRun, *flags.unsafeFixes)
 	if *flags.statistics {
 		fixOpts.statistics = map[string]int{}
 	}
@@ -135,6 +136,7 @@ func registerRunFlags() runFlags {
 		fixMode:        flag.Bool("fix", false, "Apply auto-fixes in place for katas that ship a deterministic rewrite."),
 		diffMode:       flag.Bool("diff", false, "Print a unified diff of the fixes instead of writing them."),
 		dryRun:         flag.Bool("dry-run", false, "With -fix, report what would change without modifying files."),
+		unsafeFixes:    flag.Bool("unsafe-fixes", false, "Also apply fixes that may change runtime behavior (off by default)."),
 		listRules:      flag.Bool("list-rules", false, "Print every kata (ID, severity, title) and exit."),
 		explain:        flag.String("explain", "", "Print the full description of a kata by ID (e.g. ZC1001) and exit."),
 		statistics:     flag.Bool("statistics", false, "Print a per-kata count of findings instead of individual reports."),
@@ -252,11 +254,12 @@ func parseSeverityFilter(filter string) ([]katas.Severity, int) {
 	return out, 0
 }
 
-func buildFixOpts(fixMode, diffMode, dryRun bool) fixOptions {
+func buildFixOpts(fixMode, diffMode, dryRun, unsafeFixes bool) fixOptions {
 	opts := fixOptions{
 		enabled:   fixMode || diffMode,
 		diff:      diffMode,
 		dryRun:    dryRun,
+		unsafe:    unsafeFixes,
 		maxPasses: 5,
 	}
 	if opts.diff {
@@ -267,6 +270,7 @@ func buildFixOpts(fixMode, diffMode, dryRun bool) fixOptions {
 		opts.stats = &fixStats{}
 	}
 	opts.fixable = new(int)
+	opts.unsafeFixable = new(int)
 	return opts
 }
 
@@ -319,10 +323,15 @@ func finalExitCode(total int, format string, fixOpts fixOptions) int {
 	}
 	if format == "text" {
 		fmt.Fprintf(os.Stderr, "\nFound %d violations.\n", total)
-		// Point at the auto-fixable subset, unless fixes are already
+		// Point at the auto-fixable subsets, unless fixes are already
 		// being applied or previewed this run.
-		if !fixOpts.enabled && fixOpts.fixable != nil && *fixOpts.fixable > 0 {
-			fmt.Fprintf(os.Stderr, "[*] %d fixable with the `-fix` option.\n", *fixOpts.fixable)
+		if !fixOpts.enabled {
+			if fixOpts.fixable != nil && *fixOpts.fixable > 0 {
+				fmt.Fprintf(os.Stderr, "[*] %d fixable with the `-fix` option.\n", *fixOpts.fixable)
+			}
+			if fixOpts.unsafeFixable != nil && *fixOpts.unsafeFixable > 0 {
+				fmt.Fprintf(os.Stderr, "    %d more fixable with `-fix -unsafe-fixes`.\n", *fixOpts.unsafeFixable)
+			}
 		}
 	}
 	return 1
@@ -368,9 +377,14 @@ type fixOptions struct {
 	// formats so they are emitted once as a single JSON / SARIF document.
 	// nil for the text format, which streams per file.
 	collector *[]reporter.FileViolations
-	// fixable counts findings across the run whose kata ships an auto-fix,
-	// for the `[*] N fixable` hint shown after a text report.
-	fixable *int
+	// unsafe applies fixes that may change runtime behavior. When false,
+	// only value-preserving (safe) fixes are applied.
+	unsafe bool
+	// fixable counts findings with a safe auto-fix; unsafeFixable counts
+	// those whose only fix may change behavior. Both feed the post-report
+	// `[*] N fixable` / `M with -unsafe-fixes` hints.
+	fixable       *int
+	unsafeFixable *int
 	// statistics, when non-nil, switches output to a per-kata count table:
 	// individual findings are suppressed and tallied here instead.
 	statistics map[string]int
@@ -393,7 +407,7 @@ type fixStats struct {
 // `result=`which git“ first becomes `result=$(which git)` (ZC1002),
 // which a second pass then rewrites to `result=$(whence git)`
 // (ZC1005). A single pass would leave the inner stale.
-func applyFixesUntilStable(src string, initialEdits []katas.FixEdit, registry *katas.KatasRegistry, disabled []string, cfg config.Config, allowedSeverities []katas.Severity, maxPasses int) (string, int, error) {
+func applyFixesUntilStable(src string, initialEdits []katas.FixEdit, registry *katas.KatasRegistry, disabled []string, cfg config.Config, allowedSeverities []katas.Severity, maxPasses int, unsafe bool) (string, int, error) {
 	if maxPasses < 1 {
 		maxPasses = 5
 	}
@@ -426,7 +440,7 @@ func applyFixesUntilStable(src string, initialEdits []katas.FixEdit, registry *k
 		totalEdits += applied
 		current = next
 		// Re-collect edits from the new source.
-		edits = collectEdits(current, registry, disabled, cfg, allowedSeverities)
+		edits = collectEdits(current, registry, disabled, cfg, allowedSeverities, unsafe)
 	}
 	return current, totalEdits, nil
 }
@@ -472,7 +486,7 @@ func applySafeEdits(base string, edits []katas.FixEdit) (string, int) {
 // collectEdits parses src and returns the auto-fix edits the registry
 // would emit for it under the given disabled / severity filters.
 // Used by the multi-pass loop in applyFixesUntilStable.
-func collectEdits(src string, registry *katas.KatasRegistry, disabled []string, cfg config.Config, allowedSeverities []katas.Severity) []katas.FixEdit {
+func collectEdits(src string, registry *katas.KatasRegistry, disabled []string, cfg config.Config, allowedSeverities []katas.Severity, unsafe bool) []katas.FixEdit {
 	l := lexer.New(src)
 	p := parser.New(l)
 	program := p.ParseProgram()
@@ -523,7 +537,7 @@ func collectEdits(src string, registry *katas.KatasRegistry, disabled []string, 
 		}
 		edits = filtered
 	}
-	return edits
+	return applicableEdits(edits, registry, unsafe)
 }
 
 func processPath(path string, out, errOut io.Writer, cfg config.Config, registry *katas.KatasRegistry, format string, allowedSeverities []katas.Severity, fixOpts fixOptions) int {
@@ -653,7 +667,23 @@ func applySeverityFilter(violations []katas.Violation, edits []katas.FixEdit, al
 	return filtered, edits
 }
 
+// applicableEdits drops behavior-changing (unsafe) fixes unless the run
+// opted into them with -unsafe-fixes.
+func applicableEdits(edits []katas.FixEdit, registry *katas.KatasRegistry, unsafe bool) []katas.FixEdit {
+	if unsafe {
+		return edits
+	}
+	kept := edits[:0]
+	for _, e := range edits {
+		if registry.IsSafeFix(e.KataID) {
+			kept = append(kept, e)
+		}
+	}
+	return kept
+}
+
 func applyFixIfEnabled(filename string, data []byte, registry *katas.KatasRegistry, disabled []string, cfg config.Config, allowed []katas.Severity, edits []katas.FixEdit, violations []katas.Violation, fixOpts fixOptions, out, errOut io.Writer) {
+	edits = applicableEdits(edits, registry, fixOpts.unsafe)
 	if !fixOpts.enabled || len(edits) == 0 || len(violations) == 0 {
 		return
 	}
@@ -679,7 +709,7 @@ func emitFixDiff(filename string, data []byte, edits []katas.FixEdit, out, errOu
 }
 
 func applyFixInPlace(filename string, data []byte, registry *katas.KatasRegistry, disabled []string, cfg config.Config, allowed []katas.Severity, edits []katas.FixEdit, fixOpts fixOptions, errOut io.Writer) {
-	fixed, totalEdits, perr := applyFixesUntilStable(string(data), edits, registry, disabled, cfg, allowed, fixOpts.maxPasses)
+	fixed, totalEdits, perr := applyFixesUntilStable(string(data), edits, registry, disabled, cfg, allowed, fixOpts.maxPasses, fixOpts.unsafe)
 	if perr != nil {
 		fmt.Fprintf(errOut, "fix: apply failed for %s: %s\n", filename, perr)
 		return
@@ -720,15 +750,25 @@ func emitReport(filename string, out, errOut io.Writer, format string, cfg confi
 		*fixOpts.collector = append(*fixOpts.collector, reporter.FileViolations{Filename: filename, Violations: violations})
 		return
 	}
+	// `[*]` marks the fixes the current command would apply: safe-only, or
+	// every fix under -unsafe-fixes. Findings whose only fix is unsafe are
+	// counted separately so the footer can point at -unsafe-fixes.
+	marked := registry.IsSafeFix
+	if fixOpts.unsafe {
+		marked = registry.IsFixable
+	}
 	if fixOpts.fixable != nil {
 		for _, v := range violations {
-			if registry.IsFixable(v.KataID) {
+			switch {
+			case marked(v.KataID):
 				*fixOpts.fixable++
+			case registry.IsFixable(v.KataID) && fixOpts.unsafeFixable != nil:
+				*fixOpts.unsafeFixable++
 			}
 		}
 	}
 	r := reporter.NewTextReporter(out, filename, string(data), cfg)
-	r.MarkFixable(registry.IsFixable)
+	r.MarkFixable(marked)
 	if err := r.Report(violations); err != nil {
 		fmt.Fprintf(errOut, "Error reporting violations: %s\n", err)
 	}

--- a/cmd/zshellcheck/main_test.go
+++ b/cmd/zshellcheck/main_test.go
@@ -441,7 +441,7 @@ func TestCollectEdits_ParseError(t *testing.T) {
 	src := "if true; then echo \"unterminated\n"
 	registry := katas.Registry
 	cfg := config.DefaultConfig()
-	edits := collectEdits(src, registry, nil, cfg, nil)
+	edits := collectEdits(src, registry, nil, cfg, nil, true)
 	if edits != nil {
 		t.Errorf("expected nil edits on parse error, got %d", len(edits))
 	}
@@ -455,7 +455,7 @@ func TestCollectEdits_FileWideDirective(t *testing.T) {
 	src := "x=`date`\n# noka: ZC1002\n"
 	registry := katas.Registry
 	cfg := config.DefaultConfig()
-	edits := collectEdits(src, registry, nil, cfg, nil)
+	edits := collectEdits(src, registry, nil, cfg, nil, true)
 	for _, e := range edits {
 		_ = e
 	}
@@ -465,7 +465,7 @@ func TestApplyFixesUntilStable_Idempotent(t *testing.T) {
 	src := "#!/bin/zsh\necho hello\n"
 	cfg := config.DefaultConfig()
 	registry := katas.Registry
-	out, n, err := applyFixesUntilStable(src, nil, registry, nil, cfg, nil, 5)
+	out, n, err := applyFixesUntilStable(src, nil, registry, nil, cfg, nil, 5, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -481,11 +481,11 @@ func TestApplyFixesUntilStable_RewritesBackticks(t *testing.T) {
 	src := "x=`which git`\n"
 	cfg := config.DefaultConfig()
 	registry := katas.Registry
-	initial := collectEdits(src, registry, nil, cfg, nil)
+	initial := collectEdits(src, registry, nil, cfg, nil, true)
 	if len(initial) == 0 {
 		t.Skip("no auto-fix katas fired on the input; coverage path not exercised")
 	}
-	out, n, err := applyFixesUntilStable(src, initial, registry, nil, cfg, nil, 5)
+	out, n, err := applyFixesUntilStable(src, initial, registry, nil, cfg, nil, 5, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -508,8 +508,8 @@ func TestApplyFixesUntilStable_NeverBreaksParse(t *testing.T) {
 		"(( $reply[x] )) && return\n",
 		"if [ $commands[oc] ]; then :; fi\n",
 	} {
-		initial := collectEdits(src, registry, nil, cfg, nil)
-		out, _, err := applyFixesUntilStable(src, initial, registry, nil, cfg, nil, 5)
+		initial := collectEdits(src, registry, nil, cfg, nil, true)
+		out, _, err := applyFixesUntilStable(src, initial, registry, nil, cfg, nil, 5, true)
 		if err != nil {
 			t.Fatalf("unexpected error for %q: %v", src, err)
 		}
@@ -526,7 +526,7 @@ func TestApplyFixesUntilStable_ArithSubscript(t *testing.T) {
 	cfg := config.DefaultConfig()
 	registry := katas.Registry
 	src := "(( $reply[x] )) && return\n"
-	out, _, err := applyFixesUntilStable(src, collectEdits(src, registry, nil, cfg, nil), registry, nil, cfg, nil, 5)
+	out, _, err := applyFixesUntilStable(src, collectEdits(src, registry, nil, cfg, nil, true), registry, nil, cfg, nil, 5, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -540,8 +540,8 @@ func TestApplyFixesUntilStable_NullglobIdempotent(t *testing.T) {
 	cfg := config.DefaultConfig()
 	registry := katas.Registry
 	src := "for f in *.txt; do print -r -- $f; done\n"
-	once, _, _ := applyFixesUntilStable(src, collectEdits(src, registry, nil, cfg, nil), registry, nil, cfg, nil, 5)
-	twice, _, _ := applyFixesUntilStable(once, collectEdits(once, registry, nil, cfg, nil), registry, nil, cfg, nil, 5)
+	once, _, _ := applyFixesUntilStable(src, collectEdits(src, registry, nil, cfg, nil, true), registry, nil, cfg, nil, 5, true)
+	twice, _, _ := applyFixesUntilStable(once, collectEdits(once, registry, nil, cfg, nil, true), registry, nil, cfg, nil, 5, true)
 	if once != twice {
 		t.Errorf("ZC1040 fix not idempotent:\n once:  %q\n twice: %q", once, twice)
 	}
@@ -667,6 +667,38 @@ func TestFinalExitCode_FixableFooter(t *testing.T) {
 	}
 	if code := finalExitCode(0, "text", opts); code != 0 {
 		t.Errorf("want exit 0 with no violations, got %d", code)
+	}
+}
+
+func TestRun_UnsafeFixesGate(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x=`which git`\nnetstat -a\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	old := os.Args
+	defer func() { os.Args = old }()
+
+	// Default -fix applies only the safe backtick rewrite; the unsafe
+	// netstat->ss swap is withheld.
+	safe := write("safe.zsh")
+	resetFlags()
+	os.Args = []string{"zshellcheck", "-fix", "-no-banner", safe}
+	_ = run()
+	if b, _ := os.ReadFile(safe); strings.Contains(string(b), "`which git`") || !strings.Contains(string(b), "netstat") {
+		t.Errorf("safe -fix wrong: %q", b)
+	}
+
+	// -unsafe-fixes also applies the netstat->ss swap.
+	unsafe := write("unsafe.zsh")
+	resetFlags()
+	os.Args = []string{"zshellcheck", "-fix", "-unsafe-fixes", "-no-banner", unsafe}
+	_ = run()
+	if b, _ := os.ReadFile(unsafe); strings.Contains(string(b), "netstat") {
+		t.Errorf("unsafe -fix should swap netstat: %q", b)
 	}
 }
 

--- a/cmd/zshellcheck/usage.go
+++ b/cmd/zshellcheck/usage.go
@@ -47,8 +47,8 @@ func printUsage(out io.Writer, fset *flag.FlagSet, showBanner bool) {
 		},
 		{
 			title: "AUTO-FIX",
-			names: []string{"fix", "diff", "dry-run"},
-			blurb: "Apply or preview deterministic rewrites.",
+			names: []string{"fix", "unsafe-fixes", "diff", "dry-run"},
+			blurb: "Apply or preview deterministic rewrites. -fix is safe-only by default.",
 		},
 		{
 			title: "DIAGNOSTICS",
@@ -80,7 +80,8 @@ func printUsage(out io.Writer, fset *flag.FlagSet, showBanner bool) {
 		{"Triage by frequency: per-kata counts", "zshellcheck -statistics ./scripts"},
 		{"Emit SARIF for GitHub Code Scanning", "zshellcheck -format sarif ./scripts > zshellcheck.sarif"},
 		{"Preview every available auto-fix as a diff", "zshellcheck -diff path/to/script.zsh"},
-		{"Apply auto-fixes in place", "zshellcheck -fix path/to/script.zsh"},
+		{"Apply auto-fixes in place (safe only)", "zshellcheck -fix path/to/script.zsh"},
+		{"Also apply behavior-changing fixes", "zshellcheck -fix -unsafe-fixes path/to/script.zsh"},
 		{"CI-friendly run (no banner, errors only)", "zshellcheck -no-banner -severity error ./scripts"},
 	}
 	for _, ex := range examples {

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -36,7 +36,8 @@ Files with `.go`, `.md`, `.json`, `.yml`, `.yaml`, or `.txt` extensions are skip
 | `-verbose` | off | Emit full kata descriptions in text output. |
 | `-no-color` | off | Disable ANSI colours. Implied when stdout is not a TTY. |
 | `-cpuprofile <path>` | — | Write a Go pprof CPU profile to `<path>` for benchmarking. |
-| `-fix` | off | Apply auto-fixes in place for katas that declare one. Deterministic rewrites only. |
+| `-fix` | off | Apply auto-fixes in place. Safe (value-preserving) fixes only, unless `-unsafe-fixes` is set. |
+| `-unsafe-fixes` | off | Also apply fixes that may change runtime behavior — command and flag swaps, scope changes, glob qualifiers. |
 | `-diff` | off | Preview the fixes as a unified diff instead of writing them. Implies dry-run. |
 | `-dry-run` | off | With `-fix`, report what would change without modifying files. |
 | `-list-rules` | — | Print every kata (ID, severity, title) and exit. |
@@ -78,7 +79,14 @@ zshellcheck -explain ZC1001
 
 Katas with a deterministic, reversible rewrite ship a `Fix` implementation.
 A finding from such a kata is tagged with a trailing `[*]` in the text report, and the run ends with a `[*] N fixable with the -fix option.` summary, so you can see at a glance how much the fixer resolves before touching anything.
-Run `zshellcheck -fix <path>` to apply rewrites in place, or `zshellcheck -diff <path>` to preview the unified diff.
+
+Fixes come in two tiers, following the model Ruff popularised.
+A **safe** fix is value-preserving: applying it cannot change runtime behavior or drop a comment, for example `` `cmd` `` to `$(cmd)` or `$arr[i]` to `${arr[i]}`.
+An **unsafe** fix may change behavior — a command or flag swap (`which` to `whence`, `netstat` to `ss`), a scope change (adding `local`), or a glob qualifier.
+`-fix` applies only safe fixes by default; pass `-unsafe-fixes` to apply the rest.
+The report counts each tier separately so you can apply the mechanical fixes confidently and review the behavior-changing ones by hand.
+
+Run `zshellcheck -fix <path>` to apply the safe rewrites in place, `zshellcheck -fix -unsafe-fixes <path>` to apply every fix, or `zshellcheck -diff <path>` to preview the unified diff.
 The fixer rewrites only the exact span the kata points at — arguments, quoting, and surrounding whitespace are preserved byte-for-byte.
 
 Silenced violations (via `.zshellcheckrc` or inline `# noka` directives) keep their fixes silenced too.
@@ -90,10 +98,11 @@ Combine flags freely:
 
 | Combination | Effect |
 | --- | --- |
-| `-fix` | Apply rewrites to disk. |
+| `-fix` | Apply safe rewrites to disk. |
+| `-fix -unsafe-fixes` | Apply every rewrite, including behavior-changing ones. |
 | `-diff` | Print a unified diff. Source unchanged. |
 | `-fix -dry-run` | Report which files would change without writing. |
-| `-fix -severity warning` | Apply every available rewrite; suppress style-level findings from the human-facing report. |
+| `-fix -severity warning` | Apply safe rewrites; suppress style-level findings from the human-facing report. |
 | `-no-banner -fix` | Apply rewrites without the startup banner — useful in CI. |
 
 [KATAS.md](../KATAS.md) lists every kata with an explicit `Auto-fix: yes/no` line, and the summary table reports the current count.

--- a/pkg/katas/fixes_for_test.go
+++ b/pkg/katas/fixes_for_test.go
@@ -73,3 +73,17 @@ func TestIsFixable(t *testing.T) {
 		t.Error("unknown kata should not be fixable")
 	}
 }
+
+func TestIsSafeFix(t *testing.T) {
+	// ZC1001 is in the value-preserving safe set; ZC1037 (echo->print)
+	// changes behavior and is unsafe.
+	if !Registry.IsSafeFix("ZC1001") {
+		t.Error("ZC1001 should be a safe fix")
+	}
+	if Registry.IsSafeFix("ZC1037") {
+		t.Error("ZC1037 should not be a safe fix")
+	}
+	if Registry.IsSafeFix("ZC_UNKNOWN") {
+		t.Error("unknown kata should not be a safe fix")
+	}
+}

--- a/pkg/katas/katas.go
+++ b/pkg/katas/katas.go
@@ -31,12 +31,35 @@ type Violation struct {
 // FixEdit is a single text replacement applied by the auto-fixer.
 // Coordinates are 1-based; Length is the number of bytes of source to
 // replace starting at Line:Column. Replace may be empty (deletion) and
-// may span multiple lines.
+// may span multiple lines. KataID records the kata that produced the edit
+// so the CLI can withhold behavior-changing (unsafe) fixes by default.
 type FixEdit struct {
 	Line    int
 	Column  int
 	Length  int
 	Replace string
+	KataID  string
+}
+
+// safeFixKatas lists the katas whose auto-fix is purely syntactic and
+// value-preserving — applying it cannot change runtime behavior or drop a
+// comment. Every other fix may alter behavior (a command or flag swap, a
+// scope or glob-qualifier change) and is applied only under -unsafe-fixes.
+var safeFixKatas = map[string]bool{
+	"ZC1001": true, // $arr[i] -> ${arr[i]}
+	"ZC1002": true, // `cmd` -> $(cmd)
+	"ZC1073": true, // drop redundant $ inside (( … ))
+	"ZC1086": true, // function f { } -> f() { }
+	"ZC1411": true, // enable -n name -> disable name
+	"ZC1502": true, // insert `--` end-of-options guard
+	"ZC1637": true, // readonly x -> typeset -r x
+	"ZC1643": true, // $(cat f) -> $(<f)
+}
+
+// IsSafeFix reports whether the kata's auto-fix is value-preserving and so
+// applied by `-fix` without `-unsafe-fixes`.
+func (kr *KatasRegistry) IsSafeFix(id string) bool {
+	return safeFixKatas[id]
 }
 
 // Kata represents a single linting rule. Fix is optional; when non-nil
@@ -143,7 +166,16 @@ func (kr *KatasRegistry) FixesFor(node ast.Node, v Violation, source []byte) []F
 	if !ok || kata.Fix == nil {
 		return nil
 	}
-	return kata.Fix(node, v, source)
+	return stampKataID(kata.Fix(node, v, source), kata.ID)
+}
+
+// stampKataID records the producing kata on each edit so the CLI can
+// filter behavior-changing fixes without re-deriving their origin.
+func stampKataID(edits []FixEdit, id string) []FixEdit {
+	for i := range edits {
+		edits[i].KataID = id
+	}
+	return edits
 }
 
 // CheckAndFix runs Check for every kata registered against the node
@@ -176,7 +208,7 @@ func (kr *KatasRegistry) CheckAndFix(node ast.Node, disabledKatas []string, sour
 				vs[i].Level = kata.Severity
 			}
 			if kata.Fix != nil {
-				edits = append(edits, kata.Fix(node, vs[i], source)...)
+				edits = append(edits, stampKataID(kata.Fix(node, vs[i], source), kata.ID)...)
 			}
 		}
 		violations = append(violations, vs...)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.4.0"
+const Version = "1.5.0"


### PR DESCRIPTION
Answers "are all autofixes semantically verified": no — most change behavior, and `-fix` was applying them by default.

What:
- Audited all 122 fix functions. Only 8 are purely value-preserving (safe): ZC1001, ZC1002, ZC1073, ZC1086, ZC1411, ZC1502, ZC1637, ZC1643. The rest swap commands/flags, change scope, or add glob qualifiers — unsafe.
- `-fix` now applies safe fixes only; `-unsafe-fixes` applies the rest.
- Each FixEdit carries its kata ID so edits can be filtered. The report counts the tiers separately: `[*] N fixable with -fix` then `M more fixable with -fix -unsafe-fixes`, and `[*]` marks only what the current command applies.

Why: `-fix` was silently rewriting `which`->`whence`, `netstat`->`ss`, injecting `-y`, etc. Behavior-changing rewrites must be opt-in.

Note: this changes `-fix` default behavior (fewer fixes applied), hence the minor bump to v1.5.0.

Severity: feature + safety.