### PR TITLE
fix: retire ZC1104, duplicate of ZC1188

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -54,17 +54,12 @@ antidote/tests/bin/test_fzf_opts_manual.zsh	ZC1017	1
 antidote/tests/bin/test_fzf_opts_manual.zsh	ZC1075	2
 antidote/tests/__init__.zsh	ZC1031	1
 antidote/tests/testdata/real/.zsh_plugins.zsh	ZC1001	1
-antidote/tests/testdata/real/.zsh_plugins.zsh	ZC1104	1
 antidote/tests/testdata/real/.zsh_plugins.zsh	ZC1188	1
-antidote/tests/testdata/.zplugins_fake_load.zsh	ZC1104	1
 antidote/tests/testdata/.zplugins_fake_load.zsh	ZC1188	1
 antidote/tests/testdata/.zplugins_fake_zcompile_static.zsh	ZC1075	1
 antidote/tests/testdata/.zplugins_fake_zcompile_static.zsh	ZC1086	1
-antidote/tests/testdata/.zplugins_fake_zcompile_static.zsh	ZC1104	1
 antidote/tests/testdata/.zplugins_fake_zcompile_static.zsh	ZC1188	1
-antidote/tests/testdata/.zsh_plugins_using.zsh	ZC1104	1
 antidote/tests/testdata/.zsh_plugins_using.zsh	ZC1188	1
-antidote/tests/testdata/.zsh_plugins.zsh	ZC1104	1
 antidote/tests/testdata/.zsh_plugins.zsh	ZC1188	1
 antidote/tests/tmp_home/.zsh/aliases.zsh	ZC1037	1
 antidote/tests/tmp_home/.zsh/custom/lib/lib1.zsh	ZC1037	1
@@ -283,7 +278,6 @@ fzf-tab/test/ztst.zsh	ZC1830	1
 fzf-zsh-plugin/fzf-settings.zsh	ZC1005	1
 fzf-zsh-plugin/fzf-settings.zsh	ZC1034	1
 fzf-zsh-plugin/fzf-settings.zsh	ZC1086	1
-fzf-zsh-plugin/fzf-settings.zsh	ZC1104	1
 fzf-zsh-plugin/fzf-settings.zsh	ZC1188	1
 fzf-zsh-plugin/fzf-settings.zsh	ZC1271	1
 fzf-zsh-plugin/fzf-zsh-plugin.plugin.zsh	ZC1003	1
@@ -318,7 +312,6 @@ git-flow-completion/git-flow-completion.zsh	ZC1288	4
 git-open/git-open.plugin.zsh	ZC1067	1
 git-open/git-open.plugin.zsh	ZC1074	1
 git-open/git-open.plugin.zsh	ZC1100	1
-git-open/git-open.plugin.zsh	ZC1104	1
 git-open/git-open.plugin.zsh	ZC1188	1
 git-open/git-open.plugin.zsh	ZC1275	1
 gitstatus/gitstatus.plugin.zsh	ZC1001	7
@@ -697,7 +690,6 @@ spaceship/tests/ansible.test.zsh	ZC1045	4
 spaceship/tests/ansible.test.zsh	ZC1051	3
 spaceship/tests/ansible.test.zsh	ZC1075	8
 spaceship/tests/ansible.test.zsh	ZC1097	3
-spaceship/tests/ansible.test.zsh	ZC1104	1
 spaceship/tests/ansible.test.zsh	ZC1128	3
 spaceship/tests/ansible.test.zsh	ZC1188	1
 spaceship/tests/ansible.test.zsh	ZC1602	1
@@ -706,14 +698,12 @@ spaceship/tests/azure.test.zsh	ZC1044	1
 spaceship/tests/azure.test.zsh	ZC1045	2
 spaceship/tests/azure.test.zsh	ZC1049	1
 spaceship/tests/azure.test.zsh	ZC1075	1
-spaceship/tests/azure.test.zsh	ZC1104	1
 spaceship/tests/azure.test.zsh	ZC1188	1
 spaceship/tests/azure.test.zsh	ZC1602	1
 spaceship/tests/bun.test.zsh	ZC1043	9
 spaceship/tests/bun.test.zsh	ZC1044	1
 spaceship/tests/bun.test.zsh	ZC1045	3
 spaceship/tests/bun.test.zsh	ZC1075	1
-spaceship/tests/bun.test.zsh	ZC1104	1
 spaceship/tests/bun.test.zsh	ZC1128	2
 spaceship/tests/bun.test.zsh	ZC1188	1
 spaceship/tests/bun.test.zsh	ZC1602	1
@@ -726,7 +716,6 @@ spaceship/tests/crystal.test.zsh	ZC1043	10
 spaceship/tests/crystal.test.zsh	ZC1044	1
 spaceship/tests/crystal.test.zsh	ZC1045	3
 spaceship/tests/crystal.test.zsh	ZC1075	1
-spaceship/tests/crystal.test.zsh	ZC1104	1
 spaceship/tests/crystal.test.zsh	ZC1128	2
 spaceship/tests/crystal.test.zsh	ZC1188	1
 spaceship/tests/crystal.test.zsh	ZC1602	1
@@ -737,7 +726,6 @@ spaceship/tests/dart.test.zsh	ZC1049	2
 spaceship/tests/dart.test.zsh	ZC1051	5
 spaceship/tests/dart.test.zsh	ZC1075	11
 spaceship/tests/dart.test.zsh	ZC1097	3
-spaceship/tests/dart.test.zsh	ZC1104	1
 spaceship/tests/dart.test.zsh	ZC1128	4
 spaceship/tests/dart.test.zsh	ZC1136	1
 spaceship/tests/dart.test.zsh	ZC1188	1
@@ -748,7 +736,6 @@ spaceship/tests/deno.test.zsh	ZC1045	3
 spaceship/tests/deno.test.zsh	ZC1051	2
 spaceship/tests/deno.test.zsh	ZC1075	5
 spaceship/tests/deno.test.zsh	ZC1097	2
-spaceship/tests/deno.test.zsh	ZC1104	1
 spaceship/tests/deno.test.zsh	ZC1128	2
 spaceship/tests/deno.test.zsh	ZC1188	1
 spaceship/tests/deno.test.zsh	ZC1602	1
@@ -763,7 +750,6 @@ spaceship/tests/docker_compose.test.zsh	ZC1045	2
 spaceship/tests/docker_compose.test.zsh	ZC1051	1
 spaceship/tests/docker_compose.test.zsh	ZC1075	3
 spaceship/tests/docker_compose.test.zsh	ZC1097	1
-spaceship/tests/docker_compose.test.zsh	ZC1104	1
 spaceship/tests/docker_compose.test.zsh	ZC1128	1
 spaceship/tests/docker_compose.test.zsh	ZC1188	1
 spaceship/tests/docker_compose.test.zsh	ZC1602	1
@@ -771,7 +757,6 @@ spaceship/tests/elm.test.zsh	ZC1043	15
 spaceship/tests/elm.test.zsh	ZC1044	1
 spaceship/tests/elm.test.zsh	ZC1045	5
 spaceship/tests/elm.test.zsh	ZC1075	1
-spaceship/tests/elm.test.zsh	ZC1104	1
 spaceship/tests/elm.test.zsh	ZC1128	3
 spaceship/tests/elm.test.zsh	ZC1188	1
 spaceship/tests/elm.test.zsh	ZC1602	1
@@ -781,7 +766,6 @@ spaceship/tests/erlang.test.zsh	ZC1045	2
 spaceship/tests/erlang.test.zsh	ZC1051	1
 spaceship/tests/erlang.test.zsh	ZC1075	3
 spaceship/tests/erlang.test.zsh	ZC1097	1
-spaceship/tests/erlang.test.zsh	ZC1104	1
 spaceship/tests/erlang.test.zsh	ZC1128	1
 spaceship/tests/erlang.test.zsh	ZC1188	1
 spaceship/tests/erlang.test.zsh	ZC1602	1
@@ -793,7 +777,6 @@ spaceship/tests/gleam.test.zsh	ZC1045	3
 spaceship/tests/gleam.test.zsh	ZC1051	2
 spaceship/tests/gleam.test.zsh	ZC1075	5
 spaceship/tests/gleam.test.zsh	ZC1097	2
-spaceship/tests/gleam.test.zsh	ZC1104	1
 spaceship/tests/gleam.test.zsh	ZC1128	2
 spaceship/tests/gleam.test.zsh	ZC1188	1
 spaceship/tests/gleam.test.zsh	ZC1602	1
@@ -801,7 +784,6 @@ spaceship/tests/gnu_screen.test.zsh	ZC1043	9
 spaceship/tests/gnu_screen.test.zsh	ZC1044	1
 spaceship/tests/gnu_screen.test.zsh	ZC1045	2
 spaceship/tests/gnu_screen.test.zsh	ZC1075	1
-spaceship/tests/gnu_screen.test.zsh	ZC1104	1
 spaceship/tests/gnu_screen.test.zsh	ZC1188	1
 spaceship/tests/gnu_screen.test.zsh	ZC1602	1
 spaceship/tests/haxe.test.zsh	ZC1043	12
@@ -810,7 +792,6 @@ spaceship/tests/haxe.test.zsh	ZC1045	3
 spaceship/tests/haxe.test.zsh	ZC1051	2
 spaceship/tests/haxe.test.zsh	ZC1075	5
 spaceship/tests/haxe.test.zsh	ZC1097	2
-spaceship/tests/haxe.test.zsh	ZC1104	1
 spaceship/tests/haxe.test.zsh	ZC1128	2
 spaceship/tests/haxe.test.zsh	ZC1188	1
 spaceship/tests/haxe.test.zsh	ZC1602	1
@@ -825,7 +806,6 @@ spaceship/tests/kotlin.test.zsh	ZC1045	2
 spaceship/tests/kotlin.test.zsh	ZC1051	1
 spaceship/tests/kotlin.test.zsh	ZC1075	3
 spaceship/tests/kotlin.test.zsh	ZC1097	1
-spaceship/tests/kotlin.test.zsh	ZC1104	1
 spaceship/tests/kotlin.test.zsh	ZC1128	1
 spaceship/tests/kotlin.test.zsh	ZC1188	1
 spaceship/tests/kotlin.test.zsh	ZC1602	1
@@ -835,7 +815,6 @@ spaceship/tests/lua.test.zsh	ZC1045	4
 spaceship/tests/lua.test.zsh	ZC1051	3
 spaceship/tests/lua.test.zsh	ZC1075	7
 spaceship/tests/lua.test.zsh	ZC1097	3
-spaceship/tests/lua.test.zsh	ZC1104	1
 spaceship/tests/lua.test.zsh	ZC1128	2
 spaceship/tests/lua.test.zsh	ZC1136	1
 spaceship/tests/lua.test.zsh	ZC1188	1
@@ -844,7 +823,6 @@ spaceship/tests/nix_shell.test.zsh	ZC1043	9
 spaceship/tests/nix_shell.test.zsh	ZC1044	1
 spaceship/tests/nix_shell.test.zsh	ZC1045	3
 spaceship/tests/nix_shell.test.zsh	ZC1075	1
-spaceship/tests/nix_shell.test.zsh	ZC1104	1
 spaceship/tests/nix_shell.test.zsh	ZC1188	1
 spaceship/tests/nix_shell.test.zsh	ZC1602	1
 spaceship/tests/ocaml.test.zsh	ZC1043	13
@@ -853,7 +831,6 @@ spaceship/tests/ocaml.test.zsh	ZC1045	4
 spaceship/tests/ocaml.test.zsh	ZC1051	2
 spaceship/tests/ocaml.test.zsh	ZC1075	5
 spaceship/tests/ocaml.test.zsh	ZC1097	3
-spaceship/tests/ocaml.test.zsh	ZC1104	1
 spaceship/tests/ocaml.test.zsh	ZC1128	3
 spaceship/tests/ocaml.test.zsh	ZC1188	1
 spaceship/tests/ocaml.test.zsh	ZC1602	1
@@ -865,7 +842,6 @@ spaceship/tests/package_maven.test.zsh	ZC1044	1
 spaceship/tests/package_maven.test.zsh	ZC1045	4
 spaceship/tests/package_maven.test.zsh	ZC1051	4
 spaceship/tests/package_maven.test.zsh	ZC1075	12
-spaceship/tests/package_maven.test.zsh	ZC1104	1
 spaceship/tests/package_maven.test.zsh	ZC1128	4
 spaceship/tests/package_maven.test.zsh	ZC1188	1
 spaceship/tests/package_maven.test.zsh	ZC1477	1
@@ -880,7 +856,6 @@ spaceship/tests/perl.test.zsh	ZC1045	3
 spaceship/tests/perl.test.zsh	ZC1051	2
 spaceship/tests/perl.test.zsh	ZC1075	5
 spaceship/tests/perl.test.zsh	ZC1097	2
-spaceship/tests/perl.test.zsh	ZC1104	1
 spaceship/tests/perl.test.zsh	ZC1128	2
 spaceship/tests/perl.test.zsh	ZC1188	1
 spaceship/tests/perl.test.zsh	ZC1602	1
@@ -888,7 +863,6 @@ spaceship/tests/pulumi.test.zsh	ZC1043	10
 spaceship/tests/pulumi.test.zsh	ZC1044	1
 spaceship/tests/pulumi.test.zsh	ZC1045	3
 spaceship/tests/pulumi.test.zsh	ZC1075	1
-spaceship/tests/pulumi.test.zsh	ZC1104	1
 spaceship/tests/pulumi.test.zsh	ZC1128	4
 spaceship/tests/pulumi.test.zsh	ZC1188	1
 spaceship/tests/pulumi.test.zsh	ZC1602	1
@@ -896,7 +870,6 @@ spaceship/tests/purescript.test.zsh	ZC1043	5
 spaceship/tests/purescript.test.zsh	ZC1044	1
 spaceship/tests/purescript.test.zsh	ZC1045	3
 spaceship/tests/purescript.test.zsh	ZC1075	1
-spaceship/tests/purescript.test.zsh	ZC1104	1
 spaceship/tests/purescript.test.zsh	ZC1128	2
 spaceship/tests/purescript.test.zsh	ZC1188	1
 spaceship/tests/purescript.test.zsh	ZC1602	1
@@ -906,7 +879,6 @@ spaceship/tests/red.test.zsh	ZC1045	3
 spaceship/tests/red.test.zsh	ZC1051	2
 spaceship/tests/red.test.zsh	ZC1075	5
 spaceship/tests/red.test.zsh	ZC1097	2
-spaceship/tests/red.test.zsh	ZC1104	1
 spaceship/tests/red.test.zsh	ZC1128	2
 spaceship/tests/red.test.zsh	ZC1188	1
 spaceship/tests/red.test.zsh	ZC1602	1
@@ -916,7 +888,6 @@ spaceship/tests/rlang.test.zsh	ZC1045	3
 spaceship/tests/rlang.test.zsh	ZC1051	2
 spaceship/tests/rlang.test.zsh	ZC1075	5
 spaceship/tests/rlang.test.zsh	ZC1097	2
-spaceship/tests/rlang.test.zsh	ZC1104	1
 spaceship/tests/rlang.test.zsh	ZC1128	2
 spaceship/tests/rlang.test.zsh	ZC1188	1
 spaceship/tests/rlang.test.zsh	ZC1602	1
@@ -926,7 +897,6 @@ spaceship/tests/scala.test.zsh	ZC1045	4
 spaceship/tests/scala.test.zsh	ZC1051	3
 spaceship/tests/scala.test.zsh	ZC1075	7
 spaceship/tests/scala.test.zsh	ZC1097	3
-spaceship/tests/scala.test.zsh	ZC1104	1
 spaceship/tests/scala.test.zsh	ZC1128	2
 spaceship/tests/scala.test.zsh	ZC1136	1
 spaceship/tests/scala.test.zsh	ZC1188	1
@@ -948,7 +918,6 @@ spaceship/tests/vlang.test.zsh	ZC1045	3
 spaceship/tests/vlang.test.zsh	ZC1051	2
 spaceship/tests/vlang.test.zsh	ZC1075	5
 spaceship/tests/vlang.test.zsh	ZC1097	2
-spaceship/tests/vlang.test.zsh	ZC1104	1
 spaceship/tests/vlang.test.zsh	ZC1128	2
 spaceship/tests/vlang.test.zsh	ZC1188	1
 spaceship/tests/vlang.test.zsh	ZC1602	1
@@ -956,7 +925,6 @@ spaceship/tests/zig.test.zsh	ZC1043	5
 spaceship/tests/zig.test.zsh	ZC1044	1
 spaceship/tests/zig.test.zsh	ZC1045	3
 spaceship/tests/zig.test.zsh	ZC1075	1
-spaceship/tests/zig.test.zsh	ZC1104	1
 spaceship/tests/zig.test.zsh	ZC1128	2
 spaceship/tests/zig.test.zsh	ZC1188	1
 spaceship/tests/zig.test.zsh	ZC1602	1
@@ -1322,7 +1290,6 @@ zpm/lib/imperative.zsh	ZC1288	1
 zpm/lib/imperative.zsh	ZC1686	1
 zpm/zpm.zsh	ZC1046	2
 zpm/zpm.zsh	ZC1098	2
-zpm/zpm.zsh	ZC1104	1
 zpm/zpm.zsh	ZC1188	1
 zsh-256color/zsh-256color.plugin.zsh	ZC1001	1
 zsh-256color/zsh-256color.plugin.zsh	ZC1037	1

--- a/KATAS.md
+++ b/KATAS.md
@@ -120,7 +120,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1101: Use `$(( ))` instead of `bc` for simple arithmetic](#zc1101)
 - [ZC1102: Redirecting output of `sudo` doesn't work as expected](#zc1102)
 - [ZC1103: Suggest `path` array instead of `$PATH` string manipulation (direct assignment)](#zc1103)
-- [ZC1104: Suggest `path` array instead of `export PATH` string manipulation](#zc1104)
+- [ZC1104: Superseded by ZC1188 — retired duplicate](#zc1104)
 - [ZC1105: Avoid nested arithmetic expansions for clarity](#zc1105)
 - [ZC1106: Avoid `set -x` in production scripts for sensitive data exposure](#zc1106)
 - [ZC1107: Use (( ... )) for arithmetic conditions](#zc1107)
@@ -2257,12 +2257,12 @@ Disable by adding `ZC1103` to `disabled_katas` in `.zshellcheckrc`.
 ---
 
 <a id="zc1104"></a>
-### ZC1104 — Suggest `path` array instead of `export PATH` string manipulation
+### ZC1104 — Superseded by ZC1188 — retired duplicate
 
 **Severity:** `style`  
 **Auto-fix:** `no`
 
-Zsh automatically maps the `$PATH` environment variable to the `$path` array. Modifying `$path` is cleaner and less error-prone than manipulating the colon-separated `$PATH` string.
+Retired duplicate of ZC1188, which gives the same `export PATH` advice with a direction-aware message. Stubbed to a no-op so legacy `disabled_katas` lists keep parsing; the detection lives in ZC1188.
 
 Disable by adding `ZC1104` to `disabled_katas` in `.zshellcheckrc`.
 

--- a/pkg/katas/katatests/zc1100s_test.go
+++ b/pkg/katas/katatests/zc1100s_test.go
@@ -195,16 +195,11 @@ func TestZC1104(t *testing.T) {
 		expected []katas.Violation
 	}{
 		{
-			name:  "export PATH assignment",
-			input: `export PATH=$PATH:/bin`,
-			expected: []katas.Violation{
-				{
-					KataID:  "ZC1104",
-					Message: "Use the `path` array instead of manually manipulating the `$PATH` string.",
-					Line:    1,
-					Column:  1,
-				},
-			},
+			// ZC1104 is retired — a duplicate of ZC1188, which now owns the
+			// `export PATH=…` detection. ZC1104 fires on nothing.
+			name:     "export PATH assignment is handled by ZC1188",
+			input:    `export PATH=$PATH:/bin`,
+			expected: []katas.Violation{},
 		},
 		{
 			name:     "valid path array assignment",

--- a/pkg/katas/zc1100s.go
+++ b/pkg/katas/zc1100s.go
@@ -183,36 +183,20 @@ func checkZC1103(node ast.Node) []Violation {
 func init() {
 	RegisterKata(ast.SimpleCommandNode, Kata{
 		ID:    "ZC1104",
-		Title: "Suggest `path` array instead of `export PATH` string manipulation",
-		Description: "Zsh automatically maps the `$PATH` environment variable to the `$path` array. " +
-			"Modifying `$path` is cleaner and less error-prone than manipulating the colon-separated `$PATH` string.",
+		Title: "Superseded by ZC1188 — retired duplicate",
+		Description: "Retired duplicate of ZC1188, which gives the same `export PATH` " +
+			"advice with a direction-aware message. Stubbed to a no-op so legacy " +
+			"`disabled_katas` lists keep parsing; the detection lives in ZC1188.",
 		Severity: SeverityStyle,
 		Check:    checkZC1104,
 	})
 }
 
-func checkZC1104(node ast.Node) []Violation {
-	cmd, ok := node.(*ast.SimpleCommand)
-	if !ok {
-		return nil
-	}
-
-	// Check for `export PATH=...`
-	if cmd.Name != nil && cmd.Name.String() == "export" {
-		for _, arg := range cmd.Arguments {
-			argStr := arg.String()
-			if strings.HasPrefix(argStr, "PATH=") {
-				return []Violation{{
-					KataID:  "ZC1104",
-					Message: "Use the `path` array instead of manually manipulating the `$PATH` string.",
-					Line:    cmd.Token.Line,
-					Column:  cmd.Token.Column,
-					Level:   SeverityStyle,
-				}}
-			}
-		}
-	}
-
+// ZC1104 fired on the same `export PATH=…` as the canonical ZC1188 with
+// overlapping advice — a 100% duplicate. Stubbed to a no-op so legacy
+// `disabled_katas` lists keep parsing; the detection now lives in ZC1188,
+// whose message adapts to a prepend or an append.
+func checkZC1104(ast.Node) []Violation {
 	return nil
 }
 


### PR DESCRIPTION
## What

ZC1104 and ZC1188 both fired on `export PATH=…` with the same advice — every such line was double-reported. ZC1188 now owns that detection (its message adapts to a prepend or an append), so ZC1104 is stubbed to a no-op, following the retired-duplicate pattern already used for ZC1018/ZC1019. Legacy `disabled_katas: [ZC1104]` lists keep parsing.

ZC1103 (direct `PATH=$PATH:…` assignment, no `export`) is a **distinct** case and still fires.

## Verification

- Confirmed ZC1104 and ZC1188 fire on an identical input set; ZC1103 covers the non-export form separately.
- Removes 33 redundant findings from the violation baseline; ZC1188 still fires on every one of those lines.
- KATAS.md regenerated (ZC1104 -> "retired duplicate"); the ZC1104 test asserts no finding.
- `go test ./...` passes, `golangci-lint` 0 issues, gocyclo clean, sweeps clean.