### PR TITLE
chore: release v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-06-26
+
+### Fixed
+- Code inside a `&&` / `||` logical-chain compound body (`cmd && { ... }`, `cmd && if ...; fi`, `cmd && for ...; done`, `cmd && case ... esac`) is now linted. It was previously invisible to every kata, so an unquoted `rm -rf $x` or similar inside such a block went unreported; upgrading may surface new findings.
+- A command-position assignment after `&&` / `||` or in a pipeline (`[[ cond ]] && var=value`) parses as an assignment, so a variable named for a builtin (`test=`, `seq=`, `timeout=`) is no longer mis-flagged as that command.
+- A quoted segment glued to an assignment value (`x='b'cd`) is absorbed into the assignment instead of being orphaned into a spurious `cd`-failure warning.
+- ZC1075 no longer flags flag-led expansions (`${(q)x}`), bare expansions of known arrays, width-padded expansions, `typeset` arrays, or a `$var` glued to a command-name prefix.
+- ZC1043, ZC1049, ZC1097, and ZC1098 no longer report false positives (local/global tracking, positional names, alias definitions, and the `eval "$@"` dispatch idiom).
+- ZC1044 no longer flags a `cd=` variable assignment as a `cd` command.
+- ZC1188 gives direction-aware `PATH` advice; ZC1104 is retired as a duplicate of ZC1188.
+- Auto-fixes no longer emit broken code; a corpus round-trip gate and per-kata golden tests guard every fixable kata.
+- The `-no-color` TTY note, the SARIF parse-error FAQ, exit code 2, and the integration-sweep scope are documented accurately.
+
 ## [1.7.0] - 2026-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.7.0-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.7.1-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-132%20katas-2ea44f)](KATAS.md)
 [![Dependencies](https://img.shields.io/badge/dependencies-0-2ea44f)](go.mod)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.7.0"
+const Version = "1.7.1"


### PR DESCRIPTION
Patch release `v1.7.1`. No new features (20 commits since v1.7.0: 13 fix, 2 ci, 2 docs, 2 test, 1 chore).

Bumps:
- `pkg/version/version.go` → 1.7.1
- README release badge → v1.7.1
- CHANGELOG `[1.7.1] - 2026-06-26` entry

Covers parser-correctness fixes (lint inside logical-chain compound bodies, command-position assignments, glued quote tails), kata false-positive removals (ZC1043/1044/1049/1075/1097/1098/1188; ZC1104 retired as a duplicate), the autofix-safety corpus gate, and the CLI/integration doc accuracy corrections.

The signed `v1.7.1` tag is cut on the squash-merge commit after this merges.