### PR TITLE
ci: bump govulncheck to v1.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
           go-version: 'stable'
           cache: true
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
       - name: Scan for vulnerabilities
         run: govulncheck ./...
 


### PR DESCRIPTION
The vulnerability scan pins `govulncheck@v1.1.4`, whose vendored `x/tools` v0.29.0 SSA builder panics with `unexpected expr: *ast.KeyValueExpr` under Go 1.27.0 — which `setup-go`'s `go-version: stable` now resolves. The scan job crashes with exit 2 on every run, failing the required `security` check (seen on #1440 and #1441).

Bumps the pin to `v1.7.0`, the latest `x/vuln` release (verified via `git ls-remote --tags`), which carries a current `x/tools`. This PR's own scan run exercises the new pin under the same resolved toolchain.