### PR TITLE
fix: absorb glued quote tail in assignment RHS

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -1300,7 +1300,6 @@ zsh-abbr/tests/_abbr-expand-line.ztr.zsh	ZC1075	8
 zsh-abbr/tests/_abbr-set-line-cursor.ztr.zsh	ZC1043	2
 zsh-abbr/tests/_abbr-set-line-cursor.ztr.zsh	ZC1075	3
 zsh-abbr/tests/_add.ztr.zsh	ZC1037	1
-zsh-abbr/tests/_add.ztr.zsh	ZC1044	2
 zsh-abbr/tests/_add.ztr.zsh	ZC1075	7
 zsh-abbr/tests/_erase.ztr.zsh	ZC1037	2
 zsh-abbr/tests/_erase.ztr.zsh	ZC1075	6

--- a/pkg/parser/parser_corpus_fixes_test.go
+++ b/pkg/parser/parser_corpus_fixes_test.go
@@ -454,3 +454,39 @@ func TestAbsorbGluedRhsTailBranches(t *testing.T) {
 		p.ParseProgram() // must not panic; covers the absorber branches
 	}
 }
+
+// A quoted segment or bare word glued to an assignment RHS with no
+// separating space continues the same concatenated word in zsh
+// (`expansion='b'cd` assigns `bcd`). The trailing `cd` must not be
+// orphaned into a second statement, which previously parsed it as a
+// bare `cd` command and emitted a spurious ZC1044 cd-failure warning on
+// a plain string assignment. The zsh-abbr quote-handling tests exercise
+// every glue position; the space-guarded env-prefix form is preserved.
+func TestParseAssignmentGluedQuoteTail(t *testing.T) {
+	glued := []string{
+		"expansion='b'cd\n",     // single quotes at the start
+		"expansion=b'c'd\n",     // single quotes in the middle
+		"expansion=\"b\"cd\n",   // double quotes at the start
+		"expansion='b\"c\"d'\n", // single-quoted double quotes
+	}
+	for _, src := range glued {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Fatalf("unexpected parser errors for %q: %v", src, errs)
+		}
+		if n := len(prog.Statements); n != 1 {
+			t.Errorf("glued assignment %q: want 1 statement, got %d (tail orphaned)", src, n)
+		}
+	}
+	// A separating space marks the env-prefix form: the word after the
+	// assignment is a real command, so it stays its own statement.
+	spaced := []string{"x='b' cd\n", "FOO=bar cmd\n"}
+	for _, src := range spaced {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if n := len(prog.Statements); n != 2 {
+			t.Errorf("env-prefix %q: want 2 statements, got %d (space tail wrongly absorbed)", src, n)
+		}
+	}
+}

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -584,6 +584,16 @@ func (p *Parser) absorbGluedRhsTail() {
 			// (`${DIR}/init` → `${ DIR }` then IDENT `/init`). Absorb that
 			// glued path tail so it is not orphaned into a second statement.
 			p.nextToken()
+		case p.peekTokenIs(token.STRING) || p.peekTokenIs(token.IDENT):
+			// A quoted segment or bare word glued with no preceding
+			// space continues the same concatenated word in zsh
+			// (`x='b'cd` → `bcd`, `x=b'c'd` → `bcd`, `x="b"cd` → `bcd`).
+			// Absorb it so the tail is not orphaned into a spurious
+			// command — a glued `cd`/`rm`/… otherwise parsed as its own
+			// statement and mis-flagged (ZC1044 et al.). The leading
+			// `HasPrecedingSpace` guard keeps the env-prefix form
+			// (`x='b' cd`) intact: a space means `cd` is a real command.
+			p.nextToken()
 		case p.peekTokenIs(token.SLASH):
 			// A standalone `/` before an expansion (`${a}/${b}`). Consume
 			// the slash; if a glued expansion follows, consume that too.


### PR DESCRIPTION
What: the assignment right-hand-side absorber now consumes a quoted segment or bare word glued with no separating space, so `expansion='b'cd` parses as one concatenated word (`bcd`) instead of orphaning `cd` into a second statement.

Why: in zsh, adjacent words with no space concatenate. The parser stopped at the closing quote, so the trailing `cd` parsed as a real command and drew a spurious ZC1044 cd-failure warning on a plain string assignment. The zsh-abbr quote-handling tests exercise every glue position.

Guard: the leading `HasPrecedingSpace` check preserves the env-prefix form `x='b' cd` — a space still marks the following word as a real command (two statements).

Tests: new `TestParseAssignmentGluedQuoteTail` pins statement counts for the four glue forms and the two spaced forms. Violation baseline drops the two `zsh-abbr/tests/_add.ztr.zsh` ZC1044 false positives; no other corpus drift across 402 files.

Severity: Warning (false positive removed).