### PR TITLE
docs: document -no-banner flag in CLI reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ zshellcheck-windows-amd64.exe
 # Editor and IDE files
 .vscode/
 .idea/
+*.sublime-project
+*.sublime-workspace
 *.swp
 *~
 .#*

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -41,6 +41,7 @@ Files with `.go`, `.md`, `.json`, `.yml`, `.yaml`, or `.txt` extensions are skip
 | `-detect-stale-noka` | off | Report `# noka` directives that suppress no actual finding; exit non-zero if any. |
 | `-verbose` | off | Emit full kata descriptions in text output. |
 | `-no-color` | off | Disable ANSI colours. Implied when stdout is not a TTY. |
+| `-no-banner` | off | Suppress the startup banner. Implied for JSON and SARIF output and when `-no-color` is set. |
 | `-cpuprofile <path>` | — | Write a Go pprof CPU profile to `<path>` for benchmarking. |
 | `-fix` | off | Apply auto-fixes in place. Safe (value-preserving) fixes only, unless `-unsafe-fixes` is set. |
 | `-unsafe-fixes` | off | Also apply fixes that may change runtime behavior — command and flag swaps, scope changes, glob qualifiers. |

--- a/internal/tools/gen-katas-md/main.go
+++ b/internal/tools/gen-katas-md/main.go
@@ -9,8 +9,6 @@
 // path passed via -o. Every kata's ID, title, severity, and description are
 // sourced directly from the RegisterKata() calls in pkg/katas/zc*.go so
 // the generated file cannot drift from the implementation.
-// SPDX-License-Identifier: MIT
-// Copyright the ZShellCheck contributors.
 package main
 
 import (

--- a/pkg/fix/fix.go
+++ b/pkg/fix/fix.go
@@ -5,8 +5,6 @@
 // source files. It handles offset math (1-based Line/Column to absolute
 // byte offsets), sorts edits bottom-up so earlier offsets stay valid,
 // and renders either a rewritten source string or a unified diff.
-// SPDX-License-Identifier: MIT
-// Copyright the ZShellCheck contributors.
 package fix
 
 import (


### PR DESCRIPTION
## What

- Add the `-no-banner` flag to the USER_GUIDE CLI reference table. The flag is defined and used in a combos example, but was missing from the flag list.
- Remove duplicate SPDX header lines from `pkg/fix/fix.go` and `internal/tools/gen-katas-md/main.go`. The header now appears once, at the top of each file.
- Group the Sublime editor ignores with the existing editor and IDE ignores in `.gitignore`.

## Why

A reader of the CLI reference table could not find `-no-banner` even though the same guide uses it in an example. The SPDX duplication and ignore placement are housekeeping.

## Verification

- `go build ./...`, `go vet ./...`, `go test -count=1 ./...` pass.
- `golangci-lint run ./...` reports 0 issues.
- `gocyclo -over 15 .` clean.
- KATAS.md in sync; version parity at v1.7.0.
