### PR TITLE
fix: recognise git clone --depth=1 and friends

### DIFF
--- a/.github/violation-baseline.txt
+++ b/.github/violation-baseline.txt
@@ -1125,7 +1125,6 @@ zgen/zgen.zsh	ZC1075	3
 zgen/zgen.zsh	ZC1097	7
 zgen/zgen.zsh	ZC1098	1
 zgen/zgen.zsh	ZC1099	1
-zgen/zgen.zsh	ZC1231	1
 zgen/zgen.zsh	ZC1830	1
 zhooks/zhooks.plugin.zsh	ZC1075	2
 zimfw/zimfw.zsh	ZC1040	1

--- a/pkg/fix/integration_test.go
+++ b/pkg/fix/integration_test.go
@@ -653,6 +653,23 @@ func TestFixIntegration_ZC1231_GitCloneShallow(t *testing.T) {
 	}
 }
 
+// A clone that already limits its history is left alone. Inserting a second
+// history-limiting option is never an improvement: git refuses `--depth`
+// together with `--shallow-since`, and a second `--depth` silently overrides
+// the first.
+func TestFixIntegration_ZC1231_ShallowCloneUntouched(t *testing.T) {
+	for _, src := range []string{
+		"git clone --depth=1 https://github.com/x/y\n",
+		"git clone --depth=50 https://github.com/x/y\n",
+		"git clone --shallow-since=2024-01-01 https://github.com/x/y\n",
+		"git clone --shallow-exclude=refs/tags/v1 https://github.com/x/y\n",
+	} {
+		if got := runFix(t, src); got != src {
+			t.Errorf("got %q, want it unchanged", got)
+		}
+	}
+}
+
 func TestFixIntegration_ZC1241_XargsAddNullSep(t *testing.T) {
 	src := "xargs rm\n"
 	// ZC1773 (xargs -r to skip the no-input run) shares this fixture and

--- a/pkg/katas/fixutil.go
+++ b/pkg/katas/fixutil.go
@@ -2,7 +2,11 @@
 // Copyright the ZShellCheck contributors.
 package katas
 
-import "github.com/afadesigns/zshellcheck/pkg/ast"
+import (
+	"strings"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+)
 
 // LineColToByteOffset converts a 1-based (line, column) coordinate
 // pair into a 0-based byte offset within source. It returns -1 when
@@ -115,4 +119,20 @@ func CommandIdentifier(cmd *ast.SimpleCommand) string {
 		return ""
 	}
 	return ident.Value
+}
+
+// LongFlagName splits a long option into its name and reports whether the
+// argument carried an inline value. `--depth=1` yields `--depth`, true;
+// `--depth` yields `--depth`, false. A word that is not a long option comes
+// back unchanged. Most GNU-style tools accept both spellings for a
+// value-taking option, so a kata that compares an argument against a bare
+// `--flag` sees only half of real usage.
+func LongFlagName(word string) (string, bool) {
+	if !strings.HasPrefix(word, "--") {
+		return word, false
+	}
+	if name, _, found := strings.Cut(word, "="); found {
+		return name, true
+	}
+	return word, false
 }

--- a/pkg/katas/fixutil_test.go
+++ b/pkg/katas/fixutil_test.go
@@ -2,7 +2,12 @@
 // Copyright the ZShellCheck contributors.
 package katas
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/afadesigns/zshellcheck/pkg/ast"
+	"github.com/afadesigns/zshellcheck/pkg/token"
+)
 
 func TestLineColToByteOffset(t *testing.T) {
 	src := []byte("abc\ndef\nghi")
@@ -98,5 +103,36 @@ func TestZC1231LimitsHistory(t *testing.T) {
 		if zc1231LimitsHistory(word) {
 			t.Errorf("zc1231LimitsHistory(%q) = true, want false", word)
 		}
+	}
+}
+
+// TestFixZC1231RefusesSecondShallowFlag pins the guard inside the fix. The
+// check never reports a clone that already limits its history, so this path
+// exists to keep a future change to the check from producing
+// `--depth 1 --shallow-since=...`, which git refuses outright.
+func TestFixZC1231RefusesSecondShallowFlag(t *testing.T) {
+	// The fix locates the `clone` token in the source by position, so the
+	// argument carries the column it occupies in `source`.
+	clone := func(flag string) *ast.SimpleCommand {
+		cloneArg := &ast.Identifier{
+			Token: token.Token{Literal: "clone", Line: 1, Column: 5},
+			Value: "clone",
+		}
+		args := []ast.Expression{cloneArg}
+		if flag != "" {
+			args = append(args, &ast.Identifier{Value: flag})
+		}
+		args = append(args, &ast.Identifier{Value: "https://example.com/r"})
+		return &ast.SimpleCommand{Name: &ast.Identifier{Value: "git"}, Arguments: args}
+	}
+	source := []byte("git clone https://example.com/r\n")
+	for _, flag := range []string{"--depth=1", "--shallow-since=2024-01-01", "--shallow-exclude=v1"} {
+		if edits := fixZC1231(clone(flag), Violation{}, source); edits != nil {
+			t.Errorf("fixZC1231 with %s returned %d edits, want none", flag, len(edits))
+		}
+	}
+	// A clone with no such flag still gets the insertion.
+	if edits := fixZC1231(clone(""), Violation{}, source); len(edits) != 1 {
+		t.Errorf("fixZC1231 on a full clone returned %d edits, want 1", len(edits))
 	}
 }

--- a/pkg/katas/fixutil_test.go
+++ b/pkg/katas/fixutil_test.go
@@ -53,3 +53,50 @@ func TestIdentLenAt(t *testing.T) {
 		t.Errorf("IdentLenAt(eof)=%d, want 0", got)
 	}
 }
+
+// TestLongFlagName pins the split between a long option and its inline
+// value, including the words that are not long options at all.
+func TestLongFlagName(t *testing.T) {
+	cases := []struct {
+		word      string
+		wantName  string
+		wantValue bool
+	}{
+		{"--depth=1", "--depth", true},
+		{"--depth", "--depth", false},
+		{"--filter=blob:none", "--filter", true},
+		{`--depth="1"`, "--depth", true},
+		{"--depth=", "--depth", true},
+		{"--", "--", false},
+		{"-d=1", "-d=1", false},
+		{"clone", "clone", false},
+		{"", "", false},
+	}
+	for _, tc := range cases {
+		name, value := LongFlagName(tc.word)
+		if name != tc.wantName || value != tc.wantValue {
+			t.Errorf("LongFlagName(%q) = (%q, %v), want (%q, %v)",
+				tc.word, name, value, tc.wantName, tc.wantValue)
+		}
+	}
+}
+
+// TestZC1231LimitsHistory pins which `git clone` options count as already
+// limiting the downloaded history.
+func TestZC1231LimitsHistory(t *testing.T) {
+	for _, word := range []string{
+		"--depth", "--depth=1", "--shallow-since=2024-01-01",
+		"--shallow-since", "--shallow-exclude=refs/tags/v1",
+	} {
+		if !zc1231LimitsHistory(word) {
+			t.Errorf("zc1231LimitsHistory(%q) = false, want true", word)
+		}
+	}
+	for _, word := range []string{
+		"--single-branch", "--filter=blob:none", "--recursive", "-b", "clone", "",
+	} {
+		if zc1231LimitsHistory(word) {
+			t.Errorf("zc1231LimitsHistory(%q) = true, want false", word)
+		}
+	}
+}

--- a/pkg/katas/katatests/zc1200s_test.go
+++ b/pkg/katas/katatests/zc1200s_test.go
@@ -1098,6 +1098,52 @@ func TestZC1231(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
+			// Git accepts an inline value for every option that
+			// truncates history, and that spelling is the common one.
+			name:     "valid git clone --depth=1",
+			input:    `git clone --depth=1 https://github.com/user/repo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid git clone --depth=50",
+			input:    `git clone --depth=50 https://github.com/user/repo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid git clone --depth quoted value",
+			input:    `git clone --depth="1" https://github.com/user/repo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid git clone --shallow-since inline",
+			input:    `git clone --shallow-since=2024-01-01 https://github.com/user/repo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid git clone --shallow-since spaced",
+			input:    `git clone --shallow-since 2024-01-01 https://github.com/user/repo`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid git clone --shallow-exclude",
+			input:    `git clone --shallow-exclude=refs/tags/v1 https://github.com/user/repo`,
+			expected: []katas.Violation{},
+		},
+		{
+			// `--single-branch` narrows the clone to one branch but still
+			// downloads that branch's whole history.
+			name:  "invalid git clone --single-branch",
+			input: `git clone --single-branch https://github.com/user/repo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1231",
+					Message: "Consider `git clone --depth 1` in scripts. Full clones download entire history which is unnecessary for builds and CI.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
 			name:  "invalid git clone full",
 			input: `git clone https://github.com/user/repo`,
 			expected: []katas.Violation{

--- a/pkg/katas/zc1200s.go
+++ b/pkg/katas/zc1200s.go
@@ -1724,6 +1724,22 @@ func init() {
 	})
 }
 
+// zc1231ShallowFlags are the `git clone` options that truncate the history
+// the clone downloads. Each takes a value, and git accepts both spellings:
+// `--depth 1` and `--depth=1`.
+var zc1231ShallowFlags = map[string]bool{
+	"--depth":           true,
+	"--shallow-since":   true,
+	"--shallow-exclude": true,
+}
+
+// zc1231LimitsHistory reports whether a `git clone` argument already limits
+// how much history the clone downloads.
+func zc1231LimitsHistory(word string) bool {
+	name, _ := LongFlagName(word)
+	return zc1231ShallowFlags[name]
+}
+
 // fixZC1231 inserts ` --depth 1` after the `clone` subcommand in
 // `git clone …`. Mirrors ZC1234's subcommand-level insertion for
 // docker run --rm.
@@ -1738,6 +1754,14 @@ func fixZC1231(node ast.Node, _ Violation, source []byte) []FixEdit {
 	cloneArg := cmd.Arguments[0]
 	if cloneArg.String() != "clone" {
 		return nil
+	}
+	// Adding a second history-limiting option is never right: `--depth 1`
+	// alongside `--shallow-since` makes git refuse the clone outright, and
+	// alongside another `--depth` the last value silently wins.
+	for _, arg := range cmd.Arguments[1:] {
+		if zc1231LimitsHistory(arg.String()) {
+			return nil
+		}
 	}
 	tok := cloneArg.TokenLiteralNode()
 	off := LineColToByteOffset(source, tok.Line, tok.Column)
@@ -1798,8 +1822,7 @@ func checkZC1231(node ast.Node) []Violation {
 
 	hasDepth := false
 	for _, arg := range cmd.Arguments[1:] {
-		val := arg.String()
-		if val == "--depth" || val == "--shallow-since" || val == "--single-branch" {
+		if zc1231LimitsHistory(arg.String()) {
 			hasDepth = true
 		}
 	}


### PR DESCRIPTION
## What

Every `git clone` option that truncates history takes a value, and git accepts both spellings — `--depth 1` and `--depth=1`. ZC1231 compared each argument against a bare `--depth`, so the inline form read as a full clone.

That spelling is not the rare one. Across the pinned corpora, clone lines that set a depth use `--depth=N` over `--depth N` by **2.6 to 1**; long options in general carry an inline value in roughly a third of real usages. The kata was blind to the majority form.

## Why it matters more than a stray warning

The auto-fix acted on the bad reading. On a clone that limits history by date it inserted `--depth 1` alongside `--shallow-since`, and git rejects that pair outright:

```text
fatal: git upload-pack: deepen and deepen-since (or deepen-not) cannot be used together
```

Exit 128 — a working shallow clone rewritten into a command that cannot run. The second failure mode is quieter: git keeps the **last** value of a repeated option, so inserting `--depth 1` ahead of an existing `--depth=50` accomplishes nothing while leaving a duplicate flag behind.

## The change

- Arguments split on an inline `=` before the name is compared, through a new `LongFlagName` helper in `fixutil.go`. It is the reusable primitive for this class.
- `--shallow-exclude` joins the set it always belonged to.
- The fix refuses to add a second history-limiting option, so the two failures above cannot recur even if the check is bypassed.
- `--single-branch` **leaves** the set. It narrows a clone to one branch but still downloads that branch entire, which is precisely the cost the kata warns about. Verified against git 2.55.0: `git clone --single-branch` of a six-commit repository fetches all six.

## Behaviour

| clone | before | after |
|---|---|---|
| `--depth 1` | clean | clean |
| `--depth=1`, `--depth=50`, `--depth="1"` | **flagged, fix breaks or no-ops** | clean |
| `--shallow-since=<date>` | **flagged, fix exits 128** | clean |
| `--shallow-since <date>` | clean | clean |
| `--shallow-exclude=<ref>` | **flagged** | clean |
| `--single-branch` | silent | flagged, fix valid |
| `--filter=blob:none` | flagged | flagged, fix valid |
| plain | flagged | flagged |

`--filter` stays a finding on purpose: a blobless partial clone still fetches the full commit history, and `--depth 1 --filter=blob:none` is a valid combination.

## Gates

Violation drift is one line, and it is the bug itself: `zgen/zgen.zsh:136` clones with `--depth=1 --recursive` and was being told to make it shallow. Nothing appeared. Parser sweep 402/0; fix-corpus sweep clean under the zsh oracle; suite, `golangci-lint` (0 issues), `gocyclo` green.

Severity stays Style.