### PR TITLE
fix: align ZC1044 scope with where a failed cd can do harm

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -83,7 +83,6 @@ atuin/crates/atuin/src/shell/atuin.zsh	ZC1353	1
 atuin/crates/atuin/src/shell/atuin.zsh	ZC1509	1
 autojump/bin/autojump.zsh	ZC1010	1
 autojump/bin/autojump.zsh	ZC1037	9
-autojump/bin/autojump.zsh	ZC1044	1
 autojump/bin/autojump.zsh	ZC1045	2
 autojump/bin/autojump.zsh	ZC1075	8
 autojump/bin/autojump.zsh	ZC1120	2
@@ -368,7 +367,6 @@ prezto-contrib/dotnet-completion/init.zsh	ZC1043	1
 prezto-contrib/elapsed-time/init.zsh	ZC1086	2
 prezto-contrib/elapsed-time/init.zsh	ZC1517	3
 prezto-contrib/elixir/alias.zsh	ZC1043	1
-prezto-contrib/elixir/alias.zsh	ZC1044	1
 prezto-contrib/elixir/alias.zsh	ZC1049	30
 prezto-contrib/kind/init.zsh	ZC1049	5
 prezto-contrib/kubernetes/init.zsh	ZC1049	16
@@ -678,7 +676,6 @@ spaceship/spaceship.zsh	ZC1043	1
 spaceship/spaceship.zsh	ZC1517	1
 spaceship/tests/ansible.test.zsh	ZC1037	1
 spaceship/tests/ansible.test.zsh	ZC1043	13
-spaceship/tests/ansible.test.zsh	ZC1044	1
 spaceship/tests/ansible.test.zsh	ZC1045	4
 spaceship/tests/ansible.test.zsh	ZC1051	3
 spaceship/tests/ansible.test.zsh	ZC1075	8
@@ -687,14 +684,12 @@ spaceship/tests/ansible.test.zsh	ZC1128	3
 spaceship/tests/ansible.test.zsh	ZC1188	1
 spaceship/tests/ansible.test.zsh	ZC1602	1
 spaceship/tests/azure.test.zsh	ZC1043	4
-spaceship/tests/azure.test.zsh	ZC1044	1
 spaceship/tests/azure.test.zsh	ZC1045	2
 spaceship/tests/azure.test.zsh	ZC1049	1
 spaceship/tests/azure.test.zsh	ZC1075	1
 spaceship/tests/azure.test.zsh	ZC1188	1
 spaceship/tests/azure.test.zsh	ZC1602	1
 spaceship/tests/bun.test.zsh	ZC1043	9
-spaceship/tests/bun.test.zsh	ZC1044	1
 spaceship/tests/bun.test.zsh	ZC1045	3
 spaceship/tests/bun.test.zsh	ZC1075	1
 spaceship/tests/bun.test.zsh	ZC1128	2
@@ -706,14 +701,12 @@ spaceship/tests/char.test.zsh	ZC1043	19
 spaceship/tests/char.test.zsh	ZC1045	4
 spaceship/tests/char.test.zsh	ZC1602	1
 spaceship/tests/crystal.test.zsh	ZC1043	10
-spaceship/tests/crystal.test.zsh	ZC1044	1
 spaceship/tests/crystal.test.zsh	ZC1045	3
 spaceship/tests/crystal.test.zsh	ZC1075	1
 spaceship/tests/crystal.test.zsh	ZC1128	2
 spaceship/tests/crystal.test.zsh	ZC1188	1
 spaceship/tests/crystal.test.zsh	ZC1602	1
 spaceship/tests/dart.test.zsh	ZC1043	15
-spaceship/tests/dart.test.zsh	ZC1044	1
 spaceship/tests/dart.test.zsh	ZC1045	6
 spaceship/tests/dart.test.zsh	ZC1049	2
 spaceship/tests/dart.test.zsh	ZC1051	5
@@ -724,7 +717,6 @@ spaceship/tests/dart.test.zsh	ZC1136	1
 spaceship/tests/dart.test.zsh	ZC1188	1
 spaceship/tests/dart.test.zsh	ZC1602	1
 spaceship/tests/deno.test.zsh	ZC1043	12
-spaceship/tests/deno.test.zsh	ZC1044	1
 spaceship/tests/deno.test.zsh	ZC1045	3
 spaceship/tests/deno.test.zsh	ZC1051	2
 spaceship/tests/deno.test.zsh	ZC1075	5
@@ -738,7 +730,6 @@ spaceship/tests/dir.test.zsh	ZC1045	8
 spaceship/tests/dir.test.zsh	ZC1075	6
 spaceship/tests/dir.test.zsh	ZC1602	1
 spaceship/tests/docker_compose.test.zsh	ZC1043	11
-spaceship/tests/docker_compose.test.zsh	ZC1044	1
 spaceship/tests/docker_compose.test.zsh	ZC1045	2
 spaceship/tests/docker_compose.test.zsh	ZC1051	1
 spaceship/tests/docker_compose.test.zsh	ZC1075	3
@@ -754,7 +745,6 @@ spaceship/tests/elm.test.zsh	ZC1128	3
 spaceship/tests/elm.test.zsh	ZC1188	1
 spaceship/tests/elm.test.zsh	ZC1602	1
 spaceship/tests/erlang.test.zsh	ZC1043	6
-spaceship/tests/erlang.test.zsh	ZC1044	1
 spaceship/tests/erlang.test.zsh	ZC1045	2
 spaceship/tests/erlang.test.zsh	ZC1051	1
 spaceship/tests/erlang.test.zsh	ZC1075	3
@@ -765,7 +755,6 @@ spaceship/tests/erlang.test.zsh	ZC1602	1
 spaceship/tests/extract.test.zsh	ZC1043	17
 spaceship/tests/extract.test.zsh	ZC1602	1
 spaceship/tests/gleam.test.zsh	ZC1043	12
-spaceship/tests/gleam.test.zsh	ZC1044	1
 spaceship/tests/gleam.test.zsh	ZC1045	3
 spaceship/tests/gleam.test.zsh	ZC1051	2
 spaceship/tests/gleam.test.zsh	ZC1075	5
@@ -774,13 +763,11 @@ spaceship/tests/gleam.test.zsh	ZC1128	2
 spaceship/tests/gleam.test.zsh	ZC1188	1
 spaceship/tests/gleam.test.zsh	ZC1602	1
 spaceship/tests/gnu_screen.test.zsh	ZC1043	9
-spaceship/tests/gnu_screen.test.zsh	ZC1044	1
 spaceship/tests/gnu_screen.test.zsh	ZC1045	2
 spaceship/tests/gnu_screen.test.zsh	ZC1075	1
 spaceship/tests/gnu_screen.test.zsh	ZC1188	1
 spaceship/tests/gnu_screen.test.zsh	ZC1602	1
 spaceship/tests/haxe.test.zsh	ZC1043	12
-spaceship/tests/haxe.test.zsh	ZC1044	1
 spaceship/tests/haxe.test.zsh	ZC1045	3
 spaceship/tests/haxe.test.zsh	ZC1051	2
 spaceship/tests/haxe.test.zsh	ZC1075	5
@@ -794,7 +781,6 @@ spaceship/tests/host.test.zsh	ZC1043	39
 spaceship/tests/host.test.zsh	ZC1045	3
 spaceship/tests/host.test.zsh	ZC1602	1
 spaceship/tests/kotlin.test.zsh	ZC1043	11
-spaceship/tests/kotlin.test.zsh	ZC1044	1
 spaceship/tests/kotlin.test.zsh	ZC1045	2
 spaceship/tests/kotlin.test.zsh	ZC1051	1
 spaceship/tests/kotlin.test.zsh	ZC1075	3
@@ -803,7 +789,6 @@ spaceship/tests/kotlin.test.zsh	ZC1128	1
 spaceship/tests/kotlin.test.zsh	ZC1188	1
 spaceship/tests/kotlin.test.zsh	ZC1602	1
 spaceship/tests/lua.test.zsh	ZC1043	13
-spaceship/tests/lua.test.zsh	ZC1044	1
 spaceship/tests/lua.test.zsh	ZC1045	4
 spaceship/tests/lua.test.zsh	ZC1051	3
 spaceship/tests/lua.test.zsh	ZC1075	7
@@ -813,13 +798,11 @@ spaceship/tests/lua.test.zsh	ZC1136	1
 spaceship/tests/lua.test.zsh	ZC1188	1
 spaceship/tests/lua.test.zsh	ZC1602	1
 spaceship/tests/nix_shell.test.zsh	ZC1043	9
-spaceship/tests/nix_shell.test.zsh	ZC1044	1
 spaceship/tests/nix_shell.test.zsh	ZC1045	3
 spaceship/tests/nix_shell.test.zsh	ZC1075	1
 spaceship/tests/nix_shell.test.zsh	ZC1188	1
 spaceship/tests/nix_shell.test.zsh	ZC1602	1
 spaceship/tests/ocaml.test.zsh	ZC1043	13
-spaceship/tests/ocaml.test.zsh	ZC1044	1
 spaceship/tests/ocaml.test.zsh	ZC1045	4
 spaceship/tests/ocaml.test.zsh	ZC1051	2
 spaceship/tests/ocaml.test.zsh	ZC1075	5
@@ -831,7 +814,6 @@ spaceship/tests/package_maven.test.zsh	ZC1004	2
 spaceship/tests/package_maven.test.zsh	ZC1037	1
 spaceship/tests/package_maven.test.zsh	ZC1041	1
 spaceship/tests/package_maven.test.zsh	ZC1043	11
-spaceship/tests/package_maven.test.zsh	ZC1044	1
 spaceship/tests/package_maven.test.zsh	ZC1045	4
 spaceship/tests/package_maven.test.zsh	ZC1051	4
 spaceship/tests/package_maven.test.zsh	ZC1075	12
@@ -844,7 +826,6 @@ spaceship/tests/package.test.zsh	ZC1044	1
 spaceship/tests/package.test.zsh	ZC1045	3
 spaceship/tests/package.test.zsh	ZC1602	1
 spaceship/tests/perl.test.zsh	ZC1043	12
-spaceship/tests/perl.test.zsh	ZC1044	1
 spaceship/tests/perl.test.zsh	ZC1045	3
 spaceship/tests/perl.test.zsh	ZC1051	2
 spaceship/tests/perl.test.zsh	ZC1075	5
@@ -853,21 +834,18 @@ spaceship/tests/perl.test.zsh	ZC1128	2
 spaceship/tests/perl.test.zsh	ZC1188	1
 spaceship/tests/perl.test.zsh	ZC1602	1
 spaceship/tests/pulumi.test.zsh	ZC1043	10
-spaceship/tests/pulumi.test.zsh	ZC1044	1
 spaceship/tests/pulumi.test.zsh	ZC1045	3
 spaceship/tests/pulumi.test.zsh	ZC1075	1
 spaceship/tests/pulumi.test.zsh	ZC1128	4
 spaceship/tests/pulumi.test.zsh	ZC1188	1
 spaceship/tests/pulumi.test.zsh	ZC1602	1
 spaceship/tests/purescript.test.zsh	ZC1043	5
-spaceship/tests/purescript.test.zsh	ZC1044	1
 spaceship/tests/purescript.test.zsh	ZC1045	3
 spaceship/tests/purescript.test.zsh	ZC1075	1
 spaceship/tests/purescript.test.zsh	ZC1128	2
 spaceship/tests/purescript.test.zsh	ZC1188	1
 spaceship/tests/purescript.test.zsh	ZC1602	1
 spaceship/tests/red.test.zsh	ZC1043	12
-spaceship/tests/red.test.zsh	ZC1044	1
 spaceship/tests/red.test.zsh	ZC1045	3
 spaceship/tests/red.test.zsh	ZC1051	2
 spaceship/tests/red.test.zsh	ZC1075	5
@@ -876,7 +854,6 @@ spaceship/tests/red.test.zsh	ZC1128	2
 spaceship/tests/red.test.zsh	ZC1188	1
 spaceship/tests/red.test.zsh	ZC1602	1
 spaceship/tests/rlang.test.zsh	ZC1043	13
-spaceship/tests/rlang.test.zsh	ZC1044	1
 spaceship/tests/rlang.test.zsh	ZC1045	3
 spaceship/tests/rlang.test.zsh	ZC1051	2
 spaceship/tests/rlang.test.zsh	ZC1075	5
@@ -885,7 +862,6 @@ spaceship/tests/rlang.test.zsh	ZC1128	2
 spaceship/tests/rlang.test.zsh	ZC1188	1
 spaceship/tests/rlang.test.zsh	ZC1602	1
 spaceship/tests/scala.test.zsh	ZC1043	13
-spaceship/tests/scala.test.zsh	ZC1044	1
 spaceship/tests/scala.test.zsh	ZC1045	4
 spaceship/tests/scala.test.zsh	ZC1051	3
 spaceship/tests/scala.test.zsh	ZC1075	7
@@ -906,7 +882,6 @@ spaceship/tests/utils.test.zsh	ZC1045	6
 spaceship/tests/utils.test.zsh	ZC1075	2
 spaceship/tests/utils.test.zsh	ZC1602	1
 spaceship/tests/vlang.test.zsh	ZC1043	12
-spaceship/tests/vlang.test.zsh	ZC1044	1
 spaceship/tests/vlang.test.zsh	ZC1045	3
 spaceship/tests/vlang.test.zsh	ZC1051	2
 spaceship/tests/vlang.test.zsh	ZC1075	5
@@ -915,7 +890,6 @@ spaceship/tests/vlang.test.zsh	ZC1128	2
 spaceship/tests/vlang.test.zsh	ZC1188	1
 spaceship/tests/vlang.test.zsh	ZC1602	1
 spaceship/tests/zig.test.zsh	ZC1043	5
-spaceship/tests/zig.test.zsh	ZC1044	1
 spaceship/tests/zig.test.zsh	ZC1045	3
 spaceship/tests/zig.test.zsh	ZC1075	1
 spaceship/tests/zig.test.zsh	ZC1128	2

--- a/pkg/katas/katatests/zc1000s_test.go
+++ b/pkg/katas/katatests/zc1000s_test.go
@@ -1704,6 +1704,66 @@ func TestZC1044(t *testing.T) {
 			},
 		},
 		{
+			// `function name { … }` and `name() { … }` are the same thing in
+			// Zsh, so a `cd` followed by more work must report in both.
+			name:  "cd in function-keyword body",
+			input: "function f {\n  cd /tmp\n  print x\n}",
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1044",
+					Message: "Use `cd ... || return` (or `exit`) in case cd fails.",
+					Line:    2,
+					Column:  3,
+				},
+			},
+		},
+		{
+			// A case clause body runs in the current shell, so its blast
+			// radius matches the top level.
+			name:  "cd in case clause body",
+			input: "case $q in\n  a) cd /tmp\n     print x ;;\nesac",
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1044",
+					Message: "Use `cd ... || return` (or `exit`) in case cd fails.",
+					Line:    2,
+					Column:  6,
+				},
+			},
+		},
+		{
+			name:  "cd in select body",
+			input: "select s in a; do\n  cd /tmp\n  print x\ndone",
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1044",
+					Message: "Use `cd ... || return` (or `exit`) in case cd fails.",
+					Line:    2,
+					Column:  3,
+				},
+			},
+		},
+		{
+			// Nothing runs after a failed `cd` that ends a function, and the
+			// failure leaves the directory unchanged and surfaces as the
+			// function's exit status, so the guard adds nothing.
+			name:     "cd as the last command in a function",
+			input:    "f() {\n  cd /tmp\n}",
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "cd last through a trailing if",
+			input:    "f() {\n  if [[ -n $d ]]; then\n    cd $d\n  fi\n}",
+			expected: []katas.Violation{},
+		},
+		{
+			// A subshell forks: a failed `cd` cannot move the caller, and the
+			// non-zero status is visible at the call site.
+			name:     "cd inside a subshell",
+			input:    "( cd /tmp\n  print x )",
+			expected: []katas.Violation{},
+		},
+		{
 			name:  "cd in for loop body",
 			input: `for d in /tmp /var; do cd $d; done`,
 			expected: []katas.Violation{

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -2765,19 +2765,41 @@ func walkZC1044Compound(node ast.Node, isChecked bool, violations *[]Violation) 
 		walkZC1044(n.Expression, isChecked, violations)
 	case *ast.IfStatement:
 		walkZC1044(n.Condition, true, violations)
-		walkZC1044(n.Consequence, false, violations)
-		walkZC1044(n.Alternative, false, violations)
+		walkZC1044(n.Consequence, isChecked, violations)
+		walkZC1044(n.Alternative, isChecked, violations)
 	case *ast.WhileLoopStatement:
 		walkZC1044(n.Condition, true, violations)
 		walkZC1044(n.Body, false, violations)
 	case *ast.ForLoopStatement:
 		walkZC1044ForLoop(n, violations)
 	case *ast.FunctionDefinition:
+		walkZC1044(n.Body, true, violations)
+	case *ast.FunctionLiteral:
+		// `function name { … }` builds a FunctionLiteral while `name() { … }`
+		// builds a FunctionDefinition. The two forms are identical in Zsh, so
+		// a `cd` inside either changes the caller's directory the same way.
+		walkZC1044(n.Body, true, violations)
+	case *ast.CaseStatement:
+		walkZC1044CaseClauses(n, isChecked, violations)
+	case *ast.SelectStatement:
 		walkZC1044(n.Body, false, violations)
 	default:
 		return false
 	}
 	return true
+}
+
+// walkZC1044CaseClauses descends into a case statement's clause bodies. A
+// clause body runs in the current shell, so a `cd` there has the same
+// blast radius as one at the top level; only the subject expression is
+// skipped, since it cannot hold a command whose failure matters here.
+func walkZC1044CaseClauses(n *ast.CaseStatement, isChecked bool, violations *[]Violation) {
+	for _, clause := range n.Clauses {
+		if clause == nil {
+			continue
+		}
+		walkZC1044(clause.Body, isChecked, violations)
+	}
 }
 
 func walkZC1044Leaf(node ast.Node, isChecked bool, violations *[]Violation) {


### PR DESCRIPTION
## What

ZC1044 ("Use \`cd ... || return\`") walks the tree itself, because the guard depends on whether the exit status is already consumed — an `if` condition, the left of `||`, a negation — and the shared walker cannot hand that state to one child but not its sibling. That private walker had drifted from the node set the parser produces.

**Parity bug.** `function name { … }` builds a `FunctionLiteral`; `name() { … }` builds a `FunctionDefinition`. Only the second was visited:

```
function cdf() { cd /etc; ls }   -> silent
cdf()          { cd /etc; ls }   -> ZC1044
```

Identical Zsh semantics, opposite verdicts. Case clause bodies and select bodies were also never visited, though both run in the current shell with the same blast radius as the top level.

**Exemption.** A `cd` that ends a function no longer reports, directly or through a trailing `if`. Nothing runs after it, a failed `cd` leaves the directory unchanged, and the failure surfaces as the function's exit status for the caller to test. Verified against zsh 5.9: `f() { cd /nonexistent }` leaves the caller's directory untouched and returns 1.

**Fork boundaries stay out of scope.** A subshell, `$( … )`, `<( … )`, or `coproc` cannot move the caller's directory. Measured on 933 real Zsh files, extending into subshells produced 13 warnings and zero genuine bugs — 10 of them on `( cd -- "$ROOT" && cmd )`, already guarded.

## Corpus effect

26 findings drop, all of the newly exempt last-command form, e.g. `autojump/bin/autojump.zsh` (`cd "${output}"` inside `if [[ -d "${output}" ]]` ending the function) and 23 spaceship test files (`cd $SHUNIT_TMPDIR` ending `setUp()`). Nothing is lost from a context that can still do harm.

Parser sweep 402 files / 0 errors; fix-corpus sweep 0 corruptions, 0 non-idempotent, 0 panics; full suite, `golangci-lint`, and `gocyclo` all clean (`walkZC1044Compound` sits at 11 of the 15 ceiling).

## Tests

Six cases added to `TestZC1044`: firing for a function-keyword body, a case clause body, and a select body; silence for a `cd` ending a function, one ending it through a trailing `if`, and one inside a subshell. Existing assertions — including `cd /tmp && echo ok` and the loop-body cases — are unchanged.

Severity: Warning (false negatives closed, false positives removed).
