### PR TITLE
fix: read a long flag with an inline value

### DIFF
--- a/pkg/katas/katatests/zc1100s_test.go
+++ b/pkg/katas/katatests/zc1100s_test.go
@@ -557,6 +557,23 @@ func TestZC1111(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
+			// xargs accepts the value inline for every option that takes
+			// one, and that spelling must count the same as the spaced one.
+			name:     "valid xargs with parallel inline value",
+			input:    `xargs --max-procs=4 cmd`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid xargs with replace inline value",
+			input:    `xargs --replace=@ mv @ /dest`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid xargs with max-lines inline value",
+			input:    `xargs --max-lines=1 cmd`,
+			expected: []katas.Violation{},
+		},
+		{
 			name:     "valid xargs with parallel",
 			input:    `xargs -P 4 cmd`,
 			expected: []katas.Violation{},

--- a/pkg/katas/katatests/zc1400s_test.go
+++ b/pkg/katas/katatests/zc1400s_test.go
@@ -219,6 +219,18 @@ func TestZC1406(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
+			name:  "invalid — xargs --max-procs=4",
+			input: `xargs --max-procs=4 cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1406",
+					Message: "Consider `zargs -P N` (autoload -Uz zargs) instead of `xargs -P N`. Parallel execution with Zsh functions in scope — no subshell-per-item.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
 			name:  "invalid — xargs -P 4",
 			input: `xargs -P 4 cmd`,
 			expected: []katas.Violation{
@@ -4170,6 +4182,12 @@ func TestZC1494(t *testing.T) {
 		{
 			name:     "valid — tcpdump -w capture.pcap -Z tcpdump",
 			input:    `tcpdump -i eth0 -w capture.pcap -Z tcpdump`,
+			expected: []katas.Violation{},
+		},
+		{
+			// tcpdump documents the value inline: --relinquish-privileges=user.
+			name:     "valid — tcpdump -w with inline privilege drop",
+			input:    `tcpdump -i eth0 -w capture.pcap --relinquish-privileges=tcpdump`,
 			expected: []katas.Violation{},
 		},
 		{

--- a/pkg/katas/katatests/zc1500s_test.go
+++ b/pkg/katas/katatests/zc1500s_test.go
@@ -1003,6 +1003,16 @@ func TestZC1521(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
+			name:     "valid — strace --trace=openat cmd",
+			input:    `strace --trace=openat ls`,
+			expected: []katas.Violation{},
+		},
+		{
+			name:     "valid — strace --trace-path=/etc cmd",
+			input:    `strace --trace-path=/etc ls`,
+			expected: []katas.Violation{},
+		},
+		{
 			name:  "invalid — strace -f cmd",
 			input: `strace -f ls`,
 			expected: []katas.Violation{
@@ -3863,6 +3873,12 @@ func TestZC1579(t *testing.T) {
 		{
 			name:     "valid — curl --retry-all-errors --max-time 30 URL",
 			input:    `curl https://host --retry-all-errors --max-time 30`,
+			expected: []katas.Violation{},
+		},
+		{
+			// curl accepts `--max-time=30` as well as `--max-time 30`.
+			name:     "valid — curl --retry-all-errors --max-time=30 URL",
+			input:    `curl https://host --retry-all-errors --max-time=30`,
 			expected: []katas.Violation{},
 		},
 		{

--- a/pkg/katas/zc1100s.go
+++ b/pkg/katas/zc1100s.go
@@ -506,16 +506,19 @@ func checkZC1111(node ast.Node) []Violation {
 	for _, arg := range cmd.Arguments {
 		val := arg.String()
 		if len(val) > 1 && val[0] == '-' {
+			// `--max-procs`, `--replace` and `--max-lines` take a value,
+			// which xargs accepts inline as `--max-procs=4`.
+			name, _ := LongFlagName(val)
 			switch {
-			case val == "-0", val == "--null":
+			case name == "-0", name == "--null":
 				return nil
-			case val == "-P", val == "--max-procs":
+			case name == "-P", name == "--max-procs":
 				return nil
-			case val == "-I", val == "--replace":
+			case name == "-I", name == "--replace":
 				return nil
-			case val == "-L", val == "--max-lines":
+			case name == "-L", name == "--max-lines":
 				return nil
-			case val == "-p", val == "--interactive":
+			case name == "-p", name == "--interactive":
 				return nil
 			}
 		}

--- a/pkg/katas/zc1400s.go
+++ b/pkg/katas/zc1400s.go
@@ -433,7 +433,9 @@ func checkZC1406(node ast.Node) []Violation {
 
 	for i, arg := range cmd.Arguments {
 		v := arg.String()
-		if v == "-P" || v == "--max-procs" ||
+		// xargs accepts the value inline: `--max-procs=4`.
+		name, _ := LongFlagName(v)
+		if name == "-P" || name == "--max-procs" ||
 			(len(v) > 2 && v[:2] == "-P") {
 			_ = i
 			return []Violation{{
@@ -5044,7 +5046,8 @@ func checkZC1494(node ast.Node) []Violation {
 		if v == "-w" || v == "--write-file" {
 			hasW = true
 		}
-		if v == "-Z" || v == "--relinquish-privileges" {
+		// tcpdump documents the value inline: `--relinquish-privileges=user`.
+		if name, _ := LongFlagName(v); name == "-Z" || name == "--relinquish-privileges" {
 			hasZ = true
 		}
 	}

--- a/pkg/katas/zc1500s.go
+++ b/pkg/katas/zc1500s.go
@@ -1221,7 +1221,10 @@ func checkZC1521(node ast.Node) []Violation {
 	// Any filter flag present → skip.
 	for _, arg := range cmd.Arguments {
 		v := arg.String()
-		if v == "-e" || v == "--trace" || v == "--trace-path" || v == "-P" {
+		// strace documents both as taking an inline value:
+		// `--trace=syscall_set`, `--trace-path=path`.
+		name, _ := LongFlagName(v)
+		if name == "-e" || name == "--trace" || name == "--trace-path" || name == "-P" {
 			return nil
 		}
 	}
@@ -4374,7 +4377,8 @@ func checkZC1579(node ast.Node) []Violation {
 		if v == "--retry-all-errors" {
 			hasRetryAll = true
 		}
-		if v == "--max-time" || v == "-m" {
+		// curl accepts `--max-time=5` as well as `--max-time 5`.
+		if name, _ := LongFlagName(v); name == "--max-time" || name == "-m" {
 			hasMaxTime = true
 		}
 	}


### PR DESCRIPTION
## What

Most GNU-style tools accept `--flag=value` wherever they accept `--flag value`, and roughly a third of real long-flag usage takes the inline form. Five katas compared an argument against the bare spelling only, so the inline one slipped past.

## Both directions were wrong

Sometimes in the same command. On `xargs --max-procs=4 cmd`:

| kata | before | after |
|---|---|---|
| ZC1111 | fires — sees a plain xargs, suggests a Zsh loop | silent |
| ZC1406 | silent — misses the parallel form it exists to catch | fires |

The other three are false positives on code that already does the right thing:

| kata | input that misfired |
|---|---|
| ZC1521 | `strace --trace=openat ls` read as an unscoped strace |
| ZC1579 | `curl --retry-all-errors --max-time=5` read as having no timeout |
| ZC1494 | `tcpdump -w f --relinquish-privileges=user` read as an unguarded capture |

## Spellings verified against the tools on this machine

```text
xargs     --max-procs=max-procs, --replace[=replace-str], --max-lines[=max-lines]
strace    --trace=syscall_set, --trace-path=path
curl      --max-time=5      (bad value gives the same diagnostic as the spaced form)
tcpdump   --relinquish-privileges=user
```

Boolean options are left alone — `xargs --null=x` exits with `option '--null' doesn't allow an argument`, so the inline form cannot occur.

## Deliberately excluded

`sudo --preserve-env=list` names the variables to keep rather than preserving the whole environment. It is a different flag from bare `-E`, not a spelling of it, and reporting it with ZC1584's wholesale wording would misdescribe the code. It needs its own treatment.

## Gates

Corpus drift zero — no pinned file writes these options inline, so this is a pure correctness gain with no observable change on the corpus. The new cases are non-vacuous: eight subtests fail against the previous code. Parser sweep 402/0; fix-corpus sweep clean under the zsh oracle; suite, `golangci-lint` (0 issues), `gocyclo` green.

Builds on the `LongFlagName` helper added in #1455.