### PR TITLE
fix: ZC1044 skips cd= variable assignment

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -1602,7 +1602,6 @@ zsh-vi-mode/zsh-vi-mode.zsh	ZC1477	2
 zsh-z/zsh-z.plugin.zsh	ZC1001	1
 zsh-z/zsh-z.plugin.zsh	ZC1004	2
 zsh-z/zsh-z.plugin.zsh	ZC1043	3
-zsh-z/zsh-z.plugin.zsh	ZC1044	1
 zsh-z/zsh-z.plugin.zsh	ZC1049	1
 zsh-z/zsh-z.plugin.zsh	ZC1073	6
 zsh-z/zsh-z.plugin.zsh	ZC1075	32

--- a/pkg/katas/katatests/fp_round6_test.go
+++ b/pkg/katas/katatests/fp_round6_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+// TestZC1044CdAssignmentNotFlagged pins the `cd=value` false positive. An
+// assignment to a variable named `cd` on the right of `&&`/`||` is parsed
+// as a `cd` command whose first argument is the `=value` tail; it is not a
+// directory change, so it must not be flagged.
+func TestZC1044CdAssignmentNotFlagged(t *testing.T) {
+	for _, src := range []string{
+		"foo && cd=$bar",
+		"(( ZSHZ_TILDE )) && cd=${cd/#x/y}",
+	} {
+		if n := len(testutil.Check(src, "ZC1044")); n != 0 {
+			t.Errorf("ZC1044 should not flag an assignment to a var named cd: %q (got %d)", src, n)
+		}
+	}
+	for _, src := range []string{"cd /tmp", "foo && cd /tmp"} {
+		if n := len(testutil.Check(src, "ZC1044")); n == 0 {
+			t.Errorf("ZC1044 should still flag an unguarded cd: %q", src)
+		}
+	}
+}

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -2839,15 +2839,25 @@ func checkCommandZC1044(cmd *ast.SimpleCommand, isChecked bool, violations *[]Vi
 	if isChecked {
 		return
 	}
-	if name, ok := cmd.Name.(*ast.Identifier); ok && name.Value == "cd" {
-		*violations = append(*violations, Violation{
-			KataID:  "ZC1044",
-			Message: "Use `cd ... || return` (or `exit`) in case cd fails.",
-			Line:    name.Token.Line,
-			Column:  name.Token.Column,
-			Level:   SeverityWarning,
-		})
+	name, ok := cmd.Name.(*ast.Identifier)
+	if !ok || name.Value != "cd" {
+		return
 	}
+	// An assignment to a variable named `cd` (`cd=${cd/…}`) is parsed as a
+	// `cd` command whose first argument is the `=value` tail when it sits on
+	// the right of `&&`/`||`. The cd builtin never takes an argument that
+	// begins with `=`, so this shape is the assignment, not a directory
+	// change — skip it.
+	if len(cmd.Arguments) > 0 && strings.HasPrefix(cmd.Arguments[0].String(), "=") {
+		return
+	}
+	*violations = append(*violations, Violation{
+		KataID:  "ZC1044",
+		Message: "Use `cd ... || return` (or `exit`) in case cd fails.",
+		Line:    name.Token.Line,
+		Column:  name.Token.Column,
+		Level:   SeverityWarning,
+	})
 }
 
 func init() {


### PR DESCRIPTION
## What

Stop ZC1044 ("use `cd … || return`") from flagging an assignment to a variable named `cd`.

`(( flag )) && cd=${cd/#$HOME/~}` assigns to a variable `cd`. On the right of `&&`/`||` the parser reads `cd=value` as a `cd` command whose first argument is the `=value` tail, so the kata flagged it as an unguarded directory change. The cd builtin never takes an argument beginning with `=`, so this shape is now recognised as the assignment and skipped.

## Why

The advice is meaningless on an assignment — there is no directory change to guard. The root cause is a parser quirk: an assignment word is recognised at statement start but parsed as a command after `&&`/`||`. The full parser fix is broader and risk-bearing (it shifts how every `cmd && var=value` parses), so this guards the kata precisely while the parser fix is tracked separately.

## Verification

- AST confirmed: `foo && cd=$bar` parses to `SimpleCommand{Name: cd, Args: ["=$bar"]}`; a real `cd /tmp` has no `=`-prefixed argument.
- Removes 1 finding from the violation baseline (zsh-z); a real unguarded `cd`, including `foo && cd /tmp`, still fires.
- Regression test in `pkg/katas/katatests/fp_round6_test.go`; `go test ./...` passes, `golangci-lint` 0 issues, sweeps clean.
