### PR TITLE
chore: release v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.3] - 2026-08-26
+
+### Fixed
+- Auto-fix no longer rewrites a file into code Zsh cannot parse. A violation's edits now apply as one unit, so a rewrite that only partly succeeds is dropped whole rather than left half-applied. Applying every fix across the pinned corpora previously broke eleven files; it now breaks none.
+- ZC1273 reports a `grep` that could use `-q` without rewriting the redirect. The rewrite orphaned the redirection operator, and `-q` is not equivalent in a pipeline under `pipefail` or when stderr is also redirected.
+- ZC1293 keeps a trailing redirection outside the brackets it introduces, instead of wrapping it inside them.
+- ZC1003 and ZC1010 find the bracket that really closes a test, counting nested glob character classes and glob qualifiers instead of stopping at the first `]`.
+- ZC1053 no longer reports a `grep` whose output is already discarded. The kata now recognises every redirection spelling, including the attached `>/dev/null`, and reads an option cluster left to right so a flag that takes a value cannot be mistaken for `-q`.
+- ZC1044 reports a `cd` where a failed one can actually do harm: function bodies declared with `function name { … }`, `case` clause bodies and `select` bodies are now walked, and a `cd` that ends a function is exempt.
+- A `( … )` in command position parses as a subshell rather than an array literal, so katas that walk commands see the body.
+- A redirection with no target is a parser error, as it is in Zsh. The auto-fix safety gate measures corruption with this parser, so a rewrite that dropped a redirect target while leaving its operator behind used to pass unnoticed.
+- Sixteen katas read an option written as `--flag=value`, not only as `--flag value`. Among them: ZC1231 stops reporting `git clone --depth=1` and no longer produces `--depth 1 --shallow-since=<date>`, a pair Git refuses; ZC1523 catches `tar --directory=/`; ZC1514 catches `usermod --password=<hash>`; and ZC1402's inline-form branch, which compared six characters against a seven-character literal and could never be taken, now works.
+
 ## [1.7.2] - 2026-08-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Static analysis and auto-fix for the setopts, hooks, and globs Bash never learned.
 
 [![CI](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml/badge.svg)](https://github.com/afadesigns/zshellcheck/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.7.2-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
+[![Release](https://img.shields.io/badge/release-v1.7.3-blue)](https://github.com/afadesigns/zshellcheck/releases/latest)
 [![Marketplace](https://img.shields.io/badge/Marketplace-ZshellCheck%20v1-2ea44f?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/zshellcheck-v1)
 [![Auto-fix](https://img.shields.io/badge/auto--fix-132%20katas-2ea44f)](KATAS.md)
 [![Dependencies](https://img.shields.io/badge/dependencies-0-2ea44f)](go.mod)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -5,4 +5,4 @@ package version
 // Version is the current ZShellCheck release. Bump manually when cutting
 // a new tag; semver rules apply (MAJOR.MINOR.PATCH). Never derived from
 // repo state — the string below is the single source of truth.
-const Version = "1.7.2"
+const Version = "1.7.3"


### PR DESCRIPTION
Patch release. Fourteen commits since v1.7.2, all fixes and CI work — no new katas, no feature surface, so the patch digit moves.

## What is in it

The bulk is the auto-fix corruption family, closed end to end. Applying every fix across the pinned corpora used to leave eleven files that Zsh itself rejects; it now leaves none, and the sweep proves it by asking `zsh -n` rather than trusting this project's own parser.

The root cause was the safety net. When a full pass raised the parser-error count, the fallback retried edits one at a time and kept whichever parsed alone — which tore a multi-edit rewrite apart and could turn `[[ $x -eq 0 ]]` into `[[ $x == 0 ]]`: valid Zsh, different meaning, invisible to every gate. Edits from one violation now apply as a unit or not at all.

The rest is detection accuracy: ZC1053 stops reporting greps that are already silenced, ZC1044 reports a `cd` only where a failed one can do harm, a `( … )` in command position parses as a subshell so katas can see inside it, and sixteen katas learned to read `--flag=value`.

## Version surfaces

- `pkg/version/version.go` → `1.7.3`
- README release badge → `v1.7.3`
- `CHANGELOG.md` → `[1.7.3] - 2026-08-26`

Tag follows the merge.