### PR TITLE
fix: parse command-position parens as a subshell

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -1202,7 +1202,7 @@ zinit/zinit-autoload.zsh	ZC1049	1
 zinit/zinit-autoload.zsh	ZC1053	1
 zinit/zinit-autoload.zsh	ZC1064	1
 zinit/zinit-autoload.zsh	ZC1073	3
-zinit/zinit-autoload.zsh	ZC1075	41
+zinit/zinit-autoload.zsh	ZC1075	42
 zinit/zinit-autoload.zsh	ZC1083	2
 zinit/zinit-autoload.zsh	ZC1091	33
 zinit/zinit-autoload.zsh	ZC1098	3

--- a/pkg/parser/parser_corpus_fixes_test.go
+++ b/pkg/parser/parser_corpus_fixes_test.go
@@ -576,3 +576,95 @@ func TestParseCommandPositionAssignment(t *testing.T) {
 		}
 	}
 }
+
+// A `( … )` group in command position — a pipeline stage, or the
+// right-hand side of a `&&` / `||` chain — is a subshell running a command
+// list, not an array literal. The group previously reached the array
+// parser, which flattened the body into a word list and hid it from every
+// kata that walks commands (`cmd || ( cd $d && eval "$x" )` reported
+// nothing from inside the parens). An array literal is only ever the
+// right-hand side of an assignment word, which takes the expression path
+// and is unaffected.
+func TestParseCommandPositionSubshell(t *testing.T) {
+	subshell := []string{
+		"mycmd && ( rm -rf $x )\n",
+		"test -z \"$g\" || ( cd $d && eval \"echo $g\" )\n",
+		"[[ -d $d ]] && ( rm -rf $x )\n",
+		"(( n > 0 )) && ( rm -rf $x )\n",
+		"echo a | ( rm -rf $x )\n",
+		"echo a | ( rm -rf $x ) 2>/dev/null\n",
+	}
+	for _, src := range subshell {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Fatalf("unexpected parser errors for %q: %v", src, errs)
+		}
+		var sub, arr int
+		ast.Walk(prog, func(node ast.Node) bool {
+			switch node.(type) {
+			case *ast.Subshell:
+				sub++
+			case *ast.ArrayLiteral:
+				arr++
+			}
+			return true
+		})
+		if sub == 0 {
+			t.Errorf("command-position group %q: want a Subshell node, got none", src)
+		}
+		if arr != 0 {
+			t.Errorf("command-position group %q: want no ArrayLiteral, got %d", src, arr)
+		}
+	}
+
+	// An assignment right-hand side reaches the grouped-expression parser
+	// through the expression path and still builds an array literal.
+	// `typeset` / `declare` take the declaration path instead, which has
+	// never produced an ArrayLiteral node, so they are covered by the
+	// clean-parse group below rather than here.
+	unchanged := map[string]bool{ // src -> expect an ArrayLiteral
+		"arr=(a b c)\n":          true,
+		"arr+=(x)\n":             true,
+		"local -a v=( 1 2 3 )\n": true,
+	}
+	for src, wantArray := range unchanged {
+		p := New(lexer.New(src))
+		prog := p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Fatalf("unexpected parser errors for %q: %v", src, errs)
+		}
+		var arr int
+		ast.Walk(prog, func(node ast.Node) bool {
+			if _, ok := node.(*ast.ArrayLiteral); ok {
+				arr++
+			}
+			return true
+		})
+		if wantArray && arr == 0 {
+			t.Errorf("assignment RHS %q: want an ArrayLiteral, got none", src)
+		}
+	}
+
+	// Forms that must keep parsing cleanly: the anonymous-function body,
+	// arithmetic, paren word lists, a case pattern's leading paren, and a
+	// glob alternation inside `[[ … ]]`.
+	for _, src := range []string{
+		"mycmd && () { print hi }\n",
+		"mycmd && (( i++ ))\n",
+		"for x (a b c) print -n $x\n",
+		"repeat 2 (print R)\n",
+		"case $x in (a|b) echo hi ;; esac\n",
+		"[[ $x == (wip|WIP) ]]\n",
+		"f() ( print body )\n",
+		"time ( sleep 1 )\n",
+		"typeset -a w=( \"$@\" )\n",
+		"declare -a d=( a b )\n",
+	} {
+		p := New(lexer.New(src))
+		_ = p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("unexpected parser errors for %q: %v", src, errs)
+		}
+	}
+}

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -131,7 +131,26 @@ func (p *Parser) parsePipelineHead() (ast.Expression, bool) {
 	case token.WHILE:
 		return p.parseWhileLoopStatement(), false
 	case token.LPAREN:
-		return p.parseGroupedExpression(), false
+		// A `( … )` in command position — a pipeline stage, or the
+		// right-hand side of a `&&` / `||` chain — is a subshell running a
+		// command list. An array literal is only ever the right-hand side
+		// of an assignment word (`name=(…)`, `name+=(…)`), which reaches
+		// the grouped-expression parser through the expression path
+		// instead, so it is unaffected here. Routing command position to
+		// the array parser left the body as a flat word list, hiding it
+		// from every kata that walks commands. parseSubshellStatement also
+		// recognises the anonymous-function form `() { … }`, and both
+		// parsers leave the cursor on `)` with consumedParenTerminator set,
+		// so the caller's terminator handling is unchanged.
+		//
+		// Inside `[[ … ]]` the group is a glob alternation (`[[ $x = (a|b) ]]`),
+		// not a command list, so that context keeps the grouped-expression path.
+		if p.inDoubleBracket {
+			return p.parseGroupedExpression(), false
+		}
+		left := keywordStmtToExpression(p.parseSubshellStatement())
+		p.drainFDPrefixedRedirections()
+		return left, false
 	case token.LBRACE:
 		// Brace-group: `{ cmd1; cmd2 } 2>&1` appears inside `$(…)`
 		// and as a pipeline head. Parse as a brace block so the

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -143,11 +143,10 @@ func (p *Parser) parsePipelineHead() (ast.Expression, bool) {
 		// parsers leave the cursor on `)` with consumedParenTerminator set,
 		// so the caller's terminator handling is unchanged.
 		//
-		// Inside `[[ … ]]` the group is a glob alternation (`[[ $x = (a|b) ]]`),
-		// not a command list, so that context keeps the grouped-expression path.
-		if p.inDoubleBracket {
-			return p.parseGroupedExpression(), false
-		}
+		// A glob alternation inside `[[ … ]]` (`[[ $x = (a|b) ]]`) never
+		// reaches here: the conditional parser evaluates its operands
+		// through the expression path, which keeps routing `(` to the
+		// grouped-expression parser.
 		left := keywordStmtToExpression(p.parseSubshellStatement())
 		p.drainFDPrefixedRedirections()
 		return left, false


### PR DESCRIPTION
## What

A `( … )` group in command position — a pipeline stage, or the right-hand side of a `&&` / `||` chain — was parsed as an **array literal**, flattening the body into a word list. Every kata that walks commands was blind to it:

```
|| ( cd $d && eval "echo $g")   -> ZC1006,1020,1036,1293
|| { cd $d && eval "echo $g"; } -> ZC1006,1020,1036,1293,1044,1046,1098
```

Same body, one variable (`(` vs `{`): the paren form silently loses ZC1044 (unguarded `cd`), ZC1046 (`eval`), ZC1098.

## Why this shape

In Zsh an array literal is only ever the right-hand side of an assignment word (`name=(…)`, `name+=(…)`) with no intervening space — `man zshparam`, Array Parameters; `arr= (echo hi)` is a parse error. A `(` reached in command position is a subshell (`man zshmisc`, COMPLEX COMMANDS). Every mature shell parser encodes this the same way, making the array the special case: bash sets `PST_COMPASSIGN` only after an assignment word (`parse.y`), zsh emits a distinct `ENVARRAY` token gated on `incmdpos` (`Src/lex.c`), `mvdan/sh` guards `ArrayExpr` behind `getAssign`, tree-sitter-bash reaches `array` only as a `variable_assignment` value, and shellcheck's `readArray` sits inside `readAssignmentWordExt`.

The fix follows that rule: the pipeline head is command position by construction, so it dispatches to the subshell parser. The assignment path is untouched — it reaches the grouped-expression parser through the expression path. Inside `[[ … ]]` the group is a glob alternation and keeps the previous path.

## Blast radius

`parseSubshellStatement` already recognises the anonymous-function form `() { … }`, and both parsers leave the cursor on `)` with `consumedParenTerminator` set, so terminator handling is unchanged. Verified byte-identical output against the previous build for: anonymous functions, `(( … ))` arithmetic, `arr=(…)`/`arr+=(…)`/`local -a`/`typeset -a`, `for x (a b c)`, `foreach`, `repeat 2 (…)`, a case pattern's leading paren `(a|b)`, `[[ … && ( … ) ]]` grouping, `[[ $x == (wip|WIP) ]]` glob alternation, paren-bodied functions `f() ( … )`, `time ( … )`, process substitution, and glob qualifiers.

Known remaining gap, deliberately not chased: a **literal** `true`/`false` left-hand side (`true && ( … )`) still takes the expression path. Zero corpus sites use that form, and closing it would mean touching the shared expression-prefix parser that the assignment path also uses.

## Gates

- Corpus drift: **1 finding added, 0 lost** — `zinit/zinit-autoload.zsh:3200`, an unquoted `$local_dir` inside `[[ -d $local_dir/.git ]] && ( builtin cd -q $local_dir ; … )`. True positive: an empty value sends `cd` to `$HOME`.
- Parser-corpus sweep 402 files / 0 errors; fix-corpus sweep 0 corruptions, 0 non-idempotent, 0 panics.
- Full suite green, `golangci-lint` 0 issues, `gocyclo` clean.

Tests: `TestParseCommandPositionSubshell` pins the subshell shape for six command-position forms, the array shape for assignment right-hand sides, and a clean parse for the eight look-alike constructs above.

Severity: Warning (false negatives closed).