### PR TITLE
fix: reject a redirection with no target

### DIFF
--- a/pkg/parser/parser_corpus_fixes_test.go
+++ b/pkg/parser/parser_corpus_fixes_test.go
@@ -681,6 +681,13 @@ func TestParseDanglingRedirection(t *testing.T) {
 		"grep p f 1>\n",
 		"grep p f 2>\n",
 		"echo x > | cat\n",
+		// The compound operators reach the expression-path redirection
+		// parser rather than the command one.
+		"x=1 >>\n",
+		"( cmd >> )\n",
+		"a && b >>\n",
+		"cmd | b <&\n",
+		"f() { cmd >& }\n",
 	}
 	for _, src := range dangling {
 		p := New(lexer.New(src))

--- a/pkg/parser/parser_corpus_fixes_test.go
+++ b/pkg/parser/parser_corpus_fixes_test.go
@@ -668,3 +668,46 @@ func TestParseCommandPositionSubshell(t *testing.T) {
 		}
 	}
 }
+
+// A redirection needs a target. Zsh rejects `cmd >` outright, and this
+// parser used to accept it, which is how a rewrite that removed a redirect
+// target while leaving its operator behind passed the auto-fix safety gate.
+// `>|` and `>>|` override NO_CLOBBER and are not dangling, even though the
+// lexer splits them into an operator and a pipe.
+func TestParseDanglingRedirection(t *testing.T) {
+	dangling := []string{
+		"grep p f >\n",
+		"grep p f >>\n",
+		"grep p f 1>\n",
+		"grep p f 2>\n",
+		"echo x > | cat\n",
+	}
+	for _, src := range dangling {
+		p := New(lexer.New(src))
+		p.ParseProgram()
+		if len(p.Errors()) == 0 {
+			t.Errorf("want a parser error for %q, got none", src)
+		}
+	}
+
+	clean := []string{
+		"grep p f > /dev/null\n",
+		"grep p f >/dev/null\n",
+		"echo x >> log\n",
+		"cmd > out 2>&1\n",
+		"exec 3>&1\n",
+		": >| /dev/null\n",
+		": >>| \"${FILE}\"\n",
+		"cat <<< \"$x\"\n",
+		"diff <(a) <(b)\n",
+		"grep \">\" f\n",
+		"if (( a > b )); then :; fi\n",
+	}
+	for _, src := range clean {
+		p := New(lexer.New(src))
+		p.ParseProgram()
+		if errs := p.Errors(); len(errs) != 0 {
+			t.Errorf("unexpected parser errors for %q: %v", src, errs)
+		}
+	}
+}

--- a/pkg/parser/parser_expr.go
+++ b/pkg/parser/parser_expr.go
@@ -1437,10 +1437,33 @@ func (p *Parser) parseRedirection(left ast.Expression) ast.Expression {
 		Left:     left,
 	}
 
+	// A redirection needs somewhere to redirect to. Zsh rejects `cmd >`
+	// outright, and accepting it silently is how a rewrite that deleted a
+	// redirect target while leaving its operator behind passed every gate:
+	// the fix-safety sweep measures corruption with this parser, so what
+	// this parser forgives, that gate cannot see.
+	if p.redirectTargetMissing() {
+		p.errors = append(p.errors, fmt.Sprintf("line %d:%d: redirection %q has no target",
+			expr.Token.Line, expr.Token.Column, expr.Operator))
+		return expr
+	}
+
 	p.nextToken()
 	expr.Right = p.parseExpression(LOWEST)
 
 	return expr
+}
+
+// redirectTargetMissing reports whether the redirection operator at
+// curToken is followed by nothing that could name a target: the end of the
+// input, a command separator, or the start of a new logical line.
+func (p *Parser) redirectTargetMissing() bool {
+	switch p.peekToken.Type {
+	case token.EOF, token.SEMICOLON, token.DSEMI, token.PIPE, token.AND, token.OR,
+		token.AMPERSAND, token.RPAREN, token.RBRACE, token.DoubleRparen, token.RDBRACKET:
+		return true
+	}
+	return !p.peekOnSameLogicalLine()
 }
 
 func (p *Parser) parseIndexExpression(left ast.Expression) ast.Expression {

--- a/pkg/parser/parser_stmt.go
+++ b/pkg/parser/parser_stmt.go
@@ -3,6 +3,9 @@
 package parser
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/afadesigns/zshellcheck/pkg/ast"
 	"github.com/afadesigns/zshellcheck/pkg/token"
 )
@@ -735,7 +738,95 @@ func (p *Parser) parseSingleCommand() ast.Expression {
 		cmd.Arguments = append(cmd.Arguments, arg)
 	}
 
+	p.checkDanglingRedirect(cmd)
 	return reshapeCommandAssignment(cmd)
+}
+
+// redirectOperators are the redirection operators that require a target
+// word after them. A file-descriptor prefix (`1>`, `2>>`) is stripped
+// before the lookup.
+var redirectOperators = map[string]bool{
+	">": true, ">>": true, ">|": true, ">&": true, "&>": true, "&>>": true,
+	"<": true, "<>": true, "<&": true,
+}
+
+// checkDanglingRedirect records a parser error when a command ends on a
+// redirection operator with nothing to redirect to.
+//
+// A redirection is folded into the argument list rather than parsed as a
+// redirection node, so `cmd >` arrives as a final argument holding the bare
+// operator. Zsh rejects that outright. Accepting it silently is how a
+// rewrite that removed a redirect target while leaving its operator behind
+// passed the auto-fix safety gate, which measures corruption with this
+// parser.
+func (p *Parser) checkDanglingRedirect(cmd *ast.SimpleCommand) {
+	n := len(cmd.Arguments)
+	if n == 0 {
+		return
+	}
+	// `>|` and `>>|` override NO_CLOBBER. The lexer splits them into the
+	// operator plus a pipe token, so a glued pipe after the operator means
+	// the target is still to come, not that it is missing.
+	if p.peekTokenIs(token.PIPE) && !p.peekToken.HasPrecedingSpace {
+		return
+	}
+	last := cmd.Arguments[n-1]
+	word, ok := bareRedirectOperator(last)
+	if !ok {
+		return
+	}
+	tok := last.TokenLiteralNode()
+	p.errors = append(p.errors, fmt.Sprintf("line %d:%d: redirection %q has no target",
+		tok.Line, tok.Column, word))
+}
+
+// bareRedirectOperator reports whether an argument is nothing but a
+// redirection operator. A quoted word is data, not syntax.
+func bareRedirectOperator(arg ast.Expression) (string, bool) {
+	var word string
+	switch n := arg.(type) {
+	case *ast.StringLiteral:
+		word = n.Value
+	case *ast.Identifier:
+		word = n.Value
+	case *ast.ConcatenatedExpression:
+		// A file-descriptor prefix splits the word: `2>` arrives as the
+		// integer 2 glued to the operator.
+		for _, part := range n.Parts {
+			text, ok := redirectPartText(part)
+			if !ok {
+				return "", false
+			}
+			word += text
+		}
+	default:
+		return "", false
+	}
+	if word == "" || word[0] == '\'' || word[0] == '"' {
+		return "", false
+	}
+	trimmed := strings.TrimLeft(word, "0123456789")
+	if trimmed == "" || !redirectOperators[trimmed] {
+		return "", false
+	}
+	return word, true
+}
+
+// redirectPartText renders one piece of a concatenated word, reporting
+// false for a part that cannot belong to a bare redirection operator.
+func redirectPartText(part ast.Expression) (string, bool) {
+	switch n := part.(type) {
+	case *ast.StringLiteral:
+		if n.Value != "" && (n.Value[0] == '\'' || n.Value[0] == '"') {
+			return "", false
+		}
+		return n.Value, true
+	case *ast.Identifier:
+		return n.Value, true
+	case *ast.IntegerLiteral:
+		return n.String(), true
+	}
+	return "", false
 }
 
 // reshapeCommandAssignment converts a command-position assignment that the


### PR DESCRIPTION
## What

Zsh rejects `cmd >` outright. This parser accepted it — and that silence had consequences beyond a missing diagnostic. The auto-fix safety gate measures corruption with this parser, so a rewrite that deleted a redirect target while leaving its operator behind scored **zero errors** and passed every run. That is how the ZC1273 corruption reached the corpus unnoticed.

## Where the check goes

A redirection in command position is folded into the argument list rather than parsed as a redirection node, so the check belongs where a command finishes gathering arguments: a final argument that is nothing but a redirection operator — with or without a file-descriptor prefix — now records a parser error. The expression-path redirection parser gained the same guard.

## The one subtlety

`>|` and `>>|` override `NO_CLOBBER`, and the lexer splits them into an operator plus a pipe token. A pipe **glued** to the operator therefore means the target is still to come, while a spaced `> | cat` really is dangling — which matches zsh:

```
zsh -n -c ': >>| /dev/null'      # valid
zsh -n -c 'echo x > | cat'       # parse error near '|'
```

`zaw/sources/bookmark.zsh` uses `: >>| "${BOOKMARKFILE}"`; the corpus sweep caught my first attempt flagging it, which is what surfaced this distinction.

## Agreement with zsh

Checked on eighteen forms — dangling `>`, `>>`, `1>`, `2>`, `> | cat`; and valid `> file`, `>/dev/null`, `>> log`, `2>&1`, `exec 3>&1`, `>|`, `>>|`, heredoc, here-string, process substitution, a quoted `">"`, and `(( a > b ))`. The linter and zsh agree on every one.

## Gates

Parser sweep 402 files / **0** errors; violation drift 0 added, 0 removed; fix-corpus sweep clean with the zsh oracle; suite, `golangci-lint`, `gocyclo` green.

Severity: Warning — a syntax error the linter used to accept.