### PR TITLE
fix: drop false positives in ZC1097 and ZC1049

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -226,7 +226,6 @@ fzf/shell/completion.zsh	ZC1003	3
 fzf/shell/completion.zsh	ZC1010	10
 fzf/shell/completion.zsh	ZC1043	4
 fzf/shell/completion.zsh	ZC1046	4
-fzf/shell/completion.zsh	ZC1049	1
 fzf/shell/completion.zsh	ZC1064	1
 fzf/shell/completion.zsh	ZC1074	1
 fzf/shell/completion.zsh	ZC1075	8
@@ -301,7 +300,7 @@ fzf-zsh-plugin/fzf-zsh-plugin.plugin.zsh	ZC1037	4
 fzf-zsh-plugin/fzf-zsh-plugin.plugin.zsh	ZC1043	6
 fzf-zsh-plugin/fzf-zsh-plugin.plugin.zsh	ZC1045	2
 fzf-zsh-plugin/fzf-zsh-plugin.plugin.zsh	ZC1046	2
-fzf-zsh-plugin/fzf-zsh-plugin.plugin.zsh	ZC1049	3
+fzf-zsh-plugin/fzf-zsh-plugin.plugin.zsh	ZC1049	2
 fzf-zsh-plugin/fzf-zsh-plugin.plugin.zsh	ZC1067	1
 fzf-zsh-plugin/fzf-zsh-plugin.plugin.zsh	ZC1074	1
 fzf-zsh-plugin/fzf-zsh-plugin.plugin.zsh	ZC1075	3
@@ -1016,7 +1015,6 @@ typewritten/typewritten.zsh	ZC1091	1
 typewritten/typewritten.zsh	ZC1177	1
 wd/wd.plugin.zsh	ZC1046	1
 wd/wd.plugin.zsh	ZC1098	1
-zaw/sources/aliases.zsh	ZC1049	2
 zaw/sources/aliases.zsh	ZC1086	1
 zaw/sources/aliases.zsh	ZC1284	1
 zaw/sources/applications.zsh	ZC1003	2
@@ -1035,7 +1033,6 @@ zaw/sources/cdr.zsh	ZC1075	1
 zaw/sources/cdr.zsh	ZC1086	4
 zaw/sources/command-output.zsh	ZC1076	1
 zaw/sources/command-output.zsh	ZC1086	1
-zaw/sources/commands.zsh	ZC1049	1
 zaw/sources/commands.zsh	ZC1086	1
 zaw/sources/commands.zsh	ZC1284	2
 zaw/sources/fasd.zsh	ZC1086	3
@@ -1258,7 +1255,7 @@ zinit/zinit-autoload.zsh	ZC1040	2
 zinit/zinit-autoload.zsh	ZC1043	2
 zinit/zinit-autoload.zsh	ZC1045	6
 zinit/zinit-autoload.zsh	ZC1046	6
-zinit/zinit-autoload.zsh	ZC1049	7
+zinit/zinit-autoload.zsh	ZC1049	1
 zinit/zinit-autoload.zsh	ZC1053	1
 zinit/zinit-autoload.zsh	ZC1064	1
 zinit/zinit-autoload.zsh	ZC1073	3
@@ -1365,7 +1362,6 @@ zsh-abbr/tests/index.ztr.zsh	ZC1001	2
 zsh-abbr/tests/index.ztr.zsh	ZC1037	1
 zsh-abbr/tests/index.ztr.zsh	ZC1043	30
 zsh-abbr/tests/index.ztr.zsh	ZC1046	1
-zsh-abbr/tests/index.ztr.zsh	ZC1049	1
 zsh-abbr/tests/index.ztr.zsh	ZC1051	1
 zsh-abbr/tests/index.ztr.zsh	ZC1075	6
 zsh-abbr/tests/index.ztr.zsh	ZC1078	1

--- a/pkg/katas/katatests/fp_round2_test.go
+++ b/pkg/katas/katatests/fp_round2_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+// TestZC1097PositionalLoopVar pins the positional-loop-variable false
+// positive. `for 1 in …` binds the positional `$1`, which is already
+// scoped to the function and cannot take `local` — `local 1` is a zsh
+// error — so the kata must not suggest it.
+func TestZC1097PositionalLoopVar(t *testing.T) {
+	for _, src := range []string{
+		"f() { for 1 in $p; do :; done }",
+		"f() { for 2 in a b; do :; done }",
+	} {
+		if n := len(testutil.Check(src, "ZC1097")); n != 0 {
+			t.Errorf("ZC1097 should not fire on a positional loop var: %q (got %d)", src, n)
+		}
+	}
+	if n := len(testutil.Check("f() { for x in $p; do :; done }", "ZC1097")); n == 0 {
+		t.Error("ZC1097 should still fire on a named loop var")
+	}
+}
+
+// TestZC1049ListingVsDefinition pins the alias-listing false positive.
+// The listing and query forms print existing aliases and have no
+// name=value, so no function can replace them; only real definitions
+// should fire.
+func TestZC1049ListingVsDefinition(t *testing.T) {
+	for _, src := range []string{
+		"alias",
+		"alias -L",
+		"alias $1",
+		"x=$(alias | cut -d '=' -f 1)",
+	} {
+		if n := len(testutil.Check(src, "ZC1049")); n != 0 {
+			t.Errorf("ZC1049 should not fire on an alias listing form: %q (got %d)", src, n)
+		}
+	}
+	for _, src := range []string{
+		"alias d='dirs -v'",
+		"alias -- -='cd -'",
+		"alias ${ZSHZ_CMD:-z}='zshz 2>&1'",
+	} {
+		if n := len(testutil.Check(src, "ZC1049")); n == 0 {
+			t.Errorf("ZC1049 should fire on an alias definition: %q", src)
+		}
+	}
+}

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -3136,6 +3136,14 @@ func checkZC1049(node ast.Node) []Violation {
 		if zc1049HasGlobalOrSuffixFlag(cmd) {
 			return nil
 		}
+		// Only an alias definition (`alias name=value`) can be replaced by
+		// a function. The listing and query forms (`alias`, `alias -L`,
+		// `alias name`, `alias | …`) have no `name=value` argument and just
+		// print existing aliases, so "prefer a function" is impossible
+		// advice. Skip them.
+		if !zc1049HasDefinition(cmd) {
+			return nil
+		}
 		return []Violation{{
 			KataID: "ZC1049",
 			Message: "Prefer functions over aliases. " +
@@ -3147,6 +3155,24 @@ func checkZC1049(node ast.Node) []Violation {
 	}
 
 	return nil
+}
+
+// zc1049HasDefinition reports whether the alias command actually defines
+// an alias — an argument of the form `name=value`. Without one the
+// command lists or queries existing aliases, which no function replaces.
+func zc1049HasDefinition(cmd *ast.SimpleCommand) bool {
+	for _, arg := range cmd.Arguments {
+		// A definition word carries `=` with a non-empty name in front.
+		// Flags (`-L`, `-m`, the already-handled `-g`/`-s`) never carry
+		// `=`, so an `=` past the first byte means a real definition. Use
+		// the node's full text rather than reassembling parts, so a name
+		// built from a parameter expansion (`alias ${CMD}=val`) or an
+		// unusual dashed name (`alias -- -='cd -'`) is still recognised.
+		if eq := strings.IndexByte(arg.String(), '='); eq > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // zc1049HasGlobalOrSuffixFlag reports whether an alias command carries
@@ -7420,6 +7446,12 @@ func zc1097UnscopedLoopVar(n ast.Node, locals map[string]bool) (Violation, bool)
 	if !ok || loop.Name == nil || locals[loop.Name.Value] {
 		return Violation{}, false
 	}
+	// A positional parameter name (`for 1 in …`) is already scoped to the
+	// function and cannot be declared with `local` — `local 1` is a zsh
+	// error ("not an identifier: 1"). Skip all-numeric loop variables.
+	if zc1097IsPositionalName(loop.Name.Value) {
+		return Violation{}, false
+	}
 	return Violation{
 		KataID: "ZC1097",
 		Message: "Loop variable '" + loop.Name.Value + "' is used without 'local'. It will be global. " +
@@ -7428,6 +7460,21 @@ func zc1097UnscopedLoopVar(n ast.Node, locals map[string]bool) (Violation, bool)
 		Column: loop.Name.Token.Column,
 		Level:  SeverityStyle,
 	}, true
+}
+
+// zc1097IsPositionalName reports whether name is a positional parameter
+// name (all decimal digits, such as `1` in `for 1 in …`). These are
+// already function-local and cannot be declared with `local`.
+func zc1097IsPositionalName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		if name[i] < '0' || name[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func init() {

--- a/pkg/katas/zc1097_fp_test.go
+++ b/pkg/katas/zc1097_fp_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import "testing"
+
+// TestZC1097IsPositionalName covers every branch of the positional-name
+// predicate, including the empty-string guard the loop-variable path
+// never reaches (a for-loop always names a variable).
+func TestZC1097IsPositionalName(t *testing.T) {
+	cases := map[string]bool{
+		"":   false,
+		"1":  true,
+		"12": true,
+		"x":  false,
+		"1a": false,
+		"a1": false,
+	}
+	for name, want := range cases {
+		if got := zc1097IsPositionalName(name); got != want {
+			t.Errorf("zc1097IsPositionalName(%q) = %v, want %v", name, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Stop two katas from flagging code where the advice is wrong or impossible. Found by auditing real-corpus findings against runnable Zsh.

- **ZC1097** suggested `local` for a positional loop variable (`for 1 in …`). `local 1` is a zsh error (`not an identifier: 1`), and positionals are already function-local. Now skips all-numeric loop-variable names.
- **ZC1049** flagged the alias listing/query forms (`alias`, `alias -L`, `alias name`, `alias | …`) with "prefer functions" — impossible, since they print existing aliases rather than define one. Now fires only on a real `name=value` definition, including a parameter-expansion name (`alias ${CMD}=val`) and a dashed name (`alias -- -='cd -'`).

## Why

Both produced noise that a user cannot act on: ZC1097's suggestion errors when applied, and ZC1049 cannot be satisfied for a listing command. The ZC1049 fix was iterated twice against the corpus drift — the first cut wrongly suppressed `alias -- -='cd -'` and `alias ${CMD}=val`, which the baseline review caught.

## Verification

- Every behavior confirmed against real `zsh`.
- ZC1049 removes 12 listing-form findings from the violation baseline across six corpora; every removed line is a listing/query form and every kept line is a real definition (reviewed individually).
- Regression tests in `pkg/katas/katatests/fp_round2_test.go` and `pkg/katas/zc1097_fp_test.go`.
- `go test ./...` passes, `golangci-lint` 0 issues, `gocyclo` clean, fix-corpus sweep stays 0/0/0.
