### PR TITLE
chore: bump Go toolchain to 1.27.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25.9'
+          go-version: '1.27.0'
           check-latest: true
       - name: Install Syft (for SBOM generation)
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/afadesigns/zshellcheck
 
-go 1.25.9
+go 1.27.0


### PR DESCRIPTION
Moves the `go.mod` directive and the `release.yml` `setup-go` pin from `1.25.9` to `1.27.0`, the latest stable Go release. The other workflows use `go-version: stable` and already resolve the same toolchain.

Verified locally under 1.27.0: full test suite green, `golangci-lint` 2.13.1 (built with go1.27.0) reports 0 issues, `gocyclo` clean, parser-corpus sweep 402/0, violation-corpus sweep zero drift, fix-corpus sweep 0 corruptions / 0 non-idempotent / 0 panics.

Zero dependencies in `go.mod`, so this is a pure toolchain move; the release build stays reproducible against the pinned version.