### PR TITLE
feat: add a baseline ratchet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-06-16
+
+### Added
+- `-baseline-write <path>` records a snapshot of the current findings; `-baseline <path>` then suppresses those findings and reports only ones new since the snapshot, exiting non-zero only on new findings. This lets a large existing codebase adopt ZShellCheck and fail CI on regressions without fixing every pre-existing finding first. A baseline entry is keyed by kata, file, and the trimmed source line, so unrelated line moves do not resurrect a suppressed finding.
+
 ## [1.5.1] - 2026-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.5.1-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.6.0-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-132%20katas-2ea44f)](KATAS.md)
 [![Dependencies](https://img.shields.io/badge/dependencies-0-2ea44f)](go.mod)

--- a/cmd/zshellcheck/baseline.go
+++ b/cmd/zshellcheck/baseline.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package main
+
+import (
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+)
+
+// baselineState drives the `-baseline` / `-baseline-write` ratchet. In
+// write mode it accumulates a fingerprint for every finding so a snapshot
+// can be saved; otherwise known holds the snapshot's fingerprints and any
+// finding already in it is suppressed, leaving only new findings.
+type baselineState struct {
+	write   bool
+	known   map[string]bool
+	collect []string
+}
+
+// loadBaseline reads a snapshot file into a filtering baselineState.
+func loadBaseline(path string) (*baselineState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	known := map[string]bool{}
+	for _, line := range strings.Split(string(data), "\n") {
+		if line != "" {
+			known[line] = true
+		}
+	}
+	return &baselineState{known: known}, nil
+}
+
+// baselineFingerprint identifies a finding by kata, file, and the trimmed
+// source line — not the line number — so inserting or removing unrelated
+// lines elsewhere in the file does not invalidate the snapshot.
+func baselineFingerprint(file string, lines []string, v katas.Violation) string {
+	content := ""
+	if v.Line >= 1 && v.Line <= len(lines) {
+		content = strings.TrimSpace(lines[v.Line-1])
+	}
+	return v.KataID + "\t" + file + "\t" + content
+}
+
+// applyBaseline records or filters this file's findings against the
+// baseline. In write mode it returns the findings unchanged after
+// collecting them; otherwise it returns only the findings absent from the
+// snapshot.
+func (b *baselineState) applyBaseline(filename string, data []byte, violations []katas.Violation) []katas.Violation {
+	lines := strings.Split(string(data), "\n")
+	if b.write {
+		for _, v := range violations {
+			b.collect = append(b.collect, baselineFingerprint(filename, lines, v))
+		}
+		return violations
+	}
+	kept := violations[:0]
+	for _, v := range violations {
+		if !b.known[baselineFingerprint(filename, lines, v)] {
+			kept = append(kept, v)
+		}
+	}
+	return kept
+}
+
+// writeBaseline saves the collected fingerprints as a sorted, de-duplicated
+// snapshot.
+func (b *baselineState) writeBaseline(path string) error {
+	seen := map[string]bool{}
+	uniq := make([]string, 0, len(b.collect))
+	for _, fp := range b.collect {
+		if !seen[fp] {
+			seen[fp] = true
+			uniq = append(uniq, fp)
+		}
+	}
+	sort.Strings(uniq)
+	out := strings.Join(uniq, "\n")
+	if out != "" {
+		out += "\n"
+	}
+	return os.WriteFile(path, []byte(out), 0o600)
+}

--- a/cmd/zshellcheck/baseline_test.go
+++ b/cmd/zshellcheck/baseline_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+)
+
+func TestBaselineFingerprint(t *testing.T) {
+	lines := []string{"echo one", "echo two"}
+	v := katas.Violation{KataID: "ZC1037", Line: 2, Column: 1}
+	if got := baselineFingerprint("a.zsh", lines, v); got != "ZC1037\ta.zsh\techo two" {
+		t.Errorf("fingerprint = %q", got)
+	}
+	// Out-of-range line yields an empty content field, never a panic.
+	vOut := katas.Violation{KataID: "ZC1", Line: 99}
+	if got := baselineFingerprint("a.zsh", lines, vOut); got != "ZC1\ta.zsh\t" {
+		t.Errorf("out-of-range fingerprint = %q", got)
+	}
+}
+
+func TestApplyBaselineWriteMode(t *testing.T) {
+	b := &baselineState{write: true}
+	vs := []katas.Violation{
+		{KataID: "ZC1", Line: 1}, {KataID: "ZC2", Line: 1},
+	}
+	got := b.applyBaseline("f.zsh", []byte("cmd\n"), vs)
+	if len(got) != 2 {
+		t.Errorf("write mode should return all findings, got %d", len(got))
+	}
+	if len(b.collect) != 2 {
+		t.Errorf("write mode should collect 2 fingerprints, got %d", len(b.collect))
+	}
+}
+
+func TestApplyBaselineFilterMode(t *testing.T) {
+	data := []byte("cmd\n")
+	known := baselineFingerprint("f.zsh", []string{"cmd"}, katas.Violation{KataID: "ZC1", Line: 1})
+	b := &baselineState{known: map[string]bool{known: true}}
+	vs := []katas.Violation{
+		{KataID: "ZC1", Line: 1}, // in baseline -> suppressed
+		{KataID: "ZC2", Line: 1}, // new -> kept
+	}
+	got := b.applyBaseline("f.zsh", data, vs)
+	if len(got) != 1 || got[0].KataID != "ZC2" {
+		t.Errorf("filter mode kept wrong findings: %v", got)
+	}
+}
+
+func TestWriteAndLoadBaseline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "base.txt")
+	b := &baselineState{write: true, collect: []string{
+		"ZC2\tf\tline", "ZC1\tf\tline", "ZC2\tf\tline", // duplicate + unsorted
+	}}
+	if err := b.writeBaseline(path); err != nil {
+		t.Fatalf("writeBaseline: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	got := strings.TrimSpace(string(data))
+	// De-duplicated and sorted.
+	if got != "ZC1\tf\tline\nZC2\tf\tline" {
+		t.Errorf("baseline content = %q", got)
+	}
+	loaded, err := loadBaseline(path)
+	if err != nil {
+		t.Fatalf("loadBaseline: %v", err)
+	}
+	if !loaded.known["ZC1\tf\tline"] || !loaded.known["ZC2\tf\tline"] {
+		t.Errorf("loaded baseline missing entries: %v", loaded.known)
+	}
+}
+
+func TestLoadBaselineMissing(t *testing.T) {
+	if _, err := loadBaseline("/nonexistent/baseline.txt"); err == nil {
+		t.Error("expected error for missing baseline file")
+	}
+}
+
+func TestSetupBaseline(t *testing.T) {
+	// Write mode.
+	var opts fixOptions
+	if code := setupBaseline(&opts, "", "out.txt"); code != 0 || opts.baseline == nil || !opts.baseline.write {
+		t.Errorf("write-mode setup wrong: code=%d baseline=%v", code, opts.baseline)
+	}
+	// Filter mode with a real file.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "b.txt")
+	if err := os.WriteFile(path, []byte("ZC1\tf\tline\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	opts = fixOptions{}
+	if code := setupBaseline(&opts, path, ""); code != 0 || opts.baseline == nil || opts.baseline.write {
+		t.Errorf("filter-mode setup wrong: code=%d", code)
+	}
+	// Missing file errors.
+	opts = fixOptions{}
+	if code := setupBaseline(&opts, "/nonexistent/zzz.txt", ""); code != 1 {
+		t.Errorf("missing baseline should exit 1, got %d", code)
+	}
+	// Neither flag set leaves baseline nil.
+	opts = fixOptions{}
+	if code := setupBaseline(&opts, "", ""); code != 0 || opts.baseline != nil {
+		t.Errorf("no-baseline setup should be inert, got code=%d", code)
+	}
+}
+
+func TestRun_BaselineRatchet(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "t.zsh")
+	if err := os.WriteFile(src, []byte("x=`which git`\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	base := filepath.Join(dir, "base.txt")
+	old := os.Args
+	defer func() { os.Args = old }()
+
+	// Write a baseline of the current findings; exit 0.
+	resetFlags()
+	os.Args = []string{"zshellcheck", "-no-banner", "-baseline-write", base, src}
+	if code := run(); code != 0 {
+		t.Errorf("baseline-write should exit 0, got %d", code)
+	}
+	if _, err := os.Stat(base); err != nil {
+		t.Fatalf("baseline file not written: %v", err)
+	}
+
+	// With the baseline, the same source yields no new findings: exit 0.
+	resetFlags()
+	os.Args = []string{"zshellcheck", "-no-banner", "-baseline", base, src}
+	if code := run(); code != 0 {
+		t.Errorf("all-baselined run should exit 0, got %d", code)
+	}
+
+	// A new finding fails the ratchet: exit 1.
+	if err := os.WriteFile(src, []byte("x=`which git`\nrm -rf $undefined\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resetFlags()
+	os.Args = []string{"zshellcheck", "-no-banner", "-baseline", base, src}
+	if code := run(); code != 1 {
+		t.Errorf("new finding should exit 1, got %d", code)
+	}
+}

--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -41,6 +41,8 @@ type runFlags struct {
 	listRules      *bool
 	explain        *string
 	statistics     *bool
+	baseline       *string
+	baselineWrite  *string
 }
 
 func run() int {
@@ -86,8 +88,18 @@ func run() int {
 	if *flags.statistics {
 		fixOpts.statistics = map[string]int{}
 	}
+	if code := setupBaseline(&fixOpts, *flags.baseline, *flags.baselineWrite); code != 0 {
+		return code
+	}
 	total := scanArgs(cfg, allowedSeverities, *flags.format, fixOpts)
 	emitFixSummary(fixOpts.stats)
+	if *flags.baselineWrite != "" {
+		if err := fixOpts.baseline.writeBaseline(*flags.baselineWrite); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing baseline: %s\n", err)
+			return 1
+		}
+		return 0
+	}
 	if fixOpts.statistics != nil {
 		emitStatistics(os.Stdout, katas.Registry, fixOpts.statistics)
 		if total == 0 {
@@ -124,6 +136,24 @@ func emitStatistics(out io.Writer, registry *katas.KatasRegistry, counts map[str
 	}
 }
 
+// setupBaseline configures the run for -baseline / -baseline-write,
+// returning a non-zero exit code only when a requested baseline file
+// cannot be read.
+func setupBaseline(fixOpts *fixOptions, baseline, baselineWrite string) int {
+	switch {
+	case baselineWrite != "":
+		fixOpts.baseline = &baselineState{write: true}
+	case baseline != "":
+		b, err := loadBaseline(baseline)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading baseline: %s\n", err)
+			return 1
+		}
+		fixOpts.baseline = b
+	}
+	return 0
+}
+
 func registerRunFlags() runFlags {
 	return runFlags{
 		format:         flag.String("format", "text", "Output format. One of text, json, sarif."),
@@ -140,6 +170,8 @@ func registerRunFlags() runFlags {
 		listRules:      flag.Bool("list-rules", false, "Print every kata (ID, severity, title) and exit."),
 		explain:        flag.String("explain", "", "Print the full description of a kata by ID (e.g. ZC1001) and exit."),
 		statistics:     flag.Bool("statistics", false, "Print a per-kata count of findings instead of individual reports."),
+		baseline:       flag.String("baseline", "", "Suppress findings recorded in this baseline file; report only new ones."),
+		baselineWrite:  flag.String("baseline-write", "", "Write a baseline snapshot of current findings to this path and exit 0."),
 	}
 }
 
@@ -403,6 +435,9 @@ type fixOptions struct {
 	// statistics, when non-nil, switches output to a per-kata count table:
 	// individual findings are suppressed and tallied here instead.
 	statistics map[string]int
+	// baseline, when non-nil, records or filters findings against a saved
+	// snapshot so a run reports only findings new since the baseline.
+	baseline *baselineState
 }
 
 // fixStats accumulates fix activity across all files visited in one
@@ -616,6 +651,16 @@ func processFile(filename string, out, errOut io.Writer, cfg config.Config, regi
 	violations, edits := collectViolations(program, registry, disabled, data, fixOpts.enabled)
 	violations, edits = applyDirectiveSilences(violations, edits, directives)
 	violations, edits = applySeverityFilter(violations, edits, allowedSeverities)
+
+	// The baseline ratchet records or suppresses findings against a saved
+	// snapshot. Write mode collects them and stops short of fixing or
+	// reporting; filter mode leaves only findings new since the baseline.
+	if fixOpts.baseline != nil {
+		violations = fixOpts.baseline.applyBaseline(filename, data, violations)
+		if fixOpts.baseline.write {
+			return len(violations)
+		}
+	}
 
 	applyFixIfEnabled(filename, data, registry, disabled, cfg, allowedSeverities, edits, violations, fixOpts, out, errOut)
 	emitReport(filename, out, errOut, format, cfg, violations, data, registry, fixOpts)

--- a/cmd/zshellcheck/usage.go
+++ b/cmd/zshellcheck/usage.go
@@ -42,8 +42,8 @@ func printUsage(out io.Writer, fset *flag.FlagSet, showBanner bool) {
 		},
 		{
 			title: "FILTER",
-			names: []string{"severity"},
-			blurb: "Drop violations below a threshold.",
+			names: []string{"severity", "baseline", "baseline-write"},
+			blurb: "Drop violations below a threshold, or ratchet against a baseline.",
 		},
 		{
 			title: "AUTO-FIX",
@@ -78,6 +78,7 @@ func printUsage(out io.Writer, fset *flag.FlagSet, showBanner bool) {
 		{"List every kata, or explain one", "zshellcheck -list-rules; zshellcheck -explain ZC1001"},
 		{"Lint a tree, suppress style-level findings", "zshellcheck -severity warning ./scripts"},
 		{"Triage by frequency: per-kata counts", "zshellcheck -statistics ./scripts"},
+		{"Snapshot findings, then fail only on new ones", "zshellcheck -baseline-write .zshellcheck-baseline ./scripts"},
 		{"Emit SARIF for GitHub Code Scanning", "zshellcheck -format sarif ./scripts > zshellcheck.sarif"},
 		{"Preview every available auto-fix as a diff", "zshellcheck -diff path/to/script.zsh"},
 		{"Apply auto-fixes in place (safe only)", "zshellcheck -fix path/to/script.zsh"},

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -8,6 +8,7 @@ The full list lives in [KATAS.md](../KATAS.md).
 ## Contents
 
 - [CLI reference](#cli-reference)
+- [Baseline ratchet](#baseline-ratchet)
 - [Severity levels](#severity-levels)
 - [Configuration](#configuration)
 - [Inline `noka` directives](#inline-noka-directives)
@@ -32,6 +33,8 @@ Files with `.go`, `.md`, `.json`, `.yml`, `.yaml`, or `.txt` extensions are skip
 | --- | --- | --- |
 | `-format <text\|json\|sarif>` | `text` | Output format. `sarif` is for GitHub Code Scanning ingestion. |
 | `-statistics` | off | Print a per-kata count of findings, sorted by frequency, instead of individual reports. |
+| `-baseline <path>` | — | Suppress findings recorded in the baseline file; report only findings new since it. |
+| `-baseline-write <path>` | — | Write a baseline snapshot of the current findings and exit 0. |
 | `-severity <level[,level...]>` | (all) | Comma-separated filter. Accepts `error`, `warning`, `info`, `style`. |
 | `-verbose` | off | Emit full kata descriptions in text output. |
 | `-no-color` | off | Disable ANSI colours. Implied when stdout is not a TTY. |
@@ -108,6 +111,22 @@ Combine flags freely:
 [KATAS.md](../KATAS.md) lists every kata with an explicit `Auto-fix: yes/no` line, and the summary table reports the current count.
 
 ---
+
+## Baseline ratchet
+
+Adopting ZShellCheck on a large existing codebase need not mean fixing every finding at once.
+Snapshot the current findings, then let CI fail only on findings introduced after the snapshot.
+
+```bash
+# Record the current findings once and commit the file.
+zshellcheck -baseline-write .zshellcheck-baseline ./scripts
+
+# In CI: only findings new since the baseline cause a non-zero exit.
+zshellcheck -baseline .zshellcheck-baseline ./scripts
+```
+
+A baseline entry identifies a finding by its kata, file, and the trimmed source line — not the line number — so inserting or removing unrelated lines elsewhere in a file does not resurrect a suppressed finding.
+Re-run `-baseline-write` to refresh the snapshot after you fix some findings.
 
 ## Severity levels
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.5.1"
+const Version = "1.6.0"


### PR DESCRIPTION
Clears task #35. `-baseline-write <path>` snapshots current findings; `-baseline <path>` suppresses those and reports only findings new since the snapshot, exiting non-zero only on new ones.

Lets a large existing codebase adopt ZShellCheck and fail CI on regressions without fixing every pre-existing finding first.

Fingerprint = kata + file + trimmed source line (not line number), so unrelated line moves do not resurrect a suppressed finding. New code 100% covered; docs + help + CHANGELOG updated.

Severity: feature (adoption).