### PR TITLE
fix: parse command-position assignments correctly

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -257,9 +257,6 @@ fzf-tab/test/runtests.zsh	ZC1073	2
 fzf-tab/test/runtests.zsh	ZC1075	1
 fzf-tab/test/ztst.zsh	ZC1001	3
 fzf-tab/test/ztst.zsh	ZC1004	1
-fzf-tab/test/ztst.zsh	ZC1006	1
-fzf-tab/test/ztst.zsh	ZC1020	1
-fzf-tab/test/ztst.zsh	ZC1036	1
 fzf-tab/test/ztst.zsh	ZC1037	1
 fzf-tab/test/ztst.zsh	ZC1043	19
 fzf-tab/test/ztst.zsh	ZC1044	1
@@ -272,7 +269,6 @@ fzf-tab/test/ztst.zsh	ZC1075	22
 fzf-tab/test/ztst.zsh	ZC1078	1
 fzf-tab/test/ztst.zsh	ZC1091	4
 fzf-tab/test/ztst.zsh	ZC1136	3
-fzf-tab/test/ztst.zsh	ZC1293	1
 fzf-tab/test/ztst.zsh	ZC1830	1
 fzf-zsh-plugin/fzf-settings.zsh	ZC1005	1
 fzf-zsh-plugin/fzf-settings.zsh	ZC1034	1
@@ -300,7 +296,7 @@ fzf-zsh-plugin/fzf-zsh-plugin.plugin.zsh	ZC1591	1
 geometry/geometry.zsh	ZC1001	1
 geometry/geometry.zsh	ZC1043	1
 geometry/geometry.zsh	ZC1045	5
-geometry/geometry.zsh	ZC1075	10
+geometry/geometry.zsh	ZC1075	7
 geometry/geometry.zsh	ZC1091	1
 geometry/geometry.zsh	ZC1097	1
 geometry/geometry.zsh	ZC1517	1
@@ -318,7 +314,6 @@ gitstatus/gitstatus.plugin.zsh	ZC1043	3
 gitstatus/gitstatus.plugin.zsh	ZC1046	1
 gitstatus/gitstatus.plugin.zsh	ZC1075	48
 gitstatus/gitstatus.plugin.zsh	ZC1086	11
-gitstatus/gitstatus.plugin.zsh	ZC1167	1
 gitstatus/gitstatus.plugin.zsh	ZC1176	3
 gitstatus/gitstatus.prompt.zsh	ZC1086	1
 gitstatus/gitstatus.prompt.zsh	ZC1967	1
@@ -1408,6 +1403,7 @@ zsh-completion-generator/zsh-completion-generator.plugin.zsh	ZC1010	1
 zsh-completion-generator/zsh-completion-generator.plugin.zsh	ZC1020	1
 zsh-completion-generator/zsh-completion-generator.plugin.zsh	ZC1036	1
 zsh-completion-generator/zsh-completion-generator.plugin.zsh	ZC1037	2
+zsh-completion-generator/zsh-completion-generator.plugin.zsh	ZC1071	1
 zsh-completion-generator/zsh-completion-generator.plugin.zsh	ZC1075	4
 zsh-completion-generator/zsh-completion-generator.plugin.zsh	ZC1293	1
 zsh-defer/zsh-defer.plugin.zsh	ZC1001	2
@@ -1513,10 +1509,8 @@ zsh-nvm/zsh-nvm.plugin.zsh	ZC1281	1
 zsh-nvm/zsh-nvm.plugin.zsh	ZC1293	1
 zsh-nvm/zsh-nvm.plugin.zsh	ZC1643	1
 zsh-nvm/zsh-nvm.plugin.zsh	ZC1773	1
-zsh-shift-select/zsh-shift-select.plugin.zsh	ZC1061	1
 zsh-shift-select/zsh-shift-select.plugin.zsh	ZC1075	5
 zsh-shift-select/zsh-shift-select.plugin.zsh	ZC1086	6
-zsh-shift-select/zsh-shift-select.plugin.zsh	ZC1276	1
 zsh-utils/completion/completion.plugin.zsh	ZC1128	1
 zsh-utils/completion/completion.plugin.zsh	ZC1686	1
 zsh-utils/editor/editor.plugin.zsh	ZC1053	1

--- a/pkg/katas/katatests/fp_round11_test.go
+++ b/pkg/katas/katatests/fp_round11_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/testutil"
+)
+
+// TestCommandPositionAssignmentNotMisflagged pins the command-position
+// assignment fix. A `name=value` after `&&` / `||` or in a pipeline is an
+// assignment, not a command; a variable named for a builtin was previously
+// parsed as that builtin and mis-flagged. The common guard idiom
+// `[[ cond ]] && var=value` is where this surfaced across the corpus.
+func TestCommandPositionAssignmentNotMisflagged(t *testing.T) {
+	cases := []struct {
+		src   string
+		katas []string
+	}{
+		// `test`, `seq`, `timeout` as variable names, not commands.
+		{`[[ -n $x ]] && test=$(foo)`, []string{"ZC1006", "ZC1020", "ZC1036", "ZC1293"}},
+		{`[[ $a = b ]] && seq=$seq_mac`, []string{"ZC1061", "ZC1276"}},
+		{`(( $2 >= 0 )) && timeout=-t$2`, []string{"ZC1167"}},
+	}
+	for _, tc := range cases {
+		for _, kata := range tc.katas {
+			if n := len(testutil.Check(tc.src, kata)); n != 0 {
+				t.Errorf("%s wrongly fired on a command-position assignment: %q (got %d)", kata, tc.src, n)
+			}
+		}
+	}
+}
+
+// TestCommandPositionAssignmentKeepsRealCommands confirms the reshape does
+// not hide real commands: the builtin invoked for real after a logical
+// operator still draws its finding, and an env-prefixed command keeps both
+// the assignment and the command visible.
+func TestCommandPositionAssignmentKeepsRealCommands(t *testing.T) {
+	if n := len(testutil.Check(`x && timeout 5 cmd`, "ZC1167")); n != 1 {
+		t.Errorf("a real `timeout` command after `&&` should still fire ZC1167, got %d", n)
+	}
+	// A genuine array append assignment in command position is now visible.
+	if n := len(testutil.Check(`[[ -z $x ]] && fpath=($fpath $dir)`, "ZC1071")); n != 1 {
+		t.Errorf("a real array append after `&&` should fire ZC1071, got %d", n)
+	}
+}

--- a/pkg/parser/parser_corpus_fixes_test.go
+++ b/pkg/parser/parser_corpus_fixes_test.go
@@ -527,3 +527,52 @@ func TestParseLogicalChainCompoundBodyWalked(t *testing.T) {
 		}
 	}
 }
+
+// A `name=value` in command position (after `&&` / `||`, in a pipeline)
+// is an assignment, not a command. The single-command parser captured it
+// as a bogus command whose name was the variable, so a variable named for
+// a builtin (`timeout=-t$2`, `seq=$x`, `test=$(…)`) was mis-flagged as
+// that command. reshapeCommandAssignment converts the fully-parsed node to
+// an `=` InfixExpression without changing token consumption. The
+// env-prefixed form (`FOO=bar cmd`) and the spaced form (`cd =$x`) stay
+// commands.
+func TestParseCommandPositionAssignment(t *testing.T) {
+	assignment := []string{
+		"foo && cd=$bar\n",
+		"foo || timeout=-t$2\n",
+		"a | b=1\n",
+	}
+	for _, src := range assignment {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Fatalf("unexpected parser errors for %q: %v", src, errs)
+		}
+		n := 0
+		ast.Walk(prog, func(node ast.Node) bool {
+			if ix, ok := node.(*ast.InfixExpression); ok && ix.Operator == "=" {
+				n++
+			}
+			return true
+		})
+		if n != 1 {
+			t.Errorf("command-position assignment %q: want 1 `=` InfixExpression, got %d", src, n)
+		}
+	}
+	// An env-prefixed command and a space-separated form are not standalone
+	// assignments: the following / spaced word is a real command.
+	for _, src := range []string{"foo && FOO=bar cmd\n", "foo && cd =$bar\n"} {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		n := 0
+		ast.Walk(prog, func(node ast.Node) bool {
+			if ix, ok := node.(*ast.InfixExpression); ok && ix.Operator == "=" {
+				n++
+			}
+			return true
+		})
+		if n != 0 {
+			t.Errorf("env-prefix / spaced form %q wrongly reshaped to an assignment (%d)", src, n)
+		}
+	}
+}

--- a/pkg/parser/parser_fuzz_test.go
+++ b/pkg/parser/parser_fuzz_test.go
@@ -20,6 +20,12 @@ func FuzzParser(f *testing.F) {
 		"func() { echo body; }",
 		"time command",
 		"coproc command",
+		// Command-position assignments exercise reshapeCommandAssignment,
+		// including a multi-part RHS and a truncated form whose parts may
+		// be incomplete.
+		"foo && cd=$bar",
+		"a | b=$c/$d",
+		"x && y=$(",
 	}
 
 	for _, tc := range testcases {

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -740,6 +740,14 @@ func reshapeCommandAssignment(cmd *ast.SimpleCommand) ast.Expression {
 	if !ok || len(concat.Parts) < 2 {
 		return cmd
 	}
+	// A malformed (fuzzed) input can leave a nil part in the slice; leave
+	// such a command untouched rather than build an assignment whose RHS
+	// would dereference nil downstream.
+	for _, part := range concat.Parts {
+		if part == nil {
+			return cmd
+		}
+	}
 	// `cmd =$x` with a separating space is a real command and argument, not
 	// an assignment; only a glued `=` continues the command-name word.
 	if cmd.Arguments[0].TokenLiteralNode().HasPrecedingSpace {
@@ -753,8 +761,11 @@ func reshapeCommandAssignment(cmd *ast.SimpleCommand) ast.Expression {
 	if len(concat.Parts) == 2 {
 		rhs = concat.Parts[1]
 	} else {
+		// Reuse the concatenation's own token for position — a part can be
+		// a nil expression on a malformed (fuzzed) input, so never deref
+		// `Parts[1]` for its token.
 		rhs = &ast.ConcatenatedExpression{
-			Token: concat.Parts[1].TokenLiteralNode(),
+			Token: concat.Token,
 			Parts: concat.Parts[1:],
 		}
 	}

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -717,7 +717,53 @@ func (p *Parser) parseSingleCommand() ast.Expression {
 		cmd.Arguments = append(cmd.Arguments, arg)
 	}
 
-	return cmd
+	return reshapeCommandAssignment(cmd)
+}
+
+// reshapeCommandAssignment converts a command-position assignment that the
+// single-command parser captured as a `name` plus a glued `=value` argument
+// (`foo && cd=$bar`, `a | b=1`) into the `=` InfixExpression an assignment
+// kata expects. At statement start `name=value` already parses this way via
+// the Pratt path; only the command-position forms (after `&&`/`||`, in a
+// pipeline) reach the single-command parser and were left as a bogus command
+// whose name was the variable. A lone glued `=value` argument qualifies: a
+// following word (`FOO=bar cmd`) is an env-prefixed command and stays a
+// SimpleCommand. The reshape runs after the command is fully parsed, so it
+// never changes token consumption — the caller's cursor is untouched, which
+// is what makes it safe where an early re-parse desynced the dispatch loop.
+func reshapeCommandAssignment(cmd *ast.SimpleCommand) ast.Expression {
+	name, ok := cmd.Name.(*ast.Identifier)
+	if !ok || len(cmd.Arguments) != 1 {
+		return cmd
+	}
+	concat, ok := cmd.Arguments[0].(*ast.ConcatenatedExpression)
+	if !ok || len(concat.Parts) < 2 {
+		return cmd
+	}
+	// `cmd =$x` with a separating space is a real command and argument, not
+	// an assignment; only a glued `=` continues the command-name word.
+	if cmd.Arguments[0].TokenLiteralNode().HasPrecedingSpace {
+		return cmd
+	}
+	eq, ok := concat.Parts[0].(*ast.StringLiteral)
+	if !ok || eq.String() != "=" {
+		return cmd
+	}
+	var rhs ast.Expression
+	if len(concat.Parts) == 2 {
+		rhs = concat.Parts[1]
+	} else {
+		rhs = &ast.ConcatenatedExpression{
+			Token: concat.Parts[1].TokenLiteralNode(),
+			Parts: concat.Parts[1:],
+		}
+	}
+	return &ast.InfixExpression{
+		Token:    eq.TokenLiteralNode(),
+		Operator: "=",
+		Left:     name,
+		Right:    rhs,
+	}
 }
 
 // commandWordLiteralTokens is the set of token types that appear inside


### PR DESCRIPTION
What: a `name=value` after `&&` / `||` or in a pipeline is now parsed as an assignment, not a command.

Why: the single-command parser captured it as a command whose name was the variable, with `=value` as an argument. A variable named for a builtin was mis-flagged as that builtin -- `[[ cond ]] && test=$(x)` drew the test-command katas, `timeout=-t$2` drew the timeout kata, `seq=$mac` drew the seq katas. Assignment katas also missed these, so a real `fpath=($fpath $dir)` append after `&&` went unreported.

How: `reshapeCommandAssignment` converts the fully-parsed command node into an `=` InfixExpression when it is a lone glued `=value` argument. It runs after the command is parsed, so it never changes token consumption -- the caller's cursor is untouched, which is what makes it safe where an early re-parse desynced the dispatch loop. The env-prefixed form (`FOO=bar cmd`) and the spaced form (`cd =$x`) stay commands.

Corpus effect: 10 false positives removed across 8 lines (variables named test/seq/timeout/GEOMETRY_PROMPT assigned in a logical chain); one real array append now reported. Parser-error sweep stays 402/0; fix-corpus and full suite green.

Tests: `TestParseCommandPositionAssignment` (parser), `TestCommandPositionAssignmentNotMisflagged` and `TestCommandPositionAssignmentKeepsRealCommands` (katas).

Severity: false positives removed, one false negative closed.