### PR TITLE
fix: read the last inline flag values

### DIFF
--- a/pkg/katas/katatests/zc1100s_test.go
+++ b/pkg/katas/katatests/zc1100s_test.go
@@ -3262,6 +3262,18 @@ func TestZC1184(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
+			name:  "invalid diff --unified=3",
+			input: `diff --unified=3 old.txt new.txt`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1184",
+					Message: "Consider `git diff` instead of `diff -u` when working in a repository. `git diff` provides better context and integration.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
 			name:  "invalid diff -u",
 			input: `diff -u old.txt new.txt`,
 			expected: []katas.Violation{

--- a/pkg/katas/katatests/zc1300s_test.go
+++ b/pkg/katas/katatests/zc1300s_test.go
@@ -2424,6 +2424,18 @@ func TestZC1365(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
+			name:  "invalid — stat --format=%s",
+			input: `stat --format=%s file`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1365",
+					Message: "Use Zsh `zmodload zsh/stat; zstat -H meta file` for file metadata instead of `stat -c '%...'`. The associative array `meta` exposes every stat field.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
 			name:  "invalid — stat -c %s",
 			input: `stat -c %s file`,
 			expected: []katas.Violation{

--- a/pkg/katas/katatests/zc1400s_test.go
+++ b/pkg/katas/katatests/zc1400s_test.go
@@ -87,6 +87,19 @@ func TestZC1402(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
+			// This spelling was meant to be covered already; the prefix test compared six characters against a seven-character literal.
+			name:  "invalid — date --date=",
+			input: `date --date=@1700000000 +%Y-%m-%d`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1402",
+					Message: "Use Zsh `strftime` (from `zsh/datetime`) instead of `date -d @N -- +fmt`. The `-d`/`@` form is GNU-specific; `strftime` is portable Zsh.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
 			name:  "invalid — date -d",
 			input: `date -d @1700000000 +%Y-%m-%d`,
 			expected: []katas.Violation{

--- a/pkg/katas/katatests/zc1500s_test.go
+++ b/pkg/katas/katatests/zc1500s_test.go
@@ -711,6 +711,19 @@ func TestZC1514(t *testing.T) {
 			},
 		},
 		{
+			// The hash is just as exposed written inline.
+			name:  "invalid — usermod --password=hash bob",
+			input: `usermod --password=$6$salt$hashhash bob`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1514",
+					Message: "`usermod -p <hash>` puts the hashed password in ps / /proc / history. Use `chpasswd --crypt-method=SHA512` from stdin.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
 			name:  "invalid — usermod -p hash bob",
 			input: `usermod -p $6$salt$hashhash bob`,
 			expected: []katas.Violation{
@@ -2934,6 +2947,18 @@ func TestZC1560(t *testing.T) {
 			expected: []katas.Violation{},
 		},
 		{
+			name:  "invalid — pip install --trusted-host=host foo",
+			input: `pip install --trusted-host=pypi.example.com foo`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1560",
+					Message: "`pip --trusted-host` skips TLS verification and allows plain-HTTP for that index. Fix the CA trust and keep --index-url on https://.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
 			name:  "invalid — pip install --trusted-host pypi.example.com foo",
 			input: `pip install --trusted-host pypi.example.com foo`,
 			expected: []katas.Violation{
@@ -3046,6 +3071,19 @@ func TestZC1562(t *testing.T) {
 			},
 		},
 		{
+			// env documents the name inline as well.
+			name:  "invalid — env --unset=LD_PRELOAD cmd",
+			input: `env --unset=LD_PRELOAD cmd`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1562",
+					Message: "`env -u LD_PRELOAD` clears a security-relevant variable mid-run. Use `env -i` to sanitise, or set the right value explicitly.",
+					Line:    1,
+					Column:  1,
+				},
+			},
+		},
+		{
 			name:  "invalid — env -u LD_PRELOAD cmd",
 			input: `env -u LD_PRELOAD cmd`,
 			expected: []katas.Violation{
@@ -3120,6 +3158,18 @@ func TestZC1564(t *testing.T) {
 			name:     "valid — timedatectl status",
 			input:    `timedatectl status`,
 			expected: []katas.Violation{},
+		},
+		{
+			name:  "invalid — date --set=2025-01-01",
+			input: `date --set=2025-01-01`,
+			expected: []katas.Violation{
+				{
+					KataID:  "ZC1564",
+					Message: "`date -s` sets the wall clock manually — breaks TLS certs, cron catch-up, and systemd timer math. Use timesyncd/chrony/ntpd.",
+					Line:    1,
+					Column:  1,
+				},
+			},
 		},
 		{
 			name:  "invalid — date -s 2025-01-01",

--- a/pkg/katas/zc1100s.go
+++ b/pkg/katas/zc1100s.go
@@ -4452,7 +4452,8 @@ func checkZC1184(node ast.Node) []Violation {
 
 	for _, arg := range cmd.Arguments {
 		val := arg.String()
-		if val == "-u" || val == "--unified" {
+		// diff documents `--unified[=NUM]`.
+		if name, _ := LongFlagName(val); name == "-u" || name == "--unified" {
 			return []Violation{{
 				KataID: "ZC1184",
 				Message: "Consider `git diff` instead of `diff -u` when working in a repository. " +

--- a/pkg/katas/zc1300s.go
+++ b/pkg/katas/zc1300s.go
@@ -2917,7 +2917,8 @@ func checkZC1365(node ast.Node) []Violation {
 
 	for _, arg := range cmd.Arguments {
 		v := arg.String()
-		if v == "-c" || v == "--format" || v == "--printf" {
+		// stat documents `--format=FORMAT` and `--printf=FORMAT`.
+		if name, _ := LongFlagName(v); name == "-c" || name == "--format" || name == "--printf" {
 			return []Violation{{
 				KataID: "ZC1365",
 				Message: "Use Zsh `zmodload zsh/stat; zstat -H meta file` for file metadata instead " +

--- a/pkg/katas/zc1400s.go
+++ b/pkg/katas/zc1400s.go
@@ -126,8 +126,9 @@ func checkZC1402(node ast.Node) []Violation {
 
 	for _, arg := range cmd.Arguments {
 		v := arg.String()
-		if v == "-d" || v == "--date" ||
-			(len(v) > 6 && v[:6] == "--date=") {
+		// The inline form was meant to be handled here, but `v[:6]` is
+		// `--date` and never equals the seven-character `--date=`.
+		if name, _ := LongFlagName(v); name == "-d" || name == "--date" {
 			return []Violation{{
 				KataID: "ZC1402",
 				Message: "Use Zsh `strftime` (from `zsh/datetime`) instead of `date -d @N -- +fmt`. " +

--- a/pkg/katas/zc1500s.go
+++ b/pkg/katas/zc1500s.go
@@ -886,10 +886,10 @@ func checkZC1514(node ast.Node) []Violation {
 		return nil
 	}
 
-	var prevP bool
-	for _, arg := range cmd.Arguments {
-		v := arg.String()
-		if prevP && v != "" && v[0] != '-' {
+	// The hash is just as exposed when written inline as `--password=<hash>`.
+	for i := range cmd.Arguments {
+		hash, _ := FlagValueAt(cmd.Arguments, i, "-p", "--password")
+		if hash != "" && hash[0] != '-' {
 			return []Violation{{
 				KataID: "ZC1514",
 				Message: "`" + ident.Value + " -p <hash>` puts the hashed password in ps / " +
@@ -899,7 +899,6 @@ func checkZC1514(node ast.Node) []Violation {
 				Level:  SeverityError,
 			}}
 		}
-		prevP = (v == "-p" || v == "--password")
 	}
 	return nil
 }
@@ -3328,7 +3327,8 @@ func checkZC1560(node ast.Node) []Violation {
 	}
 
 	for _, arg := range cmd.Arguments {
-		if arg.String() == "--trusted-host" {
+		// pip accepts `--trusted-host=host` as well as the spaced form.
+		if name, _ := LongFlagName(arg.String()); name == "--trusted-host" {
 			return []Violation{{
 				KataID: "ZC1560",
 				Message: "`pip --trusted-host` skips TLS verification and allows plain-HTTP " +
@@ -3420,25 +3420,19 @@ func checkZC1562(node ast.Node) []Violation {
 		return nil
 	}
 
-	var prevU bool
-	for _, arg := range cmd.Arguments {
-		v := arg.String()
-		if prevU {
-			prevU = false
-			switch v {
-			case "PATH", "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT":
-				return []Violation{{
-					KataID: "ZC1562",
-					Message: "`env -u " + v + "` clears a security-relevant variable mid-run. " +
-						"Use `env -i` to sanitise, or set the right value explicitly.",
-					Line:   cmd.Token.Line,
-					Column: cmd.Token.Column,
-					Level:  SeverityWarning,
-				}}
-			}
-		}
-		if v == "-u" || v == "--unset" {
-			prevU = true
+	// env documents the name inline as well: `env --unset=PATH`.
+	for i := range cmd.Arguments {
+		name, _ := FlagValueAt(cmd.Arguments, i, "-u", "--unset")
+		switch name {
+		case "PATH", "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT":
+			return []Violation{{
+				KataID: "ZC1562",
+				Message: "`env -u " + name + "` clears a security-relevant variable mid-run. " +
+					"Use `env -i` to sanitise, or set the right value explicitly.",
+				Line:   cmd.Token.Line,
+				Column: cmd.Token.Column,
+				Level:  SeverityWarning,
+			}}
 		}
 	}
 	return nil
@@ -3515,7 +3509,8 @@ func checkZC1564(node ast.Node) []Violation {
 
 	if ident.Value == "date" {
 		for _, arg := range cmd.Arguments {
-			if arg.String() == "-s" || arg.String() == "--set" {
+			// GNU date documents `--set=STRING`.
+			if name, _ := LongFlagName(arg.String()); name == "-s" || name == "--set" {
 				return zc1564Violation(cmd, "date -s")
 			}
 		}


### PR DESCRIPTION
## What

Seven more katas matched only the spaced spelling of an option, so the inline one walked past them. Five of the seven guard something specific:

```zsh
env --unset=LD_PRELOAD cmd        # clears a security-relevant variable
usermod --password=$6$hash bob    # puts the hash in ps and /proc
date --set=2025-01-01             # sets the system clock
pip install --trusted-host=h pkg  # skips TLS verification for an index
stat --format=%s file             # a shell-out Zsh does with zstat
date --date=@0                    # a shell-out Zsh strftime does
diff --unified=3 a b              # a diff Zsh can produce itself
```

All seven were silent. Every spaced equivalent was caught.

## One of them was already trying

ZC1402 meant to handle its inline form:

```go
if v == "-d" || v == "--date" ||
    (len(v) > 6 && v[:6] == "--date=") {
```

`v[:6]` is six characters — `--date` — and `"--date="` is seven. The comparison could never be true, so the branch was dead from the start. It now goes through the shared helper, which cannot drift that way.

ZC1562 and ZC1514 each also lose a previous-argument state machine, replaced by `FlagValueAt`.

## Every spelling confirmed by running the tool

```text
env --unset=PATH sh -c …            exit 0
date --date=@0 -u +%Y               1970
stat --format=%s /etc/hostname      9
diff --unified=1 f f                exit 0
pip install --trusted-host=host     parses; --bogus-host=x is rejected
usermod --password=x <nouser>       "user does not exist" — parsed
usermod --bogus-opt=x <nouser>      "unrecognized option"
```

The last pair is the decisive one for `usermod`, which cannot be run for real: the option is accepted far enough to reach the user lookup, while an invented one is refused outright.

## Gates

Corpus drift zero — no pinned file writes these options inline, so this adds capability without changing a single finding on the corpus. The new cases are non-vacuous: seven subtests fail against the previous code. Parser sweep 402/0; fix-corpus sweep clean under the zsh oracle; suite, `golangci-lint` (0 issues), `gocyclo` green.

Closes the sweep opened in #1455, #1456 and #1457. `sudo --preserve-env=list` stays out: it names the variables to keep rather than preserving the whole environment, so it is a different flag from bare `-E` and needs its own kata treatment.