### PR TITLE
ci: bump codeql-action to v4.36.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,15 +40,15 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         languages: ${{ matrix.language }}
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     - name: Autobuild
-      uses: github/codeql-action/autobuild@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         category: "/language:${{ matrix.language }}"

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -48,7 +48,7 @@ jobs:
             ./
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: osv-results.sarif
           category: osv-scanner


### PR DESCRIPTION
## What

Bump every `github/codeql-action` use to the latest v4 release, `v4.36.2` (`8aad20d`):

- `codeql.yml` — `init`, `autobuild`, `analyze`: v3.35.1 -> v4.36.2 (the v3 to v4 major)
- `osv-scanner.yml` — `upload-sarif`: v4.35.2 -> v4.36.2

This unifies the action: the repo previously ran v3 for code scanning and v4 for the OSV SARIF upload.

## Why

v4 is the current major; v3.35.1 is the prior line. The v3 to v4 breaking changes (minimum bundled CodeQL version, GHES-only behavior) do not affect this repo, which runs on github.com and ubuntu-latest with the default Go init/autobuild/analyze flow and no pinned CodeQL bundle.

## Verification

- SHA resolved against the upstream `v4.36.2` tag with `git ls-remote`.
- The CodeQL `Analyze (go)` job runs on this PR and exercises the bumped `init`/`autobuild`/`analyze` against v4.36.2.
- Diff is pin-only; YAML parses.
