### PR TITLE
fix: ZC1188 gives direction-aware PATH advice

### DIFF
--- a/pkg/katas/katatests/fp_round5_test.go
+++ b/pkg/katas/katatests/fp_round5_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+// TestZC1188DirectionAwareAdvice pins the PATH-direction advice. A
+// prepend (`dir:$PATH`) must be rewritten as `path=(dir $path)`; the
+// append form `path+=(dir)` would move the directory to the end and
+// reverse command precedence, so the kata must not recommend it there.
+func TestZC1188DirectionAwareAdvice(t *testing.T) {
+	prepend := testutil.Check("export PATH=/opt/bin:$PATH", "ZC1188")
+	if len(prepend) != 1 {
+		t.Fatalf("ZC1188 should fire once on a prepend, got %d", len(prepend))
+	}
+	if !strings.Contains(prepend[0].Message, "Prepend with `path=(dir $path)`") {
+		t.Errorf("ZC1188 prepend should advise the prepend form, got %q", prepend[0].Message)
+	}
+
+	appendCase := testutil.Check("export PATH=$PATH:/opt/bin", "ZC1188")
+	if len(appendCase) != 1 {
+		t.Fatalf("ZC1188 should fire once on an append, got %d", len(appendCase))
+	}
+	if !strings.Contains(appendCase[0].Message, "Append with `path+=(dir)`") {
+		t.Errorf("ZC1188 append should advise the append form, got %q", appendCase[0].Message)
+	}
+
+	// A replacement that is neither a prepend nor an append gets both forms.
+	other := testutil.Check("export PATH=/usr/local/bin", "ZC1188")
+	if len(other) != 1 || !strings.Contains(other[0].Message, "to prepend") {
+		t.Errorf("ZC1188 should give both forms for a plain PATH assignment")
+	}
+}

--- a/pkg/katas/katatests/zc1100s_test.go
+++ b/pkg/katas/katatests/zc1100s_test.go
@@ -3387,7 +3387,7 @@ func TestZC1188(t *testing.T) {
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1188",
-					Message: "Use `path+=(dir)` instead of `export PATH=$PATH:dir`. Zsh ties the `path` array to `$PATH` for cleaner manipulation.",
+					Message: "Append with `path+=(dir)` instead of `export PATH=$PATH:dir`. Zsh ties the `path` array to `$PATH`.",
 					Line:    1,
 					Column:  1,
 				},

--- a/pkg/katas/zc1100s.go
+++ b/pkg/katas/zc1100s.go
@@ -4577,17 +4577,35 @@ func checkZC1188(node ast.Node) []Violation {
 		val := arg.String()
 		if len(val) > 5 && val[:5] == "PATH=" {
 			return []Violation{{
-				KataID: "ZC1188",
-				Message: "Use `path+=(dir)` instead of `export PATH=$PATH:dir`. " +
-					"Zsh ties the `path` array to `$PATH` for cleaner manipulation.",
-				Line:   cmd.Token.Line,
-				Column: cmd.Token.Column,
-				Level:  SeverityStyle,
+				KataID:  "ZC1188",
+				Message: zc1188Advice(val[5:]),
+				Line:    cmd.Token.Line,
+				Column:  cmd.Token.Column,
+				Level:   SeverityStyle,
 			}}
 		}
 	}
 
 	return nil
+}
+
+// zc1188Advice tailors the message to the direction of the PATH edit.
+// A prepend (`dir:$PATH`) must use `path=(dir $path)`; advising the
+// append form `path+=(dir)` there would move the directory to the end
+// and reverse command precedence. An append (`$PATH:dir`) uses
+// `path+=(dir)`. Anything else gets both forms.
+func zc1188Advice(rhs string) string {
+	const tie = " Zsh ties the `path` array to `$PATH`."
+	switch {
+	case strings.HasSuffix(rhs, ":$PATH"), strings.HasSuffix(rhs, ":${PATH}"):
+		return "Prepend with `path=(dir $path)` instead of `export PATH=dir:$PATH`. " +
+			"`path+=(dir)` would append the directory and reverse command precedence."
+	case strings.HasPrefix(rhs, "$PATH:"), strings.HasPrefix(rhs, "${PATH}:"):
+		return "Append with `path+=(dir)` instead of `export PATH=$PATH:dir`." + tie
+	default:
+		return "Manipulate the tied `path` array instead of `export PATH=…`: " +
+			"`path=(dir $path)` to prepend, `path+=(dir)` to append."
+	}
 }
 
 func init() {


### PR DESCRIPTION
## What

Make ZC1188's `path` advice match the direction of the PATH edit.

The kata flagged every `export PATH=…` with one hardcoded suggestion, `path+=(dir)`. That is right only for an **append** (`$PATH:dir`). For a **prepend** (`dir:$PATH`) — used to give a directory precedence — `path+=(dir)` appends instead, moving the directory to the end and changing which binary runs.

The message now adapts:

| Edit | Advice |
| --- | --- |
| `export PATH=dir:$PATH` (prepend) | `path=(dir $path)` |
| `export PATH=$PATH:dir` (append) | `path+=(dir)` |
| `export PATH=dir` (other) | both forms |

## Why

Following the old advice on a prepend silently reverses command precedence — confirmed against real zsh, where a prepend and a `path+=` resolve to different binaries first. Twenty-six of the corpus hits are prepends.

## Verification

- Direction-aware messages verified on prepend, append, and plain assignments.
- ZC1188 is advisory-only (no auto-fix), so detection counts and the violation baseline are unchanged.
- Regression test in `pkg/katas/katatests/fp_round5_test.go`; the existing ZC1188 message test updated; `go test ./...` passes, `golangci-lint` 0 issues, sweeps clean.
