### PR TITLE
fix: ZC1098 skips the eval "$@" dispatch idiom

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -11,7 +11,6 @@ agkozak-prompt/lib/async.zsh	ZC1001	5
 agkozak-prompt/lib/async.zsh	ZC1043	2
 agkozak-prompt/lib/async.zsh	ZC1046	1
 agkozak-prompt/lib/async.zsh	ZC1075	30
-agkozak-prompt/lib/async.zsh	ZC1098	1
 agkozak-prompt/lib/async.zsh	ZC1134	1
 agkozak-prompt/lib/async.zsh	ZC1176	1
 agkozak-prompt/lib/async.zsh	ZC1509	2
@@ -502,7 +501,6 @@ purer/async.zsh	ZC1046	1
 purer/async.zsh	ZC1075	26
 purer/async.zsh	ZC1078	1
 purer/async.zsh	ZC1097	3
-purer/async.zsh	ZC1098	1
 purer/async.zsh	ZC1134	1
 purer/async.zsh	ZC1176	1
 purer/pure.zsh	ZC1001	2
@@ -520,7 +518,6 @@ spaceship/async.zsh	ZC1001	5
 spaceship/async.zsh	ZC1043	2
 spaceship/async.zsh	ZC1046	1
 spaceship/async.zsh	ZC1075	30
-spaceship/async.zsh	ZC1098	1
 spaceship/async.zsh	ZC1134	1
 spaceship/async.zsh	ZC1176	1
 spaceship/async.zsh	ZC1509	2
@@ -972,7 +969,6 @@ typewritten/async.zsh	ZC1001	5
 typewritten/async.zsh	ZC1043	2
 typewritten/async.zsh	ZC1046	1
 typewritten/async.zsh	ZC1075	30
-typewritten/async.zsh	ZC1098	1
 typewritten/async.zsh	ZC1134	1
 typewritten/async.zsh	ZC1176	1
 typewritten/async.zsh	ZC1509	2
@@ -1386,7 +1382,6 @@ zsh-async/async.zsh	ZC1001	5
 zsh-async/async.zsh	ZC1043	2
 zsh-async/async.zsh	ZC1046	1
 zsh-async/async.zsh	ZC1075	30
-zsh-async/async.zsh	ZC1098	1
 zsh-async/async.zsh	ZC1134	1
 zsh-async/async.zsh	ZC1176	1
 zsh-async/async.zsh	ZC1509	2

--- a/pkg/katas/katatests/fp_round4_test.go
+++ b/pkg/katas/katatests/fp_round4_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+// TestZC1098EvalAllArgsNotFlagged pins the argument-dispatch false
+// positive. `eval "$@"` / `eval "$*"` run the positional parameters as
+// the command (the standard async-worker idiom); quoting them with `(q)`
+// collapses the words into one literal and breaks execution, exactly like
+// the already-skipped `eval "$cmd"`.
+func TestZC1098EvalAllArgsNotFlagged(t *testing.T) {
+	for _, src := range []string{`eval "$@"`, `eval "$*"`} {
+		if n := len(testutil.Check(src, "ZC1098")); n != 0 {
+			t.Errorf("ZC1098 should not fire on the eval arg-dispatch idiom: %q (got %d)", src, n)
+		}
+	}
+	// A variable used as data inside a command string still warrants (q).
+	for _, src := range []string{`eval "echo $userdata"`, `eval "rm $path"`} {
+		if n := len(testutil.Check(src, "ZC1098")); n == 0 {
+			t.Errorf("ZC1098 should still fire on a variable embedded in an eval command: %q", src)
+		}
+	}
+}

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -7617,6 +7617,13 @@ func zc1098StringIsSingleExpansion(value string) bool {
 	if inner[1] == '{' {
 		return zc1098IsSingleBraceExpansion(inner)
 	}
+	// `$@` / `$*` expand all positional parameters as the command to run
+	// (`eval "$@"` is the standard argument-dispatch idiom). Like a bare
+	// `$cmd`, quoting them with `(q)` collapses the words and breaks
+	// execution, so treat them as standalone too.
+	if rest := inner[1:]; rest == "@" || rest == "*" {
+		return true
+	}
 	return zc1098IsBareName(inner[1:])
 }
 


### PR DESCRIPTION
## What

Stop ZC1098 ("use `(q)` for variables in `eval`") from flagging the `eval "$@"` argument-dispatch idiom.

`eval "$@"` and `eval "$*"` run the positional parameters as the command. The kata already skips the var-as-command forms (`eval "$cmd"`, `eval "$REPLY"`), but `zc1098IsBareName` rejected the `@`/`*` sigils, so `eval "$@"` slipped through and was flagged.

## Why

Following the advice breaks the code. `eval "${(q)@}"` collapses the arguments into one quoted literal, so a worker dispatched with `set -- "echo a && echo b"` fails with `command not found`. Confirmed against real zsh. The idiom is used by the zsh-async library and every prompt that vendors it.

A variable used as data inside a command string (`eval "echo $userdata"`, `eval "rm $path"`) still warrants the `(q)` advice and continues to fire.

## Verification

- Confirmed against real `zsh`: `eval "$@"` runs the command; `eval "${(q)@}"` errors.
- Removes 5 findings from the violation baseline (zsh-async and its forks: agkozak, purer, spaceship, typewritten); every removed line is an `eval "$@"` dispatch.
- Regression test in `pkg/katas/katatests/fp_round4_test.go`; `go test ./...` passes, `golangci-lint` 0 issues, sweeps clean.
