### PR TITLE
feat: embed rule metadata in SARIF output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-06-16
+
+### Added
+- The SARIF report now embeds a `rules` array in the tool driver. Each kata that produced a finding contributes a rule descriptor with its title, full description, default severity level, and a help URL, and every result references its rule by index. GitHub code scanning renders these so a finding shows what the rule means and where to read more.
+
 ## [1.5.0] - 2026-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.5.0-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.5.1-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-132%20katas-2ea44f)](KATAS.md)
 [![Dependencies](https://img.shields.io/badge/dependencies-0-2ea44f)](go.mod)

--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -302,10 +302,25 @@ func emitAggregate(out, errOut io.Writer, format string, files []reporter.FileVi
 	case "json":
 		err = reporter.ReportJSON(out, files)
 	case "sarif":
-		err = reporter.ReportSARIF(out, files, version.Version)
+		err = reporter.ReportSARIF(out, files, version.Version, sarifRuleMeta)
 	}
 	if err != nil {
 		fmt.Fprintf(errOut, "Error reporting violations: %s\n", err)
+	}
+}
+
+// sarifRuleMeta supplies SARIF rule metadata for a kata ID from the
+// registry: its title, full description, and a link to the kata catalog.
+func sarifRuleMeta(id string) reporter.RuleMeta {
+	k, ok := katas.Registry.GetKata(id)
+	if !ok {
+		return reporter.RuleMeta{}
+	}
+	return reporter.RuleMeta{
+		Name:        k.Title,
+		Title:       k.Title,
+		Description: k.Description,
+		HelpURI:     "https://github.com/afadesigns/zshellcheck/blob/main/KATAS.md",
 	}
 }
 

--- a/pkg/reporter/aggregate.go
+++ b/pkg/reporter/aggregate.go
@@ -67,13 +67,37 @@ type sarifTool struct {
 }
 
 type sarifDriver struct {
-	Name           string `json:"name"`
-	InformationURI string `json:"informationUri"`
-	Version        string `json:"version"`
+	Name           string      `json:"name"`
+	InformationURI string      `json:"informationUri"`
+	Version        string      `json:"version"`
+	Rules          []sarifRule `json:"rules"`
+}
+
+// RuleMeta is the per-kata metadata embedded in a SARIF run so code
+// scanning can render a description and link for each rule.
+type RuleMeta struct {
+	Name        string
+	Title       string
+	Description string
+	HelpURI     string
+}
+
+type sarifRule struct {
+	ID                   string          `json:"id"`
+	Name                 string          `json:"name,omitempty"`
+	ShortDescription     sarifMessage    `json:"shortDescription"`
+	FullDescription      *sarifMessage   `json:"fullDescription,omitempty"`
+	HelpURI              string          `json:"helpUri,omitempty"`
+	DefaultConfiguration sarifRuleConfig `json:"defaultConfiguration"`
+}
+
+type sarifRuleConfig struct {
+	Level string `json:"level"`
 }
 
 type sarifResult struct {
 	RuleID    string          `json:"ruleId"`
+	RuleIndex int             `json:"ruleIndex"`
 	Level     string          `json:"level"`
 	Message   sarifMessage    `json:"message"`
 	Locations []sarifLocation `json:"locations"`
@@ -103,15 +127,26 @@ type sarifRegion struct {
 
 // ReportSARIF writes every finding across all files as one SARIF 2.1.0
 // document: a single run whose results each carry a physical location
-// (file URI + 1-based line/column) so GitHub code scanning can ingest it.
-func ReportSARIF(w io.Writer, files []FileViolations, toolVersion string) error {
+// (file URI + 1-based line/column) and reference a rule in the driver's
+// rules array, which meta populates with each kata's description, level,
+// and help URI so GitHub code scanning can render them.
+func ReportSARIF(w io.Writer, files []FileViolations, toolVersion string, meta func(string) RuleMeta) error {
 	results := []sarifResult{}
+	rules := []sarifRule{}
+	ruleIndex := map[string]int{}
 	for _, f := range files {
 		for _, v := range f.Violations {
+			idx, ok := ruleIndex[v.KataID]
+			if !ok {
+				idx = len(rules)
+				ruleIndex[v.KataID] = idx
+				rules = append(rules, buildSarifRule(v, meta))
+			}
 			results = append(results, sarifResult{
-				RuleID:  v.KataID,
-				Level:   sarifLevel(v.Level),
-				Message: sarifMessage{Text: v.Message},
+				RuleID:    v.KataID,
+				RuleIndex: idx,
+				Level:     sarifLevel(v.Level),
+				Message:   sarifMessage{Text: v.Message},
 				Locations: []sarifLocation{{
 					PhysicalLocation: sarifPhysical{
 						ArtifactLocation: sarifArtifact{URI: f.Filename},
@@ -132,6 +167,7 @@ func ReportSARIF(w io.Writer, files []FileViolations, toolVersion string) error 
 				Name:           "zshellcheck",
 				InformationURI: "https://github.com/afadesigns/zshellcheck",
 				Version:        toolVersion,
+				Rules:          rules,
 			}},
 			Results: results,
 		}},
@@ -139,6 +175,31 @@ func ReportSARIF(w io.Writer, files []FileViolations, toolVersion string) error 
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(doc)
+}
+
+// buildSarifRule assembles a SARIF rule descriptor from a finding plus its
+// kata metadata. A nil meta yields a minimal descriptor.
+func buildSarifRule(v katas.Violation, meta func(string) RuleMeta) sarifRule {
+	rule := sarifRule{
+		ID:                   v.KataID,
+		ShortDescription:     sarifMessage{Text: v.Message},
+		DefaultConfiguration: sarifRuleConfig{Level: sarifLevel(v.Level)},
+	}
+	if meta == nil {
+		return rule
+	}
+	m := meta(v.KataID)
+	if m.Name != "" {
+		rule.Name = m.Name
+	}
+	if m.Title != "" {
+		rule.ShortDescription = sarifMessage{Text: m.Title}
+	}
+	if m.Description != "" {
+		rule.FullDescription = &sarifMessage{Text: m.Description}
+	}
+	rule.HelpURI = m.HelpURI
+	return rule
 }
 
 // sarifLevel maps a kata severity onto a SARIF result level. SARIF has no

--- a/pkg/reporter/aggregate_test.go
+++ b/pkg/reporter/aggregate_test.go
@@ -66,7 +66,7 @@ func TestReportJSON_WriterError(t *testing.T) {
 
 func TestReportSARIF_MultiFileIsOneValidRun(t *testing.T) {
 	var buf bytes.Buffer
-	if err := ReportSARIF(&buf, twoFiles(), "1.2.3"); err != nil {
+	if err := ReportSARIF(&buf, twoFiles(), "1.2.3", testMeta); err != nil {
 		t.Fatalf("ReportSARIF error: %v", err)
 	}
 	var doc map[string]any
@@ -111,7 +111,8 @@ func TestReportSARIF_LevelMappingAndClamp(t *testing.T) {
 		{KataID: "ZC2", Message: "s", Line: 1, Column: 1, Level: katas.SeverityStyle},
 	}}}
 	var buf bytes.Buffer
-	if err := ReportSARIF(&buf, files, "0.0.0"); err != nil {
+	// nil meta exercises the minimal-descriptor path.
+	if err := ReportSARIF(&buf, files, "0.0.0", nil); err != nil {
 		t.Fatalf("ReportSARIF error: %v", err)
 	}
 	var doc map[string]any
@@ -132,8 +133,49 @@ func TestReportSARIF_LevelMappingAndClamp(t *testing.T) {
 	}
 }
 
+func TestReportSARIF_RulesMetadata(t *testing.T) {
+	var buf bytes.Buffer
+	if err := ReportSARIF(&buf, twoFiles(), "1.2.3", testMeta); err != nil {
+		t.Fatalf("ReportSARIF error: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("not valid SARIF: %v", err)
+	}
+	run := doc["runs"].([]any)[0].(map[string]any)
+	// One rule per distinct kata, with description, help URI, and level.
+	rules := run["tool"].(map[string]any)["driver"].(map[string]any)["rules"].([]any)
+	if len(rules) != 3 {
+		t.Fatalf("want 3 rules, got %d", len(rules))
+	}
+	rule0 := rules[0].(map[string]any)
+	if rule0["id"] != "ZC1001" {
+		t.Errorf("rule0 id = %v", rule0["id"])
+	}
+	if rule0["helpUri"] == "" {
+		t.Error("rule0 missing helpUri")
+	}
+	if rule0["fullDescription"].(map[string]any)["text"] != "ZC1001 desc" {
+		t.Errorf("rule0 description = %v", rule0["fullDescription"])
+	}
+	// Results reference their rule by index.
+	results := run["results"].([]any)
+	if results[1].(map[string]any)["ruleIndex"].(float64) != 1 {
+		t.Errorf("ruleIndex not wired: %v", results[1])
+	}
+}
+
+func testMeta(id string) RuleMeta {
+	return RuleMeta{
+		Name:        id + "-name",
+		Title:       id + " title",
+		Description: id + " desc",
+		HelpURI:     "https://example.test/" + id,
+	}
+}
+
 func TestReportSARIF_WriterError(t *testing.T) {
-	if err := ReportSARIF(&failWriter{}, twoFiles(), "1.0.0"); err == nil {
+	if err := ReportSARIF(&failWriter{}, twoFiles(), "1.0.0", testMeta); err == nil {
 		t.Error("expected error from failing writer")
 	}
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.5.0"
+const Version = "1.5.1"


### PR DESCRIPTION
Clears task #37. The SARIF run now carries a `rules` array in its tool driver: each kata that produced a finding contributes a descriptor (title, full description, default level, help URL), and every result references its rule by index.

GitHub code scanning renders rule metadata, so a finding shows what the rule means and links to the kata catalog instead of showing a bare ID.

Severity: feature (SARIF completeness).