### PR TITLE
ci: correct stale checkout pin comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout repository under test
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4.1.7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Install ZShellCheck
       shell: bash


### PR DESCRIPTION
The composite `action.yml` pins `actions/checkout` at the v7.0.1 commit (`3d3c42e5`), but the version comment still read `v4.1.7` — left behind by successive dependabot SHA bumps that update the pin without touching the comment. Verified via `git ls-remote --tags`: the SHA resolves to `v7.0.1`.

Comment-only change; the executed SHA is unchanged. Every other pin in the tree (30 checked, workflows plus the composite action) matches its comment.