### PR TITLE
fix: apply a violation's edits as one unit

### DIFF
--- a/cmd/zshellcheck/main.go
+++ b/cmd/zshellcheck/main.go
@@ -560,26 +560,51 @@ func parseErrorCount(src string) int {
 // stays valid against the growing source. A failed apply or a fix that
 // would break the parse is simply skipped, so a broken file is never
 // written.
+// applySafeEdits retries a rejected pass one violation at a time, keeping
+// only the groups that parse. A group is all-or-nothing: the edits that
+// rewrite `[[ a -eq b ]]` into `(( a == b ))` are meaningless apart, and
+// applying just the operator would leave `[[ a == b ]]`, which parses but
+// compares as a glob pattern instead of a number.
 func applySafeEdits(base string, edits []katas.FixEdit) (string, int) {
 	baseErrs := parseErrorCount(base)
-	ordered := append([]katas.FixEdit(nil), edits...)
-	sort.SliceStable(ordered, func(i, j int) bool {
-		if ordered[i].Line != ordered[j].Line {
-			return ordered[i].Line > ordered[j].Line
-		}
-		return ordered[i].Column > ordered[j].Column
-	})
+	groups := groupEdits(edits)
 	acc := base
 	applied := 0
-	for _, e := range ordered {
-		trial, err := fix.Apply(acc, []katas.FixEdit{e})
+	for _, group := range groups {
+		trial, err := fix.Apply(acc, group)
 		if err != nil || parseErrorCount(trial) > baseErrs {
 			continue
 		}
 		acc = trial
-		applied++
+		applied += len(group)
 	}
 	return acc, applied
+}
+
+// groupEdits splits edits into per-violation groups, ordered from the end of
+// the file backwards so an accepted group cannot shift the offsets of a group
+// that has not been tried yet.
+func groupEdits(edits []katas.FixEdit) [][]katas.FixEdit {
+	byGroup := map[int][]katas.FixEdit{}
+	var order []int
+	for _, e := range edits {
+		if _, seen := byGroup[e.Group]; !seen {
+			order = append(order, e.Group)
+		}
+		byGroup[e.Group] = append(byGroup[e.Group], e)
+	}
+	sort.SliceStable(order, func(i, j int) bool {
+		a, b := byGroup[order[i]][0], byGroup[order[j]][0]
+		if a.Line != b.Line {
+			return a.Line > b.Line
+		}
+		return a.Column > b.Column
+	})
+	groups := make([][]katas.FixEdit, 0, len(order))
+	for _, g := range order {
+		groups = append(groups, byGroup[g])
+	}
+	return groups
 }
 
 // collectEdits parses src and returns the auto-fix edits the registry
@@ -601,42 +626,59 @@ func collectEdits(src string, registry *katas.KatasRegistry, disabled []string, 
 	var edits []katas.FixEdit
 	ast.Walk(program, func(node ast.Node) bool {
 		vs, es := registry.CheckAndFix(node, allDisabled, []byte(src))
+		// CheckAndFix numbers groups from the start of its own violation
+		// slice; shift them past the violations already gathered so each
+		// group names exactly one violation in this file.
+		base := len(violations)
+		for i := range es {
+			es[i].Group += base
+		}
 		violations = append(violations, vs...)
 		edits = append(edits, es...)
 		return true
 	})
 	if len(directives.PerLine) > 0 {
 		keptV := violations[:0]
-		keptE := edits[:0]
+		keep := make(map[int]bool, len(violations))
 		for i, v := range violations {
 			if directives.IsDisabledOn(v.KataID, v.Line) {
 				continue
 			}
+			keep[i] = true
 			keptV = append(keptV, v)
-			if i < len(edits) {
-				keptE = append(keptE, edits[i])
-			}
 		}
 		violations = keptV
-		edits = keptE
+		edits = editsForGroups(edits, keep)
 	}
 	if len(allowedSeverities) > 0 {
-		filtered := edits[:0]
 		filteredV := violations[:0]
+		keep := make(map[int]bool, len(violations))
 		for i, v := range violations {
 			for _, s := range allowedSeverities {
 				if v.Level == s {
+					keep[i] = true
 					filteredV = append(filteredV, v)
-					if i < len(edits) {
-						filtered = append(filtered, edits[i])
-					}
 					break
 				}
 			}
 		}
-		edits = filtered
+		violations = filteredV
+		edits = editsForGroups(edits, keep)
 	}
 	return applicableEdits(edits, registry, unsafe)
+}
+
+// editsForGroups keeps the edits whose group belongs to a retained
+// violation. Selecting by group rather than by position matters because one
+// violation can produce several edits, so the two slices do not line up.
+func editsForGroups(edits []katas.FixEdit, keep map[int]bool) []katas.FixEdit {
+	kept := edits[:0]
+	for _, e := range edits {
+		if keep[e.Group] {
+			kept = append(kept, e)
+		}
+	}
+	return kept
 }
 
 func processPath(path string, out, errOut io.Writer, cfg config.Config, registry *katas.KatasRegistry, format string, allowedSeverities []katas.Severity, fixOpts fixOptions) int {

--- a/cmd/zshellcheck/main_test.go
+++ b/cmd/zshellcheck/main_test.go
@@ -554,22 +554,37 @@ func TestApplySafeEdits_Bailouts(t *testing.T) {
 	base := "echo hi\n"
 	// Every candidate edit breaks the parse alone -> nothing is kept and
 	// base is returned unchanged.
-	stray := katas.FixEdit{Line: 1, Column: 1, Length: 0, Replace: "fi\n"}
+	stray := katas.FixEdit{Line: 1, Column: 1, Length: 0, Replace: "fi\n", Group: 1}
 	if out, n := applySafeEdits(base, []katas.FixEdit{stray}); out != base || n != 0 {
 		t.Errorf("all-break: want base/0, got %q/%d", out, n)
 	}
-	// A safe edit is kept while the breaking one is dropped.
-	safe := katas.FixEdit{Line: 1, Column: 1, Length: 4, Replace: "print -r --"}
+	// Two edits from different violations are independent: the safe one is
+	// kept while the breaking one is dropped.
+	safe := katas.FixEdit{Line: 1, Column: 1, Length: 4, Replace: "print -r --", Group: 2}
 	out, n := applySafeEdits(base, []katas.FixEdit{stray, safe})
 	if n != 1 || !strings.Contains(out, "print -r --") {
 		t.Errorf("mixed: want 1 kept with rewrite, got %q/%d", out, n)
 	}
 
+	// Edits from ONE violation are atomic. A rewrite that only makes sense
+	// as a whole must not be applied in part: keeping just the operator of
+	// `[[ a -eq b ]]` would leave `[[ a == b ]]`, which parses but compares
+	// as a glob pattern instead of a number.
+	atomicBase := "if [[ $a -eq 0 ]]; then :; fi\n"
+	atomic := []katas.FixEdit{
+		{Line: 1, Column: 4, Length: 2, Replace: "((", Group: 7},
+		{Line: 1, Column: 10, Length: 3, Replace: "==", Group: 7},
+		{Line: 1, Column: 1, Length: 0, Replace: "fi\n", Group: 7},
+	}
+	if aout, an := applySafeEdits(atomicBase, atomic); aout != atomicBase || an != 0 {
+		t.Errorf("atomic: a group with one breaking edit must be dropped whole, got %q/%d", aout, an)
+	}
+
 	// Two safe edits on different lines exercise the highest-offset-first
 	// ordering: the line-two edit applies before the line-one edit.
 	multi := "echo a\necho b\n"
-	e1 := katas.FixEdit{Line: 1, Column: 1, Length: 4, Replace: "print"}
-	e2 := katas.FixEdit{Line: 2, Column: 1, Length: 4, Replace: "print"}
+	e1 := katas.FixEdit{Line: 1, Column: 1, Length: 4, Replace: "print", Group: 1}
+	e2 := katas.FixEdit{Line: 2, Column: 1, Length: 4, Replace: "print", Group: 2}
 	mout, mn := applySafeEdits(multi, []katas.FixEdit{e1, e2})
 	if mn != 2 || strings.Contains(mout, "echo") {
 		t.Errorf("multiline: want both applied, got %q/%d", mout, mn)

--- a/cmd/zshellcheck/main_test.go
+++ b/cmd/zshellcheck/main_test.go
@@ -576,8 +576,8 @@ func TestApplySafeEdits_Bailouts(t *testing.T) {
 		{Line: 1, Column: 10, Length: 3, Replace: "==", Group: 7},
 		{Line: 1, Column: 1, Length: 0, Replace: "fi\n", Group: 7},
 	}
-	if aout, an := applySafeEdits(atomicBase, atomic); aout != atomicBase || an != 0 {
-		t.Errorf("atomic: a group with one breaking edit must be dropped whole, got %q/%d", aout, an)
+	if got, n := applySafeEdits(atomicBase, atomic); got != atomicBase || n != 0 {
+		t.Errorf("atomic: a group with one breaking edit must be dropped whole, got %q/%d", got, n)
 	}
 
 	// Two safe edits on different lines exercise the highest-offset-first

--- a/pkg/katas/katas.go
+++ b/pkg/katas/katas.go
@@ -39,6 +39,11 @@ type FixEdit struct {
 	Length  int
 	Replace string
 	KataID  string
+	// Group ties every edit produced by one Fix call to the violation it
+	// repairs. A rewrite such as `[[ a -eq b ]]` to `(( a == b ))` spans
+	// three edits that only make sense together, so the applier keeps or
+	// discards a group as a unit and a filter drops a group as a unit.
+	Group int
 }
 
 // safeFixKatas lists the katas whose auto-fix is purely syntactic and
@@ -166,14 +171,16 @@ func (kr *KatasRegistry) FixesFor(node ast.Node, v Violation, source []byte) []F
 	if !ok || kata.Fix == nil {
 		return nil
 	}
-	return stampKataID(kata.Fix(node, v, source), kata.ID)
+	// A single violation's edits form one group.
+	return stampKataID(kata.Fix(node, v, source), kata.ID, 0)
 }
 
 // stampKataID records the producing kata on each edit so the CLI can
 // filter behavior-changing fixes without re-deriving their origin.
-func stampKataID(edits []FixEdit, id string) []FixEdit {
+func stampKataID(edits []FixEdit, id string, group int) []FixEdit {
 	for i := range edits {
 		edits[i].KataID = id
+		edits[i].Group = group
 	}
 	return edits
 }
@@ -208,7 +215,11 @@ func (kr *KatasRegistry) CheckAndFix(node ast.Node, disabledKatas []string, sour
 				vs[i].Level = kata.Severity
 			}
 			if kata.Fix != nil {
-				edits = append(edits, stampKataID(kata.Fix(node, vs[i], source), kata.ID)...)
+				// Group is the violation's index in the slice this call
+				// returns; the caller shifts it by the number of violations
+				// already collected so every group is unique per file.
+				group := len(violations) + i
+				edits = append(edits, stampKataID(kata.Fix(node, vs[i], source), kata.ID, group)...)
 			}
 		}
 		violations = append(violations, vs...)


### PR DESCRIPTION
## The bug

A rewrite can span several edits. Turning `[[ a -eq b ]]` into `(( a == b ))` replaces the opening bracket, the operator, and the closing bracket — the three only make sense together.

The safety net that rejects a pass introducing parse errors retried the edits **one at a time**, keeping whichever parsed alone. For a condition that cannot move into arithmetic — a pattern match beside a numeric test — the bracket edits failed individually while the operator edit succeeded:

```
[[ "$w" = -* && $c -eq 0 ]]   ->   [[ "$w" = -* && $c == 0 ]]
```

That parses cleanly, so **no gate objected**. But `-eq` compares numbers and `==` matches a glob pattern:

```
zsh -c '[[ "01" -eq 1 ]]'   # true
zsh -c '[[ "01" == 1 ]]'    # false
```

The safety net was manufacturing the corruption it exists to prevent, in the one form no parser check can catch.

## The fix

Each edit now carries the identity of the violation it repairs. The retry keeps or discards a **group** whole, and a group whose full application still breaks the parse is skipped rather than partially applied.

The two filters in the edit collector had the same confusion — they indexed the edit slice by *violation* position, so any run with `-severity` or a `# noka` directive tore multi-edit rewrites apart the same way. They now select by group.

## Effect

Applying every unsafe fix across the pinned corpora previously left **11 files that Zsh itself rejects**. That count is now **0** (218 files re-checked with `zsh -n`), with **no change to reported findings** — violation drift is 0 added, 0 removed.

Two of the known corruption classes are resolved by atomicity alone:

| Input | Before | After |
|---|---|---|
| `[[ "$w" = -* && $c -eq 0 ]]` | `[[ … == 0 ]]` (silent semantic change) | unchanged |
| `[ -f file ] \| cat` | `[[ -f file ]]] \| cat` (syntax error) | unchanged |

Conversions that were always correct still happen: `[[ $a -eq 0 ]]` → `(( a == 0 ))`, `[ 1 -eq 1 ]` → `(( 1 == 1 ))`, `test -f file` → `[[ -f file ]]`.

Where a group cannot be applied safely the source is now left untouched. That is a deliberate trade: no fix beats a broken fix.

## Not covered here

`test -f f 2>/dev/null` → `[[ -f f 2>/dev/null ]]` is still wrong — the fix wraps the redirect inside the brackets as a complete group, so it is a detection/rewrite bug rather than a partial-application one. It gets its own change.

## Gates

Suite, `golangci-lint`, and `gocyclo` green; parser sweep 402/0; fix-corpus sweep clean; violation sweep unchanged. `TestApplySafeEdits_Bailouts` gains a case pinning that a group containing one breaking edit is dropped whole, and its existing fixtures now state explicitly which edits are independent.

Severity: Error — silent semantic corruption of user code removed.