### PR TITLE
ci: install zsh for the auto-fix sweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,11 @@ jobs:
           cache: true
       - name: Build zshellcheck
         run: go build -o zshellcheck ./cmd/zshellcheck
+      - name: Install Zsh
+        # The auto-fix sweep asks zsh whether a rewritten file still parses.
+        # Without zsh that check skips itself, so the gate would pass while
+        # seeing only what our own parser sees.
+        run: sudo apt-get update && sudo apt-get install -y zsh
       - name: Sweep pinned corpora against baseline
         env:
           ZSHELLCHECK_BIN: ${{ github.workspace }}/zshellcheck


### PR DESCRIPTION
The auto-fix sweep asks zsh whether a rewritten file still parses, and skips that check when zsh is missing. The corpus job did not have zsh, so its first run after #1452 reported:

```
fix-corpus sweep: files=402 corruptions=0 non_idempotent=0 panics=0 zsh=none
```

`zsh=none` means the check never executed — the gate passed while seeing only what our own, more permissive, parser sees. That is the exact blindness #1452 set out to remove, so until this lands that change is inert in CI.

The build-and-test job already installs zsh for the integration suite; the corpus job now does the same. Its summary line should read `zsh=zsh` from here on, which is why that marker was added — a silent degradation is visible in the log.

Caught by checking the merged run's output rather than assuming the runner image had zsh.