### PR TITLE
fix: keep a redirection outside the rewritten brackets

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1571,6 +1571,9 @@ func TestFixIntegration_ZC1293_RedirectStaysOutsideBrackets(t *testing.T) {
 		"test -f f 2>/dev/null\n":  "[[ -f f ]] 2>/dev/null\n",
 		"test -f f 2> /dev/null\n": "[[ -f f ]] 2> /dev/null\n",
 		"test -f f >/dev/null\n":   "[[ -f f ]] >/dev/null\n",
+		// Nothing but a redirection follows the command name, so there is
+		// no expression to wrap and the source is left alone.
+		"test 2>/dev/null\n": "test 2>/dev/null\n",
 	}
 	for src, want := range cases {
 		if got := runFix(t, src); got != want {

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1563,6 +1563,22 @@ func TestFixIntegration_ZC1293_TestToDoubleBracket(t *testing.T) {
 	}
 }
 
+// A redirection is not part of the test expression, so the closing bracket
+// goes before it. Wrapping it inside produces `[[ -f f 2>/dev/null ]]`,
+// which Zsh rejects.
+func TestFixIntegration_ZC1293_RedirectStaysOutsideBrackets(t *testing.T) {
+	cases := map[string]string{
+		"test -f f 2>/dev/null\n":  "[[ -f f ]] 2>/dev/null\n",
+		"test -f f 2> /dev/null\n": "[[ -f f ]] 2> /dev/null\n",
+		"test -f f >/dev/null\n":   "[[ -f f ]] >/dev/null\n",
+	}
+	for src, want := range cases {
+		if got := runFix(t, src); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	}
+}
+
 func TestFixIntegration_ZC1293_AlreadyDoubleBracket(t *testing.T) {
 	src := "[[ -f /etc/passwd ]]\n"
 	if got := runFix(t, src); got != src {

--- a/pkg/katas/zc1053_helpers_test.go
+++ b/pkg/katas/zc1053_helpers_test.go
@@ -170,3 +170,44 @@ func TestZC1053SilencesStdout(t *testing.T) {
 		t.Error("zc1053SilencesStdout(< /dev/null) = true, want false")
 	}
 }
+
+// TestZC1293LastExprArg pins where the rewritten conditional ends. A
+// trailing redirection belongs outside the brackets, and a quoted word that
+// merely looks like one is part of the expression.
+func TestZC1293LastExprArg(t *testing.T) {
+	concat := func(parts ...ast.Expression) ast.Expression {
+		return &ast.ConcatenatedExpression{Parts: parts}
+	}
+	cases := []struct {
+		name string
+		args []ast.Expression
+		want int
+	}{
+		{"no redirection", []ast.Expression{zc1053Ident("-f"), zc1053Ident("file")}, 1},
+		{
+			"attached redirection",
+			[]ast.Expression{zc1053Ident("-f"), zc1053Ident("f"), concat(zc1053Str("2>"), zc1053Ident("/dev/null"))},
+			1,
+		},
+		{
+			"spaced redirection",
+			[]ast.Expression{zc1053Ident("-f"), zc1053Ident("f"), zc1053Str(">"), zc1053Ident("/dev/null")},
+			1,
+		},
+		{
+			// A quoted word is an operand even when it looks like an operator.
+			"quoted operator is an operand",
+			[]ast.Expression{zc1053Ident("-n"), zc1053Str(`">"`)},
+			1,
+		},
+		{"only a redirection", []ast.Expression{concat(zc1053Str(">"), zc1053Ident("/dev/null"))}, -1},
+		{"no arguments", []ast.Expression{}, -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := zc1293LastExprArg(tc.args); got != tc.want {
+				t.Errorf("zc1293LastExprArg(%s) = %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/katas/zc1200s.go
+++ b/pkg/katas/zc1200s.go
@@ -5305,7 +5305,11 @@ func fixZC1293(node ast.Node, v Violation, source []byte) []FixEdit {
 	if string(source[cmdOff:cmdOff+len("test")]) != "test" {
 		return nil
 	}
-	lastArg := cmd.Arguments[len(cmd.Arguments)-1]
+	exprEnd := zc1293LastExprArg(cmd.Arguments)
+	if exprEnd < 0 {
+		return nil
+	}
+	lastArg := cmd.Arguments[exprEnd]
 	lastTok := lastArg.TokenLiteralNode()
 	lastOff := LineColToByteOffset(source, lastTok.Line, lastTok.Column)
 	if lastOff < 0 {
@@ -5324,6 +5328,30 @@ func fixZC1293(node ast.Node, v Violation, source []byte) []FixEdit {
 		{Line: v.Line, Column: v.Column, Length: len("test"), Replace: "[["},
 		{Line: endLine, Column: endCol, Length: 0, Replace: " ]]"},
 	}
+}
+
+// zc1293LastExprArg returns the index of the last argument belonging to the
+// test expression itself, stopping before any trailing redirection.
+//
+// The parser folds a redirection into the argument list rather than building
+// a redirection node, so `test -f f 2>/dev/null` arrives with the redirect
+// among the arguments. Closing the bracket after it would produce
+// `[[ -f f 2>/dev/null ]]`, which Zsh rejects; the redirect has to stay
+// outside, as `[[ -f f ]] 2>/dev/null`. Returns -1 when nothing but a
+// redirection follows the command name.
+func zc1293LastExprArg(args []ast.Expression) int {
+	end := len(args)
+	for i, arg := range args {
+		word, quoted := zc1053ArgWord(arg)
+		if quoted {
+			continue
+		}
+		if op, _ := zc1053SplitRedirect(word); op != "" {
+			end = i
+			break
+		}
+	}
+	return end - 1
 }
 
 func offsetLineColZC1293(source []byte, offset int) (int, int) {


### PR DESCRIPTION
## What

Rewriting `test EXPR` into `[[ EXPR ]]` closed the bracket after the **last argument**. Since the parser folds a redirection into the argument list rather than building a redirection node, the redirect ended up inside:

```
test -f f 2>/dev/null   ->   [[ -f f 2>/dev/null ]]
```

Zsh rejects that — a redirection may follow a conditional expression but not sit inside one:

```
zsh -n -c '[[ -f x ]] 2>/dev/null'    # valid
zsh -n -c '[[ -f x 2>/dev/null ]]'    # parse error near '>'
```

This was the last of the four autofix-corruption classes; unlike the others it was not a partial-application problem, so the atomic-group change in #1449 did not address it. The fix emitted a complete, wrong rewrite.

## The fix

The closing bracket now goes after the last argument that belongs to the expression, leaving any trailing redirection untouched:

```
test -f f 2>/dev/null    ->  [[ -f f ]] 2>/dev/null
test -f f 2> /dev/null   ->  [[ -f f ]] 2> /dev/null
test -f f >/dev/null     ->  [[ -f f ]] >/dev/null
```

Plain rewrites are unchanged (`test -f file` → `[[ -f file ]]`, `test "$a" = "$b"` → `[[ "$a" = "$b" ]]`), and the `[` form already behaved because its own `]` marks where the expression ends.

The fix is shared by ZC1006, ZC1020, ZC1036, and ZC1293, so all four are corrected together.

## Gates

Suite, `golangci-lint`, `gocyclo` green; parser sweep 402/0; fix-corpus sweep clean; violation drift 0 added, 0 removed. New `TestFixIntegration_ZC1293_RedirectStaysOutsideBrackets` covers the attached, spaced, and stdout spellings.

Severity: Error — a corrupting autofix removed.