### PR TITLE
fix: recognize help flag (-h, --help) in argument parsing

### DIFF
--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -27,6 +27,7 @@ func main() {
 }
 
 type runFlags struct {
+	help           *bool
 	format         *string
 	cpuprofile     *string
 	showVersion    *bool
@@ -55,6 +56,10 @@ func run() int {
 	}
 	flag.Parse()
 
+	if *flags.help || wantsHelp(os.Args[1:]) {
+		printUsage(os.Stdout, flag.CommandLine, !*flags.noBanner)
+		return 0
+	}
 	if *flags.showVersion {
 		fmt.Printf("zshellcheck version %s\n", version.Version)
 		return 0
@@ -192,7 +197,10 @@ func setupBaseline(fixOpts *fixOptions, baseline, baselineWrite string) int {
 }
 
 func registerRunFlags() runFlags {
+	help := flag.Bool("help", false, "Print this help screen and exit (alias: -h).")
+	flag.BoolVar(help, "h", false, "Print this help screen and exit (alias for -help).")
 	return runFlags{
+		help:           help,
 		format:         flag.String("format", "text", "Output format. One of text, json, sarif."),
 		cpuprofile:     flag.String("cpuprofile", "", "Write a Go pprof CPU profile to this path."),
 		showVersion:    flag.Bool("version", false, "Print the version and exit."),
@@ -234,6 +242,22 @@ func startCPUProfile(path string) (func(), int) {
 		pprof.StopCPUProfile()
 		_ = f.Close()
 	}, 0
+}
+
+// wantsHelp reports whether argv holds an explicit help request before a
+// `--` terminator. flag.Parse stops at the first positional argument, so
+// `zshellcheck script.zsh --help` never reaches the registered -help
+// flag; this scan catches it. Anything after `--` stays a literal path.
+func wantsHelp(args []string) bool {
+	for _, a := range args {
+		switch a {
+		case "--":
+			return false
+		case "-h", "--h", "-help", "--help":
+			return true
+		}
+	}
+	return false
 }
 
 func printRunUsage(noBanner bool) {

--- a/cmd/zshellcheck/main_test.go
+++ b/cmd/zshellcheck/main_test.go
@@ -1028,15 +1028,155 @@ func TestRun_NoColorWithBanner(t *testing.T) {
 	_ = code
 }
 
+// captureStdout redirects os.Stdout to a pipe around fn and returns what
+// it wrote. Reads concurrently so output can't fill the pipe and block fn.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	done := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	os.Stdout = old
+	_ = w.Close()
+	return <-done
+}
+
 func TestRun_HelpFlag(t *testing.T) {
 	resetFlags()
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()
 	os.Args = []string{"zshellcheck", "-help"}
 
-	// -help triggers flag.Usage which prints usage to stderr
-	code := run()
-	_ = code
+	var code int
+	out := captureStdout(t, func() { code = run() })
+	if code != 0 {
+		t.Errorf("expected exit code 0 for -help, got %d", code)
+	}
+	if !strings.Contains(out, "USAGE") {
+		t.Error("help output missing USAGE section")
+	}
+	if !strings.Contains(out, "-format") {
+		t.Error("help output missing -format flag")
+	}
+	if !strings.Contains(out, "quiet linter") {
+		t.Error("help output missing banner tagline")
+	}
+}
+
+func TestRun_HelpShortAlias(t *testing.T) {
+	resetFlags()
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"zshellcheck", "-h"}
+
+	var code int
+	out := captureStdout(t, func() { code = run() })
+	if code != 0 {
+		t.Errorf("expected exit code 0 for -h, got %d", code)
+	}
+	if !strings.Contains(out, "USAGE") {
+		t.Error("help output missing USAGE section")
+	}
+}
+
+func TestRun_HelpDoubleDash(t *testing.T) {
+	resetFlags()
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"zshellcheck", "--help"}
+
+	var code int
+	out := captureStdout(t, func() { code = run() })
+	if code != 0 {
+		t.Errorf("expected exit code 0 for --help, got %d", code)
+	}
+	if !strings.Contains(out, "USAGE") {
+		t.Error("help output missing USAGE section")
+	}
+}
+
+func TestRun_HelpAfterPositional(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.zsh")
+	if err := os.WriteFile(path, []byte("#!/bin/zsh\necho hello\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	resetFlags()
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"zshellcheck", path, "--help"}
+
+	var code int
+	out := captureStdout(t, func() { code = run() })
+	if code != 0 {
+		t.Errorf("expected exit code 0 for trailing --help, got %d", code)
+	}
+	if !strings.Contains(out, "USAGE") {
+		t.Error("help output missing USAGE section")
+	}
+}
+
+func TestRun_HelpRespectsNoBanner(t *testing.T) {
+	resetFlags()
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"zshellcheck", "-no-banner", "-help"}
+
+	var code int
+	out := captureStdout(t, func() { code = run() })
+	if code != 0 {
+		t.Errorf("expected exit code 0 for -no-banner -help, got %d", code)
+	}
+	if !strings.Contains(out, "USAGE") {
+		t.Error("help output missing USAGE section")
+	}
+	if strings.Contains(out, "quiet linter") {
+		t.Error("help output shows banner despite -no-banner")
+	}
+}
+
+func TestRun_DoubleDashTerminatorNotHelp(t *testing.T) {
+	resetFlags()
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"zshellcheck", "--", "--help"}
+
+	out := captureStdout(t, func() { _ = run() })
+	if strings.Contains(out, "USAGE") {
+		t.Error("--help after -- terminator must stay a literal path, not trigger help")
+	}
+}
+
+func TestWantsHelp(t *testing.T) {
+	cases := []struct {
+		args []string
+		want bool
+	}{
+		{nil, false},
+		{[]string{"-h"}, true},
+		{[]string{"--h"}, true},
+		{[]string{"-help"}, true},
+		{[]string{"--help"}, true},
+		{[]string{"a.zsh", "--help"}, true},
+		{[]string{"-no-banner", "a.zsh", "-h"}, true},
+		{[]string{"--", "--help"}, false},
+		{[]string{"a.zsh"}, false},
+	}
+	for _, tc := range cases {
+		if got := wantsHelp(tc.args); got != tc.want {
+			t.Errorf("wantsHelp(%v) = %v, want %v", tc.args, got, tc.want)
+		}
+	}
 }
 
 func TestRun_CPUProfileError(t *testing.T) {

--- a/cmd/zshellcheck/usage.go
+++ b/cmd/zshellcheck/usage.go
@@ -57,7 +57,7 @@ func printUsage(out io.Writer, fset *flag.FlagSet, showBanner bool) {
 		},
 		{
 			title: "DIAGNOSTICS",
-			names: []string{"list-rules", "explain", "cpuprofile", "version"},
+			names: []string{"list-rules", "explain", "cpuprofile", "version", "help"},
 			blurb: "Profile, inspect, or print metadata.",
 		},
 	}

--- a/cmd/zshellcheck/usage_test.go
+++ b/cmd/zshellcheck/usage_test.go
@@ -82,6 +82,22 @@ func TestPrintUsageContainsCoreSections(t *testing.T) {
 	}
 }
 
+func TestPrintUsageListsHelpFlag(t *testing.T) {
+	fs := flag.NewFlagSet("zshellcheck", flag.ContinueOnError)
+	fs.Bool("help", false, "Print this help screen and exit (alias: -h).")
+
+	var buf bytes.Buffer
+	printUsage(&buf, fs, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "-help") {
+		t.Error("printUsage missing -help flag")
+	}
+	if !strings.Contains(out, "alias: -h") {
+		t.Error("printUsage missing -h alias mention")
+	}
+}
+
 func TestRenderFlag(t *testing.T) {
 	fs := flag.NewFlagSet("t", flag.ContinueOnError)
 	fs.String("config", "default.yml", "Path to the config file")

--- a/man/man1/zshellcheck.1
+++ b/man/man1/zshellcheck.1
@@ -41,7 +41,7 @@ Emit additional diagnostic output alongside the results.
 .BR \-version
 Print the ZShellCheck version and exit.
 .TP
-.BR \-help
+.BR \-h ", " \-help
 Display help message and exit.
 
 .SH CONFIGURATION


### PR DESCRIPTION
## Description

This covers: added wantsHelp() func to catch help requests before -- terminator (since flag.Parse() stops at first positional), registered -h and --help flags, added comprehensive tests, updated usage docs and man page.

## Type of change

- [ ] `feat`: new feature or enhancement
- [X] `fix`: bug fix
- [ ] `docs`: documentation
- [ ] `ci`: CI/CD
- [ ] `deps`: dependency bump
- [ ] `refactor`: restructuring without behavior change
- [ ] `perf`: performance
- [ ] `test`: test additions or fixes
- [ ] `chore`: maintenance

## Checklist

- [X] Read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [X] `go test -count=1 ./...` passes locally.
- [X] `golangci-lint run ./...` clean.
- [X] Relevant documentation updated (`README.md`, `docs/USER_GUIDE.md`, `docs/DEVELOPER.md`, `CHANGELOG.md`).
- [X] Commits are GPG-signed.

## For new katas

- [ ] Detection file at `pkg/katas/zc<NNNN>.go` (self-registers via `init()` — no central file edit needed).
- [ ] Test file at `pkg/katas/katatests/zc<NNNN>_test.go` with both a violation case and a no-violation case.
- [ ] `Severity` set on the `Kata{…}` literal (`SeverityError` / `Warning` / `Info` / `Style`).
- [ ] Pattern is **Zsh-specific** — generic POSIX-sh anti-patterns belong in ShellCheck.
- [ ] Grepped existing katas for overlap: `grep -rn 'Title:' pkg/katas/ | grep -i '<keyword>'`.
- [ ] `Check` function uses `ok`-checked type assertions; never calls `panic()`.
