### PR TITLE
chore: release v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.2] - 2026-08-24
+
+### Fixed
+- A SARIF `artifactLocation.uri` now carries a valid URI instead of a raw filesystem path: an absolute or slash-rooted path becomes a `file://` URI with percent-encoded segments, a relative path stays a relative URI reference, and a first segment containing a colon gains a `./` prefix so it cannot be misread as a URI scheme.
+
+### Changed
+- Release builds use Go 1.27.0.
+
 ## [1.7.1] - 2026-06-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.7.1-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.7.2-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-132%20katas-2ea44f)](KATAS.md)
 [![Dependencies](https://img.shields.io/badge/dependencies-0-2ea44f)](go.mod)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.7.1"
+const Version = "1.7.2"


### PR DESCRIPTION
Patch release `v1.7.2`. No new features — 5 commits since v1.7.1 (1 fix, 2 ci, 2 chore).

Bumps:
- `pkg/version/version.go` to 1.7.2
- README release badge to v1.7.2
- CHANGELOG `[1.7.2] - 2026-08-24` entry

Covers the SARIF artifact-location URI fix (#1442, closes the #1435 report) and the move of release builds to Go 1.27.0 (#1441). CI-internal changes (action pin bumps, govulncheck 1.7.0, pin-comment correction) ship alongside without changelog entries.

The signed `v1.7.2` tag is cut on the squash-merge commit after this merges.