### PR TITLE
fix: find the bracket that really ends a test

### DIFF
--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -1566,6 +1566,22 @@ func TestFixIntegration_ZC1293_TestToDoubleBracket(t *testing.T) {
 // A redirection is not part of the test expression, so the closing bracket
 // goes before it. Wrapping it inside produces `[[ -f f 2>/dev/null ]]`,
 // which Zsh rejects.
+// The `]` that ends a test is not always the first one: a glob character
+// class or a glob qualifier can carry its own. Doubling the wrong bracket
+// produced `[[ -e f(.,@[1]]) ]`, which Zsh rejects.
+func TestFixIntegration_ZC1010_ClosingBracketPastNestedBrackets(t *testing.T) {
+	cases := map[string]string{
+		"[ -e \"$1\"/*\"$2\"(.,@[1]) ]\n": "[[ -e \"$1\"/*\"$2\"(.,@[1]) ]]\n",
+		"[ -e file[1] ]\n":                "[[ -e file[1] ]]\n",
+		"[ -e \"${arr[1]}\" ]\n":          "[[ -e \"${arr[1]}\" ]]\n",
+	}
+	for src, want := range cases {
+		if got := runFix(t, src); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	}
+}
+
 func TestFixIntegration_ZC1293_RedirectStaysOutsideBrackets(t *testing.T) {
 	cases := map[string]string{
 		"test -f f 2>/dev/null\n":  "[[ -f f ]] 2>/dev/null\n",

--- a/pkg/katas/zc1000s.go
+++ b/pkg/katas/zc1000s.go
@@ -706,6 +706,12 @@ func findTestCloseBracket(source []byte, open int) int {
 type bracketScan struct {
 	inSingle, inDouble bool
 	braceDepth         int
+	// A `[` inside the expression opens a glob character class
+	// (`file[1]`, `[^[:space:]]`) and a `(` opens a glob qualifier
+	// (`*(.,@[1])`). Both can contain a `]` that does not end the test, so
+	// the scan has to count them.
+	bracketDepth int
+	parenDepth   int
 }
 
 // advance returns (newIndex, true) when the byte at i drives the scanner
@@ -744,8 +750,20 @@ func (s *bracketScan) closedAt(source []byte, i int) bool {
 		if s.braceDepth > 0 {
 			s.braceDepth--
 		}
+	case '[':
+		s.bracketDepth++
+	case '(':
+		s.parenDepth++
+	case ')':
+		if s.parenDepth > 0 {
+			s.parenDepth--
+		}
 	case ']':
-		if s.braceDepth == 0 {
+		if s.bracketDepth > 0 {
+			s.bracketDepth--
+			return false
+		}
+		if s.braceDepth == 0 && s.parenDepth == 0 {
 			return true
 		}
 	}


### PR DESCRIPTION
## What

Rewriting `[ EXPR ]` into `[[ EXPR ]]` located the closing bracket by scanning for the next unquoted `]` outside braces. A glob character class or a glob qualifier carries its own `]`, so the scan stopped early and doubled the wrong one:

```
[ -e "$1"/*"$2"(.,@[1]) ]   ->   [[ -e "$1"/*"$2"(.,@[1]]) ]
```

Zsh rejects that. The scan now counts nested `[` and `(` as well, so the bracket that ends the test is the one that closes it.

## How it surfaced

This came out of a `zsh -n` audit of the fixer across the corpus. Notably, the atomic-group change in #1449 masks this case in isolation — the broken rewrite raises zshellcheck's own parse-error count there, so the group is skipped — but inside a large file the tool's parser does not object and the corruption lands. That is the self-oracle weakness in one sentence: the guard only works where the tool already agrees with Zsh.

## Effect

`zgen/zgen.zsh` was the last corpus file Zsh still rejected after the recent fixes; it now parses cleanly. Across all 339 baseline files, applying every unsafe fix leaves **zero** files that `zsh -n` rejects, down from 11 when this work started.

Conversions are otherwise unchanged: `[ -n "$x" ]` → `[[ -n "$x" ]]`, `[ -e file[1] ]` → `[[ -e file[1] ]]`, `[ -e "${arr[1]}" ]` → `[[ -e "${arr[1]}" ]]`.

## Gates

Suite, `golangci-lint`, `gocyclo` green; parser sweep 402/0; fix-corpus sweep clean; violation drift 0 added, 0 removed. New `TestFixIntegration_ZC1010_ClosingBracketPastNestedBrackets` covers the glob-qualifier, character-class, and subscript forms.

Severity: Error — a corrupting autofix removed.