### PR TITLE
fix: stop auto-fixes emitting broken code

### DIFF
--- a/pkg/fix/fix_regression_test.go
+++ b/pkg/fix/fix_regression_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package fix
+
+import (
+	"strings"
+	"testing"
+)
+
+// These regressions pin three auto-fixes that previously emitted broken
+// or wrong source. Each asserts the fix no longer corrupts its input.
+// They were found by auditing real-corpus findings against runnable Zsh.
+
+func TestFixRegression_ZC1086_NamespacedFunctionName(t *testing.T) {
+	// `function name"${1:-}"() { ... }` builds the function name from a
+	// parameter expansion (gitstatus does this for per-instance
+	// namespacing). The fix used to insert `()` after the parsed
+	// identifier, splitting the real name so a different function was
+	// defined. It must now leave the source untouched.
+	src := "function gitstatus_query\"${1:-}\"() { print body; }\n"
+	if got := runFix(t, src); got != src {
+		t.Errorf("ZC1086 rewrote a parameter-expanded function name\ninput: %q\ngot:   %q", src, got)
+	}
+}
+
+func TestFixRegression_ZC1010_BinaryDashODashA(t *testing.T) {
+	// `[ x -o y ]` is a POSIX OR and `[ a -a b ]` an AND. `[[ ]]` has no
+	// binary `-o`/`-a` (it uses `||`/`&&` and reads them as unary tests),
+	// so a naive `[` -> `[[` swap is a syntax error. The fix must bail.
+	for _, src := range []string{
+		"[ \"$a\" = \"\" -o \"$b\" = \"\" ] && print y\n",
+		"[ -f a -a -f b ]\n",
+	} {
+		if got := runFix(t, src); strings.Contains(got, "[[") {
+			t.Errorf("ZC1010 converted a binary -a/-o test to invalid [[ ]]\ninput: %q\ngot:   %q", src, got)
+		}
+	}
+}
+
+func TestFixRegression_ZC1010_UnaryStillConverts(t *testing.T) {
+	// The unary `[ -o opt ]` (option test) stays fixable; only binary
+	// `-a`/`-o` bail. This guards the bail from over-reaching.
+	if got := runFix(t, "[ -o nounset ]\n"); !strings.Contains(got, "[[ -o nounset ]]") {
+		t.Errorf("ZC1010 should still convert a unary -o test, got %q", got)
+	}
+}
+
+func TestFixRegression_ZC1076_NoDuplicateFlags(t *testing.T) {
+	// The fix used to insert ` -Uz` unconditionally, so `autoload -U …`
+	// became `autoload -Uz -U …`. It must add only the absent flag.
+	got := runFix(t, "autoload -U is-at-least\n")
+	if strings.Contains(got, "-Uz -U") || strings.Contains(got, "-U -U") {
+		t.Errorf("ZC1076 produced duplicate flags: %q", got)
+	}
+	if !strings.Contains(got, "-z") {
+		t.Errorf("ZC1076 should add the missing -z flag, got %q", got)
+	}
+}

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -656,6 +656,17 @@ func fixZC1010(node ast.Node, v Violation, source []byte) []FixEdit {
 	if cmd.Name == nil || cmd.Name.String() != "[" {
 		return nil
 	}
+	// Bail on binary `-a` / `-o`. In `[ ]` these are POSIX AND / OR
+	// connectives; `[[ ]]` has no binary `-a` / `-o` (it uses `&&` / `||`
+	// and reads `-a` / `-o` as unary file-exists / option-set tests), so a
+	// naive `[` -> `[[` swap turns `[ x -o y ]` into a syntax error. A
+	// leading `-a` / `-o` (the first operand) is the unary form and stays
+	// fixable.
+	for i := 1; i < len(cmd.Arguments); i++ {
+		if s := cmd.Arguments[i].String(); s == "-a" || s == "-o" {
+			return nil
+		}
+	}
 	open := LineColToByteOffset(source, v.Line, v.Column)
 	if open < 0 || open >= len(source) || source[open] != '[' {
 		return nil
@@ -5486,6 +5497,10 @@ func fixZC1076(node ast.Node, v Violation, source []byte) []FixEdit {
 	if nameLen != len("autoload") {
 		return nil
 	}
+	insert := zc1076MissingFlags(cmd)
+	if insert == "" {
+		return nil
+	}
 	insertAt := nameOffset + nameLen
 	insLine, insCol := offsetLineColZC1076(source, insertAt)
 	if insLine < 0 {
@@ -5495,8 +5510,38 @@ func fixZC1076(node ast.Node, v Violation, source []byte) []FixEdit {
 		Line:    insLine,
 		Column:  insCol,
 		Length:  0,
-		Replace: " -Uz",
+		Replace: insert,
 	}}
+}
+
+// zc1076MissingFlags returns the flags to insert after `autoload` so the
+// command carries both `-U` and `-z`, adding only the absent one. It
+// returns "" when both are already present, so a command that already
+// has `-U` gains just ` -z` rather than a duplicate ` -Uz`.
+func zc1076MissingFlags(cmd *ast.SimpleCommand) string {
+	hasU, hasZ := false, false
+	for _, arg := range cmd.Arguments {
+		s := strings.Trim(arg.String(), "\"'")
+		if !strings.HasPrefix(s, "-") {
+			continue
+		}
+		if strings.Contains(s, "U") {
+			hasU = true
+		}
+		if strings.Contains(s, "z") {
+			hasZ = true
+		}
+	}
+	switch {
+	case !hasU && !hasZ:
+		return " -Uz"
+	case !hasU:
+		return " -U"
+	case !hasZ:
+		return " -z"
+	default:
+		return ""
+	}
 }
 
 func offsetLineColZC1076(source []byte, offset int) (int, int) {
@@ -6356,6 +6401,18 @@ func fixZC1086(node ast.Node, v Violation, source []byte) []FixEdit {
 	nameStart, ok := zc1086NameStart(source, kwOffset, name)
 	if !ok {
 		return nil
+	}
+	// Bail when the source name continues past the parsed identifier — a
+	// concatenated or parameter-expanded name such as
+	// `name"${1:-}"() { ... }`. The parser captures only the leading
+	// identifier, so inserting `()` after it would split the real name
+	// and silently define a different function.
+	if after := nameStart + len(name); after < len(source) {
+		switch source[after] {
+		case ' ', '\t', '\n', '\r', '(':
+		default:
+			return nil
+		}
 	}
 	edits := []FixEdit{{
 		Line:    v.Line,

--- a/pkg/katas/zc1076_fix_test.go
+++ b/pkg/katas/zc1076_fix_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+	"github.com/afadesigns/zshellcheck/pkg/lexer"
+	"github.com/afadesigns/zshellcheck/pkg/parser"
+)
+
+// firstAutoload parses src and returns the first `autoload` command node
+// plus the source bytes, for exercising the ZC1076 fix helpers directly.
+func firstAutoload(t *testing.T, src string) (*ast.SimpleCommand, []byte) {
+	t.Helper()
+	prog := parser.New(lexer.New(src)).ParseProgram()
+	var cmd *ast.SimpleCommand
+	ast.Walk(prog, func(n ast.Node) bool {
+		if c, ok := n.(*ast.SimpleCommand); ok && cmd == nil &&
+			c.Name != nil && c.Name.String() == "autoload" {
+			cmd = c
+		}
+		return true
+	})
+	if cmd == nil {
+		t.Fatalf("no autoload command in %q", src)
+	}
+	return cmd, []byte(src)
+}
+
+// TestZC1076MissingFlags covers every branch, including the
+// both-present case the Check -> Fix pipeline never reaches (the
+// detector fires only when a flag is absent).
+func TestZC1076MissingFlags(t *testing.T) {
+	cases := []struct {
+		src  string
+		want string
+	}{
+		{"autoload foo", " -Uz"},
+		{"autoload -U foo", " -z"},
+		{"autoload -z foo", " -U"},
+		{"autoload -Uz foo", ""},
+		{"autoload -RUz foo", ""},
+	}
+	for _, c := range cases {
+		cmd, _ := firstAutoload(t, c.src)
+		if got := zc1076MissingFlags(cmd); got != c.want {
+			t.Errorf("%q: got %q, want %q", c.src, got, c.want)
+		}
+	}
+}
+
+// TestFixZC1076BothFlagsPresent guards the defensive no-edit path: even
+// if the fix is invoked directly on an already-correct command, it emits
+// nothing rather than a duplicate flag.
+func TestFixZC1076BothFlagsPresent(t *testing.T) {
+	cmd, src := firstAutoload(t, "autoload -Uz foo")
+	v := Violation{KataID: "ZC1076", Line: 1, Column: 1}
+	if edits := fixZC1076(cmd, v, src); edits != nil {
+		t.Errorf("expected no edits for an already-flagged autoload, got %v", edits)
+	}
+}


### PR DESCRIPTION
## What

Stop three auto-fixes from rewriting valid Zsh into broken or wrong source. Found by auditing real-corpus findings against runnable Zsh 5.9.

| Kata | Tier | Before | After |
| --- | --- | --- | --- |
| `ZC1086` | **safe** | `function name"${1:-}"() {}` -> `name()"${1:-}"() {}` (defines a different function) | bails when the name continues past the parsed identifier |
| `ZC1010` | unsafe | `[ x -o y ]` -> `[[ x -o y ]]` (syntax error: `[[ ]]` has no binary `-o`/`-a`) | bails on binary `-a`/`-o`; unary `[ -o opt ]` still converts |
| `ZC1076` | unsafe | `autoload -U …` -> `autoload -Uz -U …` (duplicate flag) | inserts only the absent flag |

## Why

`ZC1086` is the most serious: it is in the **safe** (value-preserving) tier, yet it silently changed which function a definition creates. With `$1=X`, `gitstatus_query"${1:-}"` defines `gitstatus_queryX`; the fix made it define `gitstatus_query`, breaking gitstatus's per-instance namespacing. A safe fix must never change behavior. `ZC1010` produced source that Zsh rejects outright (`condition expected`). `ZC1076` was merely sloppy but still wrong.

These are parseable-but-wrong rewrites, so the parser-level fix-safety sweep does not catch them — they need semantic review, which is how they surfaced.

## Verification

- Each rewrite confirmed against real `zsh`: the old output defines the wrong function / errors / duplicates; the new output is correct.
- Detection is unchanged for all three — the violation baseline holds.
- New regression tests in `pkg/fix/fix_regression_test.go`.
- `go test ./...` passes, `golangci-lint run ./...` reports 0 issues, `gocyclo` clean, fix-corpus sweep stays 0/0/0 across 402 files.
