### PR TITLE
fix: emit valid URIs in SARIF artifact locations

### DIFF
--- a/pkg/reporter/aggregate.go
+++ b/pkg/reporter/aggregate.go
@@ -215,9 +215,11 @@ func buildSarifRule(v katas.Violation, meta func(string) RuleMeta) sarifRule {
 // which broke consumers that parse the field strictly.
 func sarifFileURI(path string) string {
 	s := filepath.ToSlash(path)
-	if filepath.IsAbs(path) {
-		// A Windows drive path (C:/dir) needs a leading slash to form the
-		// file:///C:/dir shape; POSIX absolute paths already have one.
+	// A slash-rooted path is treated as absolute on every platform, so the
+	// same input renders identically on Windows, where filepath.IsAbs
+	// rejects a rooted path without a drive letter. A Windows drive path
+	// (C:/dir) gains the leading slash the file:///C:/dir shape needs.
+	if filepath.IsAbs(path) || strings.HasPrefix(s, "/") {
 		if !strings.HasPrefix(s, "/") {
 			s = "/" + s
 		}

--- a/pkg/reporter/aggregate.go
+++ b/pkg/reporter/aggregate.go
@@ -5,6 +5,9 @@ package reporter
 import (
 	"encoding/json"
 	"io"
+	"net/url"
+	"path/filepath"
+	"strings"
 
 	"github.com/afadesigns/zshellcheck/pkg/katas"
 )
@@ -149,7 +152,7 @@ func ReportSARIF(w io.Writer, files []FileViolations, toolVersion string, meta f
 				Message:   sarifMessage{Text: v.Message},
 				Locations: []sarifLocation{{
 					PhysicalLocation: sarifPhysical{
-						ArtifactLocation: sarifArtifact{URI: f.Filename},
+						ArtifactLocation: sarifArtifact{URI: sarifFileURI(f.Filename)},
 						Region: sarifRegion{
 							StartLine:   atLeastOne(v.Line),
 							StartColumn: atLeastOne(v.Column),
@@ -200,6 +203,35 @@ func buildSarifRule(v katas.Violation, meta func(string) RuleMeta) sarifRule {
 	}
 	rule.HelpURI = m.HelpURI
 	return rule
+}
+
+// sarifFileURI renders a scanned path as a SARIF artifactLocation URI.
+// An absolute path becomes a file:// URI; a relative path stays a relative
+// URI reference with forward slashes and percent-encoded segments, which
+// SARIF consumers resolve against their own base — GitHub code scanning
+// requires the relative form to map results onto repository files. A first
+// segment containing a colon gains a "./" prefix so it cannot be misread
+// as a URI scheme. Raw filesystem paths are not URIs (SARIF 2.1.0 3.4.3),
+// which broke consumers that parse the field strictly.
+func sarifFileURI(path string) string {
+	s := filepath.ToSlash(path)
+	if filepath.IsAbs(path) {
+		// A Windows drive path (C:/dir) needs a leading slash to form the
+		// file:///C:/dir shape; POSIX absolute paths already have one.
+		if !strings.HasPrefix(s, "/") {
+			s = "/" + s
+		}
+		return (&url.URL{Scheme: "file", Path: s}).String()
+	}
+	esc := (&url.URL{Path: s}).EscapedPath()
+	seg := esc
+	if i := strings.IndexByte(esc, '/'); i >= 0 {
+		seg = esc[:i]
+	}
+	if strings.Contains(seg, ":") {
+		esc = "./" + esc
+	}
+	return esc
 }
 
 // sarifLevel maps a kata severity onto a SARIF result level. SARIF has no

--- a/pkg/reporter/aggregate_test.go
+++ b/pkg/reporter/aggregate_test.go
@@ -179,3 +179,46 @@ func TestReportSARIF_WriterError(t *testing.T) {
 		t.Error("expected error from failing writer")
 	}
 }
+
+// A SARIF artifactLocation uri must be a valid URI, not a raw filesystem
+// path: an absolute path gains the file:// scheme, a relative path stays a
+// relative URI reference with percent-encoded segments, and a first segment
+// containing a colon is prefixed so it cannot parse as a URI scheme.
+func TestSarifFileURI(t *testing.T) {
+	cases := map[string]string{
+		"a.zsh":              "a.zsh",
+		"dir/sub/b.zsh":      "dir/sub/b.zsh",
+		"my file.zsh":        "my%20file.zsh",
+		"/path/to/test.zsh":  "file:///path/to/test.zsh",
+		"/tmp/with space.sh": "file:///tmp/with%20space.sh",
+		"odd:name.zsh":       "./odd:name.zsh",
+		"dir/odd:name.zsh":   "dir/odd:name.zsh",
+	}
+	for in, want := range cases {
+		if got := sarifFileURI(in); got != want {
+			t.Errorf("sarifFileURI(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// An absolute scanned path round-trips through ReportSARIF as a file:// URI
+// (issue #1435: consumers that parse the field strictly rejected the raw
+// path form).
+func TestReportSARIF_AbsolutePathURI(t *testing.T) {
+	files := []FileViolations{{Filename: "/path/to/test.zsh", Violations: []katas.Violation{
+		{KataID: "ZC1037", Message: "m", Line: 1, Column: 1, Level: katas.SeverityStyle},
+	}}}
+	var buf bytes.Buffer
+	if err := ReportSARIF(&buf, files, "1.0.0", nil); err != nil {
+		t.Fatalf("ReportSARIF error: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("invalid SARIF: %v", err)
+	}
+	run := doc["runs"].([]any)[0].(map[string]any)
+	loc := run["results"].([]any)[0].(map[string]any)["locations"].([]any)[0].(map[string]any)["physicalLocation"].(map[string]any)
+	if got := loc["artifactLocation"].(map[string]any)["uri"]; got != "file:///path/to/test.zsh" {
+		t.Errorf("want file:///path/to/test.zsh, got %v", got)
+	}
+}


### PR DESCRIPTION
Closes #1435.

What: `artifactLocation.uri` in SARIF output carried the raw filesystem path. An absolute path (`/path/to/test.zsh`) is not a valid URI, and strict consumers rejected it.

How: absolute paths become `file://` URIs with percent-encoded segments (`file:///path/to/test.zsh`). Relative paths stay relative URI references with forward slashes — the form GitHub code scanning requires to map results onto repository files — and a first segment containing a colon gains a `./` prefix so it cannot be misread as a URI scheme. Windows drive paths form `file:///C:/dir/file.zsh`.

Tests: `TestSarifFileURI` covers relative, absolute, space-encoding, and colon-segment cases; `TestReportSARIF_AbsolutePathURI` pins the issue repro end to end. Existing relative-path expectations are unchanged.

Severity: Warning (spec conformance).