### PR TITLE
fix: read a flag value written inline

### DIFF
--- a/pkg/katas/fixutil.go
+++ b/pkg/katas/fixutil.go
@@ -136,3 +136,34 @@ func LongFlagName(word string) (string, bool) {
 	}
 	return word, false
 }
+
+// FlagValueAt returns the value carried by the option at args[i] when that
+// option is one of names, together with the number of arguments it spans.
+// `--directory=/` spans one argument, `--directory /` spans two. A word that
+// names no listed option, or an option whose value never arrives, yields
+// ("", 0).
+func FlagValueAt(args []ast.Expression, i int, names ...string) (string, int) {
+	if i < 0 || i >= len(args) {
+		return "", 0
+	}
+	word := args[i].String()
+	name, inline := LongFlagName(word)
+	matched := false
+	for _, want := range names {
+		if name == want {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return "", 0
+	}
+	if inline {
+		_, value, _ := strings.Cut(word, "=")
+		return value, 1
+	}
+	if i+1 >= len(args) {
+		return "", 0
+	}
+	return args[i+1].String(), 2
+}

--- a/pkg/katas/fixutil_test.go
+++ b/pkg/katas/fixutil_test.go
@@ -136,3 +136,42 @@ func TestFixZC1231RefusesSecondShallowFlag(t *testing.T) {
 		t.Errorf("fixZC1231 on a full clone returned %d edits, want 1", len(edits))
 	}
 }
+
+// TestFlagValueAt pins how an option's value is read in either spelling,
+// including the bounds guards the kata loops never reach.
+func TestFlagValueAt(t *testing.T) {
+	args := func(words ...string) []ast.Expression {
+		out := make([]ast.Expression, 0, len(words))
+		for _, w := range words {
+			out = append(out, &ast.Identifier{Value: w})
+		}
+		return out
+	}
+	cases := []struct {
+		name      string
+		args      []ast.Expression
+		index     int
+		names     []string
+		wantValue string
+		wantSpan  int
+	}{
+		{"inline", args("--directory=/"), 0, []string{"--directory"}, "/", 1},
+		{"spaced", args("--directory", "/"), 0, []string{"--directory"}, "/", 2},
+		{"short spaced", args("-C", "/"), 0, []string{"-C", "--directory"}, "/", 2},
+		{"empty inline value", args("--directory="), 0, []string{"--directory"}, "", 1},
+		{"other option", args("--exclude=/"), 0, []string{"--directory"}, "", 0},
+		{"value missing", args("--directory"), 0, []string{"--directory"}, "", 0},
+		{"index past end", args("--directory", "/"), 2, []string{"--directory"}, "", 0},
+		{"negative index", args("--directory", "/"), -1, []string{"--directory"}, "", 0},
+		{"no names", args("--directory=/"), 0, nil, "", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			value, span := FlagValueAt(tc.args, tc.index, tc.names...)
+			if value != tc.wantValue || span != tc.wantSpan {
+				t.Errorf("FlagValueAt(%s) = (%q, %d), want (%q, %d)",
+					tc.name, value, span, tc.wantValue, tc.wantSpan)
+			}
+		})
+	}
+}

--- a/pkg/katas/katatests/zc1500s_test.go
+++ b/pkg/katas/katatests/zc1500s_test.go
@@ -1108,6 +1108,25 @@ func TestZC1523(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
+			// tar takes the directory inline too, and it extracts into
+			// exactly the same place.
+			name:  "invalid — tar xf foo.tar --directory=/",
+			input: `tar xf foo.tar --directory=/`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1523",
+					Message: "`tar -C /` extracts into the filesystem root — overwrites any path that happens to be inside the archive. Stage, inspect, then copy.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:     "valid — tar xf foo.tar --directory=/tmp/stage",
+			input:    `tar xf foo.tar --directory=/tmp/stage`,
+			expected: []katas.Violation{},
+		},
+		{
 			name:  "invalid — tar xf foo.tar -C /",
 			input: `tar xf foo.tar -C /`,
 			expected: []katas.Violation{

--- a/pkg/katas/katatests/zc1600s_test.go
+++ b/pkg/katas/katatests/zc1600s_test.go
@@ -3146,6 +3146,24 @@ func TestZC1661(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
+			// curl takes the bundle path inline as well.
+			name:  "invalid — curl URL --cacert=/dev/null",
+			input: `curl https://example.com --cacert=/dev/null`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1661",
+					Message: "`curl --cacert /dev/null` feeds curl an empty trust store — most TLS backends then accept any peer cert. Use a real bundle or `--pinnedpubkey`.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
+			name:     "valid — curl URL --cacert=/etc/ssl/cert.pem",
+			input:    `curl https://example.com --cacert=/etc/ssl/cert.pem`,
+			expected: []katas.Violation{},
+		},
+		{
 			name:  "invalid — curl URL --cacert /dev/null",
 			input: `curl https://example.com --cacert /dev/null`,
 			expected: []katas.Violation{

--- a/pkg/katas/katatests/zc1800s_test.go
+++ b/pkg/katas/katatests/zc1800s_test.go
@@ -1749,6 +1749,24 @@ func TestZC1835(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
+			name:     "valid — `smartctl --smart=on $DISK`",
+			input:    `smartctl --smart=on $DISK`,
+			expected: []katas.Violation{},
+		},
+		{
+			// smartctl documents the value inline: --smart=off.
+			name:  "invalid — `smartctl --smart=off $DISK`",
+			input: `smartctl --smart=off $DISK`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1835",
+					Message: "`smartctl -s off` disables the drive's SMART attribute collection — `smartctl -H` keeps reporting PASSED until the disk falls off the bus. Leave it `on` and configure `smartd.conf` for proactive alerts.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
 			name:  "invalid — `smartctl -s off $DISK`",
 			input: `smartctl -s off $DISK`,
 			expected: []katas.Violation{

--- a/pkg/katas/zc1500s.go
+++ b/pkg/katas/zc1500s.go
@@ -1322,24 +1322,18 @@ func checkZC1523(node ast.Node) []Violation {
 		return nil
 	}
 
-	var prevC bool
-	for _, arg := range cmd.Arguments {
-		v := arg.String()
-		if prevC {
-			prevC = false
-			if v == "/" {
-				return []Violation{{
-					KataID: "ZC1523",
-					Message: "`tar -C /` extracts into the filesystem root — overwrites any " +
-						"path that happens to be inside the archive. Stage, inspect, then copy.",
-					Line:   cmd.Token.Line,
-					Column: cmd.Token.Column,
-					Level:  SeverityError,
-				}}
-			}
-		}
-		if v == "-C" || v == "--directory" {
-			prevC = true
+	// tar documents the directory inline as `--directory=DIR` as well as
+	// spaced, and both extract into the same place.
+	for i := range cmd.Arguments {
+		if dir, _ := FlagValueAt(cmd.Arguments, i, "-C", "--directory"); dir == "/" {
+			return []Violation{{
+				KataID: "ZC1523",
+				Message: "`tar -C /` extracts into the filesystem root — overwrites any " +
+					"path that happens to be inside the archive. Stage, inspect, then copy.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityError,
+			}}
 		}
 	}
 	return nil

--- a/pkg/katas/zc1600s.go
+++ b/pkg/katas/zc1600s.go
@@ -3520,15 +3520,9 @@ func checkZC1661(node ast.Node) []Violation {
 		return nil
 	}
 
-	for i, arg := range cmd.Arguments {
-		v := arg.String()
-		if v != "--cacert" && v != "--capath" {
-			continue
-		}
-		if i+1 >= len(cmd.Arguments) {
-			continue
-		}
-		if cmd.Arguments[i+1].String() == "/dev/null" {
+	// curl takes the bundle path inline as well: `--cacert=/dev/null`.
+	for i := range cmd.Arguments {
+		if path, _ := FlagValueAt(cmd.Arguments, i, "--cacert", "--capath"); path == "/dev/null" {
 			return zc1661Hit(cmd)
 		}
 	}

--- a/pkg/katas/zc1800s.go
+++ b/pkg/katas/zc1800s.go
@@ -2251,12 +2251,9 @@ func checkZC1835(node ast.Node) []Violation {
 		return nil
 	}
 	args := cmd.Arguments
-	for i := 0; i+1 < len(args); i++ {
-		flag := args[i].String()
-		if flag != "-s" && flag != "--smart" {
-			continue
-		}
-		val := args[i+1].String()
+	// smartctl documents the value inline: `--smart=off`.
+	for i := range args {
+		val, _ := FlagValueAt(args, i, "-s", "--smart")
 		if val == "off" {
 			return []Violation{{
 				KataID: "ZC1835",


### PR DESCRIPTION
## What

Three katas read an option's value from the *following* argument, so the inline spelling hid it. Each of the three guards something that matters:

```zsh
tar --directory=/ -xf a.tar          # extracts into the filesystem root
curl --cacert=/dev/null https://h    # hands curl an empty trust store
smartctl --smart=off /dev/sda        # turns off the drive health source
```

All three were silent. The spaced form of each was caught.

ZC1523 carries **Error** severity, and writing `--directory=/` instead of `-C /` was enough to walk past it — while tar extracts to exactly the same place.

## The helper

`FlagValueAt` returns an option's value together with the number of arguments it spans, so a caller no longer keeps its own previous-argument state machine. ZC1523 loses one:

```go
for i := range cmd.Arguments {
    if dir, _ := FlagValueAt(cmd.Arguments, i, "-C", "--directory"); dir == "/" {
```

The span return is there for callers that need to skip a consumed value; `--directory=/` spans one argument, `--directory /` spans two.

## Spellings verified against the tools on this machine

```text
tar        -C, --directory=DIR
smartctl   -s VALUE, --smart=VALUE
curl       --cacert=path      (same parser that takes --max-time=5)
```

## Behaviour

| command | before | after |
|---|---|---|
| `tar --directory=/ -xf a.tar` | silent | ZC1523 |
| `tar -C / -xf a.tar` | ZC1523 | ZC1523 |
| `tar --directory=/opt -xf a.tar` | silent | silent |
| `curl --cacert=/dev/null …` | silent | ZC1661 |
| `curl --cacert=/etc/ca.pem …` | silent | silent |
| `smartctl --smart=off …` | silent | ZC1835 |
| `smartctl --smart=on …` | silent | silent |

## Gates

Corpus drift zero — no pinned file writes these options inline. The new cases are non-vacuous: three subtests fail against the previous code. Parser sweep 402/0; fix-corpus sweep clean under the zsh oracle; suite, `golangci-lint` (0 issues), `gocyclo` green.

Completes the sweep started in #1455 and #1456.