### PR TITLE
feat: rule re-grade, add-noka, stale-noka detection

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,8 +77,9 @@ linters:
           - gosec
         text: "G101"
       # Lint pipeline writes the rewritten file at the original path; the
-      # path comes from the user's CLI arg, validated upstream.
-      - path: cmd/zshellcheck/main\.go
+      # path comes from the user's CLI arg, validated upstream. The -fix
+      # writer lives in main.go and the -add-noka writer in directives.go.
+      - path: cmd/zshellcheck/(main|directives)\.go
         linters:
           - gosec
         text: "G703"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-06-16
+
+### Added
+- `-rule-severity <ZC####:level,...>` re-grades specific katas to a chosen severity (`error`, `warning`, `info`, `style`), independent of the global `-severity` floor.
+- `-add-noka` appends a `# noka: ZC####` directive to every line that carries a finding and writes the files, silencing an existing codebase in bulk for review.
+- `-detect-stale-noka` reports `# noka` directives that suppress no actual finding and exits non-zero when any are found, so stale suppressions can be pruned.
+
 ## [1.6.0] - 2026-06-16
 
 ### Added
@@ -308,7 +315,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `cmd  # noka: ZC1234`      — silences one kata on this line.
     - `cmd  # noka: ZC1234, ZC1075` — multiple, comma- or space-separated.
   Standalone `# noka` directives still apply to the next non-blank code line; placed at file tail with no code after them, they apply file-wide.
-  Rationale: shorter (18 vs 30 chars), distinctive ("no kata"), aligns with the python ecosystem's `# noqa` convention.
+  Rationale: shorter, distinctive ("no kata"), and consistent with the inline-comment suppression conventions other linters use.
   Refactored cleanly while the project is still early — no fork-side migration to coordinate.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.6.0-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.7.0-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-132%20katas-2ea44f)](KATAS.md)
 [![Dependencies](https://img.shields.io/badge/dependencies-0-2ea44f)](go.mod)

--- a/cmd/zshellcheck/directives.go
+++ b/cmd/zshellcheck/directives.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/config"
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+)
+
+// parseRuleSeverity reads a `-rule-severity` value of the form
+// `ZC1037:error,ZC1075:style` into a map from kata ID to severity. An
+// empty input yields a nil map; a malformed entry or unknown level is an
+// error.
+func parseRuleSeverity(spec string) (map[string]katas.Severity, error) {
+	if strings.TrimSpace(spec) == "" {
+		return nil, nil
+	}
+	out := map[string]katas.Severity{}
+	for _, pair := range strings.Split(spec, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		id, level, ok := strings.Cut(pair, ":")
+		id = strings.TrimSpace(id)
+		level = strings.TrimSpace(level)
+		if !ok || id == "" {
+			return nil, fmt.Errorf("rule-severity: expected ZC####:level, got %q", pair)
+		}
+		sev := katas.Severity(level)
+		switch sev {
+		case katas.SeverityError, katas.SeverityWarning, katas.SeverityInfo, katas.SeverityStyle:
+			out[id] = sev
+		default:
+			return nil, fmt.Errorf("rule-severity: %q is not error, warning, info, or style", level)
+		}
+	}
+	return out, nil
+}
+
+// regradeSeverity rewrites the level of any violation whose kata appears in
+// the re-grade map, in place.
+func regradeSeverity(violations []katas.Violation, regrade map[string]katas.Severity) {
+	if len(regrade) == 0 {
+		return
+	}
+	for i := range violations {
+		if sev, ok := regrade[violations[i].KataID]; ok {
+			violations[i].Level = sev
+		}
+	}
+}
+
+// reportStaleNoka writes a line for every per-line `# noka` directive that
+// suppresses no actual finding, and tallies them. raw is the file's
+// findings before suppression. A bare `# noka` (no IDs) is never stale: it
+// is an intentional blanket silence.
+func reportStaleNoka(out io.Writer, filename string, raw []katas.Violation, directives config.Directives, counter *int) {
+	fires := map[string]bool{}
+	for _, v := range raw {
+		fires[fmt.Sprintf("%d\x00%s", v.Line, v.KataID)] = true
+	}
+	type stale struct {
+		line int
+		id   string
+	}
+	var stales []stale
+	for line, ids := range directives.PerLine {
+		for _, id := range ids {
+			if !fires[fmt.Sprintf("%d\x00%s", line, id)] {
+				stales = append(stales, stale{line, id})
+			}
+		}
+	}
+	sort.Slice(stales, func(i, j int) bool {
+		if stales[i].line != stales[j].line {
+			return stales[i].line < stales[j].line
+		}
+		return stales[i].id < stales[j].id
+	})
+	for _, s := range stales {
+		fmt.Fprintf(out, "%s:%d: stale `# noka: %s` — no such finding on this line.\n", filename, s.line, s.id)
+		if counter != nil {
+			*counter++
+		}
+	}
+}
+
+// addNokaDirectives appends a `# noka: ZC####` directive to every line that
+// carries a finding and does not already have a `# noka`, then writes the
+// file back. It is the bulk "silence what exists" companion to the baseline
+// ratchet.
+func addNokaDirectives(filename string, data []byte, violations []katas.Violation) error {
+	byLine := map[int]map[string]bool{}
+	for _, v := range violations {
+		if byLine[v.Line] == nil {
+			byLine[v.Line] = map[string]bool{}
+		}
+		byLine[v.Line][v.KataID] = true
+	}
+	if len(byLine) == 0 {
+		return nil
+	}
+	lines := strings.Split(string(data), "\n")
+	changed := false
+	for ln, ids := range byLine {
+		idx := ln - 1
+		if idx < 0 || idx >= len(lines) || strings.Contains(lines[idx], "# noka") {
+			continue
+		}
+		sorted := make([]string, 0, len(ids))
+		for id := range ids {
+			sorted = append(sorted, id)
+		}
+		sort.Strings(sorted)
+		lines[idx] += "  # noka: " + strings.Join(sorted, ", ")
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	mode := os.FileMode(0o600)
+	if info, err := os.Stat(filename); err == nil {
+		mode = info.Mode().Perm()
+	}
+	return os.WriteFile(filename, []byte(strings.Join(lines, "\n")), mode)
+}

--- a/cmd/zshellcheck/directives_test.go
+++ b/cmd/zshellcheck/directives_test.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/config"
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+)
+
+func TestParseRuleSeverity(t *testing.T) {
+	m, err := parseRuleSeverity("ZC1037:error, ZC1075:style ,")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m["ZC1037"] != katas.SeverityError || m["ZC1075"] != katas.SeverityStyle {
+		t.Errorf("re-grade map wrong: %v", m)
+	}
+	if got, err := parseRuleSeverity(""); got != nil || err != nil {
+		t.Errorf("empty spec should be nil/nil, got %v/%v", got, err)
+	}
+	for _, bad := range []string{"ZC1037", "ZC1037:bogus", ":error"} {
+		if _, err := parseRuleSeverity(bad); err == nil {
+			t.Errorf("expected error for %q", bad)
+		}
+	}
+}
+
+func TestRegradeSeverity(t *testing.T) {
+	vs := []katas.Violation{
+		{KataID: "ZC1037", Level: katas.SeverityStyle},
+		{KataID: "ZC1075", Level: katas.SeverityWarning},
+	}
+	regradeSeverity(vs, map[string]katas.Severity{"ZC1037": katas.SeverityError})
+	if vs[0].Level != katas.SeverityError {
+		t.Errorf("ZC1037 not re-graded: %v", vs[0].Level)
+	}
+	if vs[1].Level != katas.SeverityWarning {
+		t.Errorf("ZC1075 should be unchanged: %v", vs[1].Level)
+	}
+	// Empty map is a no-op.
+	regradeSeverity(vs, nil)
+	if vs[0].Level != katas.SeverityError {
+		t.Error("nil map should not change levels")
+	}
+}
+
+func TestReportStaleNoka(t *testing.T) {
+	raw := []katas.Violation{{KataID: "ZC1002", Line: 1}}
+	directives := config.Directives{PerLine: map[int][]string{
+		1: {"ZC1002", "ZC9999", "ZC9998"}, // ZC1002 fires; two stale on one line
+		2: {"ZC1037"},                     // stale: nothing on line 2
+	}}
+	var buf bytes.Buffer
+	count := 0
+	reportStaleNoka(&buf, "f.zsh", raw, directives, &count)
+	out := buf.String()
+	if count != 3 {
+		t.Errorf("want 3 stale, got %d:\n%s", count, out)
+	}
+	if strings.Contains(out, "ZC1002") {
+		t.Error("ZC1002 fires and must not be reported stale")
+	}
+	// Sorted by line, then ID: ZC9998 < ZC9999 (same line 1) < ZC1037 (line 2).
+	if !(strings.Index(out, "ZC9998") < strings.Index(out, "ZC9999") &&
+		strings.Index(out, "ZC9999") < strings.Index(out, "ZC1037")) {
+		t.Errorf("stale output not sorted by line then id:\n%s", out)
+	}
+}
+
+func TestAddNokaDirectives(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.zsh")
+	src := "echo a\nx=1  # noka: ZC1\necho b\n"
+	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	vs := []katas.Violation{
+		{KataID: "ZC1002", Line: 1},
+		{KataID: "ZC1037", Line: 1}, // two on line 1 -> grouped
+		{KataID: "ZC9", Line: 2},    // line already has a noka -> skipped
+	}
+	if err := addNokaDirectives(path, []byte(src), vs); err != nil {
+		t.Fatalf("addNokaDirectives: %v", err)
+	}
+	out, _ := os.ReadFile(path)
+	lines := strings.Split(string(out), "\n")
+	if lines[0] != "echo a  # noka: ZC1002, ZC1037" {
+		t.Errorf("line 1 = %q", lines[0])
+	}
+	if lines[1] != "x=1  # noka: ZC1" {
+		t.Errorf("line 2 (existing noka) should be untouched: %q", lines[1])
+	}
+
+	// No findings -> no write, no error.
+	if err := addNokaDirectives(path, []byte(src), nil); err != nil {
+		t.Errorf("empty add-noka should be a no-op: %v", err)
+	}
+}
+
+func TestReportStaleNokaNilCounter(t *testing.T) {
+	d := config.Directives{PerLine: map[int][]string{1: {"ZC1"}}}
+	var buf bytes.Buffer
+	reportStaleNoka(&buf, "f.zsh", nil, d, nil) // nil counter must not panic
+	if !strings.Contains(buf.String(), "ZC1") {
+		t.Error("stale entry should still be reported with a nil counter")
+	}
+}
+
+func TestAddNokaDirectivesOutOfRange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.zsh")
+	src := "echo a\n"
+	if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A finding on a line past EOF is skipped; the file is left unchanged.
+	if err := addNokaDirectives(path, []byte(src), []katas.Violation{{KataID: "ZC1", Line: 99}}); err != nil {
+		t.Fatal(err)
+	}
+	if b, _ := os.ReadFile(path); string(b) != src {
+		t.Errorf("out-of-range finding modified the file: %q", b)
+	}
+}
+
+func TestRunBaselineWriteError(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "t.zsh")
+	if err := os.WriteFile(src, []byte("echo hi\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := os.Args
+	defer func() { os.Args = old }()
+	resetFlags()
+	// A baseline path inside a non-existent directory cannot be written.
+	os.Args = []string{"zshellcheck", "-no-banner", "-baseline-write", filepath.Join(dir, "nope", "b.txt"), src}
+	if code := run(); code != 1 {
+		t.Errorf("baseline write to a bad path should exit 1, got %d", code)
+	}
+}
+
+func TestConfigureModes(t *testing.T) {
+	resetFlags()
+	flags := registerRunFlags()
+	*flags.statistics = true
+	*flags.detectStale = true
+	*flags.addNoka = true
+	*flags.ruleSeverity = "ZC1037:error"
+	var opts fixOptions
+	if code := configureModes(flags, &opts); code != 0 {
+		t.Fatalf("configureModes code=%d", code)
+	}
+	if opts.statistics == nil || !opts.detectStale || !opts.addNoka || opts.staleCount == nil {
+		t.Errorf("modes not configured: %+v", opts)
+	}
+	if opts.ruleSeverity["ZC1037"] != katas.SeverityError {
+		t.Error("rule-severity not parsed")
+	}
+	// Malformed rule-severity -> exit 1.
+	resetFlags()
+	flags2 := registerRunFlags()
+	*flags2.ruleSeverity = "bogus"
+	var opts2 fixOptions
+	if code := configureModes(flags2, &opts2); code != 1 {
+		t.Errorf("malformed rule-severity should exit 1, got %d", code)
+	}
+}
+
+func TestRun_RuleSeverityAndStale(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.zsh")
+	old := os.Args
+	defer func() { os.Args = old }()
+
+	// rule-severity re-grade still exits 1 on findings.
+	if err := os.WriteFile(path, []byte("echo hi\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resetFlags()
+	os.Args = []string{"zshellcheck", "-no-banner", "-rule-severity", "ZC1037:error", path}
+	if code := run(); code != 1 {
+		t.Errorf("findings should exit 1, got %d", code)
+	}
+
+	// A stale directive on an otherwise clean file exits 1 under detection.
+	if err := os.WriteFile(path, []byte(": # noka: ZC9999\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resetFlags()
+	os.Args = []string{"zshellcheck", "-no-banner", "-detect-stale-noka", path}
+	if code := run(); code != 1 {
+		t.Errorf("stale directive should exit 1, got %d", code)
+	}
+
+	// add-noka exits 0 and writes the directives.
+	if err := os.WriteFile(path, []byte("echo hi\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resetFlags()
+	os.Args = []string{"zshellcheck", "-no-banner", "-add-noka", path}
+	if code := run(); code != 0 {
+		t.Errorf("add-noka should exit 0, got %d", code)
+	}
+	if b, _ := os.ReadFile(path); !strings.Contains(string(b), "# noka:") {
+		t.Errorf("add-noka did not write directive: %q", b)
+	}
+}

--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -43,6 +43,9 @@ type runFlags struct {
 	statistics     *bool
 	baseline       *string
 	baselineWrite  *string
+	ruleSeverity   *string
+	addNoka        *bool
+	detectStale    *bool
 }
 
 func run() int {
@@ -85,29 +88,63 @@ func run() int {
 		return code
 	}
 	fixOpts := buildFixOpts(*flags.fixMode, *flags.diffMode, *flags.dryRun, *flags.unsafeFixes)
-	if *flags.statistics {
-		fixOpts.statistics = map[string]int{}
-	}
-	if code := setupBaseline(&fixOpts, *flags.baseline, *flags.baselineWrite); code != 0 {
+	if code := configureModes(flags, &fixOpts); code != 0 {
 		return code
 	}
 	total := scanArgs(cfg, allowedSeverities, *flags.format, fixOpts)
 	emitFixSummary(fixOpts.stats)
-	if *flags.baselineWrite != "" {
+	return runResult(flags, total, fixOpts)
+}
+
+// configureModes parses the report-shaping flags onto fixOpts, returning a
+// non-zero exit code only on a malformed value.
+func configureModes(flags runFlags, fixOpts *fixOptions) int {
+	if *flags.statistics {
+		fixOpts.statistics = map[string]int{}
+	}
+	regrade, err := parseRuleSeverity(*flags.ruleSeverity)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		return 1
+	}
+	fixOpts.ruleSeverity = regrade
+	fixOpts.addNoka = *flags.addNoka
+	if *flags.detectStale {
+		fixOpts.detectStale = true
+		fixOpts.staleCount = new(int)
+	}
+	return setupBaseline(fixOpts, *flags.baseline, *flags.baselineWrite)
+}
+
+// runResult turns the scan total and run mode into the process exit code,
+// emitting any deferred output (baseline file, statistics table).
+func runResult(flags runFlags, total int, fixOpts fixOptions) int {
+	switch {
+	case *flags.addNoka:
+		return 0
+	case *flags.baselineWrite != "":
 		if err := fixOpts.baseline.writeBaseline(*flags.baselineWrite); err != nil {
 			fmt.Fprintf(os.Stderr, "Error writing baseline: %s\n", err)
 			return 1
 		}
 		return 0
-	}
-	if fixOpts.statistics != nil {
+	case fixOpts.statistics != nil:
 		emitStatistics(os.Stdout, katas.Registry, fixOpts.statistics)
-		if total == 0 {
+		if total == 0 && !hasStale(fixOpts) {
 			return 0
 		}
 		return 1
 	}
-	return finalExitCode(total, *flags.format, fixOpts)
+	exit := finalExitCode(total, *flags.format, fixOpts)
+	if exit == 0 && hasStale(fixOpts) {
+		return 1
+	}
+	return exit
+}
+
+// hasStale reports whether stale-suppression detection found anything.
+func hasStale(fixOpts fixOptions) bool {
+	return fixOpts.staleCount != nil && *fixOpts.staleCount > 0
 }
 
 // emitStatistics prints a per-kata count table sorted by descending count
@@ -172,6 +209,9 @@ func registerRunFlags() runFlags {
 		statistics:     flag.Bool("statistics", false, "Print a per-kata count of findings instead of individual reports."),
 		baseline:       flag.String("baseline", "", "Suppress findings recorded in this baseline file; report only new ones."),
 		baselineWrite:  flag.String("baseline-write", "", "Write a baseline snapshot of current findings to this path and exit 0."),
+		ruleSeverity:   flag.String("rule-severity", "", "Re-grade katas: comma-separated ZC####:level (error, warning, info, style)."),
+		addNoka:        flag.Bool("add-noka", false, "Append a `# noka: ZC####` directive to every line with a finding, then exit."),
+		detectStale:    flag.Bool("detect-stale-noka", false, "Report `# noka` directives that suppress no actual finding."),
 	}
 }
 
@@ -438,6 +478,15 @@ type fixOptions struct {
 	// baseline, when non-nil, records or filters findings against a saved
 	// snapshot so a run reports only findings new since the baseline.
 	baseline *baselineState
+	// ruleSeverity re-grades specific katas to a chosen severity.
+	ruleSeverity map[string]katas.Severity
+	// addNoka rewrites each file in place, appending a `# noka` directive
+	// to every line with a finding, then stops short of reporting.
+	addNoka bool
+	// detectStale reports `# noka` directives that suppress no finding;
+	// staleCount tallies them for the exit code.
+	detectStale bool
+	staleCount  *int
 }
 
 // fixStats accumulates fix activity across all files visited in one
@@ -649,7 +698,23 @@ func processFile(filename string, out, errOut io.Writer, cfg config.Config, regi
 	disabled := mergeDisabled(cfg.DisabledKatas, directives.File)
 
 	violations, edits := collectViolations(program, registry, disabled, data, fixOpts.enabled)
+	regradeSeverity(violations, fixOpts.ruleSeverity)
+	// Stale-suppression detection compares the raw findings against the
+	// `# noka` directives before any are silenced.
+	if fixOpts.detectStale {
+		reportStaleNoka(out, filename, violations, directives, fixOpts.staleCount)
+	}
 	violations, edits = applyDirectiveSilences(violations, edits, directives)
+
+	// add-noka rewrites the file in place, silencing every current finding,
+	// and stops short of severity filtering, fixing, or reporting.
+	if fixOpts.addNoka {
+		if err := addNokaDirectives(filename, data, violations); err != nil {
+			fmt.Fprintf(errOut, "add-noka: %s\n", err)
+		}
+		return len(violations)
+	}
+
 	violations, edits = applySeverityFilter(violations, edits, allowedSeverities)
 
 	// The baseline ratchet records or suppresses findings against a saved

--- a/cmd/zshellcheck/usage.go
+++ b/cmd/zshellcheck/usage.go
@@ -42,8 +42,13 @@ func printUsage(out io.Writer, fset *flag.FlagSet, showBanner bool) {
 		},
 		{
 			title: "FILTER",
-			names: []string{"severity", "baseline", "baseline-write"},
-			blurb: "Drop violations below a threshold, or ratchet against a baseline.",
+			names: []string{"severity", "rule-severity", "baseline", "baseline-write"},
+			blurb: "Drop violations below a threshold, re-grade katas, or ratchet against a baseline.",
+		},
+		{
+			title: "SUPPRESSION",
+			names: []string{"add-noka", "detect-stale-noka"},
+			blurb: "Manage `# noka` directives in bulk.",
 		},
 		{
 			title: "AUTO-FIX",
@@ -79,6 +84,8 @@ func printUsage(out io.Writer, fset *flag.FlagSet, showBanner bool) {
 		{"Lint a tree, suppress style-level findings", "zshellcheck -severity warning ./scripts"},
 		{"Triage by frequency: per-kata counts", "zshellcheck -statistics ./scripts"},
 		{"Snapshot findings, then fail only on new ones", "zshellcheck -baseline-write .zshellcheck-baseline ./scripts"},
+		{"Re-grade a kata's severity", "zshellcheck -rule-severity ZC1037:error ./scripts"},
+		{"Silence every current finding inline", "zshellcheck -add-noka ./scripts"},
 		{"Emit SARIF for GitHub Code Scanning", "zshellcheck -format sarif ./scripts > zshellcheck.sarif"},
 		{"Preview every available auto-fix as a diff", "zshellcheck -diff path/to/script.zsh"},
 		{"Apply auto-fixes in place (safe only)", "zshellcheck -fix path/to/script.zsh"},

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -36,6 +36,9 @@ Files with `.go`, `.md`, `.json`, `.yml`, `.yaml`, or `.txt` extensions are skip
 | `-baseline <path>` | — | Suppress findings recorded in the baseline file; report only findings new since it. |
 | `-baseline-write <path>` | — | Write a baseline snapshot of the current findings and exit 0. |
 | `-severity <level[,level...]>` | (all) | Comma-separated filter. Accepts `error`, `warning`, `info`, `style`. |
+| `-rule-severity <ZC####:level[,...]>` | — | Re-grade specific katas to a chosen severity, for example `ZC1037:error`. |
+| `-add-noka` | off | Append a `# noka: ZC####` directive to every line with a finding, write the files, and exit. |
+| `-detect-stale-noka` | off | Report `# noka` directives that suppress no actual finding; exit non-zero if any. |
 | `-verbose` | off | Emit full kata descriptions in text output. |
 | `-no-color` | off | Disable ANSI colours. Implied when stdout is not a TTY. |
 | `-cpuprofile <path>` | — | Write a Go pprof CPU profile to `<path>` for benchmarking. |
@@ -210,6 +213,9 @@ echo "ok"
 
 Multiple IDs may be separated by commas or whitespace.
 Inline IDs are merged with `disabled_katas` from `.zshellcheckrc`.
+
+To silence an existing codebase in bulk, `-add-noka` appends a `# noka` directive to every line that carries a finding, then exits — review the diff before committing.
+Over time directives go stale as the code around them changes; `-detect-stale-noka` reports any `# noka` that no longer suppresses a finding so you can remove it.
 
 ---
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.6.0"
+const Version = "1.7.0"


### PR DESCRIPTION
Completes the volume-management surface with three suppression/severity tools.

- `-rule-severity ZC####:level,...` re-grades chosen katas (error/warning/info/style), independent of the `-severity` floor.
- `-add-noka` appends a `# noka: ZC####` directive to every line with a finding and writes the files — bulk-silence an existing codebase for review.
- `-detect-stale-noka` reports `# noka` directives that suppress no finding and exits non-zero, so stale suppressions can be pruned.

New code covered; docs, help, and CHANGELOG updated; zero doc drift verified. Uses `# noka` (no-katas) — never noqa.

Severity: feature (UX).