### PR TITLE
fix: ZC1075 skips width-pad and typeset arrays

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -324,7 +324,7 @@ git-open/git-open.plugin.zsh	ZC1275	1
 gitstatus/gitstatus.plugin.zsh	ZC1001	7
 gitstatus/gitstatus.plugin.zsh	ZC1043	3
 gitstatus/gitstatus.plugin.zsh	ZC1046	1
-gitstatus/gitstatus.plugin.zsh	ZC1075	61
+gitstatus/gitstatus.plugin.zsh	ZC1075	60
 gitstatus/gitstatus.plugin.zsh	ZC1086	11
 gitstatus/gitstatus.plugin.zsh	ZC1167	1
 gitstatus/gitstatus.plugin.zsh	ZC1176	3
@@ -556,7 +556,7 @@ spaceship/lib/utils.zsh	ZC1010	1
 spaceship/lib/utils.zsh	ZC1037	3
 spaceship/lib/utils.zsh	ZC1045	3
 spaceship/lib/utils.zsh	ZC1073	1
-spaceship/lib/utils.zsh	ZC1075	6
+spaceship/lib/utils.zsh	ZC1075	5
 spaceship/lib/utils.zsh	ZC1097	1
 spaceship/lib/utils.zsh	ZC1517	1
 spaceship/lib/worker.zsh	ZC1043	2

--- a/pkg/katas/katatests/fp_round9_test.go
+++ b/pkg/katas/katatests/fp_round9_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+// TestZC1075WidthAndTypesetArray pins two more array/elision refinements.
+func TestZC1075WidthAndTypesetArray(t *testing.T) {
+	skip := []string{
+		"cmd ${(l:5:)x}",              // left-pad — fixed width, never empty
+		"cmd ${(r:3:)y}",              // right-pad
+		"typeset arr=(a b)\nuse $arr", // unflagged typeset array literal
+	}
+	for _, src := range skip {
+		if n := len(testutil.Check(src, "ZC1075")); n != 0 {
+			t.Errorf("ZC1075 should not flag %q (got %d)", src, n)
+		}
+	}
+	fire := []string{
+		"print ${(r)things}",              // reverse without width can be empty
+		"typeset q=\"(literal)\"\nuse $q", // quoted scalar, not an array
+	}
+	for _, src := range fire {
+		if n := len(testutil.Check(src, "ZC1075")); n == 0 {
+			t.Errorf("ZC1075 should still fire on %q", src)
+		}
+	}
+}

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -5514,54 +5514,7 @@ func zc1075FlagCommand(cmd *ast.SimpleCommand, arrays map[string]bool, violation
 				})
 			}
 		} else if aa, ok := arg.(*ast.ArrayAccess); ok {
-			// A flag-led expansion the parser cannot resolve to a subject
-			// (`${(%):-default}`, `${(P)…}`, `${(l:n:)…}`) leaves Left nil.
-			// Without the subject the elision behaviour is unknowable, and
-			// these forms commonly carry a `:-` default or a width modifier
-			// that never produces an empty word, so do not flag them.
-			if aa.Left == nil {
-				continue
-			}
-			// A `:-word` / `:=word` / `:+word` default-value expansion
-			// always yields a value, so it never elides — flagging it
-			// warns against the canonical `: ${VAR:=default}` idiom.
-			// Path modifiers (`:h`, `:t`, `:r`) still can elide, so keep
-			// flagging those.
-			if zc1075HasDefaultModifier(aa.Left) {
-				continue
-			}
-			// A word-splitting parameter flag (`${(f)x}`, `${(s:,:)x}`,
-			// `${(@)arr}`, `${(kv)map}`) is meant to expand to multiple
-			// words; quoting it would join them and defeat the idiom, so
-			// it is not an elision hazard.
-			if zc1075HasSplitFlag(aa.Flags) {
-				continue
-			}
-			// A width modifier `${(l:n:)x}` / `${(r:n:)x}` pads to a fixed
-			// width, so the result is never an empty word.
-			if zc1075HasWidthFlag(aa.Flags) {
-				continue
-			}
-			// A bare whole-array expansion `${arr}` joins under quoting, so
-			// the elision advice does not apply; an element `${arr[i]}` is a
-			// single scalar that still elides.
-			if aa.Index == nil && arrays[zc1075BareName(aa.Left.String())] {
-				continue
-			}
-			// Distinguish a true array element (`${arr[i]}`, Index set)
-			// from a plain scalar / positional (`${V}`, Index nil) so the
-			// message does not mislabel a scalar as an array element.
-			msg := "Quote this expansion. An unquoted empty or unset value is elided, dropping the word."
-			if aa.Index != nil {
-				msg = "Quote this array element. An unquoted empty value is elided, dropping the word."
-			}
-			*violations = append(*violations, Violation{
-				KataID:  "ZC1075",
-				Message: msg,
-				Line:    arg.TokenLiteralNode().Line,
-				Column:  arg.TokenLiteralNode().Column,
-				Level:   SeverityWarning,
-			})
+			zc1075FlagArrayAccess(aa, arrays, violations)
 		} else if _, ok := arg.(*ast.InvalidArrayAccess); ok {
 			_ = ok
 			// $arr[idx] - ZC1001 flags this, but it's also unquoted.
@@ -5573,6 +5526,38 @@ func zc1075FlagCommand(cmd *ast.SimpleCommand, arrays map[string]bool, violation
 		// literal part keeps the word non-empty, and Zsh does not split or
 		// glob the expansion by default. Nothing to flag here.
 	}
+}
+
+// zc1075FlagArrayAccess flags a `${…}` expansion for elision unless it is
+// a form that never produces an empty word: one the parser cannot resolve
+// (Left nil), a `:-`/`:=`/`:+` default, a word-splitting flag, a width
+// modifier, or a whole-array expansion of a known array.
+func zc1075FlagArrayAccess(aa *ast.ArrayAccess, arrays map[string]bool, violations *[]Violation) {
+	if aa.Left == nil {
+		return
+	}
+	if zc1075HasDefaultModifier(aa.Left) {
+		return
+	}
+	if zc1075HasSplitFlag(aa.Flags) || zc1075HasWidthFlag(aa.Flags) {
+		return
+	}
+	// A bare whole-array expansion `${arr}` joins under quoting; an element
+	// `${arr[i]}` is a single scalar that still elides.
+	if aa.Index == nil && arrays[zc1075BareName(aa.Left.String())] {
+		return
+	}
+	msg := "Quote this expansion. An unquoted empty or unset value is elided, dropping the word."
+	if aa.Index != nil {
+		msg = "Quote this array element. An unquoted empty value is elided, dropping the word."
+	}
+	*violations = append(*violations, Violation{
+		KataID:  "ZC1075",
+		Message: msg,
+		Line:    aa.TokenLiteralNode().Line,
+		Column:  aa.TokenLiteralNode().Column,
+		Level:   SeverityWarning,
+	})
 }
 
 // zc1075BareName returns the leading parameter name of an expansion such

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -5433,6 +5433,18 @@ func zc1075HasSplitFlag(flags string) bool {
 	return strings.ContainsAny(head, "fs0zwpkv@")
 }
 
+// zc1075HasWidthFlag reports whether flags carry a width modifier
+// (`l:n:` left-pad or `r:n:` right-pad). These produce a fixed-width
+// result that is never empty. The `:` argument distinguishes them from
+// `(r)` (reverse), which can still be empty.
+func zc1075HasWidthFlag(flags string) bool {
+	i := strings.IndexByte(flags, ':')
+	if i < 0 {
+		return false
+	}
+	return strings.ContainsAny(flags[:i], "lr")
+}
+
 func zc1075HasDefaultModifier(left ast.Expression) bool {
 	ident, ok := left.(*ast.Identifier)
 	if !ok {
@@ -5523,6 +5535,11 @@ func zc1075FlagCommand(cmd *ast.SimpleCommand, arrays map[string]bool, violation
 			// words; quoting it would join them and defeat the idiom, so
 			// it is not an elision hazard.
 			if zc1075HasSplitFlag(aa.Flags) {
+				continue
+			}
+			// A width modifier `${(l:n:)x}` / `${(r:n:)x}` pads to a fixed
+			// width, so the result is never an empty word.
+			if zc1075HasWidthFlag(aa.Flags) {
 				continue
 			}
 			// A bare whole-array expansion `${arr}` joins under quoting, so
@@ -5655,6 +5672,14 @@ func zc1075ArrayAssignName(arg ast.Expression) (string, bool) {
 // first name; when it carries `a`/`A` the remaining names are arrays. A
 // `name=(…)` assignment value is an array literal.
 func zc1075HarvestArrayDecl(ds *ast.DeclarationStatement, arrays map[string]bool) {
+	// `typeset arr=(a b)` — the array-literal value renders with a leading
+	// `(`. A quoted scalar such as `q="(literal)"` renders with the opening
+	// quote first, so it is not mistaken for an array.
+	for _, a := range ds.Assignments {
+		if a.Name != nil && a.Value != nil && strings.HasPrefix(a.Value.String(), "(") {
+			arrays[a.Name.String()] = true
+		}
+	}
 	// Only a flagged declaration can carry the `-a`/`-A` array flag. The
 	// parser stores it as the first "name", so when that name contains
 	// `a`/`A` the remaining names are arrays.

--- a/pkg/katas/zc1075_width_test.go
+++ b/pkg/katas/zc1075_width_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import "testing"
+
+func TestZC1075HasWidthFlag(t *testing.T) {
+	cases := map[string]bool{
+		"l:5:": true,  // left-pad
+		"r:3:": true,  // right-pad
+		"r":    false, // reverse, no width arg
+		"":     false, // no flags
+		"s:,:": false, // split delimiter, not a width flag
+	}
+	for flags, want := range cases {
+		if got := zc1075HasWidthFlag(flags); got != want {
+			t.Errorf("zc1075HasWidthFlag(%q) = %v, want %v", flags, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Two ZC1075 elision refinements.

- A width modifier `${(l:n:)x}` / `${(r:n:)x}` pads to a fixed width — never an empty word. The `l`/`r` flag is not a word-splitting flag, so it slipped past the existing skip. Now skipped, distinguished from `(r)` (reverse, can be empty) by the `:n:` width argument.
- `typeset arr=(a b)` declares an array, but the parser does not model its value as an `ArrayLiteral` here. The harvest now also reads a value that renders with a leading `(`; a quoted scalar `q="(literal)"` keeps its opening quote and is not mistaken for an array.

## Verification

- `${(l:5:)x}` confirmed against real zsh: an unset value yields five spaces, never empty.
- Removes 2 findings from the violation baseline (gitstatus `${(l:20:)pgid}`, spaceship `typeset -U sections=(...)`); `(r)` reverse and quoted scalars still fire.
- `go test ./...` passes, `golangci-lint` 0 issues, new helpers 100% covered, sweeps clean.