### PR TITLE
fix: stop ZC1053 reporting an already-silenced grep

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -418,7 +418,6 @@ prezto/modules/git/alias.zsh	ZC1049	212
 prezto/modules/gnu-utility/init.zsh	ZC1046	1
 prezto/modules/gnu-utility/init.zsh	ZC1098	1
 prezto/modules/gpg/init.zsh	ZC1046	1
-prezto/modules/gpg/init.zsh	ZC1053	1
 prezto/modules/gpg/init.zsh	ZC1086	1
 prezto/modules/gpg/init.zsh	ZC1098	1
 prezto/modules/gpg/init.zsh	ZC1125	1
@@ -652,7 +651,6 @@ spaceship/sections/rust.zsh	ZC1284	2
 spaceship/sections/scala.zsh	ZC1045	2
 spaceship/sections/sudo.zsh	ZC1047	1
 spaceship/sections/swiftenv.zsh	ZC1010	1
-spaceship/sections/swiftenv.zsh	ZC1053	1
 spaceship/sections/swiftenv.zsh	ZC1273	1
 spaceship/sections/swift.zsh	ZC1045	1
 spaceship/sections/swift.zsh	ZC1110	1
@@ -666,7 +664,6 @@ spaceship/sections/vlang.zsh	ZC1109	1
 spaceship/sections/vlang.zsh	ZC1284	1
 spaceship/sections/xcenv.zsh	ZC1010	2
 spaceship/sections/xcenv.zsh	ZC1045	1
-spaceship/sections/xcenv.zsh	ZC1053	1
 spaceship/sections/xcenv.zsh	ZC1075	2
 spaceship/sections/xcenv.zsh	ZC1273	1
 spaceship/sections/xcode.zsh	ZC1045	1
@@ -1173,7 +1170,6 @@ zinit/zinit-autoload.zsh	ZC1040	2
 zinit/zinit-autoload.zsh	ZC1045	6
 zinit/zinit-autoload.zsh	ZC1046	8
 zinit/zinit-autoload.zsh	ZC1049	1
-zinit/zinit-autoload.zsh	ZC1053	1
 zinit/zinit-autoload.zsh	ZC1064	1
 zinit/zinit-autoload.zsh	ZC1073	3
 zinit/zinit-autoload.zsh	ZC1075	42
@@ -1201,7 +1197,6 @@ zinit/zinit-install.zsh	ZC1037	3
 zinit/zinit-install.zsh	ZC1043	1
 zinit/zinit-install.zsh	ZC1045	10
 zinit/zinit-install.zsh	ZC1046	16
-zinit/zinit-install.zsh	ZC1053	1
 zinit/zinit-install.zsh	ZC1064	5
 zinit/zinit-install.zsh	ZC1073	1
 zinit/zinit-install.zsh	ZC1075	63
@@ -1255,7 +1250,6 @@ zpm/zpm.zsh	ZC1098	2
 zpm/zpm.zsh	ZC1188	1
 zsh-256color/zsh-256color.plugin.zsh	ZC1001	1
 zsh-256color/zsh-256color.plugin.zsh	ZC1037	1
-zsh-256color/zsh-256color.plugin.zsh	ZC1053	1
 zsh-256color/zsh-256color.plugin.zsh	ZC1097	2
 zsh-256color/zsh-256color.plugin.zsh	ZC1502	1
 zsh-abbr/tests/_abbr-expand-line.ztr.zsh	ZC1075	8
@@ -1487,7 +1481,6 @@ zsh-shift-select/zsh-shift-select.plugin.zsh	ZC1075	5
 zsh-shift-select/zsh-shift-select.plugin.zsh	ZC1086	6
 zsh-utils/completion/completion.plugin.zsh	ZC1128	1
 zsh-utils/completion/completion.plugin.zsh	ZC1686	1
-zsh-utils/editor/editor.plugin.zsh	ZC1053	1
 zsh-utils/editor/editor.plugin.zsh	ZC1086	6
 zsh-utils/editor/editor.plugin.zsh	ZC1273	1
 zsh-utils/history/history.plugin.zsh	ZC1049	1

--- a/pkg/katas/helper_coverage_test.go
+++ b/pkg/katas/helper_coverage_test.go
@@ -77,8 +77,16 @@ func TestIsDevNullAndStringValue(t *testing.T) {
 	if got := getStringValueZC1053(concat); got != "/dev/null" {
 		t.Errorf("getStringValueZC1053(concat): got %q want /dev/null", got)
 	}
-	if got := getStringValueZC1053(&ast.Identifier{Value: "x"}); got != "" {
-		t.Errorf("getStringValueZC1053(non-string): got %q want \"\"", got)
+	// A bare word is a valid redirection target (`> /dev/null` parses the
+	// path as an identifier), so the string form reads it.
+	if got := getStringValueZC1053(&ast.Identifier{Value: "/dev/null"}); got != "/dev/null" {
+		t.Errorf("getStringValueZC1053(identifier): got %q want /dev/null", got)
+	}
+	if !isDevNull(&ast.Identifier{Value: "/dev/null"}) {
+		t.Errorf("isDevNull(unquoted /dev/null): expected true")
+	}
+	if got := getStringValueZC1053(&ast.IntegerLiteral{Value: 2}); got != "" {
+		t.Errorf("getStringValueZC1053(unsupported node): got %q want \"\"", got)
 	}
 }
 

--- a/pkg/katas/katatests/zc1000s_test.go
+++ b/pkg/katas/katatests/zc1000s_test.go
@@ -2226,6 +2226,99 @@ func TestZC1053(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
+			// The kata's own advice is `grep -q` or a redirect to
+			// /dev/null, so a redirected grep must not report.
+			name:     "grep redirected to /dev/null",
+			input:    `if grep pattern file >/dev/null; then echo found; fi`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "grep redirected with a space",
+			input:    `if grep pattern file > /dev/null; then echo found; fi`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "grep redirected on both streams",
+			input:    `if grep pattern file &>/dev/null; then echo found; fi`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "grep redirected to an explicit stdout fd",
+			input:    `if grep pattern file 1>/dev/null 2>&1; then echo found; fi`,
+			expected: []katas.Violation{},
+		},
+		{
+			// A stderr-only redirect leaves stdout printing.
+			name:  "grep with stderr-only redirect",
+			input: `if grep pattern file 2>/dev/null; then echo found; fi`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1053",
+					Message: "Silence `grep` output in conditions. Use `grep -q` or redirect to `/dev/null`.",
+					Line:    1,
+					Column:  4,
+				},
+			},
+		},
+		{
+			// `/dev/null.txt` is an ordinary file, not the null device.
+			name:  "grep redirected to a look-alike path",
+			input: `if grep pattern file >/dev/null.txt; then echo found; fi`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1053",
+					Message: "Silence `grep` output in conditions. Use `grep -q` or redirect to `/dev/null`.",
+					Line:    1,
+					Column:  4,
+				},
+			},
+		},
+		{
+			// A quoted redirect is the search pattern, not a redirection.
+			name:  "grep searching for a redirect literal",
+			input: `if grep '>/dev/null' file; then echo found; fi`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1053",
+					Message: "Silence `grep` output in conditions. Use `grep -q` or redirect to `/dev/null`.",
+					Line:    1,
+					Column:  4,
+				},
+			},
+		},
+		{
+			// `-fq` is `-f q`: the q is the pattern-file operand, not the
+			// quiet flag.
+			name:  "grep with a value-taking flag cluster",
+			input: `if grep -fq file; then echo found; fi`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1053",
+					Message: "Silence `grep` output in conditions. Use `grep -q` or redirect to `/dev/null`.",
+					Line:    1,
+					Column:  4,
+				},
+			},
+		},
+		{
+			// A quoted `-quiet` is the pattern.
+			name:  "grep searching for a quiet-looking pattern",
+			input: `if grep "-quiet" file; then echo found; fi`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1053",
+					Message: "Silence `grep` output in conditions. Use `grep -q` or redirect to `/dev/null`.",
+					Line:    1,
+					Column:  4,
+				},
+			},
+		},
+		{
+			name:     "grep with a combined quiet cluster",
+			input:    `if grep -sq pattern file; then echo found; fi`,
+			expected: []katas.Violation{},
+		},
+		{
 			name:  "grep without -q in condition",
 			input: `if grep pattern file; then echo found; fi`,
 			expected: []katas.Violation{

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -3707,38 +3707,170 @@ func checkCommandZC1053(cmd *ast.SimpleCommand, isSilenced bool, violations *[]V
 	if isSilenced {
 		return
 	}
+	name, ok := cmd.Name.(*ast.Identifier)
+	if !ok {
+		return
+	}
+	switch name.Value {
+	case "grep", "egrep", "fgrep", "zgrep":
+	default:
+		return
+	}
+	if zc1053HasQuietFlag(cmd.Arguments) || zc1053HasDevNullRedirect(cmd.Arguments) {
+		return
+	}
+	*violations = append(*violations, Violation{
+		KataID:  "ZC1053",
+		Message: "Silence `grep` output in conditions. Use `grep -q` or redirect to `/dev/null`.",
+		Line:    name.Token.Line,
+		Column:  name.Token.Column,
+		Level:   SeverityStyle,
+	})
+}
 
-	if name, ok := cmd.Name.(*ast.Identifier); ok {
-		if name.Value == "grep" || name.Value == "egrep" || name.Value == "fgrep" || name.Value == "zgrep" {
-			// Check args for -q, --quiet, --silent
-			hasQuiet := false
-			for _, arg := range cmd.Arguments {
-				argStr := arg.String()
-				argStr = strings.Trim(argStr, "\"'")
-				if strings.HasPrefix(argStr, "-") {
-					if argStr == "-q" || argStr == "--quiet" || argStr == "--silent" {
-						hasQuiet = true
-						break
-					}
-					// Check for combined flags e.g. -rq
-					if !strings.HasPrefix(argStr, "--") && strings.Contains(argStr, "q") {
-						hasQuiet = true
-						break
-					}
-				}
-			}
+// zc1053ValueFlags are the single-letter grep options that consume the rest
+// of their cluster as a value (`-e PATTERN`, `-m NUM`, `-A NUM`). A `q` after
+// one of them is that value, not the quiet flag: `grep -eq f` searches for
+// the pattern `q`.
+const zc1053ValueFlags = "efmABCdD"
 
-			if !hasQuiet {
-				*violations = append(*violations, Violation{
-					KataID:  "ZC1053",
-					Message: "Silence `grep` output in conditions. Use `grep -q` or redirect to `/dev/null`.",
-					Line:    name.Token.Line,
-					Column:  name.Token.Column,
-					Level:   SeverityStyle,
-				})
+// zc1053HasQuietFlag reports whether the arguments carry a real quiet flag.
+// Only an unquoted option word counts — a quoted `"-quiet"` is the search
+// pattern — and scanning stops at `--`, after which every word is an operand.
+func zc1053HasQuietFlag(args []ast.Expression) bool {
+	skipNext := false
+	for _, arg := range args {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		word, quoted := zc1053ArgWord(arg)
+		if quoted || !strings.HasPrefix(word, "-") || word == "-" {
+			continue
+		}
+		if word == "--" {
+			return false
+		}
+		if strings.HasPrefix(word, "--") {
+			if word == "--quiet" || word == "--silent" {
+				return true
 			}
+			continue
+		}
+		quiet, wantsValue := zc1053ScanCluster(word)
+		if quiet {
+			return true
+		}
+		skipNext = wantsValue
+	}
+	return false
+}
+
+// zc1053ScanCluster walks a short-option cluster left to right, reporting
+// whether it enables quiet mode and whether it ends on an option whose value
+// is the following word (`grep -e q`).
+func zc1053ScanCluster(word string) (quiet, wantsValue bool) {
+	for i := 1; i < len(word); i++ {
+		c := word[i]
+		if c == 'q' {
+			return true, false
+		}
+		if strings.IndexByte(zc1053ValueFlags, c) >= 0 {
+			// The remainder of the cluster is this option's value; when the
+			// cluster ends here the value is the next word instead.
+			return false, i == len(word)-1
 		}
 	}
+	return false, false
+}
+
+// zc1053HasDevNullRedirect reports whether the arguments carry a redirection
+// of stdout to /dev/null. The parser folds a redirection into the argument
+// list rather than building a redirection node, so the operator arrives glued
+// to its target (`>/dev/null`) or as two adjacent words (`> /dev/null`).
+// A stderr-only redirect (`2>/dev/null`) leaves stdout live and does not
+// count, and a quoted `'>/dev/null'` is a search pattern, not a redirection.
+func zc1053HasDevNullRedirect(args []ast.Expression) bool {
+	for i, arg := range args {
+		word, quoted := zc1053ArgWord(arg)
+		if quoted {
+			continue
+		}
+		op, target := zc1053SplitRedirect(word)
+		if op == "" || !zc1053RedirectsStdout(op) {
+			continue
+		}
+		if target == "" && i+1 < len(args) {
+			target, _ = zc1053ArgWord(args[i+1])
+		}
+		if zc1053UnquoteWord(target) == "/dev/null" {
+			return true
+		}
+	}
+	return false
+}
+
+// zc1053SplitRedirect splits a word into its leading redirection operator
+// (with any file-descriptor prefix) and the target that follows it. It
+// returns an empty operator when the word does not open a redirection.
+func zc1053SplitRedirect(word string) (op, target string) {
+	i := 0
+	for i < len(word) && word[i] >= '0' && word[i] <= '9' {
+		i++
+	}
+	start := i
+	for i < len(word) && (word[i] == '>' || word[i] == '&' || word[i] == '|') {
+		i++
+	}
+	if i == start {
+		return "", ""
+	}
+	return word[:i], word[i:]
+}
+
+// zc1053RedirectsStdout reports whether a redirection operator sends stdout
+// to its target. A bare operator and an explicit `1` both mean stdout; any
+// other file descriptor (notably `2`) does not.
+func zc1053RedirectsStdout(op string) bool {
+	switch strings.TrimPrefix(op, "1") {
+	case ">", ">>", "&>", ">&", ">|":
+		return true
+	}
+	return false
+}
+
+// zc1053ArgWord renders an argument as its source word and reports whether it
+// opened with a quote, in which case it is data rather than shell syntax.
+func zc1053ArgWord(arg ast.Expression) (word string, quoted bool) {
+	if lit, ok := arg.(*ast.StringLiteral); ok {
+		return lit.Value, zc1053IsQuoted(lit.Value)
+	}
+	concat, ok := arg.(*ast.ConcatenatedExpression)
+	if !ok {
+		return getStringValueZC1053(arg), false
+	}
+	var sb strings.Builder
+	for i, part := range concat.Parts {
+		text := part.String()
+		if i == 0 && zc1053IsQuoted(text) {
+			return text, true
+		}
+		sb.WriteString(text)
+	}
+	return sb.String(), false
+}
+
+// zc1053IsQuoted reports whether a word opens with a quote character.
+func zc1053IsQuoted(word string) bool {
+	return len(word) > 0 && (word[0] == '\'' || word[0] == '"')
+}
+
+// zc1053UnquoteWord strips one layer of surrounding quotes from a word.
+func zc1053UnquoteWord(word string) string {
+	if len(word) >= 2 && (word[0] == '"' || word[0] == '\'') && word[len(word)-1] == word[0] {
+		return word[1 : len(word)-1]
+	}
+	return word
 }
 
 func isDevNull(node ast.Node) bool {
@@ -3753,6 +3885,10 @@ func isDevNull(node ast.Node) bool {
 func getStringValueZC1053(node ast.Node) string {
 	switch n := node.(type) {
 	case *ast.StringLiteral:
+		return n.Value
+	case *ast.Identifier:
+		// An unquoted redirection target (`> /dev/null`) parses as a bare
+		// identifier, so the string form has to read it too.
 		return n.Value
 	case *ast.ConcatenatedExpression:
 		var sb strings.Builder

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -3851,13 +3851,26 @@ func zc1053ArgWord(arg ast.Expression) (word string, quoted bool) {
 	}
 	var sb strings.Builder
 	for i, part := range concat.Parts {
-		text := part.String()
+		text := zc1053PartText(part)
 		if i == 0 && zc1053IsQuoted(text) {
 			return text, true
 		}
 		sb.WriteString(text)
 	}
 	return sb.String(), false
+}
+
+// zc1053PartText renders one piece of a concatenated word. A string literal
+// keeps its quotes, which is what distinguishes a redirection from a quoted
+// search pattern.
+func zc1053PartText(part ast.Expression) string {
+	switch n := part.(type) {
+	case *ast.StringLiteral:
+		return n.Value
+	case *ast.Identifier:
+		return n.Value
+	}
+	return part.String()
 }
 
 // zc1053IsQuoted reports whether a word opens with a quote character.

--- a/pkg/katas/zc1053_helpers_test.go
+++ b/pkg/katas/zc1053_helpers_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MIT
+// Copyright the ZShellCheck contributors.
+package katas
+
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
+
+// ident builds a bare-word argument.
+func zc1053Ident(v string) ast.Expression { return &ast.Identifier{Value: v} }
+
+// str builds a quoted or unquoted string-literal argument. StringLiteral
+// keeps its surrounding quotes, which is how the kata tells a redirection
+// from a search pattern.
+func zc1053Str(v string) ast.Expression { return &ast.StringLiteral{Value: v} }
+
+// TestZC1053QuietFlagScan covers the option-cluster walk: a real quiet flag
+// enables silence, an option that consumes a value swallows a following `q`,
+// `--` ends option scanning, and a quoted word is an operand.
+func TestZC1053QuietFlagScan(t *testing.T) {
+	cases := []struct {
+		name string
+		args []ast.Expression
+		want bool
+	}{
+		{"short quiet", []ast.Expression{zc1053Ident("-q")}, true},
+		{"cluster quiet", []ast.Expression{zc1053Ident("-sq")}, true},
+		{"long quiet", []ast.Expression{zc1053Ident("--quiet")}, true},
+		{"long silent", []ast.Expression{zc1053Ident("--silent")}, true},
+		{"other long flag", []ast.Expression{zc1053Ident("--color=auto")}, false},
+		{"plain cluster", []ast.Expression{zc1053Ident("-i")}, false},
+		{"value flag swallows q", []ast.Expression{zc1053Ident("-fq")}, false},
+		{"separate value is skipped", []ast.Expression{zc1053Ident("-e"), zc1053Ident("q")}, false},
+		{"quoted operand", []ast.Expression{zc1053Str(`"-quiet"`)}, false},
+		{"after double dash", []ast.Expression{zc1053Ident("--"), zc1053Ident("-q")}, false},
+		{"bare dash", []ast.Expression{zc1053Ident("-")}, false},
+		{"no flags", []ast.Expression{zc1053Ident("pattern")}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := zc1053HasQuietFlag(tc.args); got != tc.want {
+				t.Errorf("zc1053HasQuietFlag(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestZC1053DevNullRedirect covers every shape a stdout redirection reaches
+// the kata in, plus the look-alikes that must not count as silencing.
+func TestZC1053DevNullRedirect(t *testing.T) {
+	concat := func(parts ...ast.Expression) ast.Expression {
+		return &ast.ConcatenatedExpression{Parts: parts}
+	}
+	cases := []struct {
+		name string
+		args []ast.Expression
+		want bool
+	}{
+		{"glued", []ast.Expression{concat(zc1053Str(">"), zc1053Ident("/dev/null"))}, true},
+		{"spaced", []ast.Expression{zc1053Str(">"), zc1053Ident("/dev/null")}, true},
+		{"append", []ast.Expression{concat(zc1053Str(">>"), zc1053Ident("/dev/null"))}, true},
+		{"both streams", []ast.Expression{concat(zc1053Str("&>"), zc1053Ident("/dev/null"))}, true},
+		{"explicit stdout fd", []ast.Expression{concat(zc1053Str("1>"), zc1053Ident("/dev/null"))}, true},
+		{"quoted target", []ast.Expression{concat(zc1053Str(">"), zc1053Str(`"/dev/null"`))}, true},
+		{"stderr only", []ast.Expression{concat(zc1053Str("2>"), zc1053Ident("/dev/null"))}, false},
+		{"look-alike path", []ast.Expression{concat(zc1053Str(">"), zc1053Ident("/dev/null.txt"))}, false},
+		{"quoted redirect is a pattern", []ast.Expression{zc1053Str(`'>/dev/null'`)}, false},
+		{"quoted concat head", []ast.Expression{concat(zc1053Str(`'>'`), zc1053Ident("/dev/null"))}, false},
+		{"dangling operator", []ast.Expression{zc1053Str(">")}, false},
+		{"plain word", []ast.Expression{zc1053Ident("pattern")}, false},
+		{"fd duplication", []ast.Expression{concat(zc1053Str("2>&"), &ast.IntegerLiteral{Value: 1})}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := zc1053HasDevNullRedirect(tc.args); got != tc.want {
+				t.Errorf("zc1053HasDevNullRedirect(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestZC1053SplitRedirect pins the operator/target split, including the
+// file-descriptor prefix and the non-redirection case.
+func TestZC1053SplitRedirect(t *testing.T) {
+	cases := map[string][2]string{
+		">/dev/null":  {">", "/dev/null"},
+		"1>/dev/null": {"1>", "/dev/null"},
+		"2>/dev/null": {"2>", "/dev/null"},
+		"&>/dev/null": {"&>", "/dev/null"},
+		">|":          {">|", ""},
+		"pattern":     {"", ""},
+		"":            {"", ""},
+	}
+	for word, want := range cases {
+		op, target := zc1053SplitRedirect(word)
+		if op != want[0] || target != want[1] {
+			t.Errorf("zc1053SplitRedirect(%q) = (%q, %q), want (%q, %q)", word, op, target, want[0], want[1])
+		}
+	}
+}
+
+// TestZC1053RedirectsStdout pins which operators carry stdout.
+func TestZC1053RedirectsStdout(t *testing.T) {
+	for _, op := range []string{">", ">>", "&>", ">&", ">|", "1>", "1>>"} {
+		if !zc1053RedirectsStdout(op) {
+			t.Errorf("zc1053RedirectsStdout(%q) = false, want true", op)
+		}
+	}
+	for _, op := range []string{"2>", "2>&", "3>", "<", ""} {
+		if zc1053RedirectsStdout(op) {
+			t.Errorf("zc1053RedirectsStdout(%q) = true, want false", op)
+		}
+	}
+}
+
+// TestZC1053WordHelpers covers quote detection and stripping.
+func TestZC1053WordHelpers(t *testing.T) {
+	if word, quoted := zc1053ArgWord(zc1053Str(`'x'`)); !quoted || word != `'x'` {
+		t.Errorf("zc1053ArgWord(quoted) = (%q, %v), want ('x', true)", word, quoted)
+	}
+	if word, quoted := zc1053ArgWord(zc1053Ident("plain")); quoted || word != "plain" {
+		t.Errorf("zc1053ArgWord(identifier) = (%q, %v), want (plain, false)", word, quoted)
+	}
+	if got := zc1053UnquoteWord(`"/dev/null"`); got != "/dev/null" {
+		t.Errorf("zc1053UnquoteWord(double) = %q, want /dev/null", got)
+	}
+	if got := zc1053UnquoteWord(`'/dev/null'`); got != "/dev/null" {
+		t.Errorf("zc1053UnquoteWord(single) = %q, want /dev/null", got)
+	}
+	if got := zc1053UnquoteWord("/dev/null"); got != "/dev/null" {
+		t.Errorf("zc1053UnquoteWord(bare) = %q, want /dev/null", got)
+	}
+	if zc1053IsQuoted("") {
+		t.Error("zc1053IsQuoted(empty) = true, want false")
+	}
+}
+
+// TestZC1053NonIdentifierCommand covers the guard for a command whose name is
+// not a bare word, such as one invoked through a variable.
+func TestZC1053NonIdentifierCommand(t *testing.T) {
+	violations := []Violation{}
+	cmd := &ast.SimpleCommand{Name: &ast.StringLiteral{Value: `"grep"`}}
+	checkCommandZC1053(cmd, false, &violations)
+	if len(violations) != 0 {
+		t.Errorf("expected no violation for a non-identifier command name, got %d", len(violations))
+	}
+	// A silenced context reports nothing regardless of the command.
+	checkCommandZC1053(&ast.SimpleCommand{Name: &ast.Identifier{Value: "grep"}}, true, &violations)
+	if len(violations) != 0 {
+		t.Errorf("expected no violation in a silenced context, got %d", len(violations))
+	}
+}
+
+// TestZC1053SilencesStdout covers the redirection-node path, which a
+// subshell or brace group carrying the redirect still reaches.
+func TestZC1053SilencesStdout(t *testing.T) {
+	devNull := &ast.Identifier{Value: "/dev/null"}
+	for _, op := range []string{">", ">>", "&>"} {
+		red := &ast.Redirection{Operator: op, Right: devNull}
+		if !zc1053SilencesStdout(red) {
+			t.Errorf("zc1053SilencesStdout(%q /dev/null) = false, want true", op)
+		}
+	}
+	if zc1053SilencesStdout(&ast.Redirection{Operator: ">", Right: &ast.Identifier{Value: "/tmp/log"}}) {
+		t.Error("zc1053SilencesStdout(> /tmp/log) = true, want false")
+	}
+	if zc1053SilencesStdout(&ast.Redirection{Operator: "<", Right: devNull}) {
+		t.Error("zc1053SilencesStdout(< /dev/null) = true, want false")
+	}
+}

--- a/pkg/katas/zc1053_helpers_test.go
+++ b/pkg/katas/zc1053_helpers_test.go
@@ -48,7 +48,7 @@ func TestZC1053QuietFlagScan(t *testing.T) {
 }
 
 // TestZC1053DevNullRedirect covers every shape a stdout redirection reaches
-// the kata in, plus the look-alikes that must not count as silencing.
+// the kata in, plus the forms that only look like one and must still report.
 func TestZC1053DevNullRedirect(t *testing.T) {
 	concat := func(parts ...ast.Expression) ast.Expression {
 		return &ast.ConcatenatedExpression{Parts: parts}


### PR DESCRIPTION
## What

ZC1053 asks you to silence a `grep` used as a condition and names two ways to do it — `grep -q`, or a redirect to `/dev/null`. It recognised only the first, so it reported the very form it recommends:

```
zsh/Src/mkmakemod.sh:110  if grep '^#define DYNAMIC ' config.h >/dev/null; then
                          ^ ZC1053: "Use \`grep -q\` or redirect to \`/dev/null\`"
```

Across the pinned corpora, **every** ZC1053 finding was a grep that was already redirected — 7 findings, 7 false positives, 0 true positives.

## Why it happened

The parser folds a redirection into the argument list rather than building a redirection node, so the operator arrives glued to its target (`>/dev/null`, one argument) or as two adjacent words (`> /dev/null`). The existing redirection-node branch was therefore never reached in condition position, and its `/dev/null` comparison could not read an unquoted target anyway, since that parses as a bare word.

## What still reports

Verified against zsh 5.9 — these keep printing to stdout, so they remain findings:

- `grep p f 2>/dev/null` — stderr only, stdout still prints
- `grep p f >/dev/null.txt` — an ordinary file, not the null device
- `grep '>/dev/null' f` — the redirect text as a quoted search pattern
- `grep -c p f` — prints a count

## Quiet-flag scan

It accepted any short option containing the letter `q`, which silently swallowed real findings: `grep -fq file` is `-f q` (read patterns from a file named `q`), and a quoted `"-quiet"` is the pattern. Clusters are now walked left to right and stop at the first option that consumes a value (`-e -f -m -A -B -C -d -D`), scanning stops after `--`, and quoted words are treated as operands.

## Gates

Corpus drift: 7 removed, 0 added. Parser sweep 402 files / 0 errors; fix-corpus sweep 0 corruptions, 0 non-idempotent, 0 panics; suite, `golangci-lint`, and `gocyclo` clean — `checkCommandZC1053` was at the 15 ceiling and is now well under it, since the scans moved into helpers.

Tests: 10 cases added to `TestZC1053` covering each silencing form and each look-alike that must still report; the `isDevNull` helper test now pins bare-word targets.

Known, unchanged, and out of scope: `if ( grep p f )` is silent (a subshell condition is not walked; 4 hits across 2533 files), and `grep -eq` never reaches the kata because the lexer tokenises `-eq` as the numeric-comparison operator.

Severity: Style (false positives removed, false negatives closed).