### PR TITLE
test: add autofix-safety corpus round-trip gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ jobs:
         env:
           ZSHELLCHECK_BIN: ${{ github.workspace }}/zshellcheck
         run: bash scripts/violation-corpus-sweep.sh
+      - name: Sweep auto-fixes for corruption and non-convergence
+        env:
+          ZSHELLCHECK_BIN: ${{ github.workspace }}/zshellcheck
+        run: bash scripts/fix-corpus-sweep.sh
 
   lint-shell:
     name: Lint Shell Scripts

--- a/README.md
+++ b/README.md
@@ -128,10 +128,11 @@ The full catalog with file counts lives in [INTEGRATIONS.md](INTEGRATIONS.md).
 
 ## Quality
 
-Every release replays the linter over the pinned integration corpora and gates on two snapshots:
+Every release replays the linter over the pinned integration corpora and gates on:
 
 - Parser errors and crashes stay at zero.
 - Kata findings match a reviewed baseline; a new finding on known-good code fails the build as a candidate false positive.
+- Auto-fixes round-trip cleanly: applying every fix to a corpus file never raises its parser-error count and always converges, so a rewrite cannot corrupt working code.
 
 Semantic-preserving rewrites — added blank lines, comments, or variable renames — must not change which katas fire.
 See the [local checks](CONTRIBUTING.md#local-checks) for the commands.

--- a/pkg/fix/corpus_roundtrip_test.go
+++ b/pkg/fix/corpus_roundtrip_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package fix
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/lexer"
+	"github.com/afadesigns/zshellcheck/pkg/parser"
+)
+
+// parseErrorCount lexes and parses source and reports how many parser
+// errors it raises.
+func parseErrorCount(source string) int {
+	p := parser.New(lexer.New(source))
+	p.ParseProgram()
+	return len(p.Errors())
+}
+
+// fixOnce applies every registry fix edit to source in a single pass and
+// returns the rewrite plus the parser-error count of that rewrite. It
+// mirrors the collect-and-apply path used by the CLI and the per-kata
+// integration tests.
+func fixOnce(source string) (string, int, error) {
+	program := parser.New(lexer.New(source)).ParseProgram()
+	var edits []katas.FixEdit
+	ast.Walk(program, func(n ast.Node) bool {
+		_, es := katas.Registry.CheckAndFix(n, nil, []byte(source))
+		edits = append(edits, es...)
+		return true
+	})
+	out, err := Apply(source, edits)
+	if err != nil {
+		return "", 0, err
+	}
+	return out, parseErrorCount(out), nil
+}
+
+// roundTripCorpus stresses the fixer on inputs that historically broke
+// it — overlapping subscript and arithmetic rewrites (ZC1001 vs ZC1073),
+// glob-qualifier stacking (ZC1040), the echo cluster (ZC1030/1037/1092),
+// nested backticks (ZC1002 vs ZC1005) — plus a broad sample of fixable
+// constructs. Each entry parses cleanly, so a parser error after fixing
+// can only mean the fix corrupted the source.
+var roundTripCorpus = []string{
+	// Subscript wrap vs redundant-$ removal, the v1.3.5 collision class.
+	"echo $arr[1]\n",
+	"(( total = $counts[key] + 1 ))\n",
+	"(( $arr[i] ))\n",
+	"x=$arr[1]\necho ${arr[2]}\n",
+	// Glob-qualifier stacking — must converge, not append (N) forever.
+	"for f in dir/*; do echo $f; done\n",
+	"for f in *.log; do print $f; done\n",
+	// Echo cluster — three katas, one fix.
+	"echo hello world\n",
+	"echo -n prompt\n",
+	"echo -e \"a\\tb\"\n",
+	"echo \"$var\"\n",
+	// Backticks, including nesting an external-command rewrite.
+	"result=`ls -la`\n",
+	"result=`which git`\n",
+	"x=`echo hi`\n",
+	// let / arithmetic rewrites.
+	"let x=5\n",
+	"let i+=1\n",
+	"let counter=counter+1\n",
+	// test / [ ] to [[ ]].
+	"[ $x -eq 1 ]\n",
+	"[ -f /tmp/foo ] && echo yes\n",
+	"[ \"$a\" = \"$b\" ]\n",
+	// External commands with Zsh-native alternatives.
+	"which git\n",
+	"x=$(seq -s , 1 5)\n",
+	"cat file | wc -l\n",
+	// Read, sensitive read, print forms.
+	"read name\n",
+	"read -p \"pw: \" secret\n",
+	// $(cat f) collapse.
+	"x=$(cat /etc/hostname)\n",
+	// readonly / typeset.
+	"readonly NAME=value\n",
+	// Mixed multi-line program exercising several fixes at once.
+	"result=`which git`\nfor f in dir/*; do echo $f; done\n[ $x -eq 1 ] && echo $arr[1]\nlet n=n+1\n",
+	// Quoted and already-idiomatic forms must stay no-ops.
+	"result=$(ls -la)\n",
+	"echo ${arr[1]}\n",
+	"[[ $x -eq 1 ]]\n",
+	"print -r -- hello\n",
+}
+
+// maxFixPasses bounds the fixed-point search. The CLI converges its
+// multi-pass fixer (applyFixesUntilStable) within a handful of passes;
+// a corpus entry that has not stabilised well before this cap is stuck
+// in a non-convergent rewrite loop — the v1.3.5 glob-qualifier stacking
+// class — and fails the gate.
+const maxFixPasses = 10
+
+// fixToFixedPoint applies fixOnce repeatedly until the source stops
+// changing or maxFixPasses is reached. It returns the final source,
+// whether a fixed point was reached, and the highest parser-error count
+// observed on any pass. Iterating to a fixed point mirrors the CLI,
+// whose fixer is deliberately multi-pass: one fix can enable another
+// (for example `[ $x -eq 1 ]` becomes `(( $x == 1 ))`, which then loses
+// its redundant `$`). The interesting invariants are therefore that the
+// rewrite converges and never corrupts, not that a single pass is a
+// no-op.
+func fixToFixedPoint(source string) (string, bool, int, error) {
+	cur := source
+	worstErrs := parseErrorCount(source)
+	for i := 0; i < maxFixPasses; i++ {
+		next, errs, err := fixOnce(cur)
+		if err != nil {
+			return cur, false, worstErrs, err
+		}
+		if errs > worstErrs {
+			worstErrs = errs
+		}
+		if next == cur {
+			return cur, true, worstErrs, nil
+		}
+		cur = next
+	}
+	return cur, false, worstErrs, nil
+}
+
+// TestFixRoundTrip_NoCorruption_Converges is the always-on autofix
+// safety gate. For every corpus entry it asserts the fixer (1) never
+// raises the parser-error count on any pass — a fix that turns parseable
+// source into unparseable source is a destructive bug — and (2)
+// converges to a fixed point, so a stable `-fix` result exists and the
+// rewrite never loops. The corpus sweep script
+// (scripts/fix-corpus-sweep.sh) extends the same invariants to the full
+// pinned upstream corpora in CI.
+func TestFixRoundTrip_NoCorruption_Converges(t *testing.T) {
+	for _, src := range roundTripCorpus {
+		origErrs := parseErrorCount(src)
+
+		final, converged, worstErrs, err := fixToFixedPoint(src)
+		if err != nil {
+			t.Errorf("apply failed for %q: %v", src, err)
+			continue
+		}
+		if worstErrs > origErrs {
+			t.Errorf("fix corrupted source\ninput: %q\nparser errors %d -> %d\nfinal: %q",
+				src, origErrs, worstErrs, final)
+		}
+		if !converged {
+			t.Errorf("fix did not converge within %d passes (non-convergent rewrite)\ninput: %q\nfinal: %q",
+				maxFixPasses, src, final)
+		}
+	}
+}

--- a/pkg/fix/integration_gap_test.go
+++ b/pkg/fix/integration_gap_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package fix
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+	"github.com/afadesigns/zshellcheck/pkg/katas"
+	"github.com/afadesigns/zshellcheck/pkg/lexer"
+	"github.com/afadesigns/zshellcheck/pkg/parser"
+)
+
+// isolatedFix applies only the named kata's fix to source, ignoring
+// every other kata. Several fixable katas overlap on the same construct
+// (the `test` rewrites ZC1006/ZC1020/ZC1036, the `let` rewrites
+// ZC1008/ZC1022); collecting every edit through runFix would assert the
+// cross-kata cascade instead of the one fix under test. Filtering the
+// violations to a single KataID pins each kata's own rewrite.
+func isolatedFix(t *testing.T, source, kataID string) string {
+	t.Helper()
+	program := parser.New(lexer.New(source)).ParseProgram()
+	var edits []katas.FixEdit
+	ast.Walk(program, func(n ast.Node) bool {
+		for _, v := range katas.Registry.Check(n, nil) {
+			if v.KataID == kataID {
+				edits = append(edits, katas.Registry.FixesFor(n, v, []byte(source))...)
+			}
+		}
+		return true
+	})
+	out, err := Apply(source, edits)
+	if err != nil {
+		t.Fatalf("apply %s: %v", kataID, err)
+	}
+	return out
+}
+
+// TestFixIsolated_GapKatas pins the exact rewrite of seven fixable katas
+// that previously had no golden fix-output test, only detection and
+// panic-safety coverage. Each entry asserts the kata's own fix in
+// isolation so an overlapping kata cannot mask a regression.
+func TestFixIsolated_GapKatas(t *testing.T) {
+	cases := []struct {
+		name string
+		kata string
+		src  string
+		want string
+	}{
+		{"ZC1006_test_numeric", "ZC1006", "test 1 -eq 1\n", "[[ 1 -eq 1 ]]\n"},
+		// The spaced `let x = 1` form carries its surrounding whitespace
+		// into the rewrite, so the operator keeps padded spaces. The
+		// result is correct and idempotent; tightening the spacing is a
+		// cosmetic polish tracked separately.
+		{"ZC1008_let_arith", "ZC1008", "let x = 1\n", "(( x  =  1 ))\n"},
+		{"ZC1020_test_to_bracket", "ZC1020", "test 1 -eq 1\n", "[[ 1 -eq 1 ]]\n"},
+		{"ZC1022_let_expr", "ZC1022", "let x=1+1\n", "(( x = 1+1 ))\n"},
+		{"ZC1036_test_file", "ZC1036", "test -f file.txt\n", "[[ -f file.txt ]]\n"},
+		{"ZC1037_echo_var", "ZC1037", "echo $foo\n", "print -r -- $foo\n"},
+		{"ZC1217_service", "ZC1217", "service nginx start\n", "systemctl start nginx\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isolatedFix(t, tc.src, tc.kata)
+			if got != tc.want {
+				t.Errorf("%s fix\ninput: %q\ngot:   %q\nwant:  %q", tc.kata, tc.src, got, tc.want)
+			}
+			// The rewrite must itself parse cleanly.
+			if n := parseErrorCount(got); n != 0 {
+				t.Errorf("%s fix produced %d parser error(s): %q", tc.kata, n, got)
+			}
+		})
+	}
+}

--- a/scripts/fix-corpus-sweep.sh
+++ b/scripts/fix-corpus-sweep.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# fix-corpus-sweep.sh — Auto-fix safety gate. For every file in the
+# pinned corpora, apply `zshellcheck -fix` (safe tier) and
+# `zshellcheck -fix -unsafe-fixes` (every tier), then assert the fixer
+# never corrupts the source and always converges:
+#
+#   1. No corruption — the rewritten file must not raise the parser-error
+#      count above the original file's own count. A fix that turns
+#      parseable source into unparseable source is a destructive bug.
+#   2. Idempotent — a second `-fix` pass over the already-fixed file must
+#      produce no further change. A fix that keeps rewriting (for example
+#      stacking a glob qualifier every pass) never converges.
+#   3. Panic-free — the linter must never crash (exit >= 2 or a Go stack
+#      trace) on any invocation.
+#
+# This is the canonical autofix-safety check, run on real-world code at
+# scale. Unlike the parser and violation sweeps it has no baseline: fix
+# safety is an absolute invariant, so any violation fails the gate.
+#
+# Manifest: .github/parser-corpus-manifest.txt (shared with the parser sweep)
+#
+# Usage:
+#   scripts/fix-corpus-sweep.sh
+#   ZSHELLCHECK_BIN=/path/to/binary scripts/fix-corpus-sweep.sh
+#
+# Exit status:
+#   0  every file round-trips cleanly
+#   1  one or more files were corrupted or did not converge
+#   2  manifest / clone / IO error, or a linter panic (never tolerated)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST="${REPO_ROOT}/.github/parser-corpus-manifest.txt"
+WORK_DIR="${PARSER_SWEEP_WORK:-${REPO_ROOT}/testdata/external-corpora}"
+BIN="${ZSHELLCHECK_BIN:-${REPO_ROOT}/zshellcheck}"
+
+if [[ ! -f "${MANIFEST}" ]]; then
+    echo "::error::manifest not found: ${MANIFEST}" >&2
+    exit 2
+fi
+
+if [[ ! -x "${BIN}" ]]; then
+    echo ">>> building zshellcheck into ${BIN}"
+    (cd "${REPO_ROOT}" && go build -o "${BIN}" ./cmd/zshellcheck)
+fi
+
+mkdir -p "${WORK_DIR}"
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "${SCRATCH}"' EXIT
+
+# Fetch a corpus at a pinned SHA. Idempotent.
+fetch_corpus() {
+    local name="$1" sha="$2" url="$3"
+    local dir="${WORK_DIR}/${name}"
+    if [[ -d "${dir}/.git" ]]; then
+        local cur
+        cur=$(cd "${dir}" && git rev-parse HEAD 2>/dev/null || echo "")
+        if [[ "${cur}" == "${sha}"* ]]; then
+            return 0
+        fi
+        (cd "${dir}" && git fetch --quiet --depth=1 origin "${sha}" 2>/dev/null \
+            && git reset --quiet --hard "${sha}") || {
+            rm -rf "${dir}"
+        }
+    fi
+    if [[ ! -d "${dir}/.git" ]]; then
+        git clone --quiet "${url}" "${dir}"
+        (cd "${dir}" && git reset --quiet --hard "${sha}") || {
+            echo "::error::failed to checkout ${sha} in ${name}" >&2
+            return 2
+        }
+    fi
+}
+
+# Build the file list for one corpus given its glob list.
+list_files() {
+    local dir="$1"
+    shift
+    local globs=("$@")
+    local find_args=()
+    local first=1
+    for g in "${globs[@]}"; do
+        if (( first )); then
+            find_args+=(-name "${g}")
+            first=0
+        else
+            find_args+=(-o -name "${g}")
+        fi
+    done
+    find "${dir}" -type f \( "${find_args[@]}" \) -print 2>/dev/null | sort
+}
+
+# Count parser errors a file raises, suppressing the banner.
+parser_errors() {
+    "${BIN}" -no-banner "$1" 2>/dev/null | grep -c "^Parser Error" || true
+}
+
+total_files=0
+corruptions=()
+non_idempotent=()
+PANICS=()
+
+while IFS=$'\t' read -r name sha url glob_list; do
+    [[ -z "${name}" || "${name}" == \#* ]] && continue
+    fetch_corpus "${name}" "${sha}" "${url}" || exit 2
+
+    read -r -a globs <<< "${glob_list}"
+    while IFS= read -r f; do
+        [[ -z "${f}" ]] && continue
+        rel="${name}/${f#${WORK_DIR}/${name}/}"
+        total_files=$((total_files+1))
+        orig_errors=$(parser_errors "${f}")
+
+        for mode in safe unsafe; do
+            if [[ "${mode}" == unsafe ]]; then
+                fix_args=(-fix -unsafe-fixes -no-banner)
+            else
+                fix_args=(-fix -no-banner)
+            fi
+
+            cp "${f}" "${SCRATCH}/work"
+            set +e
+            out=$("${BIN}" "${fix_args[@]}" "${SCRATCH}/work" 2>&1)
+            rc=$?
+            set -e
+            if (( rc >= 2 )) || grep -qiE 'panic:|^goroutine [0-9]+ ' <<< "${out}"; then
+                PANICS+=("${rel} [${mode}] (exit ${rc})")
+                continue
+            fi
+
+            fixed_errors=$(parser_errors "${SCRATCH}/work")
+            if (( fixed_errors > orig_errors )); then
+                corruptions+=("${rel} [${mode}]: parser errors ${orig_errors} -> ${fixed_errors}")
+            fi
+
+            cp "${SCRATCH}/work" "${SCRATCH}/work2"
+            "${BIN}" "${fix_args[@]}" "${SCRATCH}/work2" > /dev/null 2>&1 || true
+            if ! cmp -s "${SCRATCH}/work" "${SCRATCH}/work2"; then
+                non_idempotent+=("${rel} [${mode}]: second -fix pass changed the file")
+            fi
+        done
+    done < <(list_files "${WORK_DIR}/${name}" "${globs[@]}")
+done < "${MANIFEST}"
+
+echo "fix-corpus sweep: files=${total_files} corruptions=${#corruptions[@]} non_idempotent=${#non_idempotent[@]} panics=${#PANICS[@]}"
+
+# A panic is always fatal.
+if (( ${#PANICS[@]} > 0 )); then
+    echo "::error::fix-corpus gate: ${#PANICS[@]} file(s) panicked the linter under -fix — fixes must be panic-free"
+    for p in "${PANICS[@]}"; do
+        echo "  ! ${p}"
+    done
+    exit 2
+fi
+
+fail=0
+if (( ${#corruptions[@]} > 0 )); then
+    echo "::error::fix-corpus gate: ${#corruptions[@]} file(s) corrupted by -fix (parseable source rewritten into unparseable source)"
+    for c in "${corruptions[@]}"; do
+        echo "  + ${c}"
+    done
+    fail=1
+fi
+
+if (( ${#non_idempotent[@]} > 0 )); then
+    echo "::error::fix-corpus gate: ${#non_idempotent[@]} file(s) did not converge (a second -fix pass kept rewriting)"
+    for n in "${non_idempotent[@]}"; do
+        echo "  + ${n}"
+    done
+    fail=1
+fi
+
+exit "${fail}"


### PR DESCRIPTION
## What

Make autofix safety a permanent, enforced invariant and close the per-kata fix-test gap.

- `scripts/fix-corpus-sweep.sh` — the canonical autofix-safety gate, wired into the corpus CI job. For every pinned-corpus file it applies `-fix` (safe) and `-fix -unsafe-fixes` (every tier), then asserts:
  1. No corruption — the rewrite never raises the file's own parser-error count.
  2. Idempotent — a second `-fix` pass produces no further change.
  3. Panic-free.
  No baseline: fix safety is an absolute invariant, so any violation fails.
- `pkg/fix/corpus_roundtrip_test.go` — an always-on (`go test`) round-trip over the historically risky fix interactions: the subscript-vs-arithmetic collision (ZC1001/ZC1073), glob-qualifier stacking (ZC1040), the echo cluster, and nested backticks.
- `pkg/fix/integration_gap_test.go` — isolated golden fix-output tests for the seven fixable katas that previously had only detection coverage: `ZC1006`, `ZC1008`, `ZC1020`, `ZC1022`, `ZC1036`, `ZC1037`, `ZC1217`.

## Why

The full-corpus fix round-trip is the method that found the three destructive-fix bugs in v1.3.5 (a subscript/arithmetic edit collision, a non-converging glob qualifier, and the engine safety net). It was run by hand and never gated, so the class could regress silently. This makes it a permanent gate and adds an always-on in-repo layer plus the missing per-kata goldens.

## Verification

- Local sweep over all 1095 corpus files: zero corruptions, zero non-idempotent rewrites, zero panics.
- `go test ./...` passes; `golangci-lint run ./...` reports 0 issues.
- The new CI step runs the sweep against the pinned corpora.
