### PR TITLE
fix: ZC1075 skips bare expansions of arrays

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -10,7 +10,7 @@ agkozak-prompt/agkozak-zsh-prompt.plugin.zsh	ZC1604	2
 agkozak-prompt/lib/async.zsh	ZC1001	5
 agkozak-prompt/lib/async.zsh	ZC1043	2
 agkozak-prompt/lib/async.zsh	ZC1046	1
-agkozak-prompt/lib/async.zsh	ZC1075	30
+agkozak-prompt/lib/async.zsh	ZC1075	24
 agkozak-prompt/lib/async.zsh	ZC1134	1
 agkozak-prompt/lib/async.zsh	ZC1176	1
 agkozak-prompt/lib/async.zsh	ZC1509	2
@@ -29,7 +29,7 @@ antidote/antidote.zsh	ZC1059	1
 antidote/antidote.zsh	ZC1065	1
 antidote/antidote.zsh	ZC1071	1
 antidote/antidote.zsh	ZC1073	2
-antidote/antidote.zsh	ZC1075	45
+antidote/antidote.zsh	ZC1075	22
 antidote/antidote.zsh	ZC1091	14
 antidote/antidote.zsh	ZC1097	1
 antidote/antidote.zsh	ZC1114	1
@@ -71,7 +71,6 @@ antidote/tests/tmp_home/.zsh/custom/lib/lib1.zsh	ZC1037	1
 antidote/tests/tmp_home/.zsh/custom/lib/lib1.zsh	ZC1071	1
 antidote/tests/tmp_home/.zsh/custom/lib/lib2.zsh	ZC1037	1
 antidote/tests/tmp_home/.zsh/custom/lib/lib2.zsh	ZC1071	1
-antidote/tests/tmp_home/.zsh/custom/plugins/grizwold/grizwold.plugin.zsh	ZC1075	1
 antidote/tests/tmp_home/.zsh/custom/plugins/myplugin/myplugin.plugin.zsh	ZC1037	1
 atuin/atuin.plugin.zsh	ZC1091	1
 atuin/crates/atuin/src/shell/atuin.zsh	ZC1010	1
@@ -193,7 +192,7 @@ fast-syntax-highlighting/test/to-parse.zsh	ZC1001	17
 fast-syntax-highlighting/test/to-parse.zsh	ZC1043	2
 fast-syntax-highlighting/test/to-parse.zsh	ZC1046	2
 fast-syntax-highlighting/test/to-parse.zsh	ZC1073	3
-fast-syntax-highlighting/test/to-parse.zsh	ZC1075	31
+fast-syntax-highlighting/test/to-parse.zsh	ZC1075	30
 fast-syntax-highlighting/test/to-parse.zsh	ZC1830	1
 forgit/forgit.plugin.zsh	ZC1091	1
 forgit/forgit.plugin.zsh	ZC1300	3
@@ -214,7 +213,7 @@ F-Sy-H/share/parse/to-parse.zsh	ZC1001	17
 F-Sy-H/share/parse/to-parse.zsh	ZC1043	2
 F-Sy-H/share/parse/to-parse.zsh	ZC1046	2
 F-Sy-H/share/parse/to-parse.zsh	ZC1073	3
-F-Sy-H/share/parse/to-parse.zsh	ZC1075	31
+F-Sy-H/share/parse/to-parse.zsh	ZC1075	30
 F-Sy-H/share/parse/to-parse.zsh	ZC1830	1
 fzf/shell/completion.zsh	ZC1003	3
 fzf/shell/completion.zsh	ZC1010	10
@@ -250,7 +249,7 @@ fzf-tab/fzf-tab.zsh	ZC1043	1
 fzf-tab/fzf-tab.zsh	ZC1045	3
 fzf-tab/fzf-tab.zsh	ZC1046	1
 fzf-tab/fzf-tab.zsh	ZC1073	1
-fzf-tab/fzf-tab.zsh	ZC1075	8
+fzf-tab/fzf-tab.zsh	ZC1075	7
 fzf-tab/fzf-tab.zsh	ZC1086	2
 fzf-tab/fzf-tab.zsh	ZC1091	1
 fzf-tab/lib/zsh-ls-colors/ls-colors.zsh	ZC1001	16
@@ -308,13 +307,12 @@ fzf-zsh-plugin/fzf-zsh-plugin.plugin.zsh	ZC1591	1
 geometry/geometry.zsh	ZC1001	1
 geometry/geometry.zsh	ZC1043	1
 geometry/geometry.zsh	ZC1045	5
-geometry/geometry.zsh	ZC1075	11
+geometry/geometry.zsh	ZC1075	10
 geometry/geometry.zsh	ZC1091	1
 geometry/geometry.zsh	ZC1097	1
 geometry/geometry.zsh	ZC1517	1
 git-extra-commands/git-extra-commands.plugin.zsh	ZC1049	3
 git-flow-completion/git-flow-completion.zsh	ZC1001	4
-git-flow-completion/git-flow-completion.zsh	ZC1075	5
 git-flow-completion/git-flow-completion.zsh	ZC1078	3
 git-flow-completion/git-flow-completion.zsh	ZC1288	4
 git-open/git-open.plugin.zsh	ZC1067	1
@@ -341,7 +339,7 @@ history-search-multi-word/test/to-parse.zsh	ZC1001	17
 history-search-multi-word/test/to-parse.zsh	ZC1043	2
 history-search-multi-word/test/to-parse.zsh	ZC1046	2
 history-search-multi-word/test/to-parse.zsh	ZC1073	3
-history-search-multi-word/test/to-parse.zsh	ZC1075	31
+history-search-multi-word/test/to-parse.zsh	ZC1075	30
 history-search-multi-word/test/to-parse.zsh	ZC1830	1
 mcfly/dev.zsh	ZC1002	1
 mcfly/dev.zsh	ZC1015	1
@@ -498,7 +496,7 @@ purer/async.zsh	ZC1001	5
 purer/async.zsh	ZC1004	1
 purer/async.zsh	ZC1043	4
 purer/async.zsh	ZC1046	1
-purer/async.zsh	ZC1075	26
+purer/async.zsh	ZC1075	23
 purer/async.zsh	ZC1078	1
 purer/async.zsh	ZC1097	3
 purer/async.zsh	ZC1134	1
@@ -517,7 +515,7 @@ purer/pure.zsh	ZC1293	1
 spaceship/async.zsh	ZC1001	5
 spaceship/async.zsh	ZC1043	2
 spaceship/async.zsh	ZC1046	1
-spaceship/async.zsh	ZC1075	30
+spaceship/async.zsh	ZC1075	24
 spaceship/async.zsh	ZC1134	1
 spaceship/async.zsh	ZC1176	1
 spaceship/async.zsh	ZC1509	2
@@ -539,7 +537,6 @@ spaceship/lib/cli.zsh	ZC1288	1
 spaceship/lib/cli.zsh	ZC1334	1
 spaceship/lib/cli.zsh	ZC1517	1
 spaceship/lib/core.zsh	ZC1043	2
-spaceship/lib/core.zsh	ZC1075	4
 spaceship/lib/core.zsh	ZC1091	1
 spaceship/lib/core.zsh	ZC1097	3
 spaceship/lib/core.zsh	ZC1517	1
@@ -590,7 +587,7 @@ spaceship/sections/dir.zsh	ZC1075	1
 spaceship/sections/dir.zsh	ZC1091	1
 spaceship/sections/docker_compose.zsh	ZC1037	3
 spaceship/sections/docker_compose.zsh	ZC1045	3
-spaceship/sections/docker_compose.zsh	ZC1075	2
+spaceship/sections/docker_compose.zsh	ZC1075	1
 spaceship/sections/docker_compose.zsh	ZC1077	1
 spaceship/sections/docker_compose.zsh	ZC1108	1
 spaceship/sections/docker_compose.zsh	ZC1118	1
@@ -943,7 +940,7 @@ spaceship/tests/user.test.zsh	ZC1602	1
 spaceship/tests/utils.test.zsh	ZC1043	22
 spaceship/tests/utils.test.zsh	ZC1044	7
 spaceship/tests/utils.test.zsh	ZC1045	6
-spaceship/tests/utils.test.zsh	ZC1075	5
+spaceship/tests/utils.test.zsh	ZC1075	2
 spaceship/tests/utils.test.zsh	ZC1602	1
 spaceship/tests/vlang.test.zsh	ZC1043	12
 spaceship/tests/vlang.test.zsh	ZC1044	1
@@ -968,7 +965,7 @@ starship/src/init/starship.zsh	ZC1967	1
 typewritten/async.zsh	ZC1001	5
 typewritten/async.zsh	ZC1043	2
 typewritten/async.zsh	ZC1046	1
-typewritten/async.zsh	ZC1075	30
+typewritten/async.zsh	ZC1075	24
 typewritten/async.zsh	ZC1134	1
 typewritten/async.zsh	ZC1176	1
 typewritten/async.zsh	ZC1509	2
@@ -1019,7 +1016,6 @@ zaw/sources/applications.zsh	ZC1362	1
 zaw/sources/applications.zsh	ZC1916	1
 zaw/sources/bookmark.zsh	ZC1076	1
 zaw/sources/bookmark.zsh	ZC1086	6
-zaw/sources/cdr.zsh	ZC1075	1
 zaw/sources/cdr.zsh	ZC1086	4
 zaw/sources/command-output.zsh	ZC1076	1
 zaw/sources/command-output.zsh	ZC1086	1
@@ -1105,7 +1101,7 @@ zcomet/zcomet.zsh	ZC1043	7
 zcomet/zcomet.zsh	ZC1065	2
 zcomet/zcomet.zsh	ZC1068	1
 zcomet/zcomet.zsh	ZC1073	2
-zcomet/zcomet.zsh	ZC1075	15
+zcomet/zcomet.zsh	ZC1075	14
 zcomet/zcomet.zsh	ZC1078	1
 zcomet/zcomet.zsh	ZC1097	1
 zcomet/zcomet.zsh	ZC1160	1
@@ -1118,7 +1114,7 @@ zephyr/plugins/color/color.plugin.zsh	ZC1049	5
 zephyr/plugins/color/color.plugin.zsh	ZC1083	1
 zephyr/plugins/completion/completion.plugin.zsh	ZC1046	1
 zephyr/plugins/completion/completion.plugin.zsh	ZC1059	1
-zephyr/plugins/completion/completion.plugin.zsh	ZC1075	5
+zephyr/plugins/completion/completion.plugin.zsh	ZC1075	2
 zephyr/plugins/completion/completion.plugin.zsh	ZC1086	3
 zephyr/plugins/completion/completion.plugin.zsh	ZC1128	1
 zephyr/plugins/completion/completion.plugin.zsh	ZC1686	1
@@ -1127,7 +1123,7 @@ zephyr/plugins/compstyle/compstyle.plugin.zsh	ZC1001	1
 zephyr/plugins/compstyle/compstyle.plugin.zsh	ZC1017	1
 zephyr/plugins/compstyle/compstyle.plugin.zsh	ZC1037	6
 zephyr/plugins/compstyle/compstyle.plugin.zsh	ZC1071	1
-zephyr/plugins/compstyle/compstyle.plugin.zsh	ZC1075	4
+zephyr/plugins/compstyle/compstyle.plugin.zsh	ZC1075	3
 zephyr/plugins/compstyle/compstyle.plugin.zsh	ZC1086	6
 zephyr/plugins/compstyle/compstyle.plugin.zsh	ZC1176	1
 zephyr/plugins/compstyle/compstyle.plugin.zsh	ZC1591	1
@@ -1168,7 +1164,7 @@ zephyr/plugins/utility/utility.plugin.zsh	ZC1052	2
 zephyr/plugins/utility/utility.plugin.zsh	ZC1086	1
 zephyr/plugins/zfunctions/zfunctions.plugin.zsh	ZC1037	7
 zephyr/plugins/zfunctions/zfunctions.plugin.zsh	ZC1064	1
-zephyr/plugins/zfunctions/zfunctions.plugin.zsh	ZC1075	2
+zephyr/plugins/zfunctions/zfunctions.plugin.zsh	ZC1075	1
 zephyr/plugins/zfunctions/zfunctions.plugin.zsh	ZC1086	4
 zephyr/plugins/zfunctions/zfunctions.plugin.zsh	ZC1591	1
 zephyr/runcoms/zshenv.zsh	ZC1031	1
@@ -1180,7 +1176,7 @@ zephyr/tests/__init__.zsh	ZC1031	1
 zephyr/tests/__init__.zsh	ZC1037	6
 zephyr/tests/__init__.zsh	ZC1051	1
 zephyr/tests/__init__.zsh	ZC1073	3
-zephyr/tests/__init__.zsh	ZC1075	11
+zephyr/tests/__init__.zsh	ZC1075	10
 zephyr/tests/__init__.zsh	ZC1086	8
 zephyr/tests/__init__.zsh	ZC1136	1
 zephyr/tests/__init__.zsh	ZC1165	1
@@ -1209,7 +1205,7 @@ zimfw/zimfw.zsh	ZC1043	23
 zimfw/zimfw.zsh	ZC1045	3
 zimfw/zimfw.zsh	ZC1046	1
 zimfw/zimfw.zsh	ZC1065	1
-zimfw/zimfw.zsh	ZC1075	117
+zimfw/zimfw.zsh	ZC1075	116
 zimfw/zimfw.zsh	ZC1080	1
 zimfw/zimfw.zsh	ZC1091	10
 zimfw/zimfw.zsh	ZC1637	19
@@ -1232,7 +1228,7 @@ zinit/zinit-additional.zsh	ZC1043	1
 zinit/zinit-additional.zsh	ZC1045	1
 zinit/zinit-additional.zsh	ZC1046	3
 zinit/zinit-additional.zsh	ZC1071	1
-zinit/zinit-additional.zsh	ZC1075	4
+zinit/zinit-additional.zsh	ZC1075	3
 zinit/zinit-additional.zsh	ZC1098	1
 zinit/zinit-additional.zsh	ZC1877	1
 zinit/zinit-additional.zsh	ZC1916	1
@@ -1277,7 +1273,7 @@ zinit/zinit-install.zsh	ZC1053	1
 zinit/zinit-install.zsh	ZC1064	5
 zinit/zinit-install.zsh	ZC1071	2
 zinit/zinit-install.zsh	ZC1073	1
-zinit/zinit-install.zsh	ZC1075	79
+zinit/zinit-install.zsh	ZC1075	63
 zinit/zinit-install.zsh	ZC1083	2
 zinit/zinit-install.zsh	ZC1091	22
 zinit/zinit-install.zsh	ZC1098	9
@@ -1305,7 +1301,7 @@ zinit/zinit.zsh	ZC1045	4
 zinit/zinit.zsh	ZC1046	13
 zinit/zinit.zsh	ZC1064	1
 zinit/zinit.zsh	ZC1071	3
-zinit/zinit.zsh	ZC1075	73
+zinit/zinit.zsh	ZC1075	69
 zinit/zinit.zsh	ZC1076	2
 zinit/zinit.zsh	ZC1091	25
 zinit/zinit.zsh	ZC1097	1
@@ -1362,7 +1358,7 @@ zsh-abbr/zsh-abbr.zsh	ZC1001	25
 zsh-abbr/zsh-abbr.zsh	ZC1043	40
 zsh-abbr/zsh-abbr.zsh	ZC1046	2
 zsh-abbr/zsh-abbr.zsh	ZC1073	1
-zsh-abbr/zsh-abbr.zsh	ZC1075	64
+zsh-abbr/zsh-abbr.zsh	ZC1075	61
 zsh-abbr/zsh-abbr.zsh	ZC1078	1
 zsh-abbr/zsh-abbr.zsh	ZC1086	3
 zsh-abbr/zsh-abbr.zsh	ZC1098	1
@@ -1381,7 +1377,7 @@ zsh-async/async_test.zsh	ZC1869	1
 zsh-async/async.zsh	ZC1001	5
 zsh-async/async.zsh	ZC1043	2
 zsh-async/async.zsh	ZC1046	1
-zsh-async/async.zsh	ZC1075	30
+zsh-async/async.zsh	ZC1075	24
 zsh-async/async.zsh	ZC1134	1
 zsh-async/async.zsh	ZC1176	1
 zsh-async/async.zsh	ZC1509	2
@@ -1391,7 +1387,7 @@ zsh-async/test.zsh	ZC1040	1
 zsh-async/test.zsh	ZC1041	2
 zsh-async/test.zsh	ZC1043	9
 zsh-async/test.zsh	ZC1046	2
-zsh-async/test.zsh	ZC1075	19
+zsh-async/test.zsh	ZC1075	17
 zsh-async/test.zsh	ZC1078	1
 zsh-async/test.zsh	ZC1080	1
 zsh-async/test.zsh	ZC1097	2
@@ -1410,7 +1406,7 @@ zsh-autoenv/autoenv.zsh	ZC1043	4
 zsh-autoenv/autoenv.zsh	ZC1045	1
 zsh-autoenv/autoenv.zsh	ZC1046	1
 zsh-autoenv/autoenv.zsh	ZC1073	1
-zsh-autoenv/autoenv.zsh	ZC1075	34
+zsh-autoenv/autoenv.zsh	ZC1075	33
 zsh-autoenv/autoenv.zsh	ZC1076	2
 zsh-autoenv/autoenv.zsh	ZC1091	2
 zsh-autoenv/autoenv.zsh	ZC1097	1
@@ -1476,7 +1472,6 @@ zsh-dircolors-solarized/zsh-dircolors-solarized.zsh	ZC1643	1
 zsh-edit/run-tests.zsh	ZC1044	1
 zsh-edit/run-tests.zsh	ZC1075	1
 zsh-edit/zsh-edit.plugin.zsh	ZC1031	1
-zsh-edit/zsh-edit.plugin.zsh	ZC1075	1
 zsh-eza/tests/setup.zsh	ZC1059	2
 zsh-fzf-history-search/zsh-fzf-history-search.zsh	ZC1010	3
 zsh-fzf-history-search/zsh-fzf-history-search.zsh	ZC1043	7
@@ -1496,7 +1491,7 @@ zsh-histdb/sqlite-history.zsh	ZC1037	10
 zsh-histdb/sqlite-history.zsh	ZC1043	4
 zsh-histdb/sqlite-history.zsh	ZC1045	5
 zsh-histdb/sqlite-history.zsh	ZC1059	1
-zsh-histdb/sqlite-history.zsh	ZC1075	10
+zsh-histdb/sqlite-history.zsh	ZC1075	6
 zsh-histdb/sqlite-history.zsh	ZC1076	1
 zsh-histdb/sqlite-history.zsh	ZC1091	6
 zsh-histdb/sqlite-history.zsh	ZC1114	1
@@ -1586,7 +1581,7 @@ zsh-vi-mode/zsh-vi-mode.zsh	ZC1059	1
 zsh-vi-mode/zsh-vi-mode.zsh	ZC1065	2
 zsh-vi-mode/zsh-vi-mode.zsh	ZC1071	2
 zsh-vi-mode/zsh-vi-mode.zsh	ZC1073	12
-zsh-vi-mode/zsh-vi-mode.zsh	ZC1075	113
+zsh-vi-mode/zsh-vi-mode.zsh	ZC1075	104
 zsh-vi-mode/zsh-vi-mode.zsh	ZC1080	1
 zsh-vi-mode/zsh-vi-mode.zsh	ZC1086	71
 zsh-vi-mode/zsh-vi-mode.zsh	ZC1091	2
@@ -1604,7 +1599,7 @@ zsh-z/zsh-z.plugin.zsh	ZC1004	2
 zsh-z/zsh-z.plugin.zsh	ZC1043	3
 zsh-z/zsh-z.plugin.zsh	ZC1049	1
 zsh-z/zsh-z.plugin.zsh	ZC1073	6
-zsh-z/zsh-z.plugin.zsh	ZC1075	32
+zsh-z/zsh-z.plugin.zsh	ZC1075	30
 zsh-z/zsh-z.plugin.zsh	ZC1076	1
 zsh-z/zsh-z.plugin.zsh	ZC1078	3
 zsh-z/zsh-z.plugin.zsh	ZC1149	2

--- a/pkg/katas/katatests/fp_round8_test.go
+++ b/pkg/katas/katatests/fp_round8_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+// TestZC1075ArrayNotFlagged pins the array-quoting false positive. A bare
+// expansion of a variable declared as an array joins its elements into one
+// word under quoting, so the elision advice (`"$var"`) is wrong; the
+// correct form is `"${arr[@]}"`. ZC1075 now skips known arrays.
+func TestZC1075ArrayNotFlagged(t *testing.T) {
+	arrays := []string{
+		"local -a flags\njj $flags",
+		"flags=(--foo --bar)\ngit $flags",
+		"typeset -A m\nprint $m",
+		"local opts=(x y)\ncmd $opts",
+		"declare -a items\nrun $items",
+		"readonly -a paths\nuse $paths",
+	}
+	for _, src := range arrays {
+		if n := len(testutil.Check(src, "ZC1075")); n != 0 {
+			t.Errorf("ZC1075 should not flag a known array: %q (got %d)", src, n)
+		}
+	}
+	// A scalar must not be mistaken for an array. The renderer prints a
+	// scalar value `$1` as `name=($1)`, so detection reads the parsed value
+	// node, not the text; these must all still fire.
+	scalars := []string{
+		"local worker=$1\nprint $worker",
+		"local x=$(cmd)\necho $x",
+		"local p=$a/$b\nrm $p",
+		"typeset -i n\necho $n",
+		"rm $file",
+	}
+	for _, src := range scalars {
+		if n := len(testutil.Check(src, "ZC1075")); n == 0 {
+			t.Errorf("ZC1075 should still flag a scalar: %q", src)
+		}
+	}
+}

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -5329,7 +5329,7 @@ func checkZC1074(node ast.Node) []Violation {
 }
 
 func init() {
-	RegisterKata(ast.SimpleCommandNode, Kata{
+	RegisterKata(ast.ProgramNode, Kata{
 		ID:    "ZC1075",
 		Title: "Quote variable expansions to prevent empty-word elision",
 		Description: "An unquoted expansion whose value is empty or unset is elided " +
@@ -5448,13 +5448,29 @@ func zc1075HasDefaultModifier(left ast.Expression) bool {
 }
 
 func checkZC1075(node ast.Node) []Violation {
-	cmd, ok := node.(*ast.SimpleCommand)
+	prog, ok := node.(*ast.Program)
 	if !ok {
 		return nil
 	}
-
+	arrays := make(map[string]bool)
+	ast.Walk(prog, func(n ast.Node) bool {
+		zc1075HarvestArrays(n, arrays)
+		return true
+	})
 	violations := []Violation{}
+	ast.Walk(prog, func(n ast.Node) bool {
+		if cmd, ok := n.(*ast.SimpleCommand); ok {
+			zc1075FlagCommand(cmd, arrays, &violations)
+		}
+		return true
+	})
+	return violations
+}
 
+// zc1075FlagCommand applies the elision check to one command, skipping a
+// bare expansion of a variable known to hold an array (quoting `$arr` as
+// `"$arr"` joins the elements; `"${arr[@]}"` is the correct form).
+func zc1075FlagCommand(cmd *ast.SimpleCommand, arrays map[string]bool, violations *[]Violation) {
 	isAssignBuiltin := zc1075IsAssignmentBuiltin(cmd.Name)
 
 	for _, arg := range cmd.Arguments {
@@ -5476,8 +5492,8 @@ func checkZC1075(node ast.Node) []Violation {
 		if ident, ok := arg.(*ast.Identifier); ok {
 			// Only a bare `$name` expansion can elide to nothing; a suffixed
 			// form like `$dir/foo` keeps a literal tail and never elides.
-			if zc1075IsBareExpansion(ident.Value) {
-				violations = append(violations, Violation{
+			if zc1075IsBareExpansion(ident.Value) && !arrays[zc1075BareName(ident.Value)] {
+				*violations = append(*violations, Violation{
 					KataID:  "ZC1075",
 					Message: "Quote `" + ident.Value + "`. An unquoted empty or unset value is elided entirely, dropping the word.",
 					Line:    ident.Token.Line,
@@ -5509,6 +5525,12 @@ func checkZC1075(node ast.Node) []Violation {
 			if zc1075HasSplitFlag(aa.Flags) {
 				continue
 			}
+			// A bare whole-array expansion `${arr}` joins under quoting, so
+			// the elision advice does not apply; an element `${arr[i]}` is a
+			// single scalar that still elides.
+			if aa.Index == nil && arrays[zc1075BareName(aa.Left.String())] {
+				continue
+			}
 			// Distinguish a true array element (`${arr[i]}`, Index set)
 			// from a plain scalar / positional (`${V}`, Index nil) so the
 			// message does not mislabel a scalar as an array element.
@@ -5516,7 +5538,7 @@ func checkZC1075(node ast.Node) []Violation {
 			if aa.Index != nil {
 				msg = "Quote this array element. An unquoted empty value is elided, dropping the word."
 			}
-			violations = append(violations, Violation{
+			*violations = append(*violations, Violation{
 				KataID:  "ZC1075",
 				Message: msg,
 				Line:    arg.TokenLiteralNode().Line,
@@ -5534,8 +5556,136 @@ func checkZC1075(node ast.Node) []Violation {
 		// literal part keeps the word non-empty, and Zsh does not split or
 		// glob the expansion by default. Nothing to flag here.
 	}
+}
 
-	return violations
+// zc1075BareName returns the leading parameter name of an expansion such
+// as `$flags` or `flags`.
+func zc1075BareName(value string) string {
+	s := value
+	if len(s) > 0 && s[0] == '$' {
+		s = s[1:]
+	}
+	end := 0
+	for end < len(s) && zc1075IsNameByte(s[end]) {
+		end++
+	}
+	return s[:end]
+}
+
+// zc1075HarvestArrays records variables declared or assigned as arrays so
+// a bare `$arr` is not flagged for elision.
+func zc1075HarvestArrays(n ast.Node, arrays map[string]bool) {
+	switch node := n.(type) {
+	case *ast.InfixExpression:
+		// `arr=(a b c)` — assignment whose right side is an array literal.
+		if node.Operator != "=" {
+			return
+		}
+		if _, ok := node.Right.(*ast.ArrayLiteral); !ok {
+			return
+		}
+		if id, ok := node.Left.(*ast.Identifier); ok {
+			arrays[zc1075BareName(id.Value)] = true
+		}
+	case *ast.SimpleCommand:
+		zc1075HarvestArrayCmd(node, arrays)
+	case *ast.DeclarationStatement:
+		zc1075HarvestArrayDecl(node, arrays)
+	}
+}
+
+// zc1075HarvestArrayCmd reads array names from a `local`/`typeset`/
+// `declare`/`readonly` command: an `-a`/`-A` flag marks its bare name
+// arguments as arrays, and a `name=(…)` argument is an array literal.
+func zc1075HarvestArrayCmd(cmd *ast.SimpleCommand, arrays map[string]bool) {
+	if !zc1075IsDeclName(cmd.Name) {
+		return
+	}
+	hasArrayFlag := false
+	var names []string
+	for _, arg := range cmd.Arguments {
+		s := arg.String()
+		if strings.HasPrefix(s, "-") {
+			if strings.ContainsAny(s, "aA") {
+				hasArrayFlag = true
+			}
+			continue
+		}
+		if name, ok := zc1075ArrayAssignName(arg); ok {
+			arrays[name] = true
+			continue
+		}
+		// A scalar assignment `name=value` is not an array name. (`String()`
+		// is unreliable for arrays here — the array node is detected above.)
+		if strings.IndexByte(s, '=') > 0 {
+			continue
+		}
+		names = append(names, s)
+	}
+	if hasArrayFlag {
+		for _, nm := range names {
+			arrays[nm] = true
+		}
+	}
+}
+
+// zc1075ArrayAssignName returns the name of a `name=(…)` array-literal
+// assignment word. It inspects the parsed value node (an ArrayLiteral
+// part) rather than the rendered text, because the renderer wraps even a
+// scalar value such as `$1` in parentheses (`name=($1)`).
+func zc1075ArrayAssignName(arg ast.Expression) (string, bool) {
+	ce, ok := arg.(*ast.ConcatenatedExpression)
+	if !ok || len(ce.Parts) < 2 {
+		return "", false
+	}
+	id, ok := ce.Parts[0].(*ast.Identifier)
+	if !ok {
+		return "", false
+	}
+	for _, p := range ce.Parts[1:] {
+		if _, ok := p.(*ast.ArrayLiteral); ok {
+			return id.Value, true
+		}
+	}
+	return "", false
+}
+
+// zc1075HarvestArrayDecl reads array names from a DeclarationStatement. A
+// flagged declaration (`typeset -A m`) parses with the flag string as the
+// first name; when it carries `a`/`A` the remaining names are arrays. A
+// `name=(…)` assignment value is an array literal.
+func zc1075HarvestArrayDecl(ds *ast.DeclarationStatement, arrays map[string]bool) {
+	// Only a flagged declaration can carry the `-a`/`-A` array flag. The
+	// parser stores it as the first "name", so when that name contains
+	// `a`/`A` the remaining names are arrays.
+	if len(ds.Flags) == 0 {
+		return
+	}
+	var names []string
+	for _, a := range ds.Assignments {
+		if a.Name != nil {
+			names = append(names, a.Name.String())
+		}
+	}
+	if len(names) > 1 && strings.ContainsAny(names[0], "aA") {
+		for _, nm := range names[1:] {
+			arrays[nm] = true
+		}
+	}
+}
+
+// zc1075IsDeclName reports whether name is a declaration builtin that can
+// declare arrays.
+func zc1075IsDeclName(name ast.Expression) bool {
+	id, ok := name.(*ast.Identifier)
+	if !ok {
+		return false
+	}
+	switch id.Value {
+	case "local", "typeset", "declare", "readonly":
+		return true
+	}
+	return false
 }
 
 func init() {

--- a/pkg/katas/zc1075_harvest_test.go
+++ b/pkg/katas/zc1075_harvest_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+// TestZC1075HarvestHelpers covers the array-harvest helper guards,
+// including the defensive type-assertion branches the corpus rarely hits.
+func TestZC1075HarvestHelpers(t *testing.T) {
+	if zc1075IsDeclName(&ast.StringLiteral{Value: "x"}) {
+		t.Error("a non-identifier command name is not a declaration")
+	}
+	if zc1075IsDeclName(&ast.Identifier{Value: "echo"}) {
+		t.Error("echo is not a declaration builtin")
+	}
+	if !zc1075IsDeclName(&ast.Identifier{Value: "local"}) {
+		t.Error("local is a declaration builtin")
+	}
+
+	if _, ok := zc1075ArrayAssignName(&ast.Identifier{Value: "flags"}); ok {
+		t.Error("a bare identifier is not an array assignment")
+	}
+	if _, ok := zc1075ArrayAssignName(&ast.ConcatenatedExpression{
+		Parts: []ast.Expression{&ast.StringLiteral{Value: "("}},
+	}); ok {
+		t.Error("fewer than two parts is not an array assignment")
+	}
+	if _, ok := zc1075ArrayAssignName(&ast.ConcatenatedExpression{
+		Parts: []ast.Expression{&ast.StringLiteral{Value: "x"}, &ast.ArrayLiteral{}},
+	}); ok {
+		t.Error("a non-identifier first part is not an array assignment")
+	}
+	name, ok := zc1075ArrayAssignName(&ast.ConcatenatedExpression{
+		Parts: []ast.Expression{&ast.Identifier{Value: "arr"}, &ast.StringLiteral{Value: "="}, &ast.ArrayLiteral{}},
+	})
+	if !ok || name != "arr" {
+		t.Errorf("array assignment should yield arr, got %q ok=%v", name, ok)
+	}
+
+	a := map[string]bool{}
+	zc1075HarvestArrayDecl(&ast.DeclarationStatement{Flags: nil}, a)
+	if len(a) != 0 {
+		t.Error("a declaration with no flags harvests nothing")
+	}
+
+	if zc1075BareName("") != "" {
+		t.Error("empty input yields empty name")
+	}
+}


### PR DESCRIPTION
## What

Stop ZC1075 from flagging a bare expansion of a variable that holds an **array**. The kata's premise — an unquoted empty value elides and drops the word — is a scalar concern. For an array, quoting `$arr` as `"$arr"` *joins* the elements into one word; the correct form is `"${arr[@]}"`, which the message already states.

ZC1075 moves from a per-command check to a program-level one:
1. Harvest every array name in the file (from `name=(…)` array literals, `local -a`/`typeset -A`/`declare -a`/`readonly -a` declarations, and `local opts=(…)`).
2. Flag only bare scalar expansions; skip a bare `$arr` / `${arr}` whose name was harvested as an array.

## Why this is careful

Array detection reads the **AST**, not rendered text. The renderer prints a scalar value `$1` as `name=($1)` (spurious parens), so a string-based `=(` check would misclassify scalars as arrays. The harvest inspects the parsed value node (an `ArrayLiteral` part) and the declaration flags instead, so a scalar `local worker=$1` is never mistaken for an array.

This was prototyped, found to over-suppress via the renderer trap, reverted, and re-done against the AST — the over-suppression is gone (`local worker=$1` still fires).

## Verification

- Removes 121 findings across 33 corpora; spot-checked the harvested set in the biggest-drop files (`async.zsh`, `zsh-vi-mode`, `gitstatus`) — every removed expansion names a genuinely array-declared variable.
- Scalars (`local worker=$1`, `local x=$(cmd)`, `rm $file`), array elements `${arr[i]}`, and the flag-led / default-modifier skips are all unchanged.
- `go test ./...` passes, `golangci-lint` 0 issues, `gocyclo` clean, the new harvest helpers are 100% covered, fix-corpus sweep stays clean.
