### PR TITLE
fix: report ZC1273 without rewriting the redirect

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -421,7 +421,6 @@ prezto/modules/gpg/init.zsh	ZC1046	1
 prezto/modules/gpg/init.zsh	ZC1086	1
 prezto/modules/gpg/init.zsh	ZC1098	1
 prezto/modules/gpg/init.zsh	ZC1125	1
-prezto/modules/gpg/init.zsh	ZC1273	1
 prezto/modules/gpg/init.zsh	ZC1502	1
 prezto/modules/helper/init.zsh	ZC1076	1
 prezto/modules/helper/init.zsh	ZC1086	9
@@ -603,7 +602,6 @@ spaceship/sections/haxe.zsh	ZC1091	1
 spaceship/sections/hg_branch.zsh	ZC1045	1
 spaceship/sections/hg_status.zsh	ZC1037	4
 spaceship/sections/hg_status.zsh	ZC1045	1
-spaceship/sections/hg_status.zsh	ZC1273	4
 spaceship/sections/hg.zsh	ZC1010	1
 spaceship/sections/hg.zsh	ZC1045	2
 spaceship/sections/hg.zsh	ZC1097	1
@@ -1184,7 +1182,6 @@ zinit/zinit-autoload.zsh	ZC1197	1
 zinit/zinit-autoload.zsh	ZC1227	2
 zinit/zinit-autoload.zsh	ZC1241	1
 zinit/zinit-autoload.zsh	ZC1255	2
-zinit/zinit-autoload.zsh	ZC1273	1
 zinit/zinit-autoload.zsh	ZC1502	1
 zinit/zinit-autoload.zsh	ZC1520	4
 zinit/zinit-autoload.zsh	ZC1604	5
@@ -1207,6 +1204,7 @@ zinit/zinit-install.zsh	ZC1099	1
 zinit/zinit-install.zsh	ZC1139	1
 zinit/zinit-install.zsh	ZC1166	1
 zinit/zinit-install.zsh	ZC1179	3
+zinit/zinit-install.zsh	ZC1273	1
 zinit/zinit-install.zsh	ZC1833	3
 zinit/zinit-install.zsh	ZC1867	1
 zinit/zinit-install.zsh	ZC1875	7
@@ -1251,6 +1249,7 @@ zpm/zpm.zsh	ZC1188	1
 zsh-256color/zsh-256color.plugin.zsh	ZC1001	1
 zsh-256color/zsh-256color.plugin.zsh	ZC1037	1
 zsh-256color/zsh-256color.plugin.zsh	ZC1097	2
+zsh-256color/zsh-256color.plugin.zsh	ZC1273	1
 zsh-256color/zsh-256color.plugin.zsh	ZC1502	1
 zsh-abbr/tests/_abbr-expand-line.ztr.zsh	ZC1075	8
 zsh-abbr/tests/_abbr-set-line-cursor.ztr.zsh	ZC1043	2

--- a/KATAS.md
+++ b/KATAS.md
@@ -11,7 +11,7 @@ Auto-generated list of all 1000 implemented checks. Do not edit by hand — rege
 | `info` | 64 |
 | `style` | 257 |
 | **total** | **1000** |
-| **with auto-fix** | **132** |
+| **with auto-fix** | **131** |
 
 Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. Run `zshellcheck -fix path/...` to apply every available rewrite, or `-diff` to preview without writing.
 
@@ -286,7 +286,7 @@ Auto-fix availability is marked per-entry below as **Auto-fix:** `yes` or `no`. 
 - [ZC1270: Use `mktemp` instead of hardcoded `/tmp` paths](#zc1270)
 - [ZC1271: Use `command -v` instead of `which` for command existence checks](#zc1271) · auto-fix
 - [ZC1272: Use `install -m` instead of separate `cp` and `chmod`](#zc1272)
-- [ZC1273: Use `grep -q` instead of redirecting grep output to `/dev/null`](#zc1273) · auto-fix
+- [ZC1273: Use `grep -q` instead of redirecting grep output to `/dev/null`](#zc1273)
 - [ZC1274: Use Zsh `${var:t}` instead of `basename`](#zc1274)
 - [ZC1275: Use Zsh `${var:h}` instead of `dirname`](#zc1275)
 - [ZC1276: Use Zsh `{start..end}` instead of `seq`](#zc1276) · auto-fix
@@ -4252,9 +4252,9 @@ Disable by adding `ZC1272` to `disabled_katas` in `.zshellcheckrc`.
 ### ZC1273 — Use `grep -q` instead of redirecting grep output to `/dev/null`
 
 **Severity:** `style`  
-**Auto-fix:** `yes`
+**Auto-fix:** `no`
 
-`grep -q` suppresses output and exits on first match, which is faster and more idiomatic than piping or redirecting to `/dev/null`.
+`grep -q` suppresses output and exits on the first match, which is faster than reading the whole input and discarding it. Rewrite by hand: the two forms are not interchangeable. `-q` exits early, so under `setopt pipefail` a producer earlier in the pipeline is killed by SIGPIPE and the pipeline status becomes 141 rather than 0. `-q` also leaves stderr alone, so it does not replace `&>` or `2>&1`.
 
 Disable by adding `ZC1273` to `disabled_katas` in `.zshellcheckrc`.
 

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1270,11 +1270,19 @@ func TestFixIntegration_ZC1675_ExportStripFlag(t *testing.T) {
 	}
 }
 
-func TestFixIntegration_ZC1273_GrepDevNullToDashQ(t *testing.T) {
-	src := "grep PAT file /dev/null\n"
-	want := "grep -q PAT file\n"
-	if got := runFix(t, src); got != want {
-		t.Errorf("got %q, want %q", got, want)
+// ZC1273 reports without rewriting. The two forms differ in exit status
+// under `setopt pipefail`, in what happens to stderr, and in how much input
+// is read, so the source must come back untouched.
+func TestFixIntegration_ZC1273_ReportsWithoutRewriting(t *testing.T) {
+	for _, src := range []string{
+		"grep PAT file > /dev/null\n",
+		"grep PAT file >/dev/null\n",
+		"grep PAT file /dev/null\n",
+		"grep PAT file &> /dev/null\n",
+	} {
+		if got := runFix(t, src); got != src {
+			t.Errorf("ZC1273 rewrote %q into %q; it must only report", src, got)
+		}
 	}
 }
 

--- a/pkg/katas/katatests/zc1200s_test.go
+++ b/pkg/katas/katatests/zc1200s_test.go
@@ -2644,16 +2644,69 @@ func TestZC1273(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
-			name:  "invalid grep redirected to /dev/null",
-			input: `grep pattern file.txt /dev/null`,
+			name:  "stdout redirected to /dev/null",
+			input: `grep pattern file.txt > /dev/null`,
 			expected: []katas.Violation{
 				{
 					KataID:  "ZC1273",
-					Message: "Use `grep -q` instead of redirecting to `/dev/null`. It is faster and more idiomatic.",
+					Message: "Use `grep -q` instead of redirecting to `/dev/null`. It exits on the first match instead of reading the whole input.",
 					Line:    1,
 					Column:  1,
 				},
 			},
+		},
+		{
+			name:  "stdout redirect written without a space",
+			input: `grep pattern file.txt >/dev/null`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1273",
+					Message: "Use `grep -q` instead of redirecting to `/dev/null`. It exits on the first match instead of reading the whole input.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:  "explicit stdout file descriptor",
+			input: `grep pattern file.txt 1>/dev/null`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1273",
+					Message: "Use `grep -q` instead of redirecting to `/dev/null`. It exits on the first match instead of reading the whole input.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			// `/dev/null` with no operator before it is a second search
+			// file, the idiom that forces grep to print file-name prefixes.
+			name:     "second search file is not a redirect",
+			input:    `grep pattern file.txt /dev/null`,
+			expected: []katas.Violation{},
+		},
+		{
+			// `grep -q` keeps printing to stderr, so it cannot replace a
+			// redirect that also discards stderr.
+			name:     "both streams discarded",
+			input:    `grep pattern file.txt &> /dev/null`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "stderr duplicated onto stdout",
+			input:    `grep pattern file.txt > /dev/null 2>&1`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "stderr only",
+			input:    `grep pattern file.txt 2> /dev/null`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "appended rather than truncated",
+			input:    `grep pattern file.txt >> /dev/null`,
+			expected: []katas.Violation{},
 		},
 	}
 

--- a/pkg/katas/offset_line_col_test.go
+++ b/pkg/katas/offset_line_col_test.go
@@ -65,7 +65,6 @@ func TestOffsetLineColHelpers(t *testing.T) {
 		offsetLineColZC1265,
 		offsetLineColZC1267,
 		offsetLineColZC1268,
-		offsetLineColZC1273,
 		offsetLineColZC1293,
 		offsetLineColZC1377,
 		offsetLineColZC1378,

--- a/pkg/katas/zc1200s.go
+++ b/pkg/katas/zc1200s.go
@@ -4356,72 +4356,13 @@ func init() {
 		ID:       "ZC1273",
 		Title:    "Use `grep -q` instead of redirecting grep output to `/dev/null`",
 		Severity: SeverityStyle,
-		Description: "`grep -q` suppresses output and exits on first match, which is faster and more " +
-			"idiomatic than piping or redirecting to `/dev/null`.",
+		Description: "`grep -q` suppresses output and exits on the first match, which is faster " +
+			"than reading the whole input and discarding it. Rewrite by hand: the two forms are " +
+			"not interchangeable. `-q` exits early, so under `setopt pipefail` a producer earlier " +
+			"in the pipeline is killed by SIGPIPE and the pipeline status becomes 141 rather than " +
+			"0. `-q` also leaves stderr alone, so it does not replace `&>` or `2>&1`.",
 		Check: checkZC1273,
-		Fix:   fixZC1273,
 	})
-}
-
-// fixZC1273 inserts ` -q` after `grep` and strips the trailing
-// `/dev/null` argument (including its leading whitespace). Two edits;
-// the detector already gates on the absence of `-q`, so the rewrite
-// is idempotent on a re-run.
-func fixZC1273(node ast.Node, v Violation, source []byte) []FixEdit {
-	cmd, ok := node.(*ast.SimpleCommand)
-	if !ok {
-		return nil
-	}
-	ident, ok := cmd.Name.(*ast.Identifier)
-	if !ok || ident.Value != "grep" {
-		return nil
-	}
-	var devNull ast.Expression
-	for _, arg := range cmd.Arguments {
-		if arg.String() == "/dev/null" {
-			devNull = arg
-			break
-		}
-	}
-	if devNull == nil {
-		return nil
-	}
-	nameOff := LineColToByteOffset(source, v.Line, v.Column)
-	if nameOff < 0 || IdentLenAt(source, nameOff) != len("grep") {
-		return nil
-	}
-	insertAt := nameOff + len("grep")
-	insLine, insCol := offsetLineColZC1273(source, insertAt)
-	if insLine < 0 {
-		return nil
-	}
-	stripEdits := zc1238StripFlag(source, devNull, "/dev/null")
-	if stripEdits == nil {
-		return nil
-	}
-	return append([]FixEdit{{
-		Line:    insLine,
-		Column:  insCol,
-		Length:  0,
-		Replace: " -q",
-	}}, stripEdits...)
-}
-
-func offsetLineColZC1273(source []byte, offset int) (int, int) {
-	if offset < 0 || offset > len(source) {
-		return -1, -1
-	}
-	line := 1
-	col := 1
-	for i := 0; i < offset; i++ {
-		if source[i] == '\n' {
-			line++
-			col = 1
-			continue
-		}
-		col++
-	}
-	return line, col
 }
 
 func checkZC1273(node ast.Node) []Violation {
@@ -4429,39 +4370,73 @@ func checkZC1273(node ast.Node) []Violation {
 	if !ok {
 		return nil
 	}
-
 	ident, ok := cmd.Name.(*ast.Identifier)
 	if !ok || ident.Value != "grep" {
 		return nil
 	}
-
-	hasQuiet := false
-	for _, arg := range cmd.Arguments {
-		val := arg.String()
-		if val == "-q" || val == "--quiet" || val == "--silent" {
-			hasQuiet = true
-			break
-		}
-	}
-
-	if hasQuiet {
+	if zc1053HasQuietFlag(cmd.Arguments) || !zc1273RedirectsStdoutToDevNull(cmd.Arguments) {
 		return nil
 	}
+	return []Violation{{
+		KataID:  "ZC1273",
+		Message: "Use `grep -q` instead of redirecting to `/dev/null`. It exits on the first match instead of reading the whole input.",
+		Line:    cmd.Token.Line,
+		Column:  cmd.Token.Column,
+		Level:   SeverityStyle,
+	}}
+}
 
-	for _, arg := range cmd.Arguments {
-		val := arg.String()
-		if val == "/dev/null" {
-			return []Violation{{
-				KataID:  "ZC1273",
-				Message: "Use `grep -q` instead of redirecting to `/dev/null`. It is faster and more idiomatic.",
-				Line:    cmd.Token.Line,
-				Column:  cmd.Token.Column,
-				Level:   SeverityStyle,
-			}}
+// zc1273RedirectsStdoutToDevNull reports whether the arguments send grep's
+// stdout, and only its stdout, to /dev/null.
+//
+// The advice holds only for a plain stdout redirect. `&>` and `2>&1` also
+// discard stderr, which `grep -q` keeps printing, and `2>` never touched
+// stdout in the first place. A bare `/dev/null` with no operator before it
+// is a second search file, not a redirection: `grep pattern file /dev/null`
+// is the idiom that forces grep to prefix its output with file names.
+func zc1273RedirectsStdoutToDevNull(args []ast.Expression) bool {
+	if zc1273SuppressesStderr(args) {
+		return false
+	}
+	for i, arg := range args {
+		word, quoted := zc1053ArgWord(arg)
+		if quoted {
+			continue
+		}
+		op, target := zc1053SplitRedirect(word)
+		if op == "" {
+			continue
+		}
+		if target == "" && i+1 < len(args) {
+			target, _ = zc1053ArgWord(args[i+1])
+		}
+		if zc1053UnquoteWord(target) != "/dev/null" {
+			continue
+		}
+		if op == ">" || op == "1>" {
+			return true
 		}
 	}
+	return false
+}
 
-	return nil
+// zc1273SuppressesStderr reports whether the arguments also discard stderr,
+// through `&>`, `2>`, or a `2>&1` duplication. `grep -q` silences only
+// stdout, so it cannot stand in for any of these: grep would start printing
+// its errors again.
+func zc1273SuppressesStderr(args []ast.Expression) bool {
+	for _, arg := range args {
+		word, quoted := zc1053ArgWord(arg)
+		if quoted {
+			continue
+		}
+		op, _ := zc1053SplitRedirect(word)
+		switch op {
+		case "&>", "2>", "2>&", "&>>":
+			return true
+		}
+	}
+	return false
 }
 
 func init() {


### PR DESCRIPTION
## The corruption

`zshellcheck -fix -unsafe-fixes` produced unparseable Zsh. A spaced redirect occupies two argument slots; the fix deleted only the `/dev/null` one:

```
grep p f > /dev/null    ->  grep -q p f >      zsh -n: parse error
grep p f >> /dev/null   ->  grep -q p f >>     zsh -n: parse error
```

On real corpus code, `prezto/modules/gpg/init.zsh:33` became `if grep -q '^enable-ssh-support' -- "$_gpg_agent_conf" &>; then`.

## Why the rewrite is dropped rather than repaired

Even performed correctly, `grep -q` is not a drop-in for a discarded redirect:

- **It inverts conditions under `pipefail`.** `-q` exits on the first match, SIGPIPE-ing the producer: `seq 1 8000000 | grep -q '^1$'` exits **141**, while `seq 1 8000000 | grep '^1$' >/dev/null` exits **0**.
- **It leaks stderr.** `grep -q p /nonexistent` prints "No such file or directory"; `grep p /nonexistent &> /dev/null` printed nothing.
- **Exit codes differ** with a missing file among several: `2` versus `0`.

So the kata now reports and explains, and the description states why the forms are not interchangeable. The advice itself stands — `grep -q` is ~31x faster on an early match — it just cannot be applied mechanically.

## Detection was wrong in both directions

It matched any `/dev/null` argument, so it fired on `grep pattern file /dev/null` — where `/dev/null` is a **second search file**, the idiom that forces grep to print file-name prefixes — and the fix deleted it, silently changing output from `file:match` to `match`. It also missed the attached spelling `>/dev/null`, which is the more common one in the corpus.

Detection is now operator-aware: a plain stdout redirect (`>` or `1>`) to `/dev/null`, attached or spaced, and never a form that also discards stderr (`&>`, `2>`, `2>&1`, `>>`).

## Why it shipped

Both tests only covered `grep PAT file /dev/null` — the argument form, no redirection operator anywhere. The fixture never exercised the case the kata's own title describes. Tests now cover each redirect spelling and each form that must stay silent, and the fix-integration test asserts the source comes back **unchanged**.

## Gates

Corpus drift: 2 added (attached-form redirects in `zinit-install.zsh` and `zsh-256color`, both genuine), 3 removed (all `&> /dev/null`, where `-q` would leak stderr). Parser sweep 402/0; fix-corpus sweep clean; suite, lint, gocyclo green. KATAS.md regenerated (auto-fix count 132 to 131).

Severity: Warning — a corrupting autofix removed, false positives removed, false negatives closed.